### PR TITLE
fix: repair 10 stale tests + 37 stale doc references (unblock CI)

### DIFF
--- a/content/CONTEXT.md
+++ b/content/CONTEXT.md
@@ -111,15 +111,15 @@ Content queue integrates with the Atlas-wide Postiz publishing pipeline:
 
 | Constant | Value | File:Line |
 |----------|-------|---------, |
-| BLOG_DIR | `path.join(process.cwd(), "content", "blog")` | `src/lib/blog.ts:33` |
+| BLOG_DIR | `path.join(process.cwd(), "content", "blog")` | `src/lib/blog.ts:50` |
 | Allowed categories | dui, drug-cases, white-collar, sex-offense, probation, general-defense, employment | `src/lib/blog.ts` |
-| Required frontmatter | title, date, tags, excerpt, author, category | `src/lib/blog.ts:15-24` |
-| Optional frontmatter | faqs, howToSteps, lastModified | `src/lib/blog.ts:55-60` |
-| Post slug regex | `/^[a-z0-9][a-z0-9-]*[a-z0-9]$/` (prevents path traversal) | `src/lib/blog.ts:106` |
-| Post sort order | By date descending (newest first) | `src/lib/blog.ts:92` |
-| Related posts limit | 2 posts (same category OR shared tag) | `src/lib/blog.ts:145, 154-155` |
-| Default author | "ImNotAnAttorney Team" | `src/lib/blog.ts:122` |
-| Default category | "general-defense" | `src/lib/blog.ts:123` |
+| Required frontmatter | title, date, tags, excerpt, author, category | `src/lib/blog.ts:21-27` |
+| Optional frontmatter | faqs, howToSteps, lastModified | `src/lib/blog.ts:229-233` |
+| Post slug regex | `/^[a-z0-9][a-z0-9-]*[a-z0-9]$/` (prevents path traversal) | `src/lib/blog.ts:293` |
+| Post sort order | By date descending (newest first) | `src/lib/blog.ts:276` |
+| Related posts limit | 2 posts (same category OR shared tag) | `src/lib/blog.ts:338` |
+| Default author | "ImNotAnAttorney Team" | `src/lib/blog.ts:311` |
+| Default category | "general-defense" | `src/lib/blog.ts:312` |
 
 ## Integration Points
 

--- a/src/app/CONTEXT.md
+++ b/src/app/CONTEXT.md
@@ -328,11 +328,10 @@ graph TD
 | `TIER_CORE` | 14 tiers (pricing + Stripe IDs) | `src/lib/tiers.ts:30-256` |
 | `PLAYBOOK_CONFIGS` | 8 charge-type sales pages | `src/lib/playbook-configs.ts` |
 | `SITE_URL` | `https://imnotanattorney.com` | `src/lib/site.ts:48-49` |
-| `metadataBase` | `new URL(SITE_URL)` | `layout.tsx:71` |
-| `title.template` | `"%s \| ImNotAnAttorney"` | `layout.tsx:74` |
+| `metadataBase` | `new URL(SITE_URL)` | `layout.tsx:74` |
+| `title.template` | `"%s \| ImNotAnAttorney"` | `layout.tsx:77` |
 | `maxDuration` (cron/demand-fetch) | 300s | `api/cron/demand-fetch/route.ts:19` |
 | `maxDuration` (cron/demand-score) | 120s | `api/cron/demand-score/route.ts:21` |
-| `maxDuration` (cron/blog-qa) | 120s | `api/cron/blog-qa/route.ts:27` |
 | `maxDuration` (cron/blog-publish) | 60s | `api/cron/blog-publish/route.ts:22` |
 | `revalidate` (score-summary) | 300s (5 min ISR) | `api/stats/score-summary/route.ts:9` |
 | `revalidate` (defense-score-data) | 3600s (1 hr ISR) | `research/defense-score-data/page.tsx:6` |

--- a/src/components/CONTEXT.md
+++ b/src/components/CONTEXT.md
@@ -94,8 +94,8 @@
 
 | Constant | Value | File:Line |
 |----------|-------|---------, |
-| CATEGORY_TO_PLAYBOOK | 6 category→tier slug mappings | `HomepageHero.tsx:18-25` |
-| CATEGORY_PLAYBOOK | 10 blog category→playbook mappings | `BlogCTA.tsx:15-26` |
+| CATEGORY_TO_PLAYBOOK | 6 category→tier slug mappings | `HomepageHero.tsx:27-34` |
+| CATEGORY_PLAYBOOK | 10 blog category→playbook mappings | `BlogCTA.tsx:16-27` |
 | ADMIN_LINKS | Inbox, Demand Intel, Partners | `AdminNav.tsx:10-14` |
 | FREE_TEXT_SLUG | `"__free_text__"` (other charge option) | `IntakeChargeSelector.tsx:32` |
 | MAX_FILE_SIZE | 50MB | `FileUpload.tsx:40` |

--- a/src/lib/CONTEXT.md
+++ b/src/lib/CONTEXT.md
@@ -55,16 +55,12 @@
 | `report-renderer.ts` | PDF/HTML report assembly for Case Decoder |
 
 ### Blog Generation Pipeline
+> **Note (2026-04-20):** Pipeline was containerized to a separate repo. Only `publish.ts` + `index.ts` barrel remain here for downstream imports; generation, QA, and topic-research modules live in the pipeline container.
+
 | File | Purpose |
 |------|---------|
-| `blog-generation/generate-post.ts` | Claude-powered post drafting |
 | `blog-generation/publish.ts` | Write MDX to `content/blog/`, commit |
-| `blog-generation/qa-humanizer.ts` | Strip AI tells from draft |
-| `blog-generation/qa-slop.ts` | Anti-slop patterns audit |
-| `blog-generation/qa-upl.ts` | UPL compliance check on post content |
-| `blog-generation/topic-research.ts` | Keyword + demand research |
-| `blog-generation/prompts.ts` | Blog generation prompt builders |
-| `blog-generation/index.ts` | Barrel export, re-exports `generatePost`, `buildGenerationPrompt`, `enrichTopic`, `runHumanizerCheck`, `runSlopAudit`, `runUPLCheck`, `publishDraft` |
+| `blog-generation/index.ts` | Barrel export kept for downstream imports from `publish.ts` |
 
 ### Scoring
 | File | Purpose |
@@ -76,7 +72,6 @@
 |------|---------|
 | `demand/fetch-signals.ts` | Pull demand signals from Reddit, search, etc. |
 | `demand/classify-signal.ts` | Classify signal type (question, complaint, urgency) |
-| `demand/classify-llm.ts` | Claude-powered signal classification |
 | `demand/score-demand.ts` | Aggregate demand score per charge type |
 | `demand/track-performance.ts` | Store + trend demand scores over time |
 
@@ -137,22 +132,22 @@ No passwords. Flow: `POST /api/customer/magic-link` → token stored in `magic_l
 | Constant | Value | File:Line |
 |----------|-------|---------, |
 | **Pricing** | | |
-| DUI First Offense | $97, `live: true` | `tiers.ts:33-45` |
-| Case Decoder | $197, priority $97 (4h) | `tiers.ts:153-165` |
-| Intelligence Brief | $997, priority $297 (24h) | `tiers.ts:168-180` |
-| X-Ray | $2,497, priority $497 (5 days) | `tiers.ts:181-195` |
-| War Room | $4,997, priority $997 (20 days) | `tiers.ts:196-210` |
-| Situation Room | $9,997 | `tiers.ts:213-225` |
-| Witness Pack | $297 add-on | `tiers.ts:243-255` |
+| DUI First Offense | $127, `live: true` | `tiers.ts:33-47` |
+| Case Decoder | $197, priority $97 (4h) | `tiers.ts:167-181` |
+| Intelligence Brief | $997, priority $297 (24h) | `tiers.ts:182-196` |
+| X-Ray | $2,497, priority $497 (5 days) | `tiers.ts:197-212` |
+| War Room | $4,997, priority $997 (20 days) | `tiers.ts:213-228` |
+| Situation Room | $9,997 | `tiers.ts:229-244` |
+| Witness Pack | $297 add-on | `tiers.ts:335-349` |
 | **Scoring** | | |
-| Base score | 50 (neutral midpoint) | `score.ts:77` |
-| Score bands | Critical 0-30, Concerning 31-50, Average 51-70, Adequate 71-85, Excellent 86-100 | `score.ts:300-304` |
-| Motions weight | 20% | `score.ts:118` |
-| Discovery weight | 15% | `score.ts:145` |
-| Communication weight | 15% | `score.ts:167` |
-| Attorney type weight | 10% | `score.ts:93` |
-| Strategy weight | 10% | `score.ts:191` |
-| Time modifier weight | 30% | `score.ts:81` |
+| Base score | 50 (neutral midpoint) | `score.ts:92` |
+| Score bands | Critical 0-30, Concerning 31-50, Average 51-70, Adequate 71-85, Excellent 86-100 | `score.ts:315-319` |
+| Motions weight | 20% | `score.ts:133` |
+| Discovery weight | 15% | `score.ts:160` |
+| Communication weight | 15% | `score.ts:182` |
+| Attorney type weight | 10% | `score.ts:108` |
+| Strategy weight | 10% | `score.ts:206` |
+| Time modifier weight | 30% | `score.ts:96` |
 | **Rate Limiting** | | |
 | Memory window | 60 seconds | `rate-limit.ts:27` |
 | Memory max requests | 3 per window | `rate-limit.ts:28` |
@@ -161,13 +156,13 @@ No passwords. Flow: `POST /api/customer/magic-link` → token stored in `magic_l
 | SITE_URL | `https://imnotanattorney.com` | `site.ts:49` |
 | CONTACT_EMAIL | `help@imnotanattorney.com` | `site.ts:55` |
 | PHYSICAL_ADDRESS | 195 Dr MLK Jr St N, St Petersburg, FL 33701 | `site.ts:66` |
-| OPERATOR_TOKEN_TTL | 24 * 60 * 60 = 86,400s (24h) | `site.ts:129` |
-| PHASE2_TOKEN_TTL | 2,592,000s (30 days) | `site.ts:132` |
+| OPERATOR_TOKEN_TTL | 24 * 60 * 60 = 86,400s (24h) | `site.ts:148` |
+| PHASE2_TOKEN_TTL | 2,592,000s (30 days) | `site.ts:151` |
 | **Email** | | |
 | FROM_EMAIL | `noreply@imnotanattorney.com` | `email.ts:53-54` |
 | Nurture days | 1, 3, 5, 7, 10, 14 | `drip-emails.ts:7` |
 | DUI crisis days | 2, 4, 7 | `drip-emails.ts:11-14` |
-| Win-back days | 75, 78, 82, 89, 96 | `drip-emails.ts:38` |
+| Win-back days | 75, 78, 82, 89, 96 | `drip-emails.ts:39` |
 | **Auth** | | |
 | Magic link TTL | 15 minutes | `customer-auth.ts:28` |
 | Session TTL | 30 days | `customer-auth.ts:29` |
@@ -177,8 +172,8 @@ No passwords. Flow: `POST /api/customer/magic-link` → token stored in `magic_l
 | **Feature Flags** | | |
 | Cache TTL | 5 minutes | `feature-flags.ts:12` |
 | **Referral** | | |
-| Master coupon ID | `bondsman-referral-10pct` | `referral.ts:17` |
-| Coupon discount | 10% off | `referral.ts:31-33` |
+| Master coupon ID | `bondsman-referral-10pct` | `referral.ts:35` |
+| Coupon discount | 10% off | `referral.ts:230-242` |
 | **Batch API** | | |
 | API base URL | `https://api.anthropic.com` | `batch-api.ts:87` |
 | API version | `2023-06-01` | `batch-api.ts:94` |

--- a/tests/api/dashboard-check-in-enabled.test.ts
+++ b/tests/api/dashboard-check-in-enabled.test.ts
@@ -4,9 +4,15 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 // All queries resolve with empty arrays / zero counts — we only care about
 // the shape of `partner.check_in_enabled` in the JSON response.
 function makeChain(): unknown {
+  // Dashboard route chains .select().eq().eq().gte() for the monthly + weekly
+  // reminder counters (src/app/api/partner/dashboard/route.ts). Every builder
+  // method on the chain returns the same chain object and resolves with the
+  // empty-shape default when awaited.
   const chain: Record<string, unknown> = {
     select: () => chain,
     eq: () => chain,
+    gte: () => chain,
+    lte: () => chain,
     order: () => chain,
     limit: async () => ({ data: [], error: null }),
     range: async () => ({ data: [], error: null }),

--- a/tests/components/BridgePage.test.tsx
+++ b/tests/components/BridgePage.test.tsx
@@ -52,14 +52,15 @@ describe("<BridgePage /> mode-aware rendering", () => {
     expect(html).not.toContain("court-date reminders and a walkthrough");
   });
 
-  it("renders outcome-tangible CTA and drops the old 'Take Back Control' copy", () => {
+  it("renders the operator-voice CTA and drops the old 'Take Back Control' copy", () => {
     const html = render({ ...baseProps });
 
-    // New CTA — apostrophe may serialize as raw ' or as &#x27; depending
-    // on react-dom/server version, so match via regex that accepts both.
-    expect(html).toMatch(/See My Case(?:&#x27;|&apos;|')s Questions/);
-    // Old CTA must be gone
+    // Current CTA post-referral-flow rewrite (09b39b2). The prior
+    // "See My Case's Questions" variant was replaced with the brand tagline.
+    expect(html).toContain("Know what they know");
+    // Old CTAs must be gone.
     expect(html).not.toContain("Take Back Control");
+    expect(html).not.toMatch(/See My Case(?:&#x27;|&apos;|')s Questions/);
   });
 
   // NOTE: `daysUntilCourt` prop + countdown block were removed from
@@ -73,8 +74,9 @@ describe("<BridgePage /> mode-aware rendering", () => {
     // "Jane Partner from ABC Bail Bonds, Tampa" should appear in the hero
     // and in the discount attribution line.
     expect(html).toContain("Jane Partner from ABC Bail Bonds, Tampa");
-    // Discount copy
-    expect(html).toContain("10% off case analysis is built in");
+    // Discount copy (09b39b2 rewrote from "10% off case analysis is built in"
+    // to operator-voice "10% is already taken off before you see any price").
+    expect(html).toContain("10% is already taken off before you see any price");
   });
 
   it("links to /r/<promoCode>/quiz on the CTA", () => {
@@ -92,8 +94,9 @@ describe("<BridgePage /> mode-aware rendering", () => {
     // Name renders, but no "from" attribution since there's no company.
     expect(html).toContain("Jordan");
     expect(html).not.toContain("Jordan from");
-    // Discount attribution still names the partner.
-    expect(html).toContain("Because Jordan sent you");
+    // Discount attribution still names the partner (operator-voice rewrite
+    // replaced "Because Jordan sent you" with "Jordan put you on the…" line).
+    expect(html).toContain("Jordan put you on the partner-referral list");
   });
 
   it("renders 'Name from Company' without city when company is set but city is null", () => {

--- a/tests/components/ComplianceReportClient.test.tsx
+++ b/tests/components/ComplianceReportClient.test.tsx
@@ -82,21 +82,27 @@ describe("<ComplianceReportClient /> mode gating (bondsman-modes v2)", () => {
 
   it("referral mode (disabled): renders the referral-mode intro copy", () => {
     const html = render("disabled");
-    expect(html).toContain("Your account is in Referral mode.");
-    expect(html).toContain("Check-in workflows are off.");
+    // Tier B bondsman-modes-v2 rewrote the intro as operator-first voice.
+    // Referral-mode intro is distinguishable by "48-hour, 24-hour, and
+    // morning-of" cadence (check-in mode doesn't mention specific windows).
+    expect(html).toContain("automated court-date reminder program");
+    expect(html).toContain("48-hour, 24-hour, and morning-of");
     // Must NOT render the check-in-enabled intro branch.
-    expect(html).not.toContain("check-in compliance");
+    expect(html).not.toContain("active compliance program");
+    expect(html).not.toContain("Check-in mode is on");
   });
 
   it("check-in mode (enabled): renders the check-in compliance intro copy", () => {
     const html = render("enabled");
-    expect(html).toContain("check-in compliance");
-    // Summary card present.
+    // Enabled-mode intro distinctive phrases (Tier B rewrite).
+    expect(html).toContain("active compliance program");
+    expect(html).toContain("Check-in mode is on");
+    // Check-in summary columns present (uppercase in thead).
     expect(html).toContain("Check-Ins");
-    expect(html).toContain("Compliance Rate");
-    // Must NOT render the referral-mode disclaimer.
-    expect(html).not.toContain("Your account is in Referral mode.");
-    expect(html).not.toContain("Check-in workflows are off.");
+    expect(html).toContain("Compliance");
+    // Must NOT render the referral-mode intro branch.
+    expect(html).not.toContain("automated court-date reminder program");
+    expect(html).not.toContain("48-hour, 24-hour, and morning-of");
   });
 
   it("check-in mode has exactly 4 more table columns than referral mode", () => {

--- a/tests/components/CourtReminderForm-compact.test.tsx
+++ b/tests/components/CourtReminderForm-compact.test.tsx
@@ -87,7 +87,7 @@ describe("<CourtReminderForm /> compact-mode rendering", () => {
     expect(html).toContain('for="consent"');
     expect(html).toContain('aria-describedby="consent-desc"');
     expect(html).toContain('id="consent-desc"');
-    expect(html).toContain("I agree to SMS and email communications");
+    expect(html).toContain("I agree to receive SMS and email reminders");
   });
 
   it("omits phone + consent when their require flags are false", () => {

--- a/tests/components/PartnerApplicationForm-bondsman-mode.test.tsx
+++ b/tests/components/PartnerApplicationForm-bondsman-mode.test.tsx
@@ -94,9 +94,13 @@ describe("<PartnerApplicationForm /> bondsman-mode rendering", () => {
     expect(html).not.toContain('id="checkin-mode-error"');
   });
 
-  it("renders 'Your Name *', 'Email *', and 'City' input labels", () => {
+  it("renders 'Your first name', 'Email *', and 'City' input labels", () => {
+    // Label updated in d8f933e — "Your Name" was causing bondsmen to enter
+    // their business name instead of their first name. Client-facing hint
+    // "(shown to clients on your referral page)" was added same commit.
     const html = render({ source: "bondsman" });
-    expect(html).toContain("Your Name *");
+    expect(html).toContain("Your first name");
+    expect(html).toContain("shown to clients on your referral page");
     expect(html).toContain("Email *");
     expect(html).toContain("City");
   });

--- a/tests/r-q-redirect.test.ts
+++ b/tests/r-q-redirect.test.ts
@@ -46,15 +46,20 @@ const hasCreds = !!SUPABASE_URL && !!SERVICE_KEY;
 const describeIfLive = hasCreds ? describe : describe.skip;
 
 describeIfLive("GET /r/q/[id]", () => {
-  const sb = createClient(SUPABASE_URL!, SERVICE_KEY!, {
-    auth: { autoRefreshToken: false, persistSession: false },
-  });
+  // `describe.skip(...)` still runs the describe callback at suite-collection
+  // time — only the `it(...)` bodies are skipped. Creating the client at the
+  // callback top-level blew up the whole file load when env was absent.
+  // Defer to beforeAll so skipped runs don't require credentials.
+  let sb: ReturnType<typeof createClient>;
 
   let abandonedId: number;
   let postedWithSlug: number;
   let postedWithoutSlug: number;
 
   beforeAll(async () => {
+    sb = createClient(SUPABASE_URL!, SERVICE_KEY!, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    });
     const uniq = `rq-test-${Date.now()}`;
     const { data: aq, error: aqErr } = await sb
       .from("abandoned_questions")


### PR DESCRIPTION
## Summary
Two-commit cleanup pass that took Docs Freshness and the Vitest suite from chronic-red → green on master.

1. **fix(tests) — 10 stale test assertions**
  Six test files were failing against copy that had been intentionally rewritten in Tier B bundle (`2c68db9`), the referral-flow rewrite (`09b39b2`), or earlier commits. The red signals had normalized and were masking real regressions. Updated assertions to match shipped copy; invariants preserved.

2. **docs(architecture) — 30 drifts + 7 missing refs**
  ARCHITECTURE.md / CONTEXT.md files had accumulated stale File:Line references (Tier B renumbered lots of constants, blog pipeline containerization removed `blog-generation/*` files). Targeted line-number + path corrections, not a restructuring pass.

## Why this matters
Docs Freshness has been chronic-red long enough that PRs started admin-merging past it — which meant the check had stopped catching the thing it exists to catch. Same for vitest: with 10 pre-existing reds, real regressions would've landed silently. Both signals are trustworthy again.

## Changes by file
**Tests (6 files, commit `bef9b60`)**
- `ComplianceReportClient.test.tsx` — referral-mode / check-in-mode intro copy updated to Tier B operator-voice.
- `BridgePage.test.tsx` — CTA / discount copy / attribution updated to referral-flow rewrite.
- `CourtReminderForm-compact.test.tsx` — consent checkbox label updated.
- `PartnerApplicationForm-bondsman-mode.test.tsx` — "Your Name" → "Your first name".
- `dashboard-check-in-enabled.test.ts` — supabase mock chain missing `.gte()` / `.lte()`.
- `r-q-redirect.test.ts` — `createClient(...)` was at describe-callback top-level, deferred into `beforeAll` so skipped runs don't need creds.

**Docs (4 files, commit `2dca313`)**
- `src/app/CONTEXT.md` — layout.tsx line refs; removed stale `cron/blog-qa` maxDuration row.
- `src/components/CONTEXT.md` — HomepageHero + BlogCTA line ranges.
- `src/lib/CONTEXT.md` — all 6 TIER_CORE tier rows, DUI value $97 → $127 (Hormozi lift landed 2026-04-07), score.ts weights, site.ts token TTLs, drip-emails win-back, referral coupon lines. Removed 6 of 7 blog-generation rows (pipeline containerized 2026-04-20); removed `demand/classify-llm.ts`.
- `content/CONTEXT.md` — all 9 blog.ts constants line refs.

## Verification
- `npx tsc --noEmit --skipLibCheck` — clean
- `npx vitest run tests/` — 172 passed, 6 skipped, 0 failed (was: 162 / 1 / 10)
- `node docs/verify-architecture.js` — exit 0, 184 verified / 0 drifted / 0 missing (was: 154 / 30 / 7, exit 1)

## Not touched (intentional, out of scope)
- 247 `?` undocumented-file warnings in `node docs/verify-architecture.js` — yellow warnings, non-blocking. Mostly Tier-9 `bulk-*` scripts. Separate pass.
- Modified tracked files from parallel sessions under `src/app/r/[code]/` — not my branch's concern.

## Test plan
- [x] `npx tsc --noEmit --skipLibCheck` passes
- [x] `npx vitest run tests/` passes (172 green)
- [x] `node docs/verify-architecture.js` exits 0
- [ ] Docs Freshness CI check goes green on this PR
- [ ] Preview deploy builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)