### PR TITLE
feat(fsd): $297 Federal Sentencing Distribution Report standalone

### DIFF
--- a/e2e/fsd-federal-sentencing-distribution.spec.ts
+++ b/e2e/fsd-federal-sentencing-distribution.spec.ts
@@ -1,0 +1,128 @@
+/**
+ * E2E: Federal Sentencing Distribution Report API against prod.
+ *
+ * Covers:
+ *   - POST /api/tools/federal-sentencing-distribution with a real prod
+ *     bucket (drug-trafficking, district 42 / W.D. Texas, CH=3) returns
+ *     a distribution + monte_carlo + histogram + district_display with
+ *     real data (not insufficient_data).
+ *   - Unmapped chargeType (dui) returns 400 with clear error.
+ *   - Missing district falls back gracefully to national averages
+ *     (match_depth=widened_district).
+ *   - Response shape matches the contract the frontend renders.
+ *
+ * Verifies the real FSD table (13,131 rows) + the ussc_districts lookup
+ * are both live + correctly joined.
+ *
+ * Gate: E2E_SKIP_LIVE=1 skips; E2E_BASE_URL overrides prod.
+ */
+import { test, expect } from "@playwright/test";
+
+const BASE = process.env.E2E_BASE_URL || "https://imnotanattorney.com";
+
+test.describe("FSD $297 product E2E", () => {
+  test.beforeEach(() => {
+    test.skip(
+      process.env.E2E_SKIP_LIVE === "1",
+      "E2E_SKIP_LIVE=1 — this spec hits live API + prod FSD table",
+    );
+  });
+
+  test("drug-trafficking W.D. Texas CH=3 returns full distribution", async ({ request }) => {
+    const res = await request.post(`${BASE}/api/tools/federal-sentencing-distribution`, {
+      data: {
+        chargeType: "drug-trafficking",
+        district: "42",
+        criminalHistoryCategory: "3",
+      },
+    });
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    expect(body.result).toBeDefined();
+    expect(body.result.match_depth).not.toBe("insufficient_data");
+    expect(body.result.match_depth).not.toBe("widened_district");
+    // District agg must exist + have percentiles
+    expect(body.result.district_agg).not.toBeNull();
+    expect(body.result.district_agg.offguide_label).toBe("Drug Trafficking");
+    expect(body.result.district_agg.percentiles.p50).toBeGreaterThan(0);
+    expect(body.result.district_agg.total_n).toBeGreaterThan(0);
+    // Monte Carlo sample of 1000
+    expect(body.result.monte_carlo).toHaveLength(1000);
+    for (const v of body.result.monte_carlo) {
+      expect(typeof v).toBe("number");
+      expect(v).toBeGreaterThanOrEqual(0);
+    }
+    // Histogram should have bins
+    expect(body.result.histogram.length).toBeGreaterThan(0);
+    // District display joined from ussc_districts
+    expect(body.result.district_display).not.toBeNull();
+    expect(body.result.district_display.short_name).toBe("W.D. Texas");
+    expect(body.result.district_display.circuit).toBe("5th");
+    // UPL safety: no banned phrases
+    const text = JSON.stringify(body);
+    expect(text).not.toMatch(/\byou should\b/i);
+    expect(text).not.toMatch(/\bwe recommend\b/i);
+  });
+
+  test("unmapped chargeType (dui) returns 400 with clear error", async ({ request }) => {
+    const res = await request.post(`${BASE}/api/tools/federal-sentencing-distribution`, {
+      data: {
+        chargeType: "dui",
+        district: "42",
+        criminalHistoryCategory: "1",
+      },
+    });
+    expect(res.status()).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/insufficient data/i);
+    expect(body.chargeType).toBe("dui");
+  });
+
+  test("missing district falls back to widened_district (national averages)", async ({ request }) => {
+    const res = await request.post(`${BASE}/api/tools/federal-sentencing-distribution`, {
+      data: {
+        chargeType: "drug-trafficking",
+        criminalHistoryCategory: "3",
+      },
+    });
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    expect(body.result.match_depth).toBe("widened_district");
+    expect(body.result.district_display).toBeNull();
+  });
+
+  test("priorConvictions derives criminalHistoryCategory when not explicit", async ({ request }) => {
+    const res = await request.post(`${BASE}/api/tools/federal-sentencing-distribution`, {
+      data: {
+        chargeType: "drug-trafficking",
+        district: "42",
+        priorConvictions: "felony",
+      },
+    });
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    // felony → category "3"
+    expect(body.result.input.criminalHistoryCategory).toBe("3");
+  });
+
+  test("rejects missing chargeType with 400", async ({ request }) => {
+    const res = await request.post(`${BASE}/api/tools/federal-sentencing-distribution`, {
+      data: { district: "42" },
+    });
+    expect(res.status()).toBe(400);
+  });
+
+  test("federalOnly flag + USSC data source citation in response", async ({ request }) => {
+    const res = await request.post(`${BASE}/api/tools/federal-sentencing-distribution`, {
+      data: {
+        chargeType: "drug-trafficking",
+        criminalHistoryCategory: "3",
+      },
+    });
+    const body = await res.json();
+    expect(body.result.federalOnly).toBe(true);
+    expect(body.result.dataSource).toMatch(/USSC/);
+    expect(body.result.sourceUrl).toMatch(/ussc\.gov/);
+    expect(body.result.disclaimer).toMatch(/legal INFORMATION/);
+  });
+});

--- a/src/app/api/intake/standalone/[slug]/route.ts
+++ b/src/app/api/intake/standalone/[slug]/route.ts
@@ -94,6 +94,10 @@ const VALID_AGE_BUCKETS = new Set([
 // quietly degrade results to widened_district.
 const DISTRICT_CODE_RE = /^(0|[1-9]\d?)$/;
 
+// USSC Criminal History Category — 6 categories ("1" = no priors/1 pt …
+// "6" = career offender / 13+ points).
+const VALID_CH_CATEGORIES = new Set(["1", "2", "3", "4", "5", "6"]);
+
 const VALID_OFFENSE_CLASS = new Set(["felony", "misdemeanor"]);
 
 const VALID_CHARGE_INVOLVES = new Set([
@@ -167,6 +171,15 @@ const OPTIONAL_FIELDS_BY_SLUG: Record<string, Set<string>> = {
   // `district` is cascaded from state in the intake form (1-4 options per state)
   // and narrows the sample to a specific federal court when supplied.
   "similar-cases-analyzer": new Set(["priorConvictions", "citizenship", "ageBucket", "district"]),
+  // Federal Sentencing Distribution — district is optional (widens to
+  // national); criminalHistoryCategory is optional (derived from
+  // priorConvictions when absent). state is required to populate the
+  // district cascade but the analysis itself is district-agnostic-capable.
+  "federal-sentencing-distribution": new Set([
+    "district",
+    "criminalHistoryCategory",
+    "state",
+  ]),
   "daubert-challenge": new Set(["expertMethodology"]),
   "body-camera-analysis": new Set(["defenseTheory"]),
   // Bundles, product-specific fields are optional since users may not have all data
@@ -362,6 +375,15 @@ export async function POST(
     }
     if (field === "district" && !DISTRICT_CODE_RE.test(String(raw))) {
       return NextResponse.json({ error: "Invalid federal district code" }, { status: 400 });
+    }
+    if (
+      field === "criminalHistoryCategory" &&
+      !VALID_CH_CATEGORIES.has(String(raw))
+    ) {
+      return NextResponse.json(
+        { error: "Invalid USSC criminal history category (1-6)" },
+        { status: 400 },
+      );
     }
     if (field === "convictionOrDismissal" && !VALID_CONVICTION_OR_DISMISSAL.has(String(raw))) {
       return NextResponse.json({ error: "Invalid value" }, { status: 400 });

--- a/src/app/api/tools/federal-sentencing-distribution/route.ts
+++ b/src/app/api/tools/federal-sentencing-distribution/route.ts
@@ -1,0 +1,212 @@
+/**
+ * @fileoverview POST /api/tools/federal-sentencing-distribution — powers the
+ * $297 Federal Sentencing Distribution Report.
+ *
+ * Input:
+ *   {
+ *     chargeType: string,                          // required (INAA slug)
+ *     district?: string | null,                    // optional USSC code
+ *     criminalHistoryCategory?: string | null,     // "1"-"6" (USSC category)
+ *     fyFrom?: number,                             // 2-digit (default 14)
+ *     fyTo?: number,                               // 2-digit (default 24)
+ *   }
+ *
+ * Output:
+ *   match_depth + widening_note + district_agg + national_agg + per_year[]
+ *   + monte_carlo[] (1000 samples) + sample_size_caveat + district_display
+ *   + dataSource + disclaimer
+ *
+ * Falls back through 4 widening tiers when the exact bucket returns zero rows.
+ * UPL-safe — returns distribution data, never advice.
+ */
+import { NextRequest, NextResponse, after } from "next/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { checkRateLimit } from "@/lib/rate-limit";
+import { getClientIp } from "@/lib/request";
+import {
+  queryDistribution,
+  histogram,
+  OFFGUIDE_CODES,
+  VALID_CH_CATEGORIES,
+  type FsdAggregate,
+} from "@/lib/fsd-distribution";
+import { chargeTypeToFsdOffguide, priorsToChCategory } from "@/lib/fsd-offguide";
+import {
+  queryDistrictDisplay,
+  type DistrictDisplay,
+} from "@/lib/ussc-similar-cases";
+
+interface FsdInput {
+  chargeType: string;
+  district?: string | null;
+  criminalHistoryCategory?: string | null;
+  priorConvictions?: string | null;
+  fyFrom?: number;
+  fyTo?: number;
+}
+
+function validate(input: unknown): { valid: boolean; errors: string[] } {
+  const errors: string[] = [];
+  if (!input || typeof input !== "object") {
+    return { valid: false, errors: ["Invalid request body"] };
+  }
+  const b = input as Record<string, unknown>;
+  if (typeof b.chargeType !== "string" || b.chargeType.length < 2) {
+    errors.push("chargeType is required");
+  }
+  if (b.district !== undefined && b.district !== null && typeof b.district !== "string") {
+    errors.push("district must be a string if provided");
+  }
+  if (
+    b.criminalHistoryCategory !== undefined &&
+    b.criminalHistoryCategory !== null &&
+    typeof b.criminalHistoryCategory !== "string"
+  ) {
+    errors.push("criminalHistoryCategory must be a string if provided");
+  }
+  if (
+    b.priorConvictions !== undefined &&
+    b.priorConvictions !== null &&
+    typeof b.priorConvictions !== "string"
+  ) {
+    errors.push("priorConvictions must be a string if provided");
+  }
+  for (const field of ["fyFrom", "fyTo"] as const) {
+    const v = b[field];
+    if (v !== undefined && v !== null) {
+      if (typeof v !== "number" || !Number.isInteger(v) || v < 14 || v > 24) {
+        errors.push(`${field} must be an integer between 14 and 24 if provided`);
+      }
+    }
+  }
+  return { valid: errors.length === 0, errors };
+}
+
+function shapeAgg(agg: FsdAggregate | null) {
+  if (!agg) return null;
+  return {
+    total_n: agg.total_n,
+    mean_months: agg.mean_months,
+    median_months: agg.median_months,
+    percentiles: {
+      p10: agg.p10_months,
+      p25: agg.p25_months,
+      p50: agg.median_months,
+      p75: agg.p75_months,
+      p90: agg.p90_months,
+    },
+    departure_rates: {
+      downward: agg.downward_departure_rate,
+      upward: agg.upward_departure_rate,
+      probation: agg.probation_rate,
+    },
+    fiscal_year_range: `FY${agg.earliest_fy}-FY${agg.latest_fy}`,
+    offguide_label: agg.offguide_label,
+    offense_category: agg.offense_category,
+  };
+}
+
+export async function POST(req: NextRequest) {
+  const ip = getClientIp(req);
+  const supabase = createAdminClient();
+  const { limited } = await checkRateLimit(supabase, `calc:fsd:${ip}`, 30, 300);
+  if (limited) {
+    return NextResponse.json({ error: "Too many requests" }, { status: 429 });
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+  }
+
+  const v = validate(body);
+  if (!v.valid) {
+    return NextResponse.json(
+      { error: "Validation failed", details: v.errors },
+      { status: 400 },
+    );
+  }
+
+  const input = body as FsdInput;
+
+  // Resolve offguide + criminal history — prefer explicit values, fall back
+  // to slug-based lookup for each.
+  const offguide_code = chargeTypeToFsdOffguide(input.chargeType);
+  if (offguide_code === null || !OFFGUIDE_CODES.has(offguide_code)) {
+    return NextResponse.json(
+      {
+        error:
+          "Insufficient data — this charge type isn't mapped to a federal sentencing guideline (mostly state offenses or rare federal).",
+        chargeType: input.chargeType,
+      },
+      { status: 400 },
+    );
+  }
+
+  const ch: string | null =
+    typeof input.criminalHistoryCategory === "string" &&
+    VALID_CH_CATEGORIES.has(input.criminalHistoryCategory)
+      ? input.criminalHistoryCategory
+      : priorsToChCategory(input.priorConvictions ?? null);
+
+  // Fire the matview query + district display in parallel.
+  const [response, districtDisplay] = await Promise.all([
+    queryDistribution(supabase, {
+      district: input.district ?? null,
+      offguide_code,
+      criminal_history_category: ch ?? "",
+      fy_from: input.fyFrom ?? 14,
+      fy_to: input.fyTo ?? 24,
+    }),
+    queryDistrictDisplay(supabase, input.district ?? null),
+  ]);
+
+  // Fire analytics after response (Vercel serverless-safe via after()).
+  after(async () => {
+    const { error } = await supabase.rpc("increment_calculator_aggregate", {
+      p_slug: "federal-sentencing-distribution",
+      p_state: null,
+      p_charge_type: input.chargeType,
+    });
+    if (error) console.error("[FSD] Analytics error:", error);
+  });
+
+  const hist = histogram(response.monte_carlo, 20);
+
+  const districtDisplayTyped: DistrictDisplay | null = districtDisplay;
+
+  return NextResponse.json({
+    result: {
+      input: {
+        chargeType: input.chargeType,
+        district: input.district ?? null,
+        criminalHistoryCategory: ch,
+        fyFrom: input.fyFrom ?? 14,
+        fyTo: input.fyTo ?? 24,
+        offguide_code,
+      },
+      match_depth: response.match_depth,
+      widening_note: response.widening_note,
+      sample_size_caveat: response.sample_size_caveat,
+      district_agg: shapeAgg(response.district_agg),
+      national_agg: shapeAgg(response.national_agg),
+      per_year: response.per_year.map((r) => ({
+        fy: r.fy,
+        n: r.n,
+        mean_months: r.mean_months,
+        median_months: r.median_months,
+      })),
+      monte_carlo: response.monte_carlo,
+      histogram: hist,
+      district_display: districtDisplayTyped,
+      federalOnly: true,
+      dataSource:
+        "USSC Individual Offender Datafiles FY2014-FY2024 (13,131 district-level buckets across 94 federal districts).",
+      sourceUrl: "https://www.ussc.gov/research/datafiles/commission-datafiles",
+      disclaimer:
+        "This provides legal INFORMATION about the historical distribution of federal sentences for this offense + criminal history + district — not legal advice. Every case is different; your attorney remains the final authority on strategy.",
+    },
+  });
+}

--- a/src/app/intake/standalone/[slug]/IntakeFormClient.tsx
+++ b/src/app/intake/standalone/[slug]/IntakeFormClient.tsx
@@ -2233,6 +2233,87 @@ const FIELD_SETS: Record<string, FieldConfig[]> = {
       ],
     },
   ],
+  "federal-sentencing-distribution": [
+    {
+      kind: "select",
+      name: "chargeType",
+      label: "Charge type",
+      placeholder: "Select charge type",
+      options: ALLOWED_CHARGE_TYPES.map((ct) => ({
+        value: ct,
+        label: ct.replace(/-/g, " ").replace(/\b\w/g, (c) => c.toUpperCase()),
+      })),
+      required: true,
+    },
+    {
+      kind: "select",
+      name: "state",
+      label: "State (where case is pending)",
+      placeholder: "Select state",
+      options: US_STATES,
+      required: true,
+    },
+    {
+      kind: "cascading-select",
+      name: "district",
+      label: "Federal district (if known)",
+      placeholder: "Select district",
+      required: false,
+      dependsOn: "state",
+      emptyDepLabel: "Pick your state above first",
+      emptyOptionsLabel: "No federal districts found for this state",
+      helpText:
+        "Skip if unsure — leaving blank returns national averages for your offense.",
+      endpoint: (stateVal: string) =>
+        `/api/ussc-districts?state=${encodeURIComponent(stateVal)}`,
+      parseOptions: (data: unknown) => {
+        if (
+          typeof data !== "object" ||
+          data === null ||
+          !("districts" in data) ||
+          !Array.isArray((data as { districts: unknown }).districts)
+        ) {
+          return [];
+        }
+        const rows = (data as { districts: Array<{ district_code?: unknown; short_name?: unknown }> }).districts;
+        return rows
+          .filter(
+            (r): r is { district_code: string; short_name: string } =>
+              typeof r.district_code === "string" && typeof r.short_name === "string",
+          )
+          .map((r) => ({ value: r.district_code, label: r.short_name }));
+      },
+    },
+    {
+      kind: "select",
+      name: "priorConvictions",
+      label: "Prior convictions",
+      placeholder: "Select",
+      required: true,
+      options: [
+        { value: "none", label: "None" },
+        { value: "misdemeanor", label: "Misdemeanor(s) only" },
+        { value: "felony", label: "One felony" },
+        { value: "multiple", label: "Multiple felonies" },
+        { value: "dont-know", label: "I don't know" },
+      ],
+    },
+    {
+      kind: "select",
+      name: "criminalHistoryCategory",
+      label: "USSC Criminal History Category (if known)",
+      placeholder: "Skip — derive from priors",
+      required: false,
+      options: [
+        { value: "1", label: "Category I (0-1 points)" },
+        { value: "2", label: "Category II (2-3 points)" },
+        { value: "3", label: "Category III (4-6 points)" },
+        { value: "4", label: "Category IV (7-9 points)" },
+        { value: "5", label: "Category V (10-12 points)" },
+        { value: "6", label: "Category VI (13+ points, career offender)" },
+      ],
+    },
+  ],
 };
 
 // ─── Bundle FIELD_SETS, computed from included products ──────

--- a/src/lib/fsd-distribution.ts
+++ b/src/lib/fsd-distribution.ts
@@ -1,0 +1,382 @@
+/**
+ * @fileoverview Shared query library for `federal_sentencing_distributions`.
+ *
+ * Powers the $297 Federal Sentencing Distribution Report — returns sentence
+ * distributions (p10/p25/p50/p75/p90 + mean) by (district, offguide_code,
+ * criminal_history_category) across a fiscal-year range. 13,131 rows covering
+ * FY14-FY24 aggregated from USSC Individual Offender Datafiles.
+ *
+ * Progressive widening mirrors the Similar Cases lib — when the exact bucket
+ * returns zero rows (rare intersection), widen by: (a) drop FY range bound,
+ * (b) drop criminal history, (c) drop district (fall back to national). UPL-safe:
+ * returns statistical distribution, never recommendations.
+ */
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+/** Offguide code allowlist — 23 USSC Primary Sentencing Guideline codes. */
+export const OFFGUIDE_CODES = new Set([
+  1, 2, 4, 5, 7, 8, 9, 10, 11, 12, 13, 15, 16, 17, 20, 21, 23, 24, 25, 26, 27, 29, 30,
+]);
+
+/** USSC Criminal History Category (1-6; "1" = no priors, "6" = career offender). */
+export const VALID_CH_CATEGORIES = new Set(["1", "2", "3", "4", "5", "6"]);
+
+export interface FsdInput {
+  /** Federal district USSC code ("0"-"96"). Null widens to national. */
+  district?: string | null;
+  /** USSC offguide code (numeric, per OFFGUIDE_CODES). */
+  offguide_code: number;
+  /** USSC criminal history category "1"-"6". */
+  criminal_history_category: string;
+  /** Inclusive fiscal-year lower bound (2-digit, e.g. 18). Defaults to 14. */
+  fy_from?: number;
+  /** Inclusive fiscal-year upper bound (2-digit, e.g. 24). Defaults to 24. */
+  fy_to?: number;
+}
+
+export interface FsdRow {
+  fy: number;
+  district: string;
+  circdist: string;
+  offguide_code: number;
+  offguide_label: string;
+  offense_category: string;
+  criminal_history_category: string;
+  n: number;
+  mean_months: number | null;
+  median_months: number | null;
+  p10_months: number | null;
+  p25_months: number | null;
+  p75_months: number | null;
+  p90_months: number | null;
+  downward_departure_rate: number | null;
+  upward_departure_rate: number | null;
+  probation_rate: number | null;
+}
+
+export type FsdMatchDepth =
+  | "exact"
+  | "widened_years"
+  | "widened_criminal_history"
+  | "widened_district"
+  | "insufficient_data";
+
+export interface FsdAggregate {
+  total_n: number;
+  mean_months: number | null;
+  median_months: number | null;
+  p10_months: number | null;
+  p25_months: number | null;
+  p75_months: number | null;
+  p90_months: number | null;
+  downward_departure_rate: number | null;
+  upward_departure_rate: number | null;
+  probation_rate: number | null;
+  earliest_fy: number;
+  latest_fy: number;
+  offguide_label: string;
+  offense_category: string;
+}
+
+export interface FsdResponse {
+  match_depth: FsdMatchDepth;
+  widening_note: string | null;
+  /** District-specific aggregate across the FY range. Null on insufficient_data. */
+  district_agg: FsdAggregate | null;
+  /** National aggregate for same offense + criminal history, independent of district. */
+  national_agg: FsdAggregate | null;
+  /** Raw rows (one per FY) in the district bucket, for per-year trend rendering. */
+  per_year: FsdRow[];
+  /** Bootstrap Monte Carlo samples (1000) drawn from the district distribution. */
+  monte_carlo: number[];
+  /** "Based on N cases FY14-FY24." Empty on insufficient_data. */
+  sample_size_caveat: string;
+}
+
+const TABLE = "federal_sentencing_distributions";
+const SELECT =
+  "fy, district, circdist, offguide_code, offguide_label, offense_category, criminal_history_category, n, mean_months, median_months, p10_months, p25_months, p75_months, p90_months, downward_departure_rate, upward_departure_rate, probation_rate";
+
+function isNonEmptyString(v: unknown): v is string {
+  return typeof v === "string" && v.length > 0;
+}
+
+/** Weighted mean of per-year metrics across rows. Weights = row.n. Returns
+ *  null if total weight is zero or all row values are null. */
+function weightedAvg(rows: FsdRow[], key: keyof FsdRow): number | null {
+  let wTotal = 0;
+  let sum = 0;
+  for (const r of rows) {
+    const v = r[key];
+    if (typeof v !== "number" || !Number.isFinite(v)) continue;
+    const w = r.n || 0;
+    if (w <= 0) continue;
+    wTotal += w;
+    sum += v * w;
+  }
+  if (wTotal === 0) return null;
+  return Number((sum / wTotal).toFixed(4));
+}
+
+function aggregate(rows: FsdRow[]): FsdAggregate | null {
+  if (rows.length === 0) return null;
+  const totalN = rows.reduce((s, r) => s + (r.n || 0), 0);
+  return {
+    total_n: totalN,
+    mean_months: weightedAvg(rows, "mean_months"),
+    median_months: weightedAvg(rows, "median_months"),
+    p10_months: weightedAvg(rows, "p10_months"),
+    p25_months: weightedAvg(rows, "p25_months"),
+    p75_months: weightedAvg(rows, "p75_months"),
+    p90_months: weightedAvg(rows, "p90_months"),
+    downward_departure_rate: weightedAvg(rows, "downward_departure_rate"),
+    upward_departure_rate: weightedAvg(rows, "upward_departure_rate"),
+    probation_rate: weightedAvg(rows, "probation_rate"),
+    earliest_fy: Math.min(...rows.map((r) => r.fy)),
+    latest_fy: Math.max(...rows.map((r) => r.fy)),
+    offguide_label: rows[0].offguide_label,
+    offense_category: rows[0].offense_category,
+  };
+}
+
+async function runQuery(
+  sb: SupabaseClient,
+  filters: {
+    district?: string;
+    offguide_code: number;
+    criminal_history_category?: string;
+    fy_from: number;
+    fy_to: number;
+  },
+): Promise<FsdRow[]> {
+  let q = sb
+    .from(TABLE)
+    .select(SELECT)
+    .eq("offguide_code", filters.offguide_code)
+    .gte("fy", filters.fy_from)
+    .lte("fy", filters.fy_to);
+  if (isNonEmptyString(filters.district)) {
+    q = q.eq("district", filters.district);
+  }
+  if (isNonEmptyString(filters.criminal_history_category)) {
+    q = q.eq("criminal_history_category", filters.criminal_history_category);
+  }
+  const { data, error } = await q;
+  if (error) {
+    console.error("[fsd-distribution] query error:", error);
+    return [];
+  }
+  return (data ?? []) as FsdRow[];
+}
+
+/**
+ * Bootstrap Monte Carlo sample drawn from a distribution's percentile CDF.
+ * Linear interpolation between p10/p25/p50/p75/p90. Tail below p10 clamped to
+ * p10; tail above p90 clamped to p90 (conservative — don't fabricate extreme
+ * outliers from sparse percentile data).
+ */
+export function monteCarloSample(agg: FsdAggregate, n = 1000): number[] {
+  const { p10_months, p25_months, median_months, p75_months, p90_months } = agg;
+  if (
+    p10_months == null ||
+    p25_months == null ||
+    median_months == null ||
+    p75_months == null ||
+    p90_months == null
+  ) {
+    return [];
+  }
+  // Build piecewise linear CDF: (quantile, value) pairs.
+  const points: Array<{ q: number; v: number }> = [
+    { q: 0.1, v: p10_months },
+    { q: 0.25, v: p25_months },
+    { q: 0.5, v: median_months },
+    { q: 0.75, v: p75_months },
+    { q: 0.9, v: p90_months },
+  ];
+
+  const samples: number[] = [];
+  for (let i = 0; i < n; i++) {
+    const u = Math.random();
+    if (u <= points[0].q) {
+      samples.push(points[0].v);
+      continue;
+    }
+    if (u >= points[points.length - 1].q) {
+      samples.push(points[points.length - 1].v);
+      continue;
+    }
+    // Find bracketing points + linear interp.
+    for (let j = 0; j < points.length - 1; j++) {
+      if (u >= points[j].q && u <= points[j + 1].q) {
+        const span = points[j + 1].q - points[j].q;
+        const frac = span === 0 ? 0 : (u - points[j].q) / span;
+        const v = points[j].v + frac * (points[j + 1].v - points[j].v);
+        samples.push(Number(v.toFixed(2)));
+        break;
+      }
+    }
+  }
+  return samples;
+}
+
+/**
+ * Query the FSD table with progressive widening. Returns district bucket +
+ * national baseline + per-year breakdown + Monte Carlo sample.
+ */
+export async function queryDistribution(
+  sb: SupabaseClient,
+  input: FsdInput,
+): Promise<FsdResponse> {
+  const fy_from = input.fy_from ?? 14;
+  const fy_to = input.fy_to ?? 24;
+  const hasDistrict = isNonEmptyString(input.district);
+  const hasCH = isNonEmptyString(input.criminal_history_category);
+
+  // 1. exact — district + CH + FY range
+  if (hasDistrict && hasCH) {
+    const rows = await runQuery(sb, {
+      district: input.district as string,
+      offguide_code: input.offguide_code,
+      criminal_history_category: input.criminal_history_category,
+      fy_from,
+      fy_to,
+    });
+    if (rows.length > 0) {
+      return buildResponse(sb, rows, "exact", null, input);
+    }
+  }
+
+  // 2. widened_years — district + CH, extend FY range to full FY14-FY24
+  if (hasDistrict && hasCH && (fy_from > 14 || fy_to < 24)) {
+    const rows = await runQuery(sb, {
+      district: input.district as string,
+      offguide_code: input.offguide_code,
+      criminal_history_category: input.criminal_history_category,
+      fy_from: 14,
+      fy_to: 24,
+    });
+    if (rows.length > 0) {
+      return buildResponse(
+        sb,
+        rows,
+        "widened_years",
+        "No data for the requested year range — widened to full FY14-FY24 coverage.",
+        input,
+      );
+    }
+  }
+
+  // 3. widened_criminal_history — drop CH, keep district
+  if (hasDistrict) {
+    const rows = await runQuery(sb, {
+      district: input.district as string,
+      offguide_code: input.offguide_code,
+      fy_from: 14,
+      fy_to: 24,
+    });
+    if (rows.length > 0) {
+      return buildResponse(
+        sb,
+        rows,
+        "widened_criminal_history",
+        "Not enough data for this criminal history category in this district — widened to all categories.",
+        input,
+      );
+    }
+  }
+
+  // 4. widened_district — fall back to national
+  const rowsNational = await runQuery(sb, {
+    offguide_code: input.offguide_code,
+    criminal_history_category: hasCH ? input.criminal_history_category : undefined,
+    fy_from: 14,
+    fy_to: 24,
+  });
+  if (rowsNational.length > 0) {
+    return buildResponse(
+      sb,
+      rowsNational,
+      "widened_district",
+      "Widened to national averages for this offense guideline and criminal history category.",
+      input,
+    );
+  }
+
+  return {
+    match_depth: "insufficient_data",
+    widening_note: "Not enough federal sentencing data for this combination across FY14-FY24.",
+    district_agg: null,
+    national_agg: null,
+    per_year: [],
+    monte_carlo: [],
+    sample_size_caveat: "",
+  };
+}
+
+async function buildResponse(
+  sb: SupabaseClient,
+  districtRows: FsdRow[],
+  match_depth: FsdMatchDepth,
+  widening_note: string | null,
+  input: FsdInput,
+): Promise<FsdResponse> {
+  const district_agg = aggregate(districtRows);
+
+  // National baseline — same offense + CH across all districts, same FY span.
+  const nationalRows = await runQuery(sb, {
+    offguide_code: input.offguide_code,
+    criminal_history_category: isNonEmptyString(input.criminal_history_category)
+      ? input.criminal_history_category
+      : undefined,
+    fy_from: 14,
+    fy_to: 24,
+  });
+  const national_agg = aggregate(nationalRows);
+
+  const per_year = districtRows.slice().sort((a, b) => a.fy - b.fy);
+  const monte_carlo = district_agg ? monteCarloSample(district_agg, 1000) : [];
+  const caveat = district_agg
+    ? `Based on ${district_agg.total_n} cases FY${district_agg.earliest_fy}-FY${district_agg.latest_fy}.`
+    : "";
+
+  return {
+    match_depth,
+    widening_note,
+    district_agg,
+    national_agg,
+    per_year,
+    monte_carlo,
+    sample_size_caveat: caveat,
+  };
+}
+
+/**
+ * Build histogram bins from a Monte Carlo sample. Returns sorted array of
+ * {range_start, range_end, count} tuples. Bin width auto-sizes to Scott's
+ * rule approximated.
+ */
+export function histogram(
+  samples: number[],
+  bins = 20,
+): Array<{ range_start: number; range_end: number; count: number }> {
+  if (samples.length === 0) return [];
+  const sorted = samples.slice().sort((a, b) => a - b);
+  const min = sorted[0];
+  const max = sorted[sorted.length - 1];
+  if (max === min) {
+    return [{ range_start: min, range_end: max, count: samples.length }];
+  }
+  const width = (max - min) / bins;
+  const out = Array.from({ length: bins }, (_, i) => ({
+    range_start: Number((min + i * width).toFixed(2)),
+    range_end: Number((min + (i + 1) * width).toFixed(2)),
+    count: 0,
+  }));
+  for (const s of samples) {
+    // Clamp to last bin on max.
+    const idx = Math.min(bins - 1, Math.floor((s - min) / width));
+    out[idx].count++;
+  }
+  return out;
+}

--- a/src/lib/fsd-offguide.ts
+++ b/src/lib/fsd-offguide.ts
@@ -1,0 +1,128 @@
+/**
+ * @fileoverview INAA chargeType → USSC offguide_code mapping for the
+ * Federal Sentencing Distribution product.
+ *
+ * Source of truth: USSC Primary Sentencing Guideline codes verified against
+ * the `federal_sentencing_distributions` table's offguide_label column (13,131
+ * rows loaded from USSC Individual Offender Datafiles FY14-FY24, 2026-04-21).
+ *
+ * 23 active codes in the current taxonomy:
+ *   1=Admin of Justice, 2=Antitrust, 4=Assault, 5=Bribery/Corruption,
+ *   7=Child Pornography, 8=Commercialized Vice, 9=Drug Possession,
+ *   10=Drug Trafficking, 11=Environmental, 12=Extortion/Racketeering,
+ *   13=Firearms, 15=Forgery/Counter/Copyright, 16=Fraud/Theft/Embezzlement,
+ *   17=Immigration, 20=Manslaughter, 21=Money Laundering, 23=National Defense,
+ *   24=Obscenity/Other Sex Offenses, 25=Prison Offenses, 26=Robbery,
+ *   27=Sex Abuse, 29=Tax, 30=Other.
+ *
+ * NOTE — src/lib/ussc-mappings.ts has several stale mappings from an earlier
+ * matview-occurrence discovery (e.g. drug-trafficking→17 → Immigration). This
+ * file is the corrected mapping for FSD; ussc-mappings.ts is flagged for a
+ * follow-up audit. Do NOT refactor consumers to share mappings until that
+ * audit lands.
+ *
+ * Unmapped slugs return null — callers should widen to all-offense or skip
+ * the matview query entirely. Partial correctness > confident wrongness.
+ */
+
+export const CHARGE_TO_FSD_OFFGUIDE: Record<string, number | null> = {
+  // Drug
+  "drug-trafficking": 10,
+  "drug-possession": 9,
+  "drug": 10, // default to trafficking — most federal drug cases
+
+  // Fraud / white-collar
+  "white-collar": 16, // Fraud/Theft/Embezzlement
+  "fraud": 16,
+  "theft": 16, // bundled in code 16
+  "money-laundering": 21,
+  "tax": 29,
+  "bribery": 5,
+  "antitrust": 2,
+
+  // Firearms / weapons
+  "weapons": 13,
+  "firearms": 13,
+
+  // Sex offenses (distinguished by codebook)
+  "sex-offense": 27, // Sex Abuse — default
+  "sex-offense-contact": 27,
+  "sex-offense-digital": 7, // Child Pornography
+  "child-abuse": 27,
+  "child-pornography": 7,
+
+  // Violence
+  "assault": 4,
+  "domestic-violence": 4,
+  "stalking": 4,
+  "manslaughter": 20,
+  "robbery": 26,
+  "extortion": 12,
+  "racketeering": 12,
+
+  // Immigration
+  "immigration": 17,
+
+  // Administration / justice
+  "contempt": 1,
+  "obstruction": 1,
+  "probation-violation": 25, // Prison Offenses is closest
+  "prison-offense": 25,
+
+  // Environmental / regulatory
+  "environmental": 11,
+
+  // Forgery + IP
+  "forgery": 15,
+  "counterfeiting": 15,
+  "copyright": 15,
+
+  // No confident federal mapping — widen.
+  "murder": null, // capital offense, separately coded or case-specific
+  "kidnapping": null,
+  "arson": null,
+  "burglary": null, // typically state
+  "hit-and-run": null, // state
+  "dui": null,
+  "dui-first": null,
+  "dui-repeat": null,
+  "self-defense": null,
+  "federal": null,
+  "other": null,
+  "other-felony": null,
+  "other-misdemeanor": null,
+};
+
+/**
+ * Look up FSD offguide code (numeric) for an INAA chargeType slug. Returns
+ * null when unmapped — callers should widen to offense_category or skip
+ * district-level bucketing.
+ */
+export function chargeTypeToFsdOffguide(
+  chargeType: string | null | undefined,
+): number | null {
+  if (typeof chargeType !== "string" || chargeType.length === 0) return null;
+  return CHARGE_TO_FSD_OFFGUIDE[chargeType] ?? null;
+}
+
+/**
+ * INAA priorConvictions slug → USSC criminal_history_category (1-6).
+ *   "1" = Category I (0-1 prior criminal history point)
+ *   "2" = Category II (2-3 points)
+ *   "3" = Category III (4-6 points)
+ *   "4" = Category IV (7-9 points)
+ *   "5" = Category V (10-12 points)
+ *   "6" = Category VI (13+ points, includes career offenders)
+ */
+export const PRIORS_TO_CH_CATEGORY: Record<string, string | null> = {
+  none: "1",
+  misdemeanor: "1", // misdemeanors rarely push above Category I
+  felony: "3", // single felony typically 4-6 points → Category III
+  multiple: "5", // multiple felonies → Category V common
+  "dont-know": null, // widen
+};
+
+export function priorsToChCategory(priors: string | null | undefined): string | null {
+  if (typeof priors !== "string" || priors.length === 0) return null;
+  return PRIORS_TO_CH_CATEGORY[priors] ?? null;
+}

--- a/src/lib/products.ts
+++ b/src/lib/products.ts
@@ -1237,6 +1237,30 @@ export const STANDALONE_PRODUCTS: Record<string, StandaloneProduct> = {
     dripSequenceKey: "research_similar_cases",
     isActive: true,
   },
+  "federal-sentencing-distribution": {
+    name: "Federal Sentencing Distribution Report",
+    category: "research",
+    price: 29700, // $297
+    priceDisplay: "$297",
+    delivery: "Instant",
+    deliveryDetail:
+      "Your Federal Sentencing Distribution Report is generated on demand from 13,131 district-level buckets within 60 seconds.",
+    description:
+      "District-specific federal sentencing distribution — percentile ranges (p10/p25/p50/p75/p90), departure rates, Monte Carlo sentence simulation, and national comparison for your charge and criminal history category.",
+    intakeFields: [
+      "chargeType",
+      "state",
+      "district",
+      "priorConvictions",
+      "criminalHistoryCategory",
+    ],
+    stripePriceId: null,
+    upsellTier: "case-decoder",
+    upsellText:
+      "A distribution tells you the range. The Case Decoder tells you where YOU fit inside it.",
+    dripSequenceKey: "research_fsd",
+    isActive: true,
+  },
 
   "district-court-intelligence": {
     name: "District Court Intelligence",

--- a/src/lib/tier9-reports/constants.ts
+++ b/src/lib/tier9-reports/constants.ts
@@ -9,6 +9,7 @@ export const TIER9_SLUGS = new Set([
   "similar-cases-analyzer",
   "district-court-intelligence",
   "arrest-survival-kit",
+  "federal-sentencing-distribution",
 ]);
 
 export function isTier9Slug(slug: string): boolean {

--- a/src/lib/tier9-reports/generate.ts
+++ b/src/lib/tier9-reports/generate.ts
@@ -29,6 +29,7 @@ import {
   renderSimilarCases,
   renderDistrictCourtIntel,
   renderArrestSurvivalKit,
+  renderFederalSentencingDistribution,
   reshapeMatviewRow,
   type UsscDistribution,
 } from "./render";
@@ -39,6 +40,8 @@ import {
   extractPleaTrialSplit,
   computeTrialTaxMonths,
 } from "@/lib/ussc-similar-cases";
+import { queryDistribution, histogram } from "@/lib/fsd-distribution";
+import { chargeTypeToFsdOffguide, priorsToChCategory } from "@/lib/fsd-offguide";
 
 const OPERATOR_EMAIL =
   process.env.OPERATOR_EMAIL || "rahim0kapadia@gmail.com";
@@ -243,6 +246,63 @@ export async function generateTier9Report(
           return;
         }
         html = renderDistrictCourtIntel(data);
+        break;
+      }
+
+      case "federal-sentencing-distribution": {
+        if (!validateIntakeFields(intake, ["chargeType"])) {
+          await notifyOperatorFailure(orderId, slug, "Invalid intake: missing chargeType");
+          return;
+        }
+        const chargeType = intake.chargeType as string;
+        const offguide_code = chargeTypeToFsdOffguide(chargeType);
+        if (offguide_code === null) {
+          // Unmapped charge — no federal sentencing guideline matches.
+          await notifyInsufficientData(order.email, productName, orderId, intake);
+          return;
+        }
+        const districtCode =
+          typeof intake.district === "string" && intake.district.length > 0
+            ? intake.district
+            : null;
+        const chFromIntake =
+          typeof intake.criminalHistoryCategory === "string" &&
+          intake.criminalHistoryCategory.length > 0
+            ? intake.criminalHistoryCategory
+            : priorsToChCategory(
+                typeof intake.priorConvictions === "string"
+                  ? intake.priorConvictions
+                  : null,
+              );
+        const sb = createAdminClient();
+        const [fsd, districtDisplay] = await Promise.all([
+          queryDistribution(sb, {
+            district: districtCode,
+            offguide_code,
+            criminal_history_category: chFromIntake ?? "",
+            fy_from: 14,
+            fy_to: 24,
+          }),
+          queryDistrictDisplay(sb, districtCode),
+        ]);
+        if (fsd.match_depth === "insufficient_data" || !fsd.district_agg) {
+          await notifyInsufficientData(order.email, productName, orderId, intake);
+          return;
+        }
+        const hist = histogram(fsd.monte_carlo, 20);
+        html = renderFederalSentencingDistribution({
+          chargeType,
+          districtDisplay,
+          match_depth: fsd.match_depth,
+          widening_note: fsd.widening_note,
+          sample_size_caveat: fsd.sample_size_caveat,
+          district_agg: fsd.district_agg,
+          national_agg: fsd.national_agg,
+          per_year: fsd.per_year,
+          monte_carlo: fsd.monte_carlo,
+          histogram: hist,
+          criminalHistoryCategory: chFromIntake,
+        });
         break;
       }
 

--- a/src/lib/tier9-reports/render.ts
+++ b/src/lib/tier9-reports/render.ts
@@ -1058,6 +1058,262 @@ function renderUsscDistribution(ussc: UsscDistribution): string {
 }
 
 // ============================================================
+// FEDERAL SENTENCING DISTRIBUTION REPORT ($297 standalone)
+// ============================================================
+
+interface FsdReportInput {
+  chargeType: string;
+  districtDisplay: {
+    district_code: string;
+    short_name: string;
+    district_name: string;
+    state_code: string | null;
+    circuit: string;
+  } | null;
+  match_depth:
+    | "exact"
+    | "widened_years"
+    | "widened_criminal_history"
+    | "widened_district"
+    | "insufficient_data";
+  widening_note: string | null;
+  sample_size_caveat: string;
+  district_agg: {
+    total_n: number;
+    mean_months: number | null;
+    median_months: number | null;
+    p10_months: number | null;
+    p25_months: number | null;
+    p75_months: number | null;
+    p90_months: number | null;
+    downward_departure_rate: number | null;
+    upward_departure_rate: number | null;
+    probation_rate: number | null;
+    earliest_fy: number;
+    latest_fy: number;
+    offguide_label: string;
+    offense_category: string;
+  };
+  national_agg: FsdReportInput["district_agg"] | null;
+  per_year: Array<{ fy: number; n: number; mean_months: number | null; median_months: number | null }>;
+  monte_carlo: number[];
+  histogram: Array<{ range_start: number; range_end: number; count: number }>;
+  criminalHistoryCategory: string | null;
+}
+
+export function renderFederalSentencingDistribution(data: FsdReportInput): string {
+  const { district_agg, national_agg, districtDisplay } = data;
+  let body = "";
+  const totalSources = 1; // USSC datafile is one source
+
+  // Local formatters — richer than the module-level fmtMonths/fmtPct used by
+  // other Tier 9 renderers. Inline because only this renderer needs the yr
+  // conversion + "Probation" sentinel.
+  const fmtMonths = (v: number | null): string => {
+    if (v == null) return "—";
+    const m = Number(v);
+    if (m <= 0) return "Probation";
+    if (m < 12) return `${m.toFixed(1)} mo`;
+    return `${m.toFixed(1)} mo (≈${(m / 12).toFixed(1)} yr)`;
+  };
+  const fmtPct = (v: number | null): string => {
+    if (v == null) return "—";
+    return `${(Number(v) * 100).toFixed(1)}%`;
+  };
+
+  // Header context
+  const districtLabel = districtDisplay
+    ? `${escapeHtml(districtDisplay.short_name)} (${escapeHtml(districtDisplay.circuit)} Circuit${districtDisplay.state_code ? " · " + escapeHtml(districtDisplay.state_code) : ""})`
+    : "All federal districts (national)";
+  const chLabel = data.criminalHistoryCategory
+    ? `Category ${escapeHtml(data.criminalHistoryCategory)}`
+    : "All criminal history categories";
+
+  body += `<p style="color: #D4D4D8; font-size: 15px; margin-bottom: 8px;">
+    <strong style="color: #FAFAF9;">${escapeHtml(district_agg.offguide_label)}</strong>
+    &middot; ${districtLabel}
+    &middot; ${chLabel}
+  </p>
+  <p style="color: #A1A1AA; font-size: 13px; margin-bottom: 20px;">
+    ${escapeHtml(data.sample_size_caveat)}
+  </p>`;
+
+  if (data.widening_note) {
+    body += `<p style="color: #78716C; font-size: 12px; margin-bottom: 16px; font-style: italic;">
+      ${escapeHtml(data.widening_note)}
+    </p>`;
+  }
+
+  // Distribution table (percentiles)
+  body += sectionHeader("Sentence Distribution");
+  body += `<p style="color: #A1A1AA; font-size: 13px; margin-bottom: 12px;">
+    How sentences spread across the ${district_agg.total_n.toLocaleString()} historical cases in this bucket.
+    The <strong style="color: #FAFAF9;">50th percentile (median)</strong> is the center point;
+    the 10th and 90th are the tails.
+  </p>`;
+
+  body += `<table style="width: 100%; border-collapse: collapse; margin-bottom: 24px;">
+    <thead><tr style="background: #1C1917;">
+      <th style="padding: 10px 12px; text-align: left; color: #F59E0B; font-size: 13px;">Percentile</th>
+      <th style="padding: 10px 12px; text-align: right; color: #F59E0B; font-size: 13px;">Sentence</th>
+      <th style="padding: 10px 12px; text-align: left; color: #F59E0B; font-size: 13px;">Interpretation</th>
+    </tr></thead><tbody>
+    <tr style="border-bottom: 1px solid #1C1917;">
+      <td style="padding: 8px 12px; color: #D4D4D8;">10th percentile</td>
+      <td style="padding: 8px 12px; color: #22C55E; text-align: right; font-weight: 600;">${fmtMonths(district_agg.p10_months)}</td>
+      <td style="padding: 8px 12px; color: #A1A1AA; font-size: 12px;">10% of cases got this sentence or less</td>
+    </tr>
+    <tr style="border-bottom: 1px solid #1C1917;">
+      <td style="padding: 8px 12px; color: #D4D4D8;">25th percentile</td>
+      <td style="padding: 8px 12px; color: #4ADE80; text-align: right;">${fmtMonths(district_agg.p25_months)}</td>
+      <td style="padding: 8px 12px; color: #A1A1AA; font-size: 12px;">Lower quarter of cases</td>
+    </tr>
+    <tr style="border-bottom: 1px solid #1C1917;">
+      <td style="padding: 8px 12px; color: #FAFAF9; font-weight: 600;">Median (50th)</td>
+      <td style="padding: 8px 12px; color: #FAFAF9; text-align: right; font-weight: 700;">${fmtMonths(district_agg.median_months)}</td>
+      <td style="padding: 8px 12px; color: #D4D4D8; font-size: 12px;">Middle case — 50% got more, 50% got less</td>
+    </tr>
+    <tr style="border-bottom: 1px solid #1C1917;">
+      <td style="padding: 8px 12px; color: #D4D4D8;">75th percentile</td>
+      <td style="padding: 8px 12px; color: #F87171; text-align: right;">${fmtMonths(district_agg.p75_months)}</td>
+      <td style="padding: 8px 12px; color: #A1A1AA; font-size: 12px;">Upper quarter of cases</td>
+    </tr>
+    <tr>
+      <td style="padding: 8px 12px; color: #D4D4D8;">90th percentile</td>
+      <td style="padding: 8px 12px; color: #EF4444; text-align: right; font-weight: 600;">${fmtMonths(district_agg.p90_months)}</td>
+      <td style="padding: 8px 12px; color: #A1A1AA; font-size: 12px;">Top 10% — severe outcomes</td>
+    </tr>
+  </tbody></table>`;
+
+  // Monte Carlo histogram
+  if (data.histogram.length > 0) {
+    body += sectionHeader("Monte Carlo Simulation (1,000 outcomes)");
+    body += `<p style="color: #A1A1AA; font-size: 13px; margin-bottom: 12px;">
+      1,000 synthetic outcomes drawn from the percentile distribution above.
+      Bars show how frequently each sentence range appeared.
+    </p>`;
+    const maxCount = Math.max(...data.histogram.map((h) => h.count));
+    body += `<table style="width: 100%; border-collapse: collapse; margin-bottom: 24px; font-family: monospace; font-size: 12px;">`;
+    for (const bin of data.histogram) {
+      const pct = maxCount === 0 ? 0 : (bin.count / maxCount) * 100;
+      const rangeLabel = `${bin.range_start.toFixed(0)}-${bin.range_end.toFixed(0)} mo`;
+      body += `<tr>
+        <td style="padding: 2px 8px; color: #A1A1AA; text-align: right; width: 100px;">${escapeHtml(rangeLabel)}</td>
+        <td style="padding: 2px 0;">
+          <div style="background: #F59E0B; height: 14px; width: ${pct.toFixed(1)}%;"></div>
+        </td>
+        <td style="padding: 2px 8px; color: #78716C; width: 60px;">${bin.count}</td>
+      </tr>`;
+    }
+    body += `</table>`;
+  }
+
+  // Departure rates
+  body += sectionHeader("Departure Rates");
+  body += `<p style="color: #A1A1AA; font-size: 13px; margin-bottom: 12px;">
+    How often judges in this bucket departed from the guideline sentence.
+  </p>
+  <table style="width: 100%; border-collapse: collapse; margin-bottom: 24px;">
+    <thead><tr style="background: #1C1917;">
+      <th style="padding: 10px 12px; text-align: left; color: #F59E0B; font-size: 13px;">Departure type</th>
+      <th style="padding: 10px 12px; text-align: right; color: #F59E0B; font-size: 13px;">Rate</th>
+      <th style="padding: 10px 12px; text-align: left; color: #F59E0B; font-size: 13px;">Meaning</th>
+    </tr></thead><tbody>
+    <tr style="border-bottom: 1px solid #1C1917;">
+      <td style="padding: 8px 12px; color: #22C55E;">Downward departure</td>
+      <td style="padding: 8px 12px; color: #22C55E; text-align: right; font-weight: 600;">${fmtPct(district_agg.downward_departure_rate)}</td>
+      <td style="padding: 8px 12px; color: #A1A1AA; font-size: 12px;">Judge sentenced below the guideline</td>
+    </tr>
+    <tr style="border-bottom: 1px solid #1C1917;">
+      <td style="padding: 8px 12px; color: #EF4444;">Upward departure</td>
+      <td style="padding: 8px 12px; color: #EF4444; text-align: right; font-weight: 600;">${fmtPct(district_agg.upward_departure_rate)}</td>
+      <td style="padding: 8px 12px; color: #A1A1AA; font-size: 12px;">Judge sentenced above the guideline</td>
+    </tr>
+    <tr>
+      <td style="padding: 8px 12px; color: #4ADE80;">Probation only</td>
+      <td style="padding: 8px 12px; color: #4ADE80; text-align: right; font-weight: 600;">${fmtPct(district_agg.probation_rate)}</td>
+      <td style="padding: 8px 12px; color: #A1A1AA; font-size: 12px;">No prison time — probation sentence</td>
+    </tr>
+  </tbody></table>`;
+
+  // National comparison
+  if (national_agg && districtDisplay) {
+    body += sectionHeader("National Comparison");
+    body += `<p style="color: #A1A1AA; font-size: 13px; margin-bottom: 12px;">
+      How this district compares to national averages for the same offense + criminal history.
+    </p>
+    <table style="width: 100%; border-collapse: collapse; margin-bottom: 24px;">
+      <thead><tr style="background: #1C1917;">
+        <th style="padding: 10px 12px; text-align: left; color: #F59E0B; font-size: 13px;">Metric</th>
+        <th style="padding: 10px 12px; text-align: right; color: #F59E0B; font-size: 13px;">${escapeHtml(districtDisplay.short_name)}</th>
+        <th style="padding: 10px 12px; text-align: right; color: #F59E0B; font-size: 13px;">National</th>
+      </tr></thead><tbody>
+      <tr style="border-bottom: 1px solid #1C1917;">
+        <td style="padding: 8px 12px; color: #D4D4D8;">Median sentence</td>
+        <td style="padding: 8px 12px; color: #FAFAF9; text-align: right; font-weight: 600;">${fmtMonths(district_agg.median_months)}</td>
+        <td style="padding: 8px 12px; color: #A1A1AA; text-align: right;">${fmtMonths(national_agg.median_months)}</td>
+      </tr>
+      <tr style="border-bottom: 1px solid #1C1917;">
+        <td style="padding: 8px 12px; color: #D4D4D8;">Mean sentence</td>
+        <td style="padding: 8px 12px; color: #D4D4D8; text-align: right;">${fmtMonths(district_agg.mean_months)}</td>
+        <td style="padding: 8px 12px; color: #A1A1AA; text-align: right;">${fmtMonths(national_agg.mean_months)}</td>
+      </tr>
+      <tr style="border-bottom: 1px solid #1C1917;">
+        <td style="padding: 8px 12px; color: #D4D4D8;">Downward departure rate</td>
+        <td style="padding: 8px 12px; color: #22C55E; text-align: right;">${fmtPct(district_agg.downward_departure_rate)}</td>
+        <td style="padding: 8px 12px; color: #A1A1AA; text-align: right;">${fmtPct(national_agg.downward_departure_rate)}</td>
+      </tr>
+      <tr>
+        <td style="padding: 8px 12px; color: #D4D4D8;">Probation rate</td>
+        <td style="padding: 8px 12px; color: #4ADE80; text-align: right;">${fmtPct(district_agg.probation_rate)}</td>
+        <td style="padding: 8px 12px; color: #A1A1AA; text-align: right;">${fmtPct(national_agg.probation_rate)}</td>
+      </tr>
+    </tbody></table>`;
+  }
+
+  // Per-year trend
+  if (data.per_year.length > 1) {
+    body += sectionHeader("Per-Fiscal-Year Trend");
+    body += `<table style="width: 100%; border-collapse: collapse; margin-bottom: 24px;">
+      <thead><tr style="background: #1C1917;">
+        <th style="padding: 10px 12px; text-align: left; color: #F59E0B; font-size: 13px;">Fiscal year</th>
+        <th style="padding: 10px 12px; text-align: right; color: #F59E0B; font-size: 13px;">Cases</th>
+        <th style="padding: 10px 12px; text-align: right; color: #F59E0B; font-size: 13px;">Median</th>
+        <th style="padding: 10px 12px; text-align: right; color: #F59E0B; font-size: 13px;">Mean</th>
+      </tr></thead><tbody>`;
+    for (const y of data.per_year) {
+      body += `<tr style="border-bottom: 1px solid #1C1917;">
+        <td style="padding: 6px 12px; color: #D4D4D8;">FY20${y.fy}</td>
+        <td style="padding: 6px 12px; color: #A1A1AA; text-align: right;">${y.n}</td>
+        <td style="padding: 6px 12px; color: #FAFAF9; text-align: right;">${fmtMonths(y.median_months)}</td>
+        <td style="padding: 6px 12px; color: #D4D4D8; text-align: right;">${fmtMonths(y.mean_months)}</td>
+      </tr>`;
+    }
+    body += `</tbody></table>`;
+  }
+
+  // Attorney question prompt (UPL-safe)
+  body += `<div style="background: #1C1917; border-left: 4px solid #F59E0B; padding: 16px 20px; margin-bottom: 24px; border-radius: 4px;">
+    <p style="color: #FAFAF9; font-weight: 600; margin: 0 0 8px;">Questions to bring to your attorney</p>
+    <ul style="color: #D4D4D8; font-size: 13px; margin: 0; padding-left: 20px;">
+      <li style="margin-bottom: 6px;">&ldquo;Given this distribution, what case-specific facts might position me at the lower percentiles?&rdquo;</li>
+      <li style="margin-bottom: 6px;">&ldquo;How does the downward departure rate in this district compare to the national rate, and what grounds qualify?&rdquo;</li>
+      <li>&ldquo;Is probation realistic given the ${fmtPct(district_agg.probation_rate)} probation rate in this bucket?&rdquo;</li>
+    </ul>
+  </div>`;
+
+  body += `<p style="color: #71717A; font-size: 12px; margin: 0 0 24px;">
+    Source: U.S. Sentencing Commission Individual Offender Datafiles, FY2014-FY2024 (13,131 district-level buckets).
+    <a href="https://www.ussc.gov/research/datafiles/commission-datafiles" style="color: #F59E0B;">[source]</a>
+  </p>`;
+
+  const title = districtDisplay
+    ? `Federal Sentencing Distribution, ${district_agg.offguide_label} in ${districtDisplay.short_name}`
+    : `Federal Sentencing Distribution, ${district_agg.offguide_label} (National)`;
+  return wrapReport(title, body, totalSources);
+}
+
+// ============================================================
 // DISTRICT COURT INTELLIGENCE
 // ============================================================
 

--- a/tests/api/federal-sentencing-distribution.test.ts
+++ b/tests/api/federal-sentencing-distribution.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Integration tests for POST /api/tools/federal-sentencing-distribution.
+ *
+ * Covers:
+ *   - Valid request returns distribution + monte_carlo + histogram + district_display
+ *   - Unmapped charge type returns 400
+ *   - Missing district falls back to national (match_depth="widened_district")
+ *   - Rate limit 429
+ *   - Validation errors 400
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const fsdRow = {
+  fy: 22,
+  district: "42",
+  circdist: "36",
+  offguide_code: 10,
+  offguide_label: "Drug Trafficking",
+  offense_category: "drug",
+  criminal_history_category: "3",
+  n: 150,
+  mean_months: 48.5,
+  median_months: 36,
+  p10_months: 12,
+  p25_months: 24,
+  p75_months: 72,
+  p90_months: 120,
+  downward_departure_rate: 0.15,
+  upward_departure_rate: 0.02,
+  probation_rate: 0.05,
+};
+
+vi.mock("next/server", async () => {
+  const actual = await vi.importActual<typeof import("next/server")>("next/server");
+  return { ...actual, after: (cb: () => Promise<void> | void) => { void cb(); } };
+});
+
+let fsdRowsForExactBucket: unknown[] = [];
+let fsdRowsForNationalFallback: unknown[] = [];
+let districtLookupRow: unknown | null = null;
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: () => ({
+    from: (table: string) => {
+      let hasDistrictFilter = false;
+      const chain = {
+        select: () => chain,
+        eq(col: string) {
+          if (col === "district") hasDistrictFilter = true;
+          return chain;
+        },
+        gte: () => chain,
+        lte: () => chain,
+        maybeSingle: () => {
+          if (table !== "ussc_districts") {
+            throw new Error(`[test-mock] Unexpected maybeSingle() on '${table}'`);
+          }
+          return Promise.resolve({ data: districtLookupRow, error: null });
+        },
+        then(resolve: (r: { data: unknown[]; error: null }) => void) {
+          if (table === "federal_sentencing_distributions") {
+            resolve({
+              data: hasDistrictFilter ? fsdRowsForExactBucket : fsdRowsForNationalFallback,
+              error: null,
+            });
+          } else {
+            resolve({ data: [], error: null });
+          }
+        },
+      };
+      return chain;
+    },
+    rpc: () => ({
+      then: (resolve: (r: { error: null }) => void) => resolve({ error: null }),
+    }),
+  }),
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  checkRateLimit: vi.fn(async () => ({ limited: false })),
+}));
+
+import { POST } from "@/app/api/tools/federal-sentencing-distribution/route";
+import { NextRequest } from "next/server";
+
+function buildReq(body: Record<string, unknown>): NextRequest {
+  return new NextRequest("http://localhost/api/tools/federal-sentencing-distribution", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "x-real-ip": "1.2.3.4" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  fsdRowsForExactBucket = [];
+  fsdRowsForNationalFallback = [];
+  districtLookupRow = null;
+});
+
+describe("POST /api/tools/federal-sentencing-distribution", () => {
+  it("returns distribution + monte_carlo + histogram + district_display for a valid request", async () => {
+    fsdRowsForExactBucket = [fsdRow];
+    fsdRowsForNationalFallback = [{ ...fsdRow, district: "0", n: 5000 }];
+    districtLookupRow = {
+      district_code: "42",
+      short_name: "W.D. Texas",
+      district_name: "Western District of Texas",
+      state_code: "TX",
+      circuit: "5th",
+    };
+    const res = await POST(
+      buildReq({
+        chargeType: "drug-trafficking",
+        district: "42",
+        criminalHistoryCategory: "3",
+      }),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.result.match_depth).toBe("exact");
+    expect(body.result.district_agg.total_n).toBe(150);
+    expect(body.result.district_agg.offguide_label).toBe("Drug Trafficking");
+    expect(body.result.monte_carlo).toHaveLength(1000);
+    expect(body.result.histogram.length).toBeGreaterThan(0);
+    expect(body.result.district_display.short_name).toBe("W.D. Texas");
+    expect(body.result.national_agg.total_n).toBe(5000);
+    expect(body.result.federalOnly).toBe(true);
+    // UPL-safe — no banned phrases in response.
+    const text = JSON.stringify(body);
+    expect(text).not.toMatch(/\byou should\b/i);
+    expect(text).not.toMatch(/\bwe recommend\b/i);
+    expect(text).not.toMatch(/\bwe advise\b/i);
+  });
+
+  it("returns 400 for unmapped chargeType (e.g. dui is state-only)", async () => {
+    const res = await POST(
+      buildReq({
+        chargeType: "dui",
+        district: "42",
+        criminalHistoryCategory: "3",
+      }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/insufficient data/i);
+  });
+
+  it("derives criminalHistoryCategory from priorConvictions when explicit not supplied", async () => {
+    fsdRowsForExactBucket = [fsdRow];
+    const res = await POST(
+      buildReq({
+        chargeType: "drug-trafficking",
+        district: "42",
+        priorConvictions: "felony", // maps to category "3"
+      }),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.result.input.criminalHistoryCategory).toBe("3");
+  });
+
+  it("falls back to national averages when the district has no data", async () => {
+    // Exact + widened_criminal_history both miss — only national fallback hits.
+    fsdRowsForExactBucket = [];
+    fsdRowsForNationalFallback = [{ ...fsdRow, district: "0" }];
+    const res = await POST(
+      buildReq({
+        chargeType: "drug-trafficking",
+        district: "99", // unknown district
+        criminalHistoryCategory: "3",
+      }),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.result.match_depth).toBe("widened_district");
+  });
+
+  it("rejects missing chargeType with 400", async () => {
+    const res = await POST(buildReq({ district: "42" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects invalid fyFrom/fyTo with 400", async () => {
+    const res = await POST(
+      buildReq({
+        chargeType: "drug-trafficking",
+        fyFrom: 10, // out of range
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 429 when rate-limited", async () => {
+    const { checkRateLimit } = await import("@/lib/rate-limit");
+    (checkRateLimit as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ limited: true });
+    const res = await POST(buildReq({ chargeType: "drug-trafficking" }));
+    expect(res.status).toBe(429);
+  });
+});

--- a/tests/lib/fsd-distribution.test.ts
+++ b/tests/lib/fsd-distribution.test.ts
@@ -1,0 +1,243 @@
+/**
+ * Unit tests for src/lib/fsd-distribution.ts — the shared query library
+ * for the $297 Federal Sentencing Distribution Report.
+ *
+ * Covers:
+ *   - queryDistribution progressive widening (exact → widened_years →
+ *     widened_criminal_history → widened_district → insufficient_data)
+ *   - monteCarloSample draws 1000 samples within the p10/p90 envelope
+ *   - histogram bins samples correctly (min/max clamped, bin widths
+ *     equal except possibly last)
+ */
+import { describe, it, expect } from "vitest";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import {
+  queryDistribution,
+  monteCarloSample,
+  histogram,
+  type FsdRow,
+  type FsdAggregate,
+} from "@/lib/fsd-distribution";
+
+const sampleRow = (overrides: Partial<FsdRow> = {}): FsdRow => ({
+  fy: 22,
+  district: "42",
+  circdist: "36",
+  offguide_code: 10,
+  offguide_label: "Drug Trafficking",
+  offense_category: "drug",
+  criminal_history_category: "3",
+  n: 50,
+  mean_months: 48.5,
+  median_months: 36,
+  p10_months: 12,
+  p25_months: 24,
+  p75_months: 72,
+  p90_months: 120,
+  downward_departure_rate: 0.15,
+  upward_departure_rate: 0.02,
+  probation_rate: 0.05,
+  ...overrides,
+});
+
+type QueryFilters = {
+  offguide_code: number;
+  criminal_history_category?: string;
+  district?: string;
+  fy_from: number;
+  fy_to: number;
+};
+
+function filterKey(f: QueryFilters): string {
+  // Sorted key so test fixtures are stable.
+  const parts: string[] = [];
+  parts.push(`offguide=${f.offguide_code}`);
+  if (f.district) parts.push(`district=${f.district}`);
+  if (f.criminal_history_category) parts.push(`ch=${f.criminal_history_category}`);
+  parts.push(`fy=${f.fy_from}-${f.fy_to}`);
+  return parts.sort().join("|");
+}
+
+function mockSupabase(rowsByKey: Record<string, FsdRow[]>): SupabaseClient {
+  return {
+    from: () => {
+      const state: QueryFilters = { offguide_code: 0, fy_from: 14, fy_to: 24 };
+      const chain = {
+        select: () => chain,
+        eq(col: string, val: string | number) {
+          if (col === "offguide_code") state.offguide_code = Number(val);
+          else if (col === "district") state.district = String(val);
+          else if (col === "criminal_history_category") state.criminal_history_category = String(val);
+          return chain;
+        },
+        gte(col: string, val: number) {
+          if (col === "fy") state.fy_from = Number(val);
+          return chain;
+        },
+        lte(col: string, val: number) {
+          if (col === "fy") state.fy_to = Number(val);
+          return chain;
+        },
+        then(resolve: (r: { data: FsdRow[]; error: null }) => void) {
+          resolve({ data: rowsByKey[filterKey(state)] ?? [], error: null });
+        },
+      };
+      return chain as unknown as ReturnType<SupabaseClient["from"]>;
+    },
+  } as unknown as SupabaseClient;
+}
+
+describe("queryDistribution — progressive widening", () => {
+  it("returns exact match when district + CH bucket has data", async () => {
+    const row = sampleRow();
+    const sb = mockSupabase({
+      [filterKey({ offguide_code: 10, district: "42", criminal_history_category: "3", fy_from: 14, fy_to: 24 })]: [row],
+    });
+    const r = await queryDistribution(sb, {
+      district: "42",
+      offguide_code: 10,
+      criminal_history_category: "3",
+    });
+    expect(r.match_depth).toBe("exact");
+    expect(r.district_agg?.total_n).toBe(50);
+    expect(r.district_agg?.median_months).toBe(36);
+    expect(r.widening_note).toBeNull();
+    expect(r.sample_size_caveat).toMatch(/Based on 50 cases FY22-FY22/);
+  });
+
+  it("widens to widened_criminal_history when district has data but CH misses", async () => {
+    const row = sampleRow();
+    const sb = mockSupabase({
+      // exact + widened_years both miss — only district-wide hits.
+      [filterKey({ offguide_code: 10, district: "42", fy_from: 14, fy_to: 24 })]: [row],
+    });
+    const r = await queryDistribution(sb, {
+      district: "42",
+      offguide_code: 10,
+      criminal_history_category: "6",
+    });
+    expect(r.match_depth).toBe("widened_criminal_history");
+    expect(r.widening_note).toMatch(/criminal history/i);
+  });
+
+  it("widens to widened_district when everything else misses", async () => {
+    const row = sampleRow({ district: "0" });
+    // National fallback carries criminal_history_category when supplied, so
+    // the fixture key includes ch=3 to match the queryDistribution call.
+    const sb = mockSupabase({
+      [filterKey({ offguide_code: 10, criminal_history_category: "3", fy_from: 14, fy_to: 24 })]: [row],
+    });
+    const r = await queryDistribution(sb, {
+      district: "99",
+      offguide_code: 10,
+      criminal_history_category: "3",
+    });
+    expect(r.match_depth).toBe("widened_district");
+    expect(r.widening_note).toMatch(/national/i);
+  });
+
+  it("returns insufficient_data when nothing matches at any tier", async () => {
+    const sb = mockSupabase({});
+    const r = await queryDistribution(sb, {
+      district: "42",
+      offguide_code: 99,
+      criminal_history_category: "3",
+    });
+    expect(r.match_depth).toBe("insufficient_data");
+    expect(r.district_agg).toBeNull();
+    expect(r.monte_carlo).toEqual([]);
+  });
+
+  it("aggregates multiple rows (different FYs) via weighted mean", async () => {
+    const rows = [
+      sampleRow({ fy: 22, n: 100, median_months: 30 }),
+      sampleRow({ fy: 23, n: 200, median_months: 60 }),
+    ];
+    const sb = mockSupabase({
+      [filterKey({ offguide_code: 10, district: "42", criminal_history_category: "3", fy_from: 14, fy_to: 24 })]: rows,
+    });
+    const r = await queryDistribution(sb, {
+      district: "42",
+      offguide_code: 10,
+      criminal_history_category: "3",
+    });
+    expect(r.district_agg?.total_n).toBe(300);
+    // Weighted mean of 30*100 + 60*200 = 15000 / 300 = 50.
+    expect(r.district_agg?.median_months).toBeCloseTo(50, 1);
+    expect(r.per_year).toHaveLength(2);
+    expect(r.per_year[0].fy).toBe(22);
+    expect(r.per_year[1].fy).toBe(23);
+  });
+});
+
+describe("monteCarloSample", () => {
+  const agg: FsdAggregate = {
+    total_n: 100,
+    mean_months: 50,
+    median_months: 40,
+    p10_months: 10,
+    p25_months: 20,
+    p75_months: 80,
+    p90_months: 120,
+    downward_departure_rate: 0.2,
+    upward_departure_rate: 0.05,
+    probation_rate: 0.1,
+    earliest_fy: 20,
+    latest_fy: 24,
+    offguide_label: "Drug Trafficking",
+    offense_category: "drug",
+  };
+
+  it("draws exactly n samples", () => {
+    const out = monteCarloSample(agg, 1000);
+    expect(out).toHaveLength(1000);
+  });
+
+  it("all samples are within p10..p90 envelope (CDF is clamped)", () => {
+    const out = monteCarloSample(agg, 1000);
+    for (const v of out) {
+      expect(v).toBeGreaterThanOrEqual(10);
+      expect(v).toBeLessThanOrEqual(120);
+    }
+  });
+
+  it("empirical median is near the theoretical median (statistical smoke test)", () => {
+    const out = monteCarloSample(agg, 2000);
+    const sorted = out.slice().sort((a, b) => a - b);
+    const empMedian = sorted[Math.floor(sorted.length / 2)];
+    // Piecewise linear CDF at q=0.5 returns the configured median (40).
+    expect(empMedian).toBeGreaterThan(30);
+    expect(empMedian).toBeLessThan(55);
+  });
+
+  it("returns empty when any percentile is null (can't interpolate)", () => {
+    const bad = { ...agg, p10_months: null };
+    expect(monteCarloSample(bad, 100)).toEqual([]);
+  });
+});
+
+describe("histogram", () => {
+  it("returns empty for empty samples", () => {
+    expect(histogram([])).toEqual([]);
+  });
+
+  it("groups samples into 20 bins by default (counts sum to input size)", () => {
+    const samples = Array.from({ length: 1000 }, () => Math.random() * 100);
+    const bins = histogram(samples);
+    expect(bins).toHaveLength(20);
+    const total = bins.reduce((s, b) => s + b.count, 0);
+    expect(total).toBe(1000);
+  });
+
+  it("handles single-value input as one bin", () => {
+    const bins = histogram([7, 7, 7, 7]);
+    expect(bins).toHaveLength(1);
+    expect(bins[0].count).toBe(4);
+  });
+
+  it("respects the bins argument", () => {
+    const samples = Array.from({ length: 100 }, (_, i) => i);
+    const bins = histogram(samples, 10);
+    expect(bins).toHaveLength(10);
+  });
+});

--- a/tests/lib/fsd-offguide.test.ts
+++ b/tests/lib/fsd-offguide.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Unit tests for src/lib/fsd-offguide.ts — chargeType → USSC offguide_code
+ * mapping for FSD. Source of truth is USSC's offguide_label column in the
+ * federal_sentencing_distributions table.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  chargeTypeToFsdOffguide,
+  priorsToChCategory,
+} from "@/lib/fsd-offguide";
+
+describe("chargeTypeToFsdOffguide", () => {
+  it("maps drug offenses to the correct FSD codes (not the stale matview ones)", () => {
+    // Source of truth: offguide_code=10 is Drug Trafficking, 9 is Drug Possession.
+    expect(chargeTypeToFsdOffguide("drug-trafficking")).toBe(10);
+    expect(chargeTypeToFsdOffguide("drug-possession")).toBe(9);
+    expect(chargeTypeToFsdOffguide("drug")).toBe(10);
+  });
+
+  it("maps white-collar / fraud to code 16 (Fraud/Theft/Embezzlement)", () => {
+    expect(chargeTypeToFsdOffguide("white-collar")).toBe(16);
+    expect(chargeTypeToFsdOffguide("fraud")).toBe(16);
+    expect(chargeTypeToFsdOffguide("theft")).toBe(16);
+  });
+
+  it("maps firearms/weapons to code 13 (Firearms) — NOT 16", () => {
+    expect(chargeTypeToFsdOffguide("weapons")).toBe(13);
+    expect(chargeTypeToFsdOffguide("firearms")).toBe(13);
+  });
+
+  it("maps sex-offense to code 27 (Sex Abuse) — not 26 (which is Robbery)", () => {
+    expect(chargeTypeToFsdOffguide("sex-offense")).toBe(27);
+    expect(chargeTypeToFsdOffguide("sex-offense-contact")).toBe(27);
+    expect(chargeTypeToFsdOffguide("sex-offense-digital")).toBe(7); // Child Porn
+    expect(chargeTypeToFsdOffguide("child-abuse")).toBe(27);
+  });
+
+  it("maps violence-adjacent slugs", () => {
+    expect(chargeTypeToFsdOffguide("assault")).toBe(4);
+    expect(chargeTypeToFsdOffguide("domestic-violence")).toBe(4);
+    expect(chargeTypeToFsdOffguide("robbery")).toBe(26);
+    expect(chargeTypeToFsdOffguide("manslaughter")).toBe(20);
+  });
+
+  it("returns null for slugs without a confident federal mapping", () => {
+    expect(chargeTypeToFsdOffguide("murder")).toBeNull();
+    expect(chargeTypeToFsdOffguide("kidnapping")).toBeNull();
+    expect(chargeTypeToFsdOffguide("arson")).toBeNull();
+    expect(chargeTypeToFsdOffguide("burglary")).toBeNull();
+    expect(chargeTypeToFsdOffguide("dui")).toBeNull();
+    expect(chargeTypeToFsdOffguide("dui-first")).toBeNull();
+    expect(chargeTypeToFsdOffguide("other")).toBeNull();
+    expect(chargeTypeToFsdOffguide("federal")).toBeNull();
+  });
+
+  it("returns null for null / undefined / empty / unknown slugs", () => {
+    expect(chargeTypeToFsdOffguide(null)).toBeNull();
+    expect(chargeTypeToFsdOffguide(undefined)).toBeNull();
+    expect(chargeTypeToFsdOffguide("")).toBeNull();
+    expect(chargeTypeToFsdOffguide("entirely-made-up-slug")).toBeNull();
+  });
+});
+
+describe("priorsToChCategory", () => {
+  it("maps known priors values to USSC categories", () => {
+    expect(priorsToChCategory("none")).toBe("1");
+    expect(priorsToChCategory("misdemeanor")).toBe("1");
+    expect(priorsToChCategory("felony")).toBe("3");
+    expect(priorsToChCategory("multiple")).toBe("5");
+  });
+
+  it("returns null for 'dont-know' (widen in matview)", () => {
+    expect(priorsToChCategory("dont-know")).toBeNull();
+  });
+
+  it("returns null for unknown / empty inputs", () => {
+    expect(priorsToChCategory(null)).toBeNull();
+    expect(priorsToChCategory(undefined)).toBeNull();
+    expect(priorsToChCategory("")).toBeNull();
+    expect(priorsToChCategory("invalid-slug")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
New Tier 9 data-driven product: bucket-specific federal sentencing distribution with Monte Carlo simulation, departure rates, national comparison, and per-year trends. Unblocks priority #3 from the USSC session handoff.

## What it does
Given (chargeType + optional district + criminal history), returns:
- p10/p25/p50/p75/p90 percentile distribution
- Departure rates (downward/upward/probation)
- 1,000-sample Monte Carlo simulation (piecewise linear CDF, clamped tails)
- Histogram of the Monte Carlo sample
- National baseline for same offense + CH
- Per-fiscal-year trend when multi-year
- UPL-safe attorney-question prompts

Progressive widening (exact → widened_years → widened_criminal_history → widened_district → insufficient_data).

## New files
- \`src/lib/fsd-distribution.ts\` — query lib + monteCarloSample + histogram
- \`src/lib/fsd-offguide.ts\` — chargeType → offguide_code mapping (CORRECT codebook mappings — see note below)
- \`src/app/api/tools/federal-sentencing-distribution/route.ts\` — \$297 API
- Unit + integration tests (30 cases, all pass)

## Modified
- \`src/lib/tier9-reports/constants.ts\` — new TIER9_SLUGS entry
- \`src/lib/tier9-reports/generate.ts\` — new case branch
- \`src/lib/tier9-reports/render.ts\` — renderFederalSentencingDistribution
- \`src/lib/products.ts\` — STANDALONE_PRODUCTS entry
- \`src/app/api/intake/standalone/[slug]/route.ts\` — district + CH validation
- \`src/app/intake/standalone/[slug]/IntakeFormClient.tsx\` — FIELD_SETS entry

## ⚠️ Flag for follow-up
Existing \`src/lib/ussc-mappings.ts\` (used by Similar Cases Analyzer \$297) has multiple STALE chargeType → offguide mappings — e.g. drug-trafficking → "17" (Immigration) should be "10" (Drug Trafficking); fraud → "13" (Firearms) should be "16" (Fraud/Theft/Embez); weapons → "16" should be "13".

Every live Similar Cases Analyzer order for a mapped chargeType is currently matching the defendant to the WRONG federal offense bucket. Fix is a separate PR because it's a customer-observable behavior change and needs explicit approval.

This PR uses a separate, corrected mapping in \`src/lib/fsd-offguide.ts\` rather than reusing the stale one. Unit tests assert the correct codes.

## Test plan
- [x] \`npx tsc --noEmit --skipLibCheck\`: clean
- [x] \`npx vitest run\`: 542/548 pass (30 new + 512 prior), 0 regressions
- [ ] CI green
- [ ] Post-merge: E2E spec against prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)