### PR TITLE
fix(ussc): chargeType→offguide mapping — match USSC codebook (prod correctness)

### DIFF
--- a/src/lib/ussc-mappings.ts
+++ b/src/lib/ussc-mappings.ts
@@ -25,79 +25,49 @@ import { normalizeAgeBucket, type AgeBucket } from "./ussc-similar-cases";
 /* ------------------------------------------------------------------ */
 
 /**
- * Map INAA chargeType slug → USSC offguide code (text, matview-native).
+ * Map INAA chargeType slug → USSC offguide code (text — matview stores the
+ * code as a string column for efficient indexing).
  *
- * Offguide codes from USSC FY18+ Individual Datafile (FY14-17 don't have
- * offguide and are coded as 'UNK' in the matview — those rows still appear
- * but only via the widen_district path when offguide is 'UNK').
+ * Source of truth: USSC Primary Sentencing Guideline codes verified against
+ * the `federal_sentencing_distributions` table's `offguide_label` column
+ * (loaded from USSC Individual Offender Datafiles, audited 2026-04-21).
  *
- * Verified distinct offguide values in the matview (2026-04-21):
- *   UNK (270K cases, FY14-17 legacy),
- *   17 drug trafficking (150K), 10 immigration (126K), 13 fraud (55K),
- *   16 firearms (35K), 26 sexual abuse (8.5K), 7 arson/property (7.8K),
- *   27 pornography (6.4K), 21 larceny (6.2K), 30 money laundering (4.3K),
- *   4 assault (3.7K), 1 murder (2.7K), 25 obstruction (2.5K),
- *   29 prison/escape (2.5K), 5 burglary (1.7K), 9 extortion (1.6K),
- *   22 drug possession-simple (1.4K), 24 tax (1.2K), 23 racketeering (0.9K),
- *   plus 12 low-volume codes.
+ * The 23 codes + labels (shared between matview + FSD):
+ *   1=Admin of Justice, 2=Antitrust, 4=Assault, 5=Bribery/Corruption,
+ *   7=Child Pornography, 8=Commercialized Vice, 9=Drug Possession,
+ *   10=Drug Trafficking, 11=Environmental, 12=Extortion/Racketeering,
+ *   13=Firearms, 15=Forgery/Counter/Copyright, 16=Fraud/Theft/Embezzlement,
+ *   17=Immigration, 20=Manslaughter, 21=Money Laundering, 23=National Defense,
+ *   24=Obscenity/Other Sex Offenses, 25=Prison Offenses, 26=Robbery,
+ *   27=Sex Abuse, 29=Tax, 30=Other.
+ *
+ * Matview also carries 3/6/14/18/19/22/28/UNK for FY14-FY17 legacy rows
+ * (pre-taxonomy reorganization). Those aren't mappable from INAA chargeType
+ * enum and are reached via the widen_district tier when offguide filter is
+ * dropped.
+ *
+ * HISTORICAL NOTE: Prior to 2026-04-21 this map had hand-coded labels
+ * derived from matview occurrence counts that eyeballed the wrong side of
+ * several codes (drug-trafficking was mapped to 17/Immigration instead of
+ * 10/Drug Trafficking, fraud→13/Firearms instead of 16/Fraud, etc.). Every
+ * Similar Cases Analyzer report issued during that window matched the
+ * defendant to the wrong federal offense bucket. The corrected mapping
+ * below is imported from `fsd-offguide.ts` which uses the FSD table's
+ * `offguide_label` column as authoritative source.
  *
  * When no mapping is confident, return null — the lookup will omit offguide
  * and the matview query will widen immediately. Partial is better than wrong.
  */
-export const CHARGE_TO_OFFGUIDE: Record<string, string | null> = {
-  // Drug offenses
-  "drug-trafficking": "17",
-  "drug-possession": "22",
-  "drug": "22",
+import { CHARGE_TO_FSD_OFFGUIDE } from "./fsd-offguide";
 
-  // Immigration — no INAA slug maps cleanly (primarily a federal-only issue
-  // that INAA's state-focused chargeType enum doesn't cover). Left null.
-
-  // Fraud / white-collar
-  "white-collar": "13",
-  "fraud": "13",
-
-  // Firearms
-  "weapons": "16",
-
-  // Sexual offenses
-  "sex-offense": "26",
-  "sex-offense-contact": "26",
-  "sex-offense-digital": "27",
-
-  // Violence
-  "murder": "1",
-  "manslaughter": "1",
-  "assault": "4",
-  "domestic-violence": "4",
-  "kidnapping": "3",
-  "child-abuse": "26",
-
-  // Property
-  "theft": "21",
-  "burglary": "5",
-  "robbery": "5",
-  "arson": "7",
-
-  // Other
-  "stalking": "4",
-  "hit-and-run": "4",
-  "contempt": "25",
-  "probation-violation": "29",
-  "federal": null,
-
-  // DUI — state offense in 99%+ of cases; federal cases rare enough to not
-  // confidently map. Widen.
-  "dui": null,
-  "dui-first": null,
-  "dui-repeat": null,
-
-  // Self-defense / other — no mapping
-  "self-defense": null,
-  "other": null,
-  "other-felony": null,
-  "other-misdemeanor": null,
-};
+/** Charge slug → matview offguide (string form). Derived from the FSD
+ *  integer-keyed source of truth. Canonical since 2026-04-21. */
+export const CHARGE_TO_OFFGUIDE: Record<string, string | null> = Object.fromEntries(
+  Object.entries(CHARGE_TO_FSD_OFFGUIDE).map(([slug, code]) => [
+    slug,
+    code === null ? null : String(code),
+  ]),
+);
 
 /** Look up offguide code for a chargeType slug. Returns null when unmapped. */
 export function chargeTypeToOffguide(chargeType: string | null | undefined): string | null {

--- a/tests/lib/ussc-mappings.test.ts
+++ b/tests/lib/ussc-mappings.test.ts
@@ -15,28 +15,43 @@ import {
 } from "@/lib/ussc-mappings";
 
 describe("chargeTypeToOffguide", () => {
-  it("maps drug offenses to matview codes", () => {
-    expect(chargeTypeToOffguide("drug-trafficking")).toBe("17");
-    expect(chargeTypeToOffguide("drug-possession")).toBe("22");
-    expect(chargeTypeToOffguide("drug")).toBe("22");
+  // Source of truth: USSC offguide_label column in federal_sentencing_distributions.
+  // Pre-2026-04-21 values here were transposed (drug-trafficking→17/Immigration
+  // instead of 10/Drug Trafficking, etc.) — the fix replaced the hand-coded
+  // occurrence-count labels with codebook-verified mappings.
+
+  it("maps drug offenses to codebook-correct offguide codes", () => {
+    expect(chargeTypeToOffguide("drug-trafficking")).toBe("10");
+    expect(chargeTypeToOffguide("drug-possession")).toBe("9");
+    expect(chargeTypeToOffguide("drug")).toBe("10");
   });
 
   it("maps violence offenses", () => {
-    expect(chargeTypeToOffguide("murder")).toBe("1");
+    // Murder has no direct code (federal murder is a capital/separately-coded
+    // offense); callers widen.
+    expect(chargeTypeToOffguide("murder")).toBeNull();
+    expect(chargeTypeToOffguide("manslaughter")).toBe("20");
     expect(chargeTypeToOffguide("assault")).toBe("4");
     expect(chargeTypeToOffguide("domestic-violence")).toBe("4");
-    expect(chargeTypeToOffguide("kidnapping")).toBe("3");
+    expect(chargeTypeToOffguide("robbery")).toBe("26");
+    // Kidnapping has no direct code in the current taxonomy — widen.
+    expect(chargeTypeToOffguide("kidnapping")).toBeNull();
   });
 
-  it("maps white-collar to fraud code", () => {
-    expect(chargeTypeToOffguide("white-collar")).toBe("13");
-    expect(chargeTypeToOffguide("fraud")).toBe("13");
+  it("maps white-collar / fraud to code 16 (Fraud/Theft/Embez)", () => {
+    expect(chargeTypeToOffguide("white-collar")).toBe("16");
+    expect(chargeTypeToOffguide("fraud")).toBe("16");
+    expect(chargeTypeToOffguide("theft")).toBe("16");
   });
 
-  it("maps firearms + sex offenses", () => {
-    expect(chargeTypeToOffguide("weapons")).toBe("16");
-    expect(chargeTypeToOffguide("sex-offense-contact")).toBe("26");
-    expect(chargeTypeToOffguide("sex-offense-digital")).toBe("27");
+  it("maps firearms to code 13 + sex offenses to codebook-correct codes", () => {
+    expect(chargeTypeToOffguide("weapons")).toBe("13");
+    expect(chargeTypeToOffguide("firearms")).toBe("13");
+    // Sex Abuse = code 27 (not 26 which is Robbery).
+    expect(chargeTypeToOffguide("sex-offense-contact")).toBe("27");
+    expect(chargeTypeToOffguide("sex-offense")).toBe("27");
+    // Digital sex offense → code 7 (Child Pornography).
+    expect(chargeTypeToOffguide("sex-offense-digital")).toBe("7");
   });
 
   it("returns null for DUI (state offense, no federal mapping)", () => {
@@ -45,7 +60,11 @@ describe("chargeTypeToOffguide", () => {
     expect(chargeTypeToOffguide("dui-repeat")).toBeNull();
   });
 
-  it("returns null for unmapped / generic slugs", () => {
+  it("returns null for unmapped / ambiguous slugs", () => {
+    // No confident federal mapping for these — widen rather than guess.
+    expect(chargeTypeToOffguide("arson")).toBeNull();
+    expect(chargeTypeToOffguide("burglary")).toBeNull();
+    expect(chargeTypeToOffguide("hit-and-run")).toBeNull();
     expect(chargeTypeToOffguide("other")).toBeNull();
     expect(chargeTypeToOffguide("federal")).toBeNull();
     expect(chargeTypeToOffguide("unknown-slug")).toBeNull();
@@ -129,7 +148,7 @@ describe("mapIntakeToBucket", () => {
       ageBucket: "25-34",
       district: "42",
     });
-    expect(result.offguide).toBe("17");
+    expect(result.offguide).toBe("10");
     expect(result.xcrhissr).toBe("1");
     expect(result.citizen).toBe("1");
     expect(result.age_bucket).toBe("25-34");
@@ -163,7 +182,7 @@ describe("mapIntakeToBucket", () => {
       chargeType: "drug-trafficking",
       priorConvictions: "felony",
     });
-    expect(result.offguide).toBe("17");
+    expect(result.offguide).toBe("10");
     expect(result.xcrhissr).toBe("3");
     expect(result.citizen).toBeNull();
     expect(result.age_bucket).toBeNull();


### PR DESCRIPTION
## The bug (CRITICAL prod data correctness)

\`chargeTypeToOffguide("drug-trafficking")\` returned "17" — which is USSC code for Immigration. Similar transpositions across ~12 chargeType slugs. Every Similar Cases Analyzer (\$297) and plea-analyzer report with a mapped chargeType matched the defendant to the WRONG federal offense bucket.

## Transposition matrix

| Slug | Old (wrong) | Correct |
|---|---|---|
| drug-trafficking | 17 (Immigration) | 10 (Drug Trafficking) |
| drug-possession | 22 (not in FSD) | 9 (Drug Possession) |
| white-collar / fraud | 13 (Firearms) | 16 (Fraud/Theft/Embez) |
| weapons | 16 (Fraud) | 13 (Firearms) |
| sex-offense-contact | 26 (Robbery) | 27 (Sex Abuse) |
| sex-offense-digital | 27 (Sex Abuse) | 7 (Child Pornography) |
| murder | 1 (Admin) | null |
| kidnapping | 3 (not in FSD) | null |
| theft | 21 (Money Laundry) | 16 |
| burglary / robbery | 5 (Bribery) | null / 26 |
| arson | 7 (Child Porn) | null |
| contempt | 25 (Prison Off) | 1 (Admin of Justice) |
| probation-violation | 29 (Tax) | 25 (Prison Offenses) |

## Root cause
Original map hand-coded from matview OCCURRENCE COUNTS (PR #7) without cross-checking against USSC codebook's offguide_label column. Header comment itself labeled code 17 as "drug trafficking" (it's Immigration). Tests hardcoded the wrong expected values so couldn't catch it.

## The fix
ussc-mappings.ts now imports from \`src/lib/fsd-offguide.ts\` (shipped in PR #16) which uses FSD table's offguide_label as authoritative source. Single source of truth. Ambiguous slugs (murder/kidnapping/arson/burglary) return null instead of fabricated codes.

## Impact
- Customers getting correct federal sentencing data starting at deploy time
- Existing data (reports already delivered) not retroactively fixed — operator may want to manually re-run recent high-value orders
- Positive cascade: every $297 Similar Cases Analyzer order is now matched to the right bucket

## Test plan
- [x] tsc clean
- [x] 542/548 vitest pass (6 pre-existing skips), 0 regressions
- [ ] CI green
- [ ] Post-merge: spot-check prod with curl for drug-trafficking + verify response mentions Drug Trafficking not Immigration

🤖 Generated with [Claude Code](https://claude.com/claude-code)