### PR TITLE
fix(e2e): USSC cascade cache-header assertion matches Vercel reality

### DIFF
--- a/e2e/ussc-state-district-cascade.spec.ts
+++ b/e2e/ussc-state-district-cascade.spec.ts
@@ -88,11 +88,16 @@ test.describe("USSC state→district cascade E2E", () => {
     expect(res3.status()).toBe(400);
   });
 
-  test("response cache headers allow CDN edge caching", async ({ request }) => {
+  test("response cache headers allow client-side caching", async ({ request }) => {
+    // Vercel's edge strips s-maxage on dynamic query-param routes even when
+    // the route handler sets it explicitly — only the browser-cache
+    // max-age survives the edge. 1h browser cache still covers the common
+    // case (user editing their form doesn't re-fetch). Asserting max-age
+    // prevents the route from regressing to no-cache; asserting s-maxage
+    // would fail against Vercel's documented behavior.
     const res = await request.get(`${BASE}/api/ussc-districts?state=TX`);
     const cc = res.headers()["cache-control"] || "";
     expect(cc).toMatch(/max-age=3600/);
-    expect(cc).toMatch(/s-maxage=86400/);
   });
 
   test("single-district state (e.g. DC) returns 1 row", async ({ request }) => {

--- a/src/lib/types/blog-pipeline.ts
+++ b/src/lib/types/blog-pipeline.ts
@@ -90,6 +90,43 @@ export interface AntiHallucinationDetails {
   checks_passed: number;
   checks_total: number;
   results: Array<AntiHallucinationCheckResult>;
+  /**
+   * SHA-256 of the committed rule snapshot at
+   * `ImNotAnAttorney-engine/content/rules/no-hallucinated-legal-data.md` that
+   * the gate was bound to at module load time. Added in engine commit
+   * `06afeb9` (Task 5/5a — RULE_VERSION_HASH binding). Populated on every
+   * gate run; surfaces in audit logs for post-hoc integrity checks.
+   */
+  rule_version_hash?: string;
+}
+
+/**
+ * Per-claim verification result from `runAntiHallucinationVerify` in
+ * `ImNotAnAttorney-engine/src/lib/blog-gen/qa-anti-hallucination-verify.mjs`
+ * (Task 2, engine commit `abe11a2`). Complements the format-only
+ * STATISTICS_CHECK with a runtime allowlist authenticity check.
+ */
+export interface AntiHallucinationVerifyClaimResult {
+  claim_text: string;
+  cited_source: string | null;
+  citation_format: 'parenthetical' | 'preceding-sentence' | 'none';
+  locator: { line: number } | null;
+  match_status:
+    | 'allowlisted'
+    | 'state-allowlisted-without-state'
+    | 'banned'
+    | 'unknown'
+    | 'no-source';
+  matched_entry_name: string | null;
+  source_algorithm: 'structural' | 'llm' | 'both';
+}
+
+export interface AntiHallucinationVerifyDetails {
+  claims_total: number;
+  claims_passed: number;
+  claims_failed: number;
+  results: Array<AntiHallucinationVerifyClaimResult>;
+  failures: Array<AntiHallucinationVerifyClaimResult>;
 }
 
 export interface DNACheckResult {
@@ -127,6 +164,13 @@ export interface BlogDraft {
   upl_details: UPLDetails | null;
   anti_hallucination_result: QAResult | null;
   anti_hallucination_details: AntiHallucinationDetails | null;
+  /**
+   * Forward-declared. Populated once the Task 2 verify gate is wired into
+   * `blog-qa.mjs` as Gate 5 (engine-side). DB column + write path land with
+   * that wiring; until then, these fields are absent on existing rows.
+   */
+  anti_hallucination_verify_result?: QAResult | null;
+  anti_hallucination_verify_details?: AntiHallucinationVerifyDetails | null;
   dna_result: QAResult | null;
   dna_details: DNADetails | null;
   qa_attempts: number;

--- a/tests/api/ussc-districts.test.ts
+++ b/tests/api/ussc-districts.test.ts
@@ -142,6 +142,11 @@ describe("GET /api/ussc-districts", () => {
   it("sets a long-lived Cache-Control header (codebook data is static)", async () => {
     const res = await GET(buildReq("?state=TX"));
     const cc = res.headers.get("Cache-Control") || "";
+    // Unit test asserts both directives — the Next.js route handler preserves
+    // them in the response object. Vercel's edge strips s-maxage on dynamic
+    // query-param routes at deploy time, so the E2E spec only asserts max-age
+    // (browser-observable reality). Keeping both here prevents the handler
+    // from regressing to no-store silently.
     expect(cc).toMatch(/max-age=3600/);
     expect(cc).toMatch(/s-maxage=86400/);
   });


### PR DESCRIPTION
## Summary
PR #13 + #14's E2E spec asserted both \`max-age=3600\` and \`s-maxage=86400\`. Vercel's edge strips \`s-maxage\` on dynamic query-param routes, so the E2E failed against prod even though the Next.js handler sets both directives. Aligns the spec with Vercel's documented behavior.

## Changes
- \`e2e/ussc-state-district-cascade.spec.ts\` — asserts only \`max-age=3600\` (browser-observable at the client)
- \`tests/api/ussc-districts.test.ts\` — keeps asserting both (Next.js handler-level layer preserves them, catches regression to no-store)

Comments in both files explain the layer split.

## Verified
- Unit: 8/8 pass
- E2E against prod passes 6/7 with the old assertion; 7/7 with the new one

🤖 Generated with [Claude Code](https://claude.com/claude-code)