### PR TITLE
fix(ussc): pristine-or-nothing pass on state→district cascade review

### DIFF
--- a/src/app/api/intake/standalone/[slug]/route.ts
+++ b/src/app/api/intake/standalone/[slug]/route.ts
@@ -88,9 +88,11 @@ const VALID_AGE_BUCKETS = new Set([
 ]);
 
 // Federal district code for similar-cases-analyzer — USSC DISTRICT codes run
-// 0-96 in the codebook. Accept 1-2 digits (with or without leading zero)
-// defensively; queryDistrictDisplay + mapIntakeToBucket both tolerate either.
-const DISTRICT_CODE_RE = /^\d{1,2}$/;
+// 0-96 in the codebook. ussc_districts stores single-digit codes unpadded
+// ("0"-"9") per build-ussc-districts.mjs, so we reject "01" etc. up front
+// — hand-submitted padded codes would miss the matview bucket silently and
+// quietly degrade results to widened_district.
+const DISTRICT_CODE_RE = /^(0|[1-9]\d?)$/;
 
 const VALID_OFFENSE_CLASS = new Set(["felony", "misdemeanor"]);
 

--- a/src/app/api/ussc-districts/route.ts
+++ b/src/app/api/ussc-districts/route.ts
@@ -28,7 +28,10 @@ const STATE_CODE_RE = /^[A-Z]{2}$/;
 export async function GET(req: NextRequest) {
   const supabase = createAdminClient();
   const ip = getClientIp(req);
-  const { limited } = await checkRateLimit(supabase, `ussc-districts:${ip}`, 60, 60);
+  // 300/min per IP — shared-office NATs (law firms, libraries) need headroom
+  // for concurrent form-fillers; the endpoint is CDN-cached 24h so DB hit
+  // rate is near-zero at steady state.
+  const { limited } = await checkRateLimit(supabase, `ussc-districts:${ip}`, 300, 60);
   if (limited) {
     return NextResponse.json({ error: "Too many requests" }, { status: 429 });
   }
@@ -53,7 +56,16 @@ export async function GET(req: NextRequest) {
 
   if (error) {
     console.error("[ussc-districts] query error:", error);
-    return NextResponse.json({ districts: [] }, { status: 200 });
+    // 503 + no-store so the CDN doesn't cache a transient DB-blip as an
+    // empty-districts fixture for 24 hours. Frontend's fetchError branch
+    // surfaces "try again" messaging to the user.
+    return NextResponse.json(
+      { districts: [], error: "Lookup temporarily unavailable" },
+      {
+        status: 503,
+        headers: { "Cache-Control": "no-store" },
+      },
+    );
   }
 
   return NextResponse.json(

--- a/src/app/intake/standalone/[slug]/IntakeFormClient.tsx
+++ b/src/app/intake/standalone/[slug]/IntakeFormClient.tsx
@@ -313,6 +313,10 @@ type FieldConfig =
       placeholder?: string;
       helpText?: string;
       emptyDepLabel: string;
+      /** Optional label shown when the fetch returned zero options.
+       *  Defaults to a generic "No options for this selection" — override
+       *  per-use-case (e.g. "No federal districts for this state"). */
+      emptyOptionsLabel?: string;
     };
 
 const FIELD_SETS: Record<string, FieldConfig[]> = {
@@ -2204,6 +2208,7 @@ const FIELD_SETS: Record<string, FieldConfig[]> = {
           required: false,
           dependsOn: "state",
           emptyDepLabel: "Pick your state above first",
+          emptyOptionsLabel: "No federal districts found for this state",
           helpText: "Skip if unsure — leaving blank returns national averages.",
           endpoint: (stateVal: string) =>
             `/api/ussc-districts?state=${encodeURIComponent(stateVal)}`,
@@ -2343,30 +2348,56 @@ export default function IntakeFormClient({ slug, productName, token }: Props) {
   const depSignature = cascadingFields
     .map((f) => `${f.name}:${String(formData[f.dependsOn] ?? "")}`)
     .join("|");
+  // Failure surface: when fetch fails (network, non-2xx, parse error) we
+  // flip an amber warning state so the customer knows to retry rather than
+  // silently rendering "No districts for this state" — which would mislead
+  // users into thinking their state has no federal districts.
+  const [dynamicError, setDynamicError] = useState<Record<string, string | null>>({});
   useEffect(() => {
     const controllers: AbortController[] = [];
     for (const field of cascadingFields) {
       const depValue = String(formData[field.dependsOn] ?? "");
-      // Reset the cascading field's value + drop stale options regardless
-      // of whether the new dep value is empty or not.
+      // Reset state only when we actually have something to do — skipping
+      // empty-dep idle mount-time resets avoids 2 redundant re-renders.
+      if (!depValue) {
+        if ((formData[field.name] ?? "") !== "") setField(field.name, "");
+        setDynamicOptions((prev) => (prev[field.name] ? { ...prev, [field.name]: [] } : prev));
+        setDynamicError((prev) => (prev[field.name] ? { ...prev, [field.name]: null } : prev));
+        continue;
+      }
+      // Real dep change — clear stale cascading value + options + error.
       setField(field.name, "");
       setDynamicOptions((prev) => ({ ...prev, [field.name]: [] }));
-      if (!depValue) continue;
+      setDynamicError((prev) => ({ ...prev, [field.name]: null }));
       const ctl = new AbortController();
       controllers.push(ctl);
       setDynamicLoading((prev) => ({ ...prev, [field.name]: true }));
       fetch(field.endpoint(depValue), { signal: ctl.signal })
-        .then((res) => (res.ok ? res.json() : null))
-        .then((data) => {
-          if (data == null) return;
+        .then(async (res) => {
+          // Race-safe: if this fetch was aborted before the response came
+          // back, a newer effect run is already in flight — do NOT touch
+          // the loading flag or options, the newer run owns them now.
+          if (ctl.signal.aborted) return;
+          if (!res.ok) {
+            setDynamicError((prev) => ({
+              ...prev,
+              [field.name]: "Couldn't load options. Try selecting your state again.",
+            }));
+            setDynamicLoading((prev) => ({ ...prev, [field.name]: false }));
+            return;
+          }
+          const data = await res.json();
           const opts = field.parseOptions(data);
           setDynamicOptions((prev) => ({ ...prev, [field.name]: opts }));
+          setDynamicLoading((prev) => ({ ...prev, [field.name]: false }));
         })
         .catch((err) => {
-          if (err?.name === "AbortError") return;
+          if (ctl.signal.aborted || err?.name === "AbortError") return;
           console.error(`[intake-form] cascading-select fetch failed for ${field.name}:`, err);
-        })
-        .finally(() => {
+          setDynamicError((prev) => ({
+            ...prev,
+            [field.name]: "Couldn't load options. Check your connection and retry.",
+          }));
           setDynamicLoading((prev) => ({ ...prev, [field.name]: false }));
         });
     }
@@ -2549,14 +2580,21 @@ export default function IntakeFormClient({ slug, productName, token }: Props) {
       const depValue = String(formData[field.dependsOn] ?? "");
       const opts = dynamicOptions[field.name] ?? [];
       const isLoading = dynamicLoading[field.name] ?? false;
+      const fetchError = dynamicError[field.name] ?? null;
       const isDepEmpty = depValue === "";
+      // Empty-options label generic fallback: cascading-select may grow
+      // non-district uses (county, court, etc.) — swap in future config.
+      const emptyOptionsLabel = field.emptyOptionsLabel ?? "No options for this selection";
       const placeholder = isDepEmpty
         ? field.emptyDepLabel
         : isLoading
           ? "Loading…"
-          : opts.length === 0
-            ? "No districts for this state"
-            : field.placeholder || "Select";
+          : fetchError
+            ? "Failed to load — see error below"
+            : opts.length === 0
+              ? emptyOptionsLabel
+              : field.placeholder || "Select";
+      const errorId = `${id}-error`;
       return (
         <div key={field.name}>
           <label htmlFor={id} className={labelClass}>
@@ -2574,9 +2612,12 @@ export default function IntakeFormClient({ slug, productName, token }: Props) {
             onChange={(e) => setField(field.name, e.target.value)}
             required={field.required}
             aria-required={field.required || undefined}
-            aria-describedby={field.helpText ? helpId : undefined}
+            aria-describedby={[
+              field.helpText ? helpId : null,
+              fetchError ? errorId : null,
+            ].filter(Boolean).join(" ") || undefined}
             aria-busy={isLoading || undefined}
-            disabled={isDepEmpty || isLoading || opts.length === 0}
+            disabled={isDepEmpty || isLoading || (opts.length === 0 && !fetchError)}
             className={selectClass}
           >
             <option value="">{placeholder}</option>
@@ -2584,6 +2625,16 @@ export default function IntakeFormClient({ slug, productName, token }: Props) {
               <option key={o.value} value={o.value}>{o.label}</option>
             ))}
           </select>
+          {fetchError && (
+            <p
+              id={errorId}
+              className="text-xs text-amber-400 mt-1.5"
+              role="alert"
+              aria-live="polite"
+            >
+              {fetchError}
+            </p>
+          )}
         </div>
       );
     }

--- a/tests/api/ussc-districts.test.ts
+++ b/tests/api/ussc-districts.test.ts
@@ -22,6 +22,7 @@ const txRows = [
 
 let rowsByState: Record<string, unknown[]> = {};
 let queryError: Error | null = null;
+let lastOrderCall: { col: string; opts: unknown } | null = null;
 
 vi.mock("@/lib/supabase/admin", () => ({
   createAdminClient: () => ({
@@ -33,7 +34,11 @@ vi.mock("@/lib/supabase/admin", () => ({
           if (col === "state_code") stateFilter = val;
           return chain;
         },
-        order() {
+        order(col: string, opts: unknown) {
+          // Assert mock fidelity to the real supabase-js chain — route MUST
+          // sort by short_name ascending or the E2E spec's ordering assertion
+          // breaks silently (fixture alphabetical order is load-bearing).
+          lastOrderCall = { col, opts };
           if (table !== "ussc_districts") {
             return Promise.resolve({ data: [], error: null });
           }
@@ -67,10 +72,11 @@ function buildReq(query: string): NextRequest {
 beforeEach(() => {
   rowsByState = { TX: txRows };
   queryError = null;
+  lastOrderCall = null;
 });
 
 describe("GET /api/ussc-districts", () => {
-  it("returns districts for a valid state", async () => {
+  it("returns districts for a valid state + sorts short_name ascending", async () => {
     const res = await GET(buildReq("?state=TX"));
     expect(res.status).toBe(200);
     const body = await res.json();
@@ -78,6 +84,11 @@ describe("GET /api/ussc-districts", () => {
     expect(body.districts.every((d: { state_code?: string }) => !("state_code" in d))).toBe(true);
     const codes = body.districts.map((d: { district_code: string }) => d.district_code);
     expect(codes).toContain("42");
+    // Contract: route calls .order("short_name", { ascending: true }). Any
+    // drift (e.g. descending, or sorting by a different column) would
+    // silently break the frontend's expected alphabetical render order —
+    // assert the exact args so the test catches it pre-merge.
+    expect(lastOrderCall).toEqual({ col: "short_name", opts: { ascending: true } });
   });
 
   it("upper-cases lowercase state codes before query", async () => {
@@ -109,12 +120,16 @@ describe("GET /api/ussc-districts", () => {
     expect(body.districts).toEqual([]);
   });
 
-  it("returns empty array (not 500) when the query errors", async () => {
+  it("returns 503 + no-store when the query errors (CDN must not cache)", async () => {
     queryError = new Error("connection refused");
     const res = await GET(buildReq("?state=TX"));
-    expect(res.status).toBe(200);
+    // 503 signals transient failure — CDN edge won't cache, so a DB blip
+    // doesn't poison the cache for 24h.
+    expect(res.status).toBe(503);
     const body = await res.json();
     expect(body.districts).toEqual([]);
+    expect(body.error).toBeTruthy();
+    expect(res.headers.get("Cache-Control") || "").toContain("no-store");
   });
 
   it("returns 429 when rate-limited", async () => {


### PR DESCRIPTION
## Summary
Addresses code-reviewer findings on PR #13 (USSC intake cascade). All CRITICALs + WARNINGs + actionable SUGGESTIONs resolved.

## Findings fixed
| Sev | File | Fix |
|---|---|---|
| CRITICAL #2 | \`IntakeFormClient.tsx\` | Race: aborted fetch's .finally was wiping newer request's loading flag. Guard both .then and .catch with \`ctl.signal.aborted\` check before touching state. |
| WARNING #2 | \`IntakeFormClient.tsx\` | Silent failure on non-2xx → new \`dynamicError\` state + visible amber \`role="alert"\` message. |
| WARNING #3 | \`IntakeFormClient.tsx\` | Redundant mount reset — skip setField/setDynamicOptions writes when dep is empty AND cascading field already empty. |
| WARNING #4 | \`api/ussc-districts/route.ts\` | Rate limit 60/min → 300/min. Office NATs + CDN 24h cache make the higher ceiling safe. |
| WARNING #5 | \`tests/api/ussc-districts.test.ts\` | Test mock now captures \`.order()\` args — asserts exact \`(short_name, {ascending: true})\` so sort drift breaks tests pre-merge. |
| WARNING #6 | \`api/intake/standalone/[slug]/route.ts\` | Tightened \`DISTRICT_CODE_RE\` to \`/^(0\|[1-9]\d?)$/\` — rejects padded "01" etc. that would miss the matview bucket. |
| SUGGESTION #9 | \`IntakeFormClient.tsx\` | Added \`emptyOptionsLabel\` FieldConfig attr — cascading-select no longer hardcodes "districts" nomenclature. |
| SUGGESTION #10 | \`api/ussc-districts/route.ts\` | Query error now returns 503 + \`Cache-Control: no-store\` instead of 200 + empty. Prevents CDN poisoning on DB blips. |

## Explicitly deferred
- **CRITICAL #1** (collision with concurrent f3c042d) — f3c042d is an orphan branch that overwrote \`similar-cases-analyzer.intakeFields\` to drop priorConvictions/citizenship/ageBucket. Not on master. Whoever merges that branch next must 3-way-merge to preserve all 6 optional fields. Documented in commit body + handoff.
- **SUGGESTION #7** (exhaustive-deps refactor) — useMemo + inline disable is cleaner but touches enough surface to warrant its own refactor PR.
- **SUGGESTION #8** (alphabetical vs directional ordering) — kept alphabetical to match E2E spec assertion + codebook convention.

## Test plan
- [x] \`npx tsc --noEmit --skipLibCheck\` clean
- [x] \`npx vitest run\` — 512/518 pass (unchanged), 0 regressions
- [ ] CI green
- [ ] Post-merge: E2E spec runs against prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)