### PR TITLE
fix(intake): cap email length at 254 + unblock tsc gate

### DIFF
--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -138,4 +138,26 @@ if echo "$STAGED_FILES" | grep -qE "src/lib/(tiers|products)\.ts$"; then
   echo "[price-check] All anchors valid."
 fi
 
+# ── TypeScript check ──
+# When any .ts/.tsx under src/ is staged, run `tsc --noEmit` as a cheap
+# sanity gate. This catches the most common class of build failures fast
+# (~5-10s vs ~60s for a full next build). It is NOT sufficient on its own —
+# see pre-push for the next build gate. Incident 2026-04-20 at 8d40ba5 showed
+# tsc missing errors that next build catches (stricter page-data collection +
+# Next's internal tsconfig with noUncheckedIndexedAccess). Belt AND suspenders.
+#
+# Escape hatch: SKIP_TSC=1 git commit ... (emergencies only)
+if [ "${SKIP_TSC:-0}" != "1" ] && echo "$STAGED_FILES" | grep -qE '^src/.*\.(ts|tsx)$'; then
+  echo "[tsc] src/ TS files staged — running tsc --noEmit..."
+  if ! npx tsc --noEmit --skipLibCheck; then
+    echo ""
+    echo "[tsc] BLOCKED: TypeScript errors must be fixed before commit."
+    echo "[tsc] NOTE: tsc is cheaper but less strict than next build."
+    echo "[tsc]       If this passes but Vercel still fails, run: npm run build"
+    echo "[tsc] Emergency bypass: SKIP_TSC=1 git commit ..."
+    exit 1
+  fi
+  echo "[tsc] No TypeScript errors."
+fi
+
 exit 0

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+#
+# pre-push — Full next build gate.
+#
+# Runs `npm run build` before every push so broken master commits never
+# reach Vercel. Incident 2026-04-20 at 8d40ba5: tsc --noEmit passed in
+# pre-commit but next build failed on Vercel because Next's internal
+# tsconfig is stricter (page-data collection, noUncheckedIndexedAccess).
+# Every PR since 8d40ba5 had to be admin-merged because master CI was red.
+# next build locally takes ~60s but catches the class tsc misses.
+#
+# Escape hatches:
+#   SKIP_BUILD=1      Skip the build gate entirely (emergencies only)
+#
+# Enabled via core.hooksPath=scripts/hooks (set by `npm install` via
+# prepare script in package.json).
+
+set -e
+
+if [ "${SKIP_BUILD:-0}" = "1" ]; then
+  echo "[pre-push] SKIP_BUILD=1 — skipping next build gate."
+  exit 0
+fi
+
+# Only gate on pushes that touch src/ code. Docs/content-only pushes skip
+# the slow build. Compare local commits about to be pushed against their
+# upstream.
+protected_range=""
+while read -r local_ref local_sha remote_ref remote_sha; do
+  if [ "$local_sha" = "0000000000000000000000000000000000000000" ]; then
+    continue  # Delete, skip.
+  fi
+  if [ "$remote_sha" = "0000000000000000000000000000000000000000" ]; then
+    # New branch: compare against master.
+    base=$(git merge-base "$local_sha" origin/master 2>/dev/null || echo "")
+    if [ -n "$base" ]; then
+      protected_range="$base..$local_sha"
+    fi
+  else
+    protected_range="$remote_sha..$local_sha"
+  fi
+done
+
+if [ -z "$protected_range" ]; then
+  exit 0
+fi
+
+changed=$(git diff --name-only "$protected_range" 2>/dev/null || echo "")
+if ! echo "$changed" | grep -qE '^(src/|package\.json|tsconfig|next\.config|middleware)'; then
+  echo "[pre-push] No src/ or config changes — skipping build gate."
+  exit 0
+fi
+
+echo "[pre-push] src/ changes detected — running npm run build..."
+if ! npm run build; then
+  echo ""
+  echo "[pre-push] BLOCKED: next build failed. Fix before pushing."
+  echo "[pre-push] Emergency bypass: SKIP_BUILD=1 git push ..."
+  exit 1
+fi
+
+echo "[pre-push] Build succeeded."
+exit 0

--- a/src/app/api/intake/route.ts
+++ b/src/app/api/intake/route.ts
@@ -94,8 +94,11 @@ export async function POST(req: NextRequest) {
     // Strip control characters from firstName (prevent email header injection)
     const sanitizedFirstName = firstName.replace(/[\r\n]/g, "").slice(0, 100);
 
-    // Validate email format (basic regex, not exhaustive, but catches typos)
-    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+    // Validate email format (basic regex, not exhaustive, but catches typos).
+    // 254-char cap = RFC 5321 practical limit; prevents megabyte payloads
+    // flowing into DB + email headers even though the permissive regex would
+    // otherwise match arbitrarily long strings.
+    if (email.length > 254 || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
       return NextResponse.json(
         { error: "Invalid email format" },
         { status: 400 }

--- a/tests/r-q-redirect.test.ts
+++ b/tests/r-q-redirect.test.ts
@@ -50,14 +50,18 @@ describeIfLive("GET /r/q/[id]", () => {
   // time — only the `it(...)` bodies are skipped. Creating the client at the
   // callback top-level blew up the whole file load when env was absent.
   // Defer to beforeAll so skipped runs don't require credentials.
-  let sb: ReturnType<typeof createClient>;
+  // Untyped client — this repo doesn't generate Database types and the
+  // test uses tables (abandoned_questions, posted_answers) that would resolve
+  // to `never` under the default signature. Generic `any` matches the prod
+  // path (createAdminClient in src/lib/supabase/admin.ts is also untyped).
+  let sb: ReturnType<typeof createClient<any>>;
 
   let abandonedId: number;
   let postedWithSlug: number;
   let postedWithoutSlug: number;
 
   beforeAll(async () => {
-    sb = createClient(SUPABASE_URL!, SERVICE_KEY!, {
+    sb = createClient<any>(SUPABASE_URL!, SERVICE_KEY!, {
       auth: { autoRefreshToken: false, persistSession: false },
     });
     const uniq = `rq-test-${Date.now()}`;


### PR DESCRIPTION
## Summary
- **B2 audit** of `/api/partners/apply`, `/api/intake/*`, `/api/generate/*` against the permissive-regex abuse pattern fixed in court-reminders. Outcome: `intake` missing one defense (email length cap). Every other route either already hardened (partners/apply) or N/A (token/webhook/HMAC-gated).
- **intake/route.ts** — reject email when length > 254 (RFC 5321 practical). Keeps existing regex; rate-limit + charge allowlist + Resend final verify handle deeper abuse surfaces, same rationale `court-reminders-input.ts` documents.
- **tests/r-q-redirect.test.ts** — cast supabase client to `<any>` generic. Test file shipped pre-tsc-gate (2026-04-19 E4+E5) and started failing after `71154a3` enabled the hook; new tables (`abandoned_questions`, `posted_answers`) resolved to `never`. No Database types file exists; matches the untyped `createAdminClient()` convention already in `src/lib/supabase/admin.ts`.

No new zod dep (bootstrap mode): kept the hand-rolled pattern shipped in `court-reminders-input.ts` rather than introducing a second validation style.

Plan ref: `docs/plans/2026-04-20-quality-gate-deferred-fixes.md` Tier B2.

## Test plan
- [x] tsc --noEmit clean
- [x] npm run build passes (pre-push gate)
- [ ] Manual: POST /api/intake with 300-char email -> 400 "Invalid email format"
- [ ] Manual: POST /api/intake with normal payload -> 200 as before

Generated with [Claude Code](https://claude.com/claude-code)