### PR TITLE
feat(bondsman): H7 inline hero quick-apply (name + email)

### DIFF
--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -138,4 +138,26 @@ if echo "$STAGED_FILES" | grep -qE "src/lib/(tiers|products)\.ts$"; then
   echo "[price-check] All anchors valid."
 fi
 
+# ── TypeScript check ──
+# When any .ts/.tsx under src/ is staged, run `tsc --noEmit` as a cheap
+# sanity gate. This catches the most common class of build failures fast
+# (~5-10s vs ~60s for a full next build). It is NOT sufficient on its own —
+# see pre-push for the next build gate. Incident 2026-04-20 at 8d40ba5 showed
+# tsc missing errors that next build catches (stricter page-data collection +
+# Next's internal tsconfig with noUncheckedIndexedAccess). Belt AND suspenders.
+#
+# Escape hatch: SKIP_TSC=1 git commit ... (emergencies only)
+if [ "${SKIP_TSC:-0}" != "1" ] && echo "$STAGED_FILES" | grep -qE '^src/.*\.(ts|tsx)$'; then
+  echo "[tsc] src/ TS files staged — running tsc --noEmit..."
+  if ! npx tsc --noEmit --skipLibCheck; then
+    echo ""
+    echo "[tsc] BLOCKED: TypeScript errors must be fixed before commit."
+    echo "[tsc] NOTE: tsc is cheaper but less strict than next build."
+    echo "[tsc]       If this passes but Vercel still fails, run: npm run build"
+    echo "[tsc] Emergency bypass: SKIP_TSC=1 git commit ..."
+    exit 1
+  fi
+  echo "[tsc] No TypeScript errors."
+fi
+
 exit 0

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+#
+# pre-push — Full next build gate.
+#
+# Runs `npm run build` before every push so broken master commits never
+# reach Vercel. Incident 2026-04-20 at 8d40ba5: tsc --noEmit passed in
+# pre-commit but next build failed on Vercel because Next's internal
+# tsconfig is stricter (page-data collection, noUncheckedIndexedAccess).
+# Every PR since 8d40ba5 had to be admin-merged because master CI was red.
+# next build locally takes ~60s but catches the class tsc misses.
+#
+# Escape hatches:
+#   SKIP_BUILD=1      Skip the build gate entirely (emergencies only)
+#
+# Enabled via core.hooksPath=scripts/hooks (set by `npm install` via
+# prepare script in package.json).
+
+set -e
+
+if [ "${SKIP_BUILD:-0}" = "1" ]; then
+  echo "[pre-push] SKIP_BUILD=1 — skipping next build gate."
+  exit 0
+fi
+
+# Only gate on pushes that touch src/ code. Docs/content-only pushes skip
+# the slow build. Compare local commits about to be pushed against their
+# upstream.
+protected_range=""
+while read -r local_ref local_sha remote_ref remote_sha; do
+  if [ "$local_sha" = "0000000000000000000000000000000000000000" ]; then
+    continue  # Delete, skip.
+  fi
+  if [ "$remote_sha" = "0000000000000000000000000000000000000000" ]; then
+    # New branch: compare against master.
+    base=$(git merge-base "$local_sha" origin/master 2>/dev/null || echo "")
+    if [ -n "$base" ]; then
+      protected_range="$base..$local_sha"
+    fi
+  else
+    protected_range="$remote_sha..$local_sha"
+  fi
+done
+
+if [ -z "$protected_range" ]; then
+  exit 0
+fi
+
+changed=$(git diff --name-only "$protected_range" 2>/dev/null || echo "")
+if ! echo "$changed" | grep -qE '^(src/|package\.json|tsconfig|next\.config|middleware)'; then
+  echo "[pre-push] No src/ or config changes — skipping build gate."
+  exit 0
+fi
+
+echo "[pre-push] src/ changes detected — running npm run build..."
+if ! npm run build; then
+  echo ""
+  echo "[pre-push] BLOCKED: next build failed. Fix before pushing."
+  echo "[pre-push] Emergency bypass: SKIP_BUILD=1 git push ..."
+  exit 1
+fi
+
+echo "[pre-push] Build succeeded."
+exit 0

--- a/src/app/partners/bondsman/page.tsx
+++ b/src/app/partners/bondsman/page.tsx
@@ -12,7 +12,7 @@ export const metadata: Metadata = {
   description: "Partner with ImNotAnAttorney to help your clients prepare for court. Free court reminders, compliance tools, and commission on referrals.",
 };
 import { xRayEarning, xRayFiveMonthly, BONDSMAN_FAQS, FORFEITURE_RANGE_DISPLAY } from "@/lib/partner-data";
-import { PartnerCommissionTable, PartnerHowItWorks, PartnerApplicationForm, PartnerWhyItWorks } from "@/components/partner";
+import { PartnerCommissionTable, PartnerHowItWorks, PartnerApplicationForm, PartnerWhyItWorks, HeroQuickApply } from "@/components/partner";
 import { FAQAccordion } from "@/components/FAQAccordion";
 import { FadeInUp } from "@/components/motion/FadeInUp";
 import { StaggerContainer, StaggerItem } from "@/components/motion/StaggerContainer";
@@ -67,12 +67,13 @@ export default function BondsmanPartnersPage() {
             (You also earn 10&ndash;20% when they buy a pre-court research report. But that&apos;s not why
             you&apos;re here.)
           </p>
-          <a
-            href="#apply"
-            className="inline-block px-8 py-4 bg-amber-500 text-black font-bold rounded-xl text-lg hover:bg-amber-400 hover:scale-[1.02] hover:shadow-lg hover:shadow-amber-500/20 transition-all cursor-pointer"
-          >
-            Get My Partner Code
-          </a>
+          <HeroQuickApply />
+          <p className="mt-6 text-sm text-zinc-500">
+            Rather read everything first?{" "}
+            <a href="#apply" className="text-amber-400 underline-offset-4 hover:underline">
+              Skip to the full form &darr;
+            </a>
+          </p>
         </FadeInUp>
       </section>
 

--- a/src/components/partner/HeroQuickApply.tsx
+++ b/src/components/partner/HeroQuickApply.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+/**
+ * HeroQuickApply — inline 2-field quick-apply for the bondsman hero.
+ *
+ * Laja/H7: the full PartnerApplicationForm lives below ~7 sections of sales
+ * copy. A single anchor-jump CTA bypasses all of them. This component lets
+ * a bondsman START the application above the fold, then soft-scrolls them
+ * into the full form with name + email already filled in.
+ *
+ * No backend change: values are stashed in sessionStorage under
+ * `partnerApp.prefill`. PartnerApplicationForm reads + clears on mount.
+ * Deliberate tradeoff — with zero traffic at ship time the dropout-capture
+ * value of a "partial application" row is ~0. If future analytics show
+ * meaningful hero-start vs full-submit gap, wire a partial POST then.
+ *
+ * Plan ref: docs/plans/2026-04-20-bondsman-inline-hero-form.md
+ */
+
+import { useState, type FormEvent } from "react";
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const STORAGE_KEY = "partnerApp.prefill";
+
+export function HeroQuickApply() {
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    setError(null);
+
+    const trimmedName = name.trim();
+    const trimmedEmail = email.trim();
+    if (!trimmedName) {
+      setError("Enter your first name.");
+      return;
+    }
+    if (trimmedEmail.length > 254 || !EMAIL_RE.test(trimmedEmail)) {
+      setError("Enter a valid email.");
+      return;
+    }
+
+    try {
+      window.sessionStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({ name: trimmedName, email: trimmedEmail }),
+      );
+    } catch {
+      // Storage can be blocked (private mode, disabled cookies). Proceed —
+      // user will re-type the two fields in the full form.
+    }
+
+    const anchor = document.getElementById("apply");
+    if (anchor) {
+      anchor.scrollIntoView({ behavior: "smooth", block: "start" });
+      // Shift focus to the first input of the full form for screen readers.
+      // Defer until after scroll animation settles.
+      window.setTimeout(() => {
+        const firstInput = document.getElementById("partner-city");
+        firstInput?.focus();
+      }, 600);
+    }
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="mx-auto mt-2 max-w-xl text-left"
+      aria-label="Quick apply, start your partner application"
+    >
+      {error && (
+        <div
+          role="alert"
+          className="mb-3 rounded-lg border border-red-700 bg-red-900/50 px-4 py-2 text-sm text-red-300"
+        >
+          {error}
+        </div>
+      )}
+      <div className="flex flex-col gap-3 sm:flex-row">
+        <div className="flex-1">
+          <label htmlFor="hero-qa-name" className="sr-only">
+            First name
+          </label>
+          <input
+            id="hero-qa-name"
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="First name"
+            autoComplete="given-name"
+            required
+            aria-invalid={!!error && !name.trim()}
+            className="w-full rounded-lg border border-zinc-700 bg-zinc-800 px-4 py-3 text-white placeholder-zinc-500 focus:border-amber-500 focus:outline-none focus:ring-1 focus:ring-amber-500"
+          />
+        </div>
+        <div className="flex-1">
+          <label htmlFor="hero-qa-email" className="sr-only">
+            Email
+          </label>
+          <input
+            id="hero-qa-email"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="Email"
+            autoComplete="email"
+            required
+            aria-invalid={!!error && !EMAIL_RE.test(email.trim())}
+            className="w-full rounded-lg border border-zinc-700 bg-zinc-800 px-4 py-3 text-white placeholder-zinc-500 focus:border-amber-500 focus:outline-none focus:ring-1 focus:ring-amber-500"
+          />
+        </div>
+        <button
+          type="submit"
+          className="cursor-pointer rounded-lg bg-amber-500 px-6 py-3 font-bold text-black transition-all hover:scale-[1.02] hover:bg-amber-400 hover:shadow-lg hover:shadow-amber-500/20"
+        >
+          Continue
+        </button>
+      </div>
+      <p className="mt-3 text-xs text-zinc-500">
+        Takes 30 seconds. We never cold-call or share your email.
+      </p>
+    </form>
+  );
+}

--- a/src/components/partner/PartnerApplicationForm.tsx
+++ b/src/components/partner/PartnerApplicationForm.tsx
@@ -25,6 +25,23 @@ export function PartnerApplicationForm({ source }: PartnerApplicationFormProps) 
     if (submitted) successRef.current?.focus();
   }, [submitted]);
 
+  // HeroQuickApply (H7) stashes name + email in sessionStorage before
+  // scrolling here. Hydrate once on mount, then clear so a second visit
+  // in the same tab doesn't re-prefill stale values.
+  useEffect(() => {
+    try {
+      const raw = window.sessionStorage.getItem("partnerApp.prefill");
+      if (!raw) return;
+      const parsed = JSON.parse(raw) as { name?: unknown; email?: unknown };
+      if (typeof parsed.name === "string" && parsed.name) setName(parsed.name);
+      if (typeof parsed.email === "string" && parsed.email) setEmail(parsed.email);
+      window.sessionStorage.removeItem("partnerApp.prefill");
+    } catch {
+      // Malformed storage value or storage blocked — ignore and let the
+      // user type normally.
+    }
+  }, []);
+
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     setFormError(null);

--- a/src/components/partner/index.ts
+++ b/src/components/partner/index.ts
@@ -1,6 +1,7 @@
 export { PartnerCommissionTable } from "./PartnerCommissionTable";
 export { PartnerHowItWorks } from "./PartnerHowItWorks";
 export { PartnerApplicationForm } from "./PartnerApplicationForm";
+export { HeroQuickApply } from "./HeroQuickApply";
 export { PartnerWhyItWorks } from "./PartnerWhyItWorks";
 export { ToolkitSection } from "./ToolkitSection";
 export { EarningsSection } from "./EarningsSection";

--- a/tests/r-q-redirect.test.ts
+++ b/tests/r-q-redirect.test.ts
@@ -50,14 +50,18 @@ describeIfLive("GET /r/q/[id]", () => {
   // time — only the `it(...)` bodies are skipped. Creating the client at the
   // callback top-level blew up the whole file load when env was absent.
   // Defer to beforeAll so skipped runs don't require credentials.
-  let sb: ReturnType<typeof createClient>;
+  // Untyped client — this repo doesn't generate Database types and the
+  // test uses tables (abandoned_questions, posted_answers) that would resolve
+  // to `never` under the default signature. Generic `any` matches the prod
+  // path (createAdminClient in src/lib/supabase/admin.ts is also untyped).
+  let sb: ReturnType<typeof createClient<any>>;
 
   let abandonedId: number;
   let postedWithSlug: number;
   let postedWithoutSlug: number;
 
   beforeAll(async () => {
-    sb = createClient(SUPABASE_URL!, SERVICE_KEY!, {
+    sb = createClient<any>(SUPABASE_URL!, SERVICE_KEY!, {
       auth: { autoRefreshToken: false, persistSession: false },
     });
     const uniq = `rq-test-${Date.now()}`;


### PR DESCRIPTION
## Summary
- **H7** from `docs/plans/2026-04-20-bondsman-inline-hero-form.md`. Laja flagged the hero: single CTA anchor-jumps past 7 sections of copy to the form at the bottom.
- New `HeroQuickApply` — 2-field (name, email) above-fold form in the hero. Submit stashes `{ name, email }` in `sessionStorage` and smooth-scrolls to `#apply`; focus lands on the first empty field (`city`).
- `PartnerApplicationForm` hydrates from `sessionStorage` on mount once, then clears the stash.
- Zero backend change. Deliberate tradeoff — at 0 traffic the dropout-capture value of a POST-partial/PATCH-complete flow is ~0. Ship the friction reduction; add backend capture if/when analytics prove dropout between hero submit and full submit.
- Secondary `Skip to the full form` link preserves the careful-reader path.

Plan drift note: plan specified "name/email/company" but the existing form has no company field — shipped 2 fields matching reality.

Includes cherry-picked `6e3382e` (supabase client `<any>` cast in `r-q-redirect.test.ts`) so this branch's pre-commit tsc gate passes independently of PR #5.

## Test plan
- [x] `npx tsc --noEmit --skipLibCheck` clean
- [x] `npm run build` passes
- [ ] Manual: load `/partners/bondsman`, type name + email in hero, click Continue → page scrolls to `#apply`, name + email pre-filled, focus on city
- [ ] Manual: hero submit with bad email → inline error, no scroll
- [ ] Manual: hero submit with empty name → inline error
- [ ] Manual: submit the full form from that flow → success state renders

Generated with [Claude Code](https://claude.com/claude-code)