### PR TITLE
feat(ussc): wire 94-row ussc_districts lookup into matview renderers + APIs

### DIFF
--- a/src/app/api/plea-analyzer/route.ts
+++ b/src/app/api/plea-analyzer/route.ts
@@ -34,6 +34,7 @@ import { getClientIp } from "@/lib/request";
 import { hashToken } from "@/lib/site";
 import {
   queryBucket,
+  queryDistrictDisplay,
   extractPleaTrialSplit,
   computeTrialTaxMonths,
 } from "@/lib/ussc-similar-cases";
@@ -200,20 +201,29 @@ export async function POST(req: NextRequest) {
   });
   if (bucket.has_minimum_signal && bucket.offguide && bucket.xcrhissr) {
     try {
-      const mv = await queryBucket(supabase, {
-        district: bucket.district,
-        offguide: bucket.offguide,
-        xcrhissr: bucket.xcrhissr,
-        citizen: bucket.citizen,
-        age_bucket: bucket.age_bucket,
-      });
+      const [mv, districtDisplay] = await Promise.all([
+        queryBucket(supabase, {
+          district: bucket.district,
+          offguide: bucket.offguide,
+          xcrhissr: bucket.xcrhissr,
+          citizen: bucket.citizen,
+          age_bucket: bucket.age_bucket,
+        }),
+        queryDistrictDisplay(supabase, bucket.district),
+      ]);
       const { plea, trial } = extractPleaTrialSplit(mv.rows);
       const trialTax = computeTrialTaxMonths(plea, trial);
       if (plea && trial && trialTax !== null) {
         const depthLabel = mv.match_depth === "exact" ? "exact match" : `widened (${mv.match_depth})`;
         const pleaMed = plea.median_senttot == null ? "N/A" : Number(plea.median_senttot).toFixed(1);
         const trialMed = trial.median_senttot == null ? "N/A" : Number(trial.median_senttot).toFixed(1);
-        const addendum = `Federal plea median for this offense + criminal history: ${pleaMed} months (N=${plea.n_cases}). Federal trial median: ${trialMed} months (N=${trial.n_cases}). Observed trial-vs-plea gap: ${trialTax.toFixed(1)} months (${depthLabel}). Source: USSC Individual Offender Datafiles FY14-FY24.`;
+        // Prepend human-readable district name when the lookup resolved and
+        // we didn't fall back to national averages (widened_district tier).
+        const districtPrefix =
+          districtDisplay && mv.match_depth !== "widened_district"
+            ? `${districtDisplay.short_name} — `
+            : "";
+        const addendum = `${districtPrefix}Federal plea median for this offense + criminal history: ${pleaMed} months (N=${plea.n_cases}). Federal trial median: ${trialMed} months (N=${trial.n_cases}). Observed trial-vs-plea gap: ${trialTax.toFixed(1)} months (${depthLabel}). Source: USSC Individual Offender Datafiles FY14-FY24.`;
         sentencingContext = sentencingContext
           ? `${sentencingContext} ${addendum}`
           : addendum;

--- a/src/app/api/tools/sentencing-calculator/route.ts
+++ b/src/app/api/tools/sentencing-calculator/route.ts
@@ -19,9 +19,11 @@ import { checkRateLimit } from "@/lib/rate-limit";
 import { getClientIp } from "@/lib/request";
 import {
   queryBucket,
+  queryDistrictDisplay,
   extractPleaTrialSplit,
   computeTrialTaxMonths,
   normalizeAgeBucket,
+  type DistrictDisplay,
   type SimilarCasesRow,
 } from "@/lib/ussc-similar-cases";
 
@@ -198,17 +200,21 @@ export async function POST(req: NextRequest) {
       trial: ReturnType<typeof shapeOutcome>;
     };
     trial_tax_months: number | null;
+    district_display: DistrictDisplay | null;
   } | null = null;
 
   if (input.district && input.offguide && input.xcrhissr) {
     try {
-      const mv = await queryBucket(supabase, {
-        district: input.district,
-        offguide: input.offguide,
-        xcrhissr: input.xcrhissr,
-        citizen: input.citizen ?? "UNK",
-        age_bucket: normalizeAgeBucket(input.age ?? null),
-      });
+      const [mv, districtDisplay] = await Promise.all([
+        queryBucket(supabase, {
+          district: input.district,
+          offguide: input.offguide,
+          xcrhissr: input.xcrhissr,
+          citizen: input.citizen ?? "UNK",
+          age_bucket: normalizeAgeBucket(input.age ?? null),
+        }),
+        queryDistrictDisplay(supabase, input.district),
+      ]);
       const { plea, trial } = extractPleaTrialSplit(mv.rows);
       districtDistribution = {
         match_depth: mv.match_depth,
@@ -220,6 +226,7 @@ export async function POST(req: NextRequest) {
           trial: shapeOutcome(trial),
         },
         trial_tax_months: computeTrialTaxMonths(plea, trial),
+        district_display: districtDisplay,
       };
     } catch (err) {
       console.error("[SentencingCalc] Matview augmentation failed:", err);

--- a/src/app/api/tools/similar-cases/route.ts
+++ b/src/app/api/tools/similar-cases/route.ts
@@ -24,6 +24,7 @@ import { checkRateLimit } from "@/lib/rate-limit";
 import { getClientIp } from "@/lib/request";
 import {
   queryBucket,
+  queryDistrictDisplay,
   extractPleaTrialSplit,
   computeTrialTaxMonths,
   normalizeAgeBucket,
@@ -119,13 +120,16 @@ export async function POST(req: NextRequest) {
         ? normalizeAgeBucket(input.age)
         : null;
 
-  const response = await queryBucket(supabase, {
-    district: input.district ?? null,
-    offguide: input.offguide,
-    xcrhissr: input.xcrhissr,
-    citizen: input.citizen ?? null,
-    age_bucket,
-  });
+  const [response, districtDisplay] = await Promise.all([
+    queryBucket(supabase, {
+      district: input.district ?? null,
+      offguide: input.offguide,
+      xcrhissr: input.xcrhissr,
+      citizen: input.citizen ?? null,
+      age_bucket,
+    }),
+    queryDistrictDisplay(supabase, input.district ?? null),
+  ]);
 
   const { plea, trial } = extractPleaTrialSplit(response.rows);
   const trial_tax_months = computeTrialTaxMonths(plea, trial);
@@ -167,6 +171,7 @@ export async function POST(req: NextRequest) {
         trial: shapeOutcome(trial),
       },
       trial_tax_months,
+      district_display: districtDisplay,
       federalOnly: true,
       dataSource:
         "USSC Individual Offender Datafiles FY2014-FY2024 (690,491 federal sentences across 23,210 buckets)",

--- a/src/app/api/tools/similar-cases/route.ts
+++ b/src/app/api/tools/similar-cases/route.ts
@@ -8,7 +8,7 @@
  *
  * Output:
  *   match_depth + widening_note + outcomes { plea, trial } + trial_tax_months
- *   + sample_size_caveat + dataSource
+ *   + sample_size_caveat + district_display + dataSource
  *
  * Queries public.ussc_similar_cases_summary (23,210 buckets, 690K federal cases,
  * FY14-FY24). Progressive widening when the exact bucket is empty:

--- a/src/lib/tier9-reports/generate.ts
+++ b/src/lib/tier9-reports/generate.ts
@@ -35,6 +35,7 @@ import {
 import { mapIntakeToBucket } from "@/lib/ussc-mappings";
 import {
   queryBucket,
+  queryDistrictDisplay,
   extractPleaTrialSplit,
   computeTrialTaxMonths,
 } from "@/lib/ussc-similar-cases";
@@ -197,13 +198,16 @@ export async function generateTier9Report(
 
           if (bucket.has_minimum_signal && bucket.offguide && bucket.xcrhissr) {
             const sb = createAdminClient();
-            const response = await queryBucket(sb, {
-              district: bucket.district,
-              offguide: bucket.offguide,
-              xcrhissr: bucket.xcrhissr,
-              citizen: bucket.citizen,
-              age_bucket: bucket.age_bucket,
-            });
+            const [response, districtDisplay] = await Promise.all([
+              queryBucket(sb, {
+                district: bucket.district,
+                offguide: bucket.offguide,
+                xcrhissr: bucket.xcrhissr,
+                citizen: bucket.citizen,
+                age_bucket: bucket.age_bucket,
+              }),
+              queryDistrictDisplay(sb, bucket.district),
+            ]);
             const { plea, trial } = extractPleaTrialSplit(response.rows);
             ussc = {
               match_depth: response.match_depth,
@@ -215,6 +219,7 @@ export async function generateTier9Report(
                 trial: reshapeMatviewRow(trial),
               },
               trial_tax_months: computeTrialTaxMonths(plea, trial),
+              district_display: districtDisplay,
             };
           }
         } catch (err) {

--- a/src/lib/tier9-reports/render.ts
+++ b/src/lib/tier9-reports/render.ts
@@ -976,13 +976,25 @@ function renderUsscDistribution(ussc: UsscDistribution): string {
     </p>`;
   }
 
-  const depthLabel: Record<UsscDistribution["match_depth"], string> = {
-    exact: "Exact match for your case profile",
-    widened_age: "Matched on district, offense, criminal history, and citizenship (age bracket widened)",
-    widened_citizen: "Matched on district, offense, and criminal history (citizenship + age widened)",
-    widened_district: "National averages for this offense guideline and criminal history",
-    insufficient_data: "Insufficient data",
-  };
+  // When district_display renders above (widened_age + widened_citizen paths),
+  // the district label is already anchored in the heading, so the depth
+  // caption drops the "district" prefix to avoid duplicated context.
+  const hasDistrictHeading = narrowedToDistrict && Boolean(ussc.district_display);
+  const depthLabel: Record<UsscDistribution["match_depth"], string> = hasDistrictHeading
+    ? {
+        exact: "Exact match for your case profile",
+        widened_age: "Matched on offense, criminal history, and citizenship (age bracket widened)",
+        widened_citizen: "Matched on offense and criminal history (citizenship + age widened)",
+        widened_district: "National averages for this offense guideline and criminal history",
+        insufficient_data: "Insufficient data",
+      }
+    : {
+        exact: "Exact match for your case profile",
+        widened_age: "Matched on district, offense, criminal history, and citizenship (age bracket widened)",
+        widened_citizen: "Matched on district, offense, and criminal history (citizenship + age widened)",
+        widened_district: "National averages for this offense guideline and criminal history",
+        insufficient_data: "Insufficient data",
+      };
 
   html += `<p style="color: #A1A1AA; margin-bottom: 12px; font-size: 14px;">
     ${escapeHtml(depthLabel[ussc.match_depth])}. ${escapeHtml(ussc.sample_size_caveat)}

--- a/src/lib/tier9-reports/render.ts
+++ b/src/lib/tier9-reports/render.ts
@@ -46,6 +46,16 @@ export interface UsscDistribution {
     trial: UsscOutcomeSummary | null;
   };
   trial_tax_months: number | null;
+  /** Optional district metadata from ussc_districts lookup. Null when no
+   *  district was matched (widened_district tier) or the code isn't in the
+   *  94-row codebook lookup. */
+  district_display?: {
+    district_code: string;
+    short_name: string;
+    district_name: string;
+    state_code: string | null;
+    circuit: string;
+  } | null;
 }
 
 /** Helper — reshape a raw matview row into UsscOutcomeSummary. */
@@ -951,6 +961,20 @@ export function renderSimilarCases(
  */
 function renderUsscDistribution(ussc: UsscDistribution): string {
   let html = sectionHeader("Federal Sentencing Distribution (USSC FY14-FY24)");
+
+  // District attribution — only surface when we actually narrowed to a
+  // specific district. The widened_district tier shows national data, so
+  // displaying a district name there would misrepresent the sample.
+  const narrowedToDistrict = ussc.match_depth !== "widened_district" && ussc.match_depth !== "insufficient_data";
+  if (narrowedToDistrict && ussc.district_display) {
+    const d = ussc.district_display;
+    const circuit = d.circuit ? `${escapeHtml(d.circuit)} Circuit` : "";
+    const state = d.state_code ? escapeHtml(d.state_code) : "";
+    const meta = [circuit, state].filter(Boolean).join(" &middot; ");
+    html += `<p style="color: #F59E0B; margin-bottom: 8px; font-size: 14px; font-weight: 600;">
+      ${escapeHtml(d.short_name)}${meta ? ` <span style="color: #A1A1AA; font-weight: 400;">(${meta})</span>` : ""}
+    </p>`;
+  }
 
   const depthLabel: Record<UsscDistribution["match_depth"], string> = {
     exact: "Exact match for your case profile",

--- a/src/lib/ussc-similar-cases.ts
+++ b/src/lib/ussc-similar-cases.ts
@@ -110,6 +110,14 @@ const MATVIEW = "ussc_similar_cases_summary";
 const SELECT_COLS =
   "district, offguide, xcrhissr, citizen, age_bucket, plea_or_trial, n_cases, p10_senttot, p25_senttot, median_senttot, p75_senttot, p90_senttot, mean_senttot, pct_got_prison, pct_downward_departure, earliest_fy, latest_fy";
 
+/** Shared "is non-empty string" check — keeps queryBucket's hasDistrict /
+ *  hasCitizen / hasAgeBucket guards and queryDistrictDisplay's null-safety in
+ *  lock-step. If the "valid input" definition ever tightens (e.g. trim
+ *  whitespace) the change lands in one place. */
+function isNonEmptyString(v: unknown): v is string {
+  return typeof v === "string" && v.length > 0;
+}
+
 async function runQuery(
   sb: SupabaseClient,
   filters: Partial<Record<keyof BucketInput, string>>,
@@ -144,9 +152,9 @@ export async function queryBucket(
   sb: SupabaseClient,
   input: BucketInput,
 ): Promise<SimilarCasesResponse> {
-  const hasDistrict = typeof input.district === "string" && input.district.length > 0;
-  const hasCitizen = typeof input.citizen === "string" && input.citizen.length > 0;
-  const hasAgeBucket = typeof input.age_bucket === "string" && input.age_bucket.length > 0;
+  const hasDistrict = isNonEmptyString(input.district);
+  const hasCitizen = isNonEmptyString(input.citizen);
+  const hasAgeBucket = isNonEmptyString(input.age_bucket);
 
   if (hasDistrict && hasCitizen && hasAgeBucket) {
     const exact = await runQuery(sb, {
@@ -297,7 +305,7 @@ export async function queryDistrictDisplay(
   sb: SupabaseClient,
   districtCode: string | null | undefined,
 ): Promise<DistrictDisplay | null> {
-  if (typeof districtCode !== "string" || districtCode.length === 0) return null;
+  if (!isNonEmptyString(districtCode)) return null;
   const { data, error } = await sb
     .from("ussc_districts")
     .select("district_code, short_name, district_name, state_code, circuit")

--- a/src/lib/ussc-similar-cases.ts
+++ b/src/lib/ussc-similar-cases.ts
@@ -269,3 +269,50 @@ export function computeTrialTaxMonths(
   if (plea.median_senttot == null || trial.median_senttot == null) return null;
   return Number((Number(trial.median_senttot) - Number(plea.median_senttot)).toFixed(2));
 }
+
+/**
+ * Human-readable metadata for a USSC district code, sourced from `ussc_districts`
+ * (94-row lookup, USSC Codebook Appendix A FY99-FY24). Attached to bucket
+ * responses so renderers can display "W.D. Texas" instead of the raw "42" code.
+ */
+export interface DistrictDisplay {
+  /** Raw USSC DISTRICT code, e.g. "42". */
+  district_code: string;
+  /** Short form, e.g. "W.D. Texas". */
+  short_name: string;
+  /** Full form, e.g. "Western District of Texas". */
+  district_name: string;
+  /** 2-letter state code, e.g. "TX". Null for non-state districts (DC, PR, VI). */
+  state_code: string | null;
+  /** Circuit label, e.g. "5th", "DC". */
+  circuit: string;
+}
+
+/**
+ * Fetch display metadata for a USSC district code. Returns null when the code
+ * isn't in the lookup table — callers fall back to the raw code so downstream
+ * rendering never breaks when a new / unknown code surfaces.
+ */
+export async function queryDistrictDisplay(
+  sb: SupabaseClient,
+  districtCode: string | null | undefined,
+): Promise<DistrictDisplay | null> {
+  if (typeof districtCode !== "string" || districtCode.length === 0) return null;
+  const { data, error } = await sb
+    .from("ussc_districts")
+    .select("district_code, short_name, district_name, state_code, circuit")
+    .eq("district_code", districtCode)
+    .maybeSingle();
+  if (error) {
+    console.error("[ussc-districts] lookup error:", error);
+    return null;
+  }
+  if (!data) return null;
+  return {
+    district_code: data.district_code as string,
+    short_name: data.short_name as string,
+    district_name: data.district_name as string,
+    state_code: (data.state_code as string | null) ?? null,
+    circuit: data.circuit as string,
+  };
+}

--- a/tests/api/sentencing-calculator-matview.test.ts
+++ b/tests/api/sentencing-calculator-matview.test.ts
@@ -45,10 +45,16 @@ vi.mock("@/lib/supabase/admin", () => {
       order: () => chain,
       limit: () => Promise.resolve({ data: [], error: null }),
       maybeSingle: () => {
-        if (table === "ussc_districts") {
-          return Promise.resolve({ data: districtRow, error: null });
+        // Defensive — only ussc_districts uses maybeSingle in the tested
+        // code paths. Throw loudly if a future code change routes another
+        // table through maybeSingle so tests fail fast instead of passing
+        // against a silently-null mock.
+        if (table !== "ussc_districts") {
+          throw new Error(
+            `[test-mock] Unexpected maybeSingle() on table '${table}' — only ussc_districts is wired`,
+          );
         }
-        return Promise.resolve({ data: null, error: null });
+        return Promise.resolve({ data: districtRow, error: null });
       },
       then(resolve: (r: { data: unknown[]; error: null }) => void) {
         if (table === "ussc_similar_cases_summary") {

--- a/tests/api/sentencing-calculator-matview.test.ts
+++ b/tests/api/sentencing-calculator-matview.test.ts
@@ -32,6 +32,7 @@ const pleaRow = {
 };
 
 let matviewRows: unknown[] = [];
+let districtRow: unknown | null = null;
 
 vi.mock("@/lib/supabase/admin", () => {
   const makeChain = (table: string) => {
@@ -43,6 +44,12 @@ vi.mock("@/lib/supabase/admin", () => {
       ilike: () => chain,
       order: () => chain,
       limit: () => Promise.resolve({ data: [], error: null }),
+      maybeSingle: () => {
+        if (table === "ussc_districts") {
+          return Promise.resolve({ data: districtRow, error: null });
+        }
+        return Promise.resolve({ data: null, error: null });
+      },
       then(resolve: (r: { data: unknown[]; error: null }) => void) {
         if (table === "ussc_similar_cases_summary") {
           resolve({ data: matviewRows, error: null });
@@ -80,6 +87,7 @@ function buildReq(body: Record<string, unknown>): NextRequest {
 
 beforeEach(() => {
   matviewRows = [];
+  districtRow = null;
   process.env.NEXT_PUBLIC_SUPABASE_URL = "https://example.supabase.co";
   process.env.SUPABASE_SERVICE_ROLE_KEY = "service-role-key";
 });
@@ -147,5 +155,51 @@ describe("POST /api/tools/sentencing-calculator — districtDistribution perspec
       }),
     );
     expect(res.status).toBe(400);
+  });
+
+  it("attaches district_display metadata when the code resolves in ussc_districts", async () => {
+    matviewRows = [pleaRow];
+    districtRow = {
+      district_code: "42",
+      short_name: "W.D. Texas",
+      district_name: "Western District of Texas",
+      state_code: "TX",
+      circuit: "5th",
+    };
+    const res = await POST(
+      buildReq({
+        state: "TX",
+        chargeType: "drug-possession",
+        district: "42",
+        offguide: "17",
+        xcrhissr: "1",
+        citizen: "3",
+        age: 28,
+      }),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.result.districtDistribution.district_display).not.toBeNull();
+    expect(body.result.districtDistribution.district_display.short_name).toBe("W.D. Texas");
+    expect(body.result.districtDistribution.district_display.circuit).toBe("5th");
+  });
+
+  it("leaves district_display null when the code is not in ussc_districts", async () => {
+    matviewRows = [pleaRow];
+    districtRow = null;
+    const res = await POST(
+      buildReq({
+        state: "FL",
+        chargeType: "drug-possession",
+        district: "42",
+        offguide: "17",
+        xcrhissr: "1",
+        citizen: "3",
+        age: 28,
+      }),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.result.districtDistribution.district_display).toBeNull();
   });
 });

--- a/tests/api/similar-cases.test.ts
+++ b/tests/api/similar-cases.test.ts
@@ -57,10 +57,11 @@ function filterKey(filters: Record<string, string>): string {
 }
 
 let rowsByFilterKey: Record<string, unknown[]> = {};
+let districtRowsByCode: Record<string, unknown | null> = {};
 
 vi.mock("@/lib/supabase/admin", () => ({
   createAdminClient: () => ({
-    from: () => {
+    from: (table: string) => {
       const filters: Record<string, string> = {};
       const chain = {
         select: () => chain,
@@ -70,6 +71,15 @@ vi.mock("@/lib/supabase/admin", () => ({
         },
         then(resolve: (r: { data: unknown[]; error: null }) => void) {
           resolve({ data: rowsByFilterKey[filterKey(filters)] ?? [], error: null });
+        },
+        maybeSingle() {
+          // ussc_districts lookup — return null by default so district_display
+          // is absent unless the test explicitly opts in via a keyed fixture.
+          if (table === "ussc_districts") {
+            const row = districtRowsByCode[filters.district_code ?? ""] ?? null;
+            return Promise.resolve({ data: row, error: null });
+          }
+          return Promise.resolve({ data: null, error: null });
         },
       };
       return chain;
@@ -97,6 +107,7 @@ function buildReq(body: Record<string, unknown>): NextRequest {
 
 beforeEach(() => {
   rowsByFilterKey = {};
+  districtRowsByCode = {};
 });
 
 describe("POST /api/tools/similar-cases", () => {
@@ -231,6 +242,47 @@ describe("POST /api/tools/similar-cases", () => {
     const body = await res.json();
     expect(body.result.match_depth).toBe("widened_district");
     expect(body.result.widening_note).toMatch(/district was not supplied/i);
+  });
+
+  it("surfaces district_display metadata when the code resolves in ussc_districts", async () => {
+    rowsByFilterKey[
+      filterKey({
+        age_bucket: "25-34",
+        citizen: "3",
+        district: "42",
+        offguide: "17",
+        xcrhissr: "1",
+      })
+    ] = [fixturePlea, fixtureTrial];
+    districtRowsByCode["42"] = {
+      district_code: "42",
+      short_name: "W.D. Texas",
+      district_name: "Western District of Texas",
+      state_code: "TX",
+      circuit: "5th",
+    };
+    const res = await POST(
+      buildReq({ district: "42", offguide: "17", xcrhissr: "1", citizen: "3", age: 28 }),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.result.district_display).not.toBeNull();
+    expect(body.result.district_display.short_name).toBe("W.D. Texas");
+    expect(body.result.district_display.state_code).toBe("TX");
+  });
+
+  it("leaves district_display null when district absent (widened_district tier)", async () => {
+    rowsByFilterKey[
+      filterKey({
+        offguide: "17",
+        xcrhissr: "1",
+      })
+    ] = [fixturePlea];
+    const res = await POST(buildReq({ offguide: "17", xcrhissr: "1" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.result.match_depth).toBe("widened_district");
+    expect(body.result.district_display).toBeNull();
   });
 
   it("returns 429 when rate-limited", async () => {

--- a/tests/api/similar-cases.test.ts
+++ b/tests/api/similar-cases.test.ts
@@ -73,13 +73,17 @@ vi.mock("@/lib/supabase/admin", () => ({
           resolve({ data: rowsByFilterKey[filterKey(filters)] ?? [], error: null });
         },
         maybeSingle() {
-          // ussc_districts lookup — return null by default so district_display
-          // is absent unless the test explicitly opts in via a keyed fixture.
-          if (table === "ussc_districts") {
-            const row = districtRowsByCode[filters.district_code ?? ""] ?? null;
-            return Promise.resolve({ data: row, error: null });
+          // Defensive: only ussc_districts uses maybeSingle in the tested
+          // code paths. Surfacing this at mock level catches future routing
+          // mistakes (e.g. a matview call accidentally terminated with
+          // maybeSingle) before they produce silent green tests.
+          if (table !== "ussc_districts") {
+            throw new Error(
+              `[test-mock] Unexpected maybeSingle() on table '${table}' — only ussc_districts is wired`,
+            );
           }
-          return Promise.resolve({ data: null, error: null });
+          const row = districtRowsByCode[filters.district_code ?? ""] ?? null;
+          return Promise.resolve({ data: row, error: null });
         },
       };
       return chain;

--- a/tests/lib/ussc-similar-cases.test.ts
+++ b/tests/lib/ussc-similar-cases.test.ts
@@ -14,6 +14,7 @@ import { describe, it, expect } from "vitest";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import {
   queryBucket,
+  queryDistrictDisplay,
   normalizeAgeBucket,
   extractPleaTrialSplit,
   computeTrialTaxMonths,
@@ -244,5 +245,72 @@ describe("computeTrialTaxMonths", () => {
     expect(computeTrialTaxMonths(pleaNoMedian, row42Trial)).toBeNull();
     const trialNoMedian = { ...row42Trial, median_senttot: null };
     expect(computeTrialTaxMonths(row42, trialNoMedian)).toBeNull();
+  });
+});
+
+/**
+ * Mock that mimics supabase.from(t).select().eq().maybeSingle() — returns
+ * the single row keyed by the .eq filter column+value, or null when absent.
+ */
+function mockDistrictLookup(rowsByCode: Record<string, unknown | null>): SupabaseClient {
+  return {
+    from: () => {
+      let code: string | undefined;
+      const chain = {
+        select: () => chain,
+        eq(_col: string, val: string) {
+          code = val;
+          return chain;
+        },
+        maybeSingle() {
+          const row = code !== undefined ? (rowsByCode[code] ?? null) : null;
+          return Promise.resolve({ data: row, error: null });
+        },
+      };
+      return chain as unknown as ReturnType<SupabaseClient["from"]>;
+    },
+  } as unknown as SupabaseClient;
+}
+
+describe("queryDistrictDisplay", () => {
+  const wdTex = {
+    district_code: "42",
+    short_name: "W.D. Texas",
+    district_name: "Western District of Texas",
+    state_code: "TX",
+    circuit: "5th",
+  };
+
+  it("returns full display metadata for a known district code", async () => {
+    const sb = mockDistrictLookup({ "42": wdTex });
+    const out = await queryDistrictDisplay(sb, "42");
+    expect(out).toEqual(wdTex);
+  });
+
+  it("returns null for unknown district codes (graceful fallback)", async () => {
+    const sb = mockDistrictLookup({ "42": wdTex });
+    const out = await queryDistrictDisplay(sb, "99");
+    expect(out).toBeNull();
+  });
+
+  it("returns null when district code is null/empty (no query issued)", async () => {
+    const sb = mockDistrictLookup({ "42": wdTex });
+    expect(await queryDistrictDisplay(sb, null)).toBeNull();
+    expect(await queryDistrictDisplay(sb, undefined)).toBeNull();
+    expect(await queryDistrictDisplay(sb, "")).toBeNull();
+  });
+
+  it("normalizes missing state_code to null for non-state districts", async () => {
+    const dc = {
+      district_code: "92",
+      short_name: "D.D.C.",
+      district_name: "District of Columbia",
+      state_code: null,
+      circuit: "DC",
+    };
+    const sb = mockDistrictLookup({ "92": dc });
+    const out = await queryDistrictDisplay(sb, "92");
+    expect(out?.state_code).toBeNull();
+    expect(out?.short_name).toBe("D.D.C.");
   });
 });


### PR DESCRIPTION
## Summary
Wires the ussc_districts lookup (PR #9) into every customer-facing USSC matview consumer. Raw district codes ("42") never render to users again — they see "W.D. Texas (5th Circuit · TX)" instead.

Surfaces:
- \`/api/tools/similar-cases\` (\$297 product) — returns \`district_display\` in payload
- \`/api/tools/sentencing-calculator\` — \`districtDistribution.district_display\` attached
- \`renderUsscDistribution\` (similar-cases-analyzer report) — header line with short_name + circuit + state

Display suppressed on \`widened_district\` tier (national averages — showing a district name would misrepresent the sample).

## Files
- \`src/lib/ussc-similar-cases.ts\` — new \`DistrictDisplay\` type + \`queryDistrictDisplay\` helper (maybeSingle, null fallback on unknown codes)
- \`src/lib/tier9-reports/render.ts\` — \`UsscDistribution.district_display\` added + rendered
- \`src/lib/tier9-reports/generate.ts\` — parallel lookup via \`Promise.all\` (no latency tax)
- \`src/app/api/tools/similar-cases/route.ts\`, \`sentencing-calculator/route.ts\` — lookup + payload attach
- 8 new targeted test cases; all existing mocks extended with \`maybeSingle()\`

## Unblocks
Priority #2 from USSC session handoff — state→district cascade wiring in the intake form can now proceed without further renderer work.

## Test plan
- [x] \`npx tsc --noEmit --skipLibCheck\` clean
- [x] \`npx vitest run\` — 504/510 pass (6 pre-existing skips), 0 regressions
- [ ] CI green on this PR
- [ ] Manual spot-check post-merge: \`/api/tools/similar-cases\` response includes \`district_display\` when district="42"

🤖 Generated with [Claude Code](https://claude.com/claude-code)