### PR TITLE
feat(ussc): intake state→district cascade for Similar Cases Analyzer

### DIFF
--- a/e2e/ussc-state-district-cascade.spec.ts
+++ b/e2e/ussc-state-district-cascade.spec.ts
@@ -1,0 +1,112 @@
+/**
+ * E2E: state→district cascade on the Similar Cases Analyzer intake.
+ *
+ * Verifies:
+ *   - GET /api/ussc-districts?state=TX returns 4 Texas districts sorted by
+ *     short_name, each with district_code + short_name + district_name +
+ *     circuit. Catches lookup-stale regressions (e.g. matview refreshed but
+ *     ussc_districts not re-ingested).
+ *   - Case-insensitive state codes resolve.
+ *   - Unknown state codes yield empty districts array (graceful).
+ *   - Invalid state codes are rejected 400.
+ *
+ * Hits real prod / preview. Codebook data is stable so the concrete
+ * assertions (W.D. Texas = 5th Circuit = code "42") should remain true
+ * until USSC publishes a breaking codebook revision.
+ *
+ * Gate: E2E_SKIP_LIVE=1 skips; E2E_BASE_URL overrides prod URL.
+ */
+import { test, expect } from "@playwright/test";
+
+const BASE = process.env.E2E_BASE_URL || "https://imnotanattorney.com";
+
+test.describe("USSC state→district cascade E2E", () => {
+  test.beforeEach(() => {
+    test.skip(
+      process.env.E2E_SKIP_LIVE === "1",
+      "E2E_SKIP_LIVE=1 — this spec hits the live API + prod ussc_districts",
+    );
+  });
+
+  test("GET /api/ussc-districts?state=TX returns 4 Texas districts", async ({ request }) => {
+    const res = await request.get(`${BASE}/api/ussc-districts?state=TX`);
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    expect(Array.isArray(body.districts)).toBe(true);
+    // Texas has exactly 4 federal districts (Eastern, Northern, Southern, Western).
+    expect(body.districts.length).toBe(4);
+
+    const shortNames = body.districts.map(
+      (d: { short_name: string }) => d.short_name,
+    );
+    // Sort order: alphabetical by short_name. E.D. < N.D. < S.D. < W.D. for Texas.
+    expect(shortNames).toEqual(["E.D. Texas", "N.D. Texas", "S.D. Texas", "W.D. Texas"]);
+
+    // Every row carries the four fields the form needs to render + submit.
+    for (const d of body.districts) {
+      expect(typeof d.district_code).toBe("string");
+      expect(typeof d.short_name).toBe("string");
+      expect(typeof d.district_name).toBe("string");
+      expect(d.circuit).toBe("5th");
+    }
+
+    // Code "42" anchors to W.D. Texas per USSC Codebook Appendix A fixture.
+    const wdTex = body.districts.find(
+      (d: { district_code: string }) => d.district_code === "42",
+    );
+    expect(wdTex).toBeDefined();
+    expect(wdTex.short_name).toBe("W.D. Texas");
+  });
+
+  test("case-insensitive state code resolves", async ({ request }) => {
+    const res = await request.get(`${BASE}/api/ussc-districts?state=tx`);
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    expect(body.districts.length).toBe(4);
+  });
+
+  test("unknown state code yields empty districts array", async ({ request }) => {
+    // ZZ is not a real state — the query should return 200 with empty list
+    // (not 500, not 404) so the intake form can render gracefully.
+    const res = await request.get(`${BASE}/api/ussc-districts?state=ZZ`);
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    expect(body.districts).toEqual([]);
+  });
+
+  test("missing state param returns 400", async ({ request }) => {
+    const res = await request.get(`${BASE}/api/ussc-districts`);
+    expect(res.status()).toBe(400);
+  });
+
+  test("invalid state format returns 400", async ({ request }) => {
+    const res1 = await request.get(`${BASE}/api/ussc-districts?state=T`);
+    expect(res1.status()).toBe(400);
+    const res2 = await request.get(`${BASE}/api/ussc-districts?state=TXX`);
+    expect(res2.status()).toBe(400);
+    const res3 = await request.get(`${BASE}/api/ussc-districts?state=42`);
+    expect(res3.status()).toBe(400);
+  });
+
+  test("response cache headers allow CDN edge caching", async ({ request }) => {
+    const res = await request.get(`${BASE}/api/ussc-districts?state=TX`);
+    const cc = res.headers()["cache-control"] || "";
+    expect(cc).toMatch(/max-age=3600/);
+    expect(cc).toMatch(/s-maxage=86400/);
+  });
+
+  test("single-district state (e.g. DC) returns 1 row", async ({ request }) => {
+    // DC has just one federal district. This catches single-row edge cases
+    // that the multi-row sort logic might mishandle.
+    const res = await request.get(`${BASE}/api/ussc-districts?state=DC`);
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    // DC's federal district may be labeled differently per codebook — don't
+    // lock in the exact short_name, just confirm non-zero rows.
+    expect(body.districts.length).toBeGreaterThanOrEqual(1);
+    for (const d of body.districts) {
+      expect(typeof d.district_code).toBe("string");
+      expect(typeof d.short_name).toBe("string");
+    }
+  });
+});

--- a/src/app/api/intake/standalone/[slug]/route.ts
+++ b/src/app/api/intake/standalone/[slug]/route.ts
@@ -87,6 +87,11 @@ const VALID_AGE_BUCKETS = new Set([
   "<25", "25-34", "35-44", "45-54", "55+", "prefer-not-to-say",
 ]);
 
+// Federal district code for similar-cases-analyzer — USSC DISTRICT codes run
+// 0-96 in the codebook. Accept 1-2 digits (with or without leading zero)
+// defensively; queryDistrictDisplay + mapIntakeToBucket both tolerate either.
+const DISTRICT_CODE_RE = /^\d{1,2}$/;
+
 const VALID_OFFENSE_CLASS = new Set(["felony", "misdemeanor"]);
 
 const VALID_CHARGE_INVOLVES = new Set([
@@ -155,9 +160,11 @@ const OPTIONAL_FIELDS_BY_SLUG: Record<string, Set<string>> = {
   "ach-matrix": new Set(["alternativeExplanations"]),
   "adversarial-prosecution-sim": new Set(["prosecutionTheory"]),
   "sentencing-intelligence": new Set(["priorConvictions", "currentSentencingRange"]),
-  // Similar Cases Analyzer — all three USSC-matching fields are optional;
+  // Similar Cases Analyzer — all four USSC-matching fields are optional;
   // missing answers trigger progressive widening in the matview lookup.
-  "similar-cases-analyzer": new Set(["priorConvictions", "citizenship", "ageBucket"]),
+  // `district` is cascaded from state in the intake form (1-4 options per state)
+  // and narrows the sample to a specific federal court when supplied.
+  "similar-cases-analyzer": new Set(["priorConvictions", "citizenship", "ageBucket", "district"]),
   "daubert-challenge": new Set(["expertMethodology"]),
   "body-camera-analysis": new Set(["defenseTheory"]),
   // Bundles, product-specific fields are optional since users may not have all data
@@ -350,6 +357,9 @@ export async function POST(
     }
     if (field === "ageBucket" && !VALID_AGE_BUCKETS.has(String(raw))) {
       return NextResponse.json({ error: "Invalid age bracket" }, { status: 400 });
+    }
+    if (field === "district" && !DISTRICT_CODE_RE.test(String(raw))) {
+      return NextResponse.json({ error: "Invalid federal district code" }, { status: 400 });
     }
     if (field === "convictionOrDismissal" && !VALID_CONVICTION_OR_DISMISSAL.has(String(raw))) {
       return NextResponse.json({ error: "Invalid value" }, { status: 400 });

--- a/src/app/api/ussc-districts/route.ts
+++ b/src/app/api/ussc-districts/route.ts
@@ -1,0 +1,68 @@
+/**
+ * @fileoverview GET /api/ussc-districts — state → federal district lookup.
+ *
+ * Input:  ?state=XX  (2-letter state code, required, case-insensitive)
+ * Output: { districts: [{ district_code, short_name, district_name, circuit }] }
+ *         Sorted by short_name. Empty array when the state has no match.
+ *
+ * Powers the cascading-select in the Similar Cases Analyzer intake — when a
+ * defendant picks their state, the form loads the 1-4 federal districts in
+ * that state so the matview query can bucket on district instead of widening
+ * to national averages.
+ *
+ * Static data (94 rows, one-time codebook load) — cached 1 hour on CDN.
+ * Rate-limited cheaply (60/min per IP) so the cascading select doesn't
+ * produce a nonsensical DoS vector from spammed state-change clicks.
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { checkRateLimit } from "@/lib/rate-limit";
+import { getClientIp } from "@/lib/request";
+
+// 50 states + DC + territories that appear in ussc_districts.state_code.
+// The codebook's non-state rows (DC, PR, VI, Guam, NMI) pass through because
+// DB has them — the allowlist just screens obvious junk / injection attempts
+// without encoding a redundant copy of the full valid set.
+const STATE_CODE_RE = /^[A-Z]{2}$/;
+
+export async function GET(req: NextRequest) {
+  const supabase = createAdminClient();
+  const ip = getClientIp(req);
+  const { limited } = await checkRateLimit(supabase, `ussc-districts:${ip}`, 60, 60);
+  if (limited) {
+    return NextResponse.json({ error: "Too many requests" }, { status: 429 });
+  }
+
+  const rawState = req.nextUrl.searchParams.get("state");
+  if (typeof rawState !== "string") {
+    return NextResponse.json({ error: "state query param required" }, { status: 400 });
+  }
+  const stateCode = rawState.trim().toUpperCase();
+  if (!STATE_CODE_RE.test(stateCode)) {
+    return NextResponse.json(
+      { error: "state must be a 2-letter code" },
+      { status: 400 },
+    );
+  }
+
+  const { data, error } = await supabase
+    .from("ussc_districts")
+    .select("district_code, short_name, district_name, circuit")
+    .eq("state_code", stateCode)
+    .order("short_name", { ascending: true });
+
+  if (error) {
+    console.error("[ussc-districts] query error:", error);
+    return NextResponse.json({ districts: [] }, { status: 200 });
+  }
+
+  return NextResponse.json(
+    { districts: data ?? [] },
+    {
+      headers: {
+        // Codebook is static — safe to cache aggressively.
+        "Cache-Control": "public, max-age=3600, s-maxage=86400",
+      },
+    },
+  );
+}

--- a/src/app/intake/standalone/[slug]/IntakeFormClient.tsx
+++ b/src/app/intake/standalone/[slug]/IntakeFormClient.tsx
@@ -28,7 +28,7 @@
  *   - Optional fields omit aria-required and use a help hint
  */
 
-import { useState, useRef, useMemo } from "react";
+import { useState, useRef, useMemo, useEffect } from "react";
 import { ALLOWED_CHARGE_TYPES } from "@/lib/charge-types";
 
 const US_STATES = [
@@ -296,6 +296,23 @@ type FieldConfig =
       summary: string;
       helpText?: string;
       fields: FieldConfig[];
+    }
+  | {
+      /** Select whose options depend on another field's current value.
+       *  When dependsOn is empty the field renders disabled with emptyDepLabel.
+       *  On dependsOn change the form fetches `endpoint(value)` and parses
+       *  options via parseOptions. Current value is reset on dep change.
+       *  Works at top level or nested inside an optional-group. */
+      kind: "cascading-select";
+      name: string;
+      label: string;
+      required: boolean;
+      dependsOn: string;
+      endpoint: (depValue: string) => string;
+      parseOptions: (data: unknown) => SelectOption[];
+      placeholder?: string;
+      helpText?: string;
+      emptyDepLabel: string;
     };
 
 const FIELD_SETS: Record<string, FieldConfig[]> = {
@@ -2176,6 +2193,38 @@ const FIELD_SETS: Record<string, FieldConfig[]> = {
           ],
           required: false,
         },
+        // Federal district cascade — options populate from ussc_districts
+        // filtered by the top-level `state` field. Optional — skipping it
+        // triggers district-agnostic widening in the matview lookup.
+        {
+          kind: "cascading-select",
+          name: "district",
+          label: "Federal district (if known)",
+          placeholder: "Select district",
+          required: false,
+          dependsOn: "state",
+          emptyDepLabel: "Pick your state above first",
+          helpText: "Skip if unsure — leaving blank returns national averages.",
+          endpoint: (stateVal: string) =>
+            `/api/ussc-districts?state=${encodeURIComponent(stateVal)}`,
+          parseOptions: (data: unknown) => {
+            if (
+              typeof data !== "object" ||
+              data === null ||
+              !("districts" in data) ||
+              !Array.isArray((data as { districts: unknown }).districts)
+            ) {
+              return [];
+            }
+            const rows = (data as { districts: Array<{ district_code?: unknown; short_name?: unknown }> }).districts;
+            return rows
+              .filter(
+                (r): r is { district_code: string; short_name: string } =>
+                  typeof r.district_code === "string" && typeof r.short_name === "string",
+              )
+              .map((r) => ({ value: r.district_code, label: r.short_name }));
+          },
+        },
       ],
     },
   ],
@@ -2268,9 +2317,64 @@ export default function IntakeFormClient({ slug, productName, token }: Props) {
 
   const errorRef = useRef<HTMLDivElement>(null);
 
+  // Cascading-select option cache + loading flags. Keyed by field name so
+  // multiple cascading fields on the same form each own their own state.
+  const [dynamicOptions, setDynamicOptions] = useState<Record<string, SelectOption[]>>({});
+  const [dynamicLoading, setDynamicLoading] = useState<Record<string, boolean>>({});
+
   function setField(name: string, value: FormValue) {
     setFormData((prev) => ({ ...prev, [name]: value }));
   }
+
+  // Watch every cascading-select field's dep value. On change:
+  //   (a) reset the cascading field's own value (stale selection invalid)
+  //   (b) clear any prior fetched options
+  //   (c) if the new dep value is non-empty, fetch fresh options
+  // AbortController prevents late responses from overwriting post-navigate
+  // state.
+  const cascadingFields = useMemo(
+    () =>
+      leafFields.filter(
+        (f): f is Extract<FieldConfig, { kind: "cascading-select" }> =>
+          f.kind === "cascading-select",
+      ),
+    [leafFields],
+  );
+  const depSignature = cascadingFields
+    .map((f) => `${f.name}:${String(formData[f.dependsOn] ?? "")}`)
+    .join("|");
+  useEffect(() => {
+    const controllers: AbortController[] = [];
+    for (const field of cascadingFields) {
+      const depValue = String(formData[field.dependsOn] ?? "");
+      // Reset the cascading field's value + drop stale options regardless
+      // of whether the new dep value is empty or not.
+      setField(field.name, "");
+      setDynamicOptions((prev) => ({ ...prev, [field.name]: [] }));
+      if (!depValue) continue;
+      const ctl = new AbortController();
+      controllers.push(ctl);
+      setDynamicLoading((prev) => ({ ...prev, [field.name]: true }));
+      fetch(field.endpoint(depValue), { signal: ctl.signal })
+        .then((res) => (res.ok ? res.json() : null))
+        .then((data) => {
+          if (data == null) return;
+          const opts = field.parseOptions(data);
+          setDynamicOptions((prev) => ({ ...prev, [field.name]: opts }));
+        })
+        .catch((err) => {
+          if (err?.name === "AbortError") return;
+          console.error(`[intake-form] cascading-select fetch failed for ${field.name}:`, err);
+        })
+        .finally(() => {
+          setDynamicLoading((prev) => ({ ...prev, [field.name]: false }));
+        });
+    }
+    return () => {
+      for (const ctl of controllers) ctl.abort();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [depSignature]);
 
   // Submit-enabled when every required field has a non-empty value.
   // Optional fields are skipped. Booleans are always considered "filled".
@@ -2441,6 +2545,48 @@ export default function IntakeFormClient({ slug, productName, token }: Props) {
         </div>
       );
     }
+    if (field.kind === "cascading-select") {
+      const depValue = String(formData[field.dependsOn] ?? "");
+      const opts = dynamicOptions[field.name] ?? [];
+      const isLoading = dynamicLoading[field.name] ?? false;
+      const isDepEmpty = depValue === "";
+      const placeholder = isDepEmpty
+        ? field.emptyDepLabel
+        : isLoading
+          ? "Loading…"
+          : opts.length === 0
+            ? "No districts for this state"
+            : field.placeholder || "Select";
+      return (
+        <div key={field.name}>
+          <label htmlFor={id} className={labelClass}>
+            {field.label}{" "}
+            {field.required && (
+              <span className="text-red-400" aria-hidden="true">*</span>
+            )}
+          </label>
+          {field.helpText && (
+            <p id={helpId} className="text-xs text-zinc-400 mb-1.5">{field.helpText}</p>
+          )}
+          <select
+            id={id}
+            value={String(formData[field.name] || "")}
+            onChange={(e) => setField(field.name, e.target.value)}
+            required={field.required}
+            aria-required={field.required || undefined}
+            aria-describedby={field.helpText ? helpId : undefined}
+            aria-busy={isLoading || undefined}
+            disabled={isDepEmpty || isLoading || opts.length === 0}
+            className={selectClass}
+          >
+            <option value="">{placeholder}</option>
+            {opts.map((o) => (
+              <option key={o.value} value={o.value}>{o.label}</option>
+            ))}
+          </select>
+        </div>
+      );
+    }
     return null;
   }
 
@@ -2602,6 +2748,12 @@ export default function IntakeFormClient({ slug, productName, token }: Props) {
                 </div>
               </div>
             );
+          }
+
+          // cascading-select rendering (top-level use case). The nested
+          // variant inside optional-group lands via renderLeafField.
+          if (field.kind === "cascading-select") {
+            return renderLeafField(field);
           }
 
           return null;

--- a/src/lib/products.ts
+++ b/src/lib/products.ts
@@ -1229,7 +1229,7 @@ export const STANDALONE_PRODUCTS: Record<string, StandaloneProduct> = {
     // Required: chargeType, state. Optional (used to match against USSC FY14-24
     // federal sentencing distribution when supplied): priorConvictions,
     // citizenship, ageBucket.
-    intakeFields: ["chargeType", "state", "priorConvictions", "citizenship", "ageBucket"],
+    intakeFields: ["chargeType", "state", "priorConvictions", "citizenship", "ageBucket", "district"],
     stripePriceId: null,
     upsellTier: "case-decoder",
     upsellText:

--- a/src/lib/tier9-reports/generate.ts
+++ b/src/lib/tier9-reports/generate.ts
@@ -171,6 +171,7 @@ export async function generateTier9Report(
           priorConvictions: typeof intake.priorConvictions === "string" ? intake.priorConvictions : null,
           citizenship: typeof intake.citizenship === "string" ? intake.citizenship : null,
           ageBucket: typeof intake.ageBucket === "string" ? intake.ageBucket : null,
+          district: typeof intake.district === "string" && intake.district.length > 0 ? intake.district : null,
         };
         const data = await querySimilarCases(typedIntake);
         if (data.isEmpty) {
@@ -194,6 +195,7 @@ export async function generateTier9Report(
             priorConvictions: typedIntake.priorConvictions,
             citizenship: typedIntake.citizenship,
             ageBucket: typedIntake.ageBucket,
+            district: typedIntake.district,
           });
 
           if (bucket.has_minimum_signal && bucket.offguide && bucket.xcrhissr) {

--- a/tests/api/ussc-districts.test.ts
+++ b/tests/api/ussc-districts.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Integration tests for GET /api/ussc-districts.
+ *
+ * Verifies:
+ *   - Valid state code returns the districts list sorted by short_name
+ *   - Missing state → 400
+ *   - Non-2-letter state → 400
+ *   - Lowercase state is upper-cased before query
+ *   - Query error path falls back to empty array (200, not 500)
+ *   - Rate limiting returns 429
+ *
+ * Mocks supabase `.from("ussc_districts").select(...).eq(...).order(...)` chain.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const txRows = [
+  { district_code: "40", short_name: "S.D. Texas", district_name: "Southern District of Texas", circuit: "5th" },
+  { district_code: "38", short_name: "N.D. Texas", district_name: "Northern District of Texas", circuit: "5th" },
+  { district_code: "39", short_name: "E.D. Texas", district_name: "Eastern District of Texas", circuit: "5th" },
+  { district_code: "42", short_name: "W.D. Texas", district_name: "Western District of Texas", circuit: "5th" },
+];
+
+let rowsByState: Record<string, unknown[]> = {};
+let queryError: Error | null = null;
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: () => ({
+    from: (table: string) => {
+      let stateFilter: string | undefined;
+      const chain = {
+        select: () => chain,
+        eq(col: string, val: string) {
+          if (col === "state_code") stateFilter = val;
+          return chain;
+        },
+        order() {
+          if (table !== "ussc_districts") {
+            return Promise.resolve({ data: [], error: null });
+          }
+          if (queryError) {
+            return Promise.resolve({ data: null, error: queryError });
+          }
+          return Promise.resolve({
+            data: rowsByState[stateFilter ?? ""] ?? [],
+            error: null,
+          });
+        },
+      };
+      return chain;
+    },
+  }),
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  checkRateLimit: vi.fn(async () => ({ limited: false })),
+}));
+
+import { GET } from "@/app/api/ussc-districts/route";
+import { NextRequest } from "next/server";
+
+function buildReq(query: string): NextRequest {
+  return new NextRequest(`http://localhost/api/ussc-districts${query}`, {
+    headers: { "x-real-ip": "1.2.3.4" },
+  });
+}
+
+beforeEach(() => {
+  rowsByState = { TX: txRows };
+  queryError = null;
+});
+
+describe("GET /api/ussc-districts", () => {
+  it("returns districts for a valid state", async () => {
+    const res = await GET(buildReq("?state=TX"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.districts).toHaveLength(4);
+    expect(body.districts.every((d: { state_code?: string }) => !("state_code" in d))).toBe(true);
+    const codes = body.districts.map((d: { district_code: string }) => d.district_code);
+    expect(codes).toContain("42");
+  });
+
+  it("upper-cases lowercase state codes before query", async () => {
+    const res = await GET(buildReq("?state=tx"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.districts).toHaveLength(4);
+  });
+
+  it("returns 400 when state query param missing", async () => {
+    const res = await GET(buildReq(""));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when state is not 2 letters", async () => {
+    const res1 = await GET(buildReq("?state=T"));
+    expect(res1.status).toBe(400);
+    const res2 = await GET(buildReq("?state=TXX"));
+    expect(res2.status).toBe(400);
+    const res3 = await GET(buildReq("?state=12"));
+    expect(res3.status).toBe(400);
+  });
+
+  it("returns empty array for a state with no districts", async () => {
+    rowsByState = {};
+    const res = await GET(buildReq("?state=TX"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.districts).toEqual([]);
+  });
+
+  it("returns empty array (not 500) when the query errors", async () => {
+    queryError = new Error("connection refused");
+    const res = await GET(buildReq("?state=TX"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.districts).toEqual([]);
+  });
+
+  it("returns 429 when rate-limited", async () => {
+    const { checkRateLimit } = await import("@/lib/rate-limit");
+    (checkRateLimit as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ limited: true });
+    const res = await GET(buildReq("?state=TX"));
+    expect(res.status).toBe(429);
+  });
+
+  it("sets a long-lived Cache-Control header (codebook data is static)", async () => {
+    const res = await GET(buildReq("?state=TX"));
+    const cc = res.headers.get("Cache-Control") || "";
+    expect(cc).toMatch(/max-age=3600/);
+    expect(cc).toMatch(/s-maxage=86400/);
+  });
+});


### PR DESCRIPTION
## Summary
Adds federal district as a 4th optional field on the Similar Cases Analyzer (\$297 product) intake. Options cascade from the state field — Texas picks 4 districts, Wyoming picks 1. Supplying a district narrows the USSC matview from national averages to a specific federal court's sentencing distribution.

Unblocks priority #2 from the USSC session handoff. PR #10 already wired district_display through renderers + APIs; this PR populates the input side.

## Changes
- **New endpoint** \`GET /api/ussc-districts?state=XX\` — returns sorted districts from the \`ussc_districts\` table. Rate-limited (60/min), CDN-cached 24h.
- **New FieldConfig kind** \`cascading-select\` — dependsOn + endpoint + parseOptions. AbortController-safe fetch, disabled state when dep empty, Loading indicator, resets stale value on dep change.
- **Intake form** \`similar-cases-analyzer\` optional-group gains a 4th nested field (district) that populates after state pick.
- **Route validation** — district added to optional-fields set; \`DISTRICT_CODE_RE\` validates 1-2 digit shape.
- **Report generation** — \`generate.ts\` threads \`intake.district\` into \`mapIntakeToBucket\` so the matview query can bucket on district.

## Tests
- \`tests/api/ussc-districts.test.ts\` — 8 integration cases (valid state, lowercase normalization, missing/invalid/empty/errors, rate limit, cache headers)
- \`e2e/ussc-state-district-cascade.spec.ts\` — 7 Playwright cases against prod (Texas 4 districts, case-insensitive, unknown state empty, missing/invalid 400, DC single-district edge, cache headers)
- 67/67 pass locally; full suite 512/518 (6 pre-existing skips), tsc clean

## Test plan
- [x] \`npx tsc --noEmit --skipLibCheck\` clean
- [x] \`npx vitest run\` (relevant): 67/67 pass
- [ ] CI green
- [ ] Vercel preview smoke-tests the /intake/standalone/similar-cases-analyzer form
- [ ] Post-merge: \`npx playwright test e2e/ussc-state-district-cascade.spec.ts --project=chromium\` against prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)