### PR TITLE
fix(upl): global sweep — remove "your attorney remains the final authority"

### DIFF
--- a/docs/plans/2026-04-21-upl-drift-global-sweep.md
+++ b/docs/plans/2026-04-21-upl-drift-global-sweep.md
@@ -1,0 +1,89 @@
+# Plan — Global UPL Drift Sweep
+
+**Date:** 2026-04-21
+**Branch:** fix/upl-drift-global-sweep
+**Base:** master (post PR #12 merge at 1161a72)
+**Triage:** FEATURE (auto-promoted from QUICK_FIX — 23 file scope)
+
+## Worry
+
+PR #12 fixed the Footer.tsx instance of the banned UPL phrase. But 25 other files still emit the same banned pattern — paying-customer reports (IB, X-Ray, playbooks, tier9), FAQ answers on product pages, intake confirmations, checkout copy. Every rendered report and every landing page still puts the defendant's decision in an attorney's hands they may not have. Violates the rule at `~/.claude/rules/no-hallucinated-legal-data.md` which states the defendant is alone and will NOT have an attorney verify.
+
+## Files to modify
+
+22 files, mechanical substitution.
+
+Library generators (fixes future output as well as existing):
+- `src/lib/intelligence-brief/prompts.ts` (LLM prompt template)
+- `src/lib/intelligence-brief/render.ts` (2 hits: body plus footer)
+- `src/lib/report-renderer.ts`
+- `src/lib/tier9-reports/render.ts`
+- `src/lib/playbook-configs.ts` (7 hits: methodologyText per charge type)
+
+Page components:
+- `src/app/arrest-survival-kit/page.tsx` (2 hits)
+- `src/app/arrested/page.tsx`
+- `src/app/checkout/page.tsx`
+- `src/app/district-court-intelligence/page.tsx` (2 hits)
+- `src/app/dui-defense/page.tsx`
+- `src/app/guides/[slug]/page.tsx`
+- `src/app/intake/standalone/[slug]/IntakeFormClient.tsx`
+- `src/app/judge-report-card/page.tsx`
+- `src/app/officer-background-check/page.tsx` (2 hits)
+- `src/app/playbooks/page.tsx`
+- `src/app/plea-analyzer/page.tsx`
+- `src/app/report/standalone/[token]/page.tsx`
+- `src/app/resources/page.tsx`
+- `src/app/score/ScoreClient.tsx`
+- `src/app/score/results/[token]/page.tsx`
+- `src/app/services/[slug]/page.tsx`
+- `src/app/similar-cases-analyzer/page.tsx`
+
+API routes (JSON disclaimer strings returned to clients):
+- `src/app/api/tools/sentencing-calculator/route.ts`
+- `src/app/api/tools/similar-cases/route.ts`
+- `src/app/api/tools/federal-sentencing-distribution/route.ts`
+
+## Files to create
+
+- `scripts/ops/upl-drift-sweep.mjs` — one-shot Node helper using split-plus-join substitution per the project rule `pattern-batch-token-sub-helper.md`. No regex on contents. Script already written and executed, producing 32 replacements across 22 files.
+
+## Numbered tasks
+
+1. Write sweep script (done). Script path: `scripts/ops/upl-drift-sweep.mjs`.
+2. Run sweep on page and lib files (done). Result: 32 replacements across 22 files.
+3. Handle 4 stragglers whose phrasings did not match the script's exact-match list (different suffix such as "on all strategy decisions" or "on strategy"):
+   - `src/app/similar-cases-analyzer/page.tsx` at line 421 (done)
+   - `src/app/api/tools/similar-cases/route.ts` at line 180
+   - `src/app/api/tools/sentencing-calculator/route.ts` at line 262
+   - `src/app/api/tools/federal-sentencing-distribution/route.ts` at line 216
+4. Verify zero banned hits remain. Grep the exact phrase `remains the final authority` across `src/`. Expected result: 0 hits.
+5. Typecheck and build gate. Run `npx tsc --noEmit --skipLibCheck` with exit code 0. Run `npm run build` with exit code 0.
+6. Commit and create PR.
+
+## Replacement policy
+
+Banned phrase family: any variation of "Your attorney remains the final authority on strategy decisions". Full banned variations include "on strategy decisions", "on strategy decisions specific to your situation", "on strategy", "on all strategy decisions", "on how to use this information in your defense", "on your defense strategy".
+
+Primary replacement: "Decisions about how to use this information stay with you."
+
+Exception for `src/app/arrested/page.tsx` (subject is "your case" not "your attorney"): "Decisions about what to do with this information stay with you. If you have counsel, talk it over with them."
+
+Both replacements own the decision at the crisis-buyer's end and acknowledge optional counsel without assuming presence. Both satisfy the brand-voice rule that "the defendant is alone — they will NOT have an attorney verify".
+
+## Out of scope
+
+- The "verify with attorney" pattern in MDX blog posts. Content-layer sweep, separate task.
+- Redesigning the methodology-note section of reports. This pass is copy-level only.
+- `src/lib/products.ts` line 875 contains "verification URLs your attorney can confirm in minutes". Reviewed: this is describing WHAT a paid product includes (verification URLs that any attorney could confirm), not implying the READER has an attorney. Kept as-is, out of scope for this sweep.
+
+## Success criteria
+
+- `grep -n "remains the final authority" src/` returns 0 hits.
+- `npx tsc --noEmit --skipLibCheck` exits 0.
+- `npm run build` exits 0.
+- Manual spot-check of 3 rendered pages: `/checkout`, `/judge-report-card`, `/similar-cases-analyzer` — footer and disclaimer copy no longer references "final authority" or "your attorney remains".
+
+## Approval
+
+User approved merge-then-sweep flow with "yes" after presenting option A in the session. Hook auto-promoted triage mid-sweep after 3 files touched; proceeding under FEATURE gates is compatible with user's prior approval.

--- a/scripts/ops/upl-drift-sweep.mjs
+++ b/scripts/ops/upl-drift-sweep.mjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+/**
+ * @fileoverview One-shot UPL drift sweep — replaces the "Your attorney remains
+ * the final authority" family of phrases (banned by
+ * ~/.claude/rules/no-hallucinated-legal-data.md) with a crisis-buyer-safe
+ * replacement that owns the decision moment.
+ *
+ * Split + join substitution only (no regex on contents per project rule).
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const REPLACEMENT = "Decisions about how to use this information stay with you.";
+
+const EDITS = [
+  { file: "src/app/resources/page.tsx", replacements: [
+    ["Your attorney remains the final authority on strategy\n              decisions specific to your situation.", REPLACEMENT],
+  ]},
+  { file: "src/app/score/results/[token]/page.tsx", replacements: [
+    ["Your attorney remains the final authority\n          on strategy decisions specific to your situation.", REPLACEMENT],
+  ]},
+  { file: "src/app/dui-defense/page.tsx", replacements: [
+    ["Your attorney remains the\n            final authority on strategy decisions specific to your situation.", REPLACEMENT],
+  ]},
+  { file: "src/app/score/ScoreClient.tsx", replacements: [
+    ["Your attorney remains the final authority on strategy decisions\n            specific to your situation.", REPLACEMENT],
+  ]},
+  { file: "src/app/arrest-survival-kit/page.tsx", replacements: [
+    ["Your attorney remains the final authority on how to use this information in your defense.", REPLACEMENT],
+    ["Your attorney remains the final authority on\n            your defense strategy.", REPLACEMENT],
+  ]},
+  { file: "src/app/officer-background-check/page.tsx", replacements: [
+    ["Your attorney remains the final authority on how to use this information in your defense.", REPLACEMENT],
+    ["Your attorney remains the final authority on\n            your defense strategy.", REPLACEMENT],
+  ]},
+  { file: "src/app/district-court-intelligence/page.tsx", replacements: [
+    ["Your attorney remains the final authority on strategy decisions.", REPLACEMENT],
+    ["Your attorney remains the final authority on your defense\n            strategy.", REPLACEMENT],
+  ]},
+  { file: "src/app/arrested/page.tsx", replacements: [
+    ["An attorney familiar with your jurisdiction and the specific facts of\n        your case remains the final authority on strategy decisions.",
+      "Decisions about what to do with this information stay with you. If you have counsel, talk it over with them."],
+  ]},
+  { file: "src/app/intake/standalone/[slug]/IntakeFormClient.tsx", replacements: [
+    ["Your\n        attorney remains the final authority on strategy decisions.", REPLACEMENT],
+  ]},
+  { file: "src/app/guides/[slug]/page.tsx", replacements: [
+    ["Your attorney\n        remains the final authority on strategy decisions.", REPLACEMENT],
+  ]},
+  { file: "src/app/plea-analyzer/page.tsx", replacements: [
+    ["Your attorney\n          remains the final authority on strategy decisions.", REPLACEMENT],
+  ]},
+  { file: "src/app/playbooks/page.tsx", replacements: [
+    ["Your attorney remains the\n            final authority on strategy decisions.", REPLACEMENT],
+  ]},
+  { file: "src/app/report/standalone/[token]/page.tsx", replacements: [
+    ["Your attorney remains the final\n          authority on strategy decisions.", REPLACEMENT],
+  ]},
+  { file: "src/app/services/[slug]/page.tsx", replacements: [
+    ["Your\n          attorney remains the final authority on strategy decisions.", REPLACEMENT],
+  ]},
+  { file: "src/app/checkout/page.tsx", replacements: [
+    ["Your attorney remains the final authority on strategy decisions.", REPLACEMENT],
+  ]},
+  { file: "src/app/judge-report-card/page.tsx", replacements: [
+    ["Your attorney remains the final authority on strategy decisions.", REPLACEMENT],
+  ]},
+  { file: "src/app/similar-cases-analyzer/page.tsx", replacements: [
+    ["Your attorney remains the final authority on strategy decisions.", REPLACEMENT],
+  ]},
+  { file: "src/lib/intelligence-brief/render.ts", replacements: [
+    ["Your attorney remains the final authority on strategy decisions.", REPLACEMENT],
+  ]},
+  { file: "src/lib/intelligence-brief/prompts.ts", replacements: [
+    ["Your attorney remains the final authority on strategy decisions.", REPLACEMENT],
+  ]},
+  { file: "src/lib/report-renderer.ts", replacements: [
+    ["Your attorney remains the final authority on strategy decisions.", REPLACEMENT],
+  ]},
+  { file: "src/lib/tier9-reports/render.ts", replacements: [
+    ["Your attorney remains the final authority\n      on strategy decisions.", REPLACEMENT],
+  ]},
+  { file: "src/lib/playbook-configs.ts", replacements: [
+    ["Your attorney remains the final authority on strategy decisions.", REPLACEMENT],
+  ]},
+  { file: "src/app/api/tools/sentencing-calculator/route.ts", replacements: [
+    ["Your attorney remains the final authority on strategy decisions.", REPLACEMENT],
+  ]},
+];
+
+let totalReplacements = 0;
+const report = [];
+
+for (const { file, replacements } of EDITS) {
+  const abs = resolve(process.cwd(), file);
+  let content;
+  try {
+    content = readFileSync(abs, "utf8");
+  } catch (err) {
+    report.push(`[MISS] ${file} — ${err.message}`);
+    continue;
+  }
+  let fileChanges = 0;
+  for (const [from, to] of replacements) {
+    const parts = content.split(from);
+    if (parts.length === 1) {
+      report.push(`[NOTFOUND] ${file} :: "${from.slice(0, 60)}..."`);
+      continue;
+    }
+    const hits = parts.length - 1;
+    content = parts.join(to);
+    fileChanges += hits;
+    totalReplacements += hits;
+  }
+  if (fileChanges > 0) {
+    writeFileSync(abs, content);
+    report.push(`[OK] ${file} — ${fileChanges} replaced`);
+  } else {
+    report.push(`[SKIP] ${file} — no matches`);
+  }
+}
+
+console.log(report.join("\n"));
+console.log(`\nTotal replacements: ${totalReplacements}`);

--- a/src/app/api/tools/federal-sentencing-distribution/route.ts
+++ b/src/app/api/tools/federal-sentencing-distribution/route.ts
@@ -213,7 +213,7 @@ export async function POST(req: NextRequest) {
         "USSC Individual Offender Datafiles FY2014-FY2024 (13,131 district-level buckets across 94 federal districts).",
       sourceUrl: "https://www.ussc.gov/research/datafiles/commission-datafiles",
       disclaimer:
-        "This provides legal INFORMATION about the historical distribution of federal sentences for this offense + criminal history + district — not legal advice. Every case is different; your attorney remains the final authority on strategy.",
+        "This provides legal INFORMATION about the historical distribution of federal sentences for this offense + criminal history + district — not legal advice. Every case is different. Decisions about how to use this information stay with you.",
     },
   });
 }

--- a/src/app/api/tools/sentencing-calculator/route.ts
+++ b/src/app/api/tools/sentencing-calculator/route.ts
@@ -259,7 +259,7 @@ export async function POST(req: NextRequest) {
         "USSC Individual Offender Datafiles FY2014-FY2024 + JUSTFAIR FY2001-FY2023 (690K+ federal sentencing records, 1,126 judges)",
       sourceUrl: "https://www.ussc.gov/research/datafiles/commission-datafiles",
       disclaimer:
-        "Federal courts only. This provides legal INFORMATION about historical sentencing distributions — not legal advice. Your attorney remains the final authority on strategy.",
+        "Federal courts only. This provides legal INFORMATION about historical sentencing distributions — not legal advice. Decisions about how to use this information stay with you.",
     },
   });
 }

--- a/src/app/api/tools/similar-cases/route.ts
+++ b/src/app/api/tools/similar-cases/route.ts
@@ -177,7 +177,7 @@ export async function POST(req: NextRequest) {
         "USSC Individual Offender Datafiles FY2014-FY2024 (690,491 federal sentences across 23,210 buckets)",
       sourceUrl: "https://www.ussc.gov/research/datafiles/commission-datafiles",
       disclaimer:
-        "This provides legal INFORMATION about what similar federal cases resulted in — not legal advice. Every case is different; your attorney remains the final authority on strategy.",
+        "This provides legal INFORMATION about what similar federal cases resulted in — not legal advice. Every case is different. Decisions about how to use this information stay with you.",
     },
   });
 }

--- a/src/app/arrest-survival-kit/page.tsx
+++ b/src/app/arrest-survival-kit/page.tsx
@@ -81,7 +81,7 @@ const FAQ_ITEMS = [
   {
     question: "Is this legal advice?",
     answer:
-      "No. This is legal INFORMATION \u2014 verified rights and procedures from official sources. Your attorney remains the final authority on how to use this information in your defense.",
+      "No. This is legal INFORMATION \u2014 verified rights and procedures from official sources. Decisions about how to use this information stay with you.",
   },
   {
     question: "How fast do I get it?",
@@ -335,8 +335,7 @@ export default function ArrestSurvivalKitPage() {
           <p className="mt-4 text-xs text-zinc-400">
             This is legal information, not legal advice. ImNotAnAttorney
             provides verified legal data to help you prepare for conversations
-            with your attorney. Your attorney remains the final authority on
-            your defense strategy.
+            with your attorney. Decisions about how to use this information stay with you.
           </p>
 
           <p className="mt-3 text-sm text-zinc-400">

--- a/src/app/arrested/page.tsx
+++ b/src/app/arrested/page.tsx
@@ -199,8 +199,7 @@ export default async function ArrestedPage({ searchParams }: PageProps) {
       {/* Disclaimer */}
       <footer className="border-t border-zinc-800 pt-6 text-xs text-zinc-400">
         This is legal information, not legal advice. Every case is different.
-        An attorney familiar with your jurisdiction and the specific facts of
-        your case remains the final authority on strategy decisions.
+        Decisions about what to do with this information stay with you. If you have counsel, talk it over with them.
       </footer>
     </main>
   );

--- a/src/app/checkout/page.tsx
+++ b/src/app/checkout/page.tsx
@@ -176,7 +176,7 @@ function StandaloneCheckout({
       </div>
 
       <p className="mt-6 text-xs text-zinc-400">
-        This report provides legal INFORMATION, not legal ADVICE. Your attorney remains the final authority on strategy decisions.
+        This report provides legal INFORMATION, not legal ADVICE. Decisions about how to use this information stay with you.
       </p>
     </div>
   );

--- a/src/app/district-court-intelligence/page.tsx
+++ b/src/app/district-court-intelligence/page.tsx
@@ -80,7 +80,7 @@ const FAQ_ITEMS = [
   {
     question: "Is this legal advice?",
     answer:
-      "No. This is legal INFORMATION \u2014 verified court data compiled into a structured report. Your attorney remains the final authority on strategy decisions.",
+      "No. This is legal INFORMATION \u2014 verified court data compiled into a structured report. Decisions about how to use this information stay with you.",
   },
   {
     question: "How fast do I get it?",
@@ -367,8 +367,7 @@ export default function DistrictCourtIntelligencePage() {
           <p className="mt-4 text-xs text-zinc-400">
             This is legal information, not legal advice. ImNotAnAttorney provides
             verified court data to help you prepare for conversations with your
-            attorney. Your attorney remains the final authority on your defense
-            strategy.
+            attorney. Decisions about how to use this information stay with you.
           </p>
 
           <p className="mt-3 text-sm text-zinc-400">

--- a/src/app/dui-defense/page.tsx
+++ b/src/app/dui-defense/page.tsx
@@ -165,8 +165,7 @@ export default function DuiDefenseHubPage() {
           <p className="text-xs text-zinc-400">
             <strong>Important:</strong> This page provides general legal
             information about DUI laws across the United States. Laws change
-            frequently. This is not legal advice. Your attorney remains the
-            final authority on strategy decisions specific to your situation.
+            frequently. This is not legal advice. Decisions about how to use this information stay with you.
           </p>
         </div>
       </section>

--- a/src/app/guides/[slug]/page.tsx
+++ b/src/app/guides/[slug]/page.tsx
@@ -170,8 +170,7 @@ export default async function GuidePage({ params }: Props) {
       {/* UPL-approved methodology disclaimer */}
       <p className="mt-12 border-t border-zinc-800 pt-6 text-xs text-zinc-400">
         This guide provides legal INFORMATION, not legal ADVICE. The content
-        draws on methods developed by elite defense attorneys. Your attorney
-        remains the final authority on strategy decisions.
+        draws on methods developed by elite defense attorneys. Decisions about how to use this information stay with you.
       </p>
     </article>
   );

--- a/src/app/intake/standalone/[slug]/IntakeFormClient.tsx
+++ b/src/app/intake/standalone/[slug]/IntakeFormClient.tsx
@@ -2929,8 +2929,7 @@ export default function IntakeFormClient({ slug, productName, token }: Props) {
 
       {/* UPL disclaimer */}
       <p className="mt-4 text-xs text-zinc-400">
-        This report provides legal INFORMATION, not legal ADVICE. Your
-        attorney remains the final authority on strategy decisions.
+        This report provides legal INFORMATION, not legal ADVICE. Decisions about how to use this information stay with you.
       </p>
     </form>
   );

--- a/src/app/judge-report-card/page.tsx
+++ b/src/app/judge-report-card/page.tsx
@@ -42,7 +42,7 @@ const FAQ_ITEMS = [
   {
     question: "Is this legal advice?",
     answer:
-      "No. This is legal INFORMATION \u2014 verified court data compiled into a structured report. Your attorney remains the final authority on strategy decisions.",
+      "No. This is legal INFORMATION \u2014 verified court data compiled into a structured report. Decisions about how to use this information stay with you.",
   },
   {
     question: "How fast do I get it?",

--- a/src/app/officer-background-check/page.tsx
+++ b/src/app/officer-background-check/page.tsx
@@ -82,7 +82,7 @@ const FAQ_ITEMS = [
   {
     question: "Is this legal advice?",
     answer:
-      "No. This is legal INFORMATION \u2014 verified court data. Your attorney remains the final authority on how to use this information in your defense.",
+      "No. This is legal INFORMATION \u2014 verified court data. Decisions about how to use this information stay with you.",
   },
   {
     question: "How fast do I get it?",
@@ -348,8 +348,7 @@ export default function OfficerBackgroundCheckPage() {
           <p className="mt-4 text-xs text-zinc-400">
             This is legal information, not legal advice. ImNotAnAttorney
             provides verified court data to help you prepare for conversations
-            with your attorney. Your attorney remains the final authority on
-            your defense strategy.
+            with your attorney. Decisions about how to use this information stay with you.
           </p>
 
           <p className="mt-3 text-sm text-zinc-400">

--- a/src/app/playbooks/page.tsx
+++ b/src/app/playbooks/page.tsx
@@ -250,8 +250,7 @@ export default function PlaybooksCatalogPage() {
           <p className="text-sm leading-relaxed text-zinc-400">
             These playbooks provide legal information, not legal advice. The
             analysis draws on methods developed by elite defense attorneys,
-            applied specifically to your charge type. Your attorney remains the
-            final authority on strategy decisions.
+            applied specifically to your charge type. Decisions about how to use this information stay with you.
           </p>
         </div>
       </section>

--- a/src/app/plea-analyzer/page.tsx
+++ b/src/app/plea-analyzer/page.tsx
@@ -121,8 +121,7 @@ export default function PleaAnalyzerPage() {
         <p className="text-xs text-zinc-400 border-t border-zinc-800 pt-6">
           This tool provides legal INFORMATION, not legal ADVICE. The
           analysis draws on methods developed by elite defense attorneys,
-          applied specifically to your plea offer details. Your attorney
-          remains the final authority on strategy decisions. Your plea
+          applied specifically to your plea offer details. Decisions about how to use this information stay with you. Your plea
           details are used only to generate your analysis and are not shared
           with third parties.
         </p>

--- a/src/app/report/standalone/[token]/page.tsx
+++ b/src/app/report/standalone/[token]/page.tsx
@@ -170,8 +170,7 @@ export default async function StandaloneReportPage({ params }: Props) {
         <p className="mt-8 text-xs text-zinc-600 border-t border-zinc-100 pt-6">
           This report provides legal INFORMATION, not legal ADVICE. The
           analysis draws on methods developed by elite defense attorneys, applied
-          specifically to your case details. Your attorney remains the final
-          authority on strategy decisions.
+          specifically to your case details. Decisions about how to use this information stay with you.
         </p>
       </div>
 

--- a/src/app/resources/page.tsx
+++ b/src/app/resources/page.tsx
@@ -370,8 +370,7 @@ export default function ResourcesPage() {
             <p className="text-sm text-zinc-400">
               <span className="font-semibold text-amber-400">Disclaimer:</span>{" "}
               This is general legal information, not legal advice. Rights vary
-              by state and jurisdiction. Your attorney remains the final authority on strategy
-              decisions specific to your situation.
+              by state and jurisdiction. Decisions about how to use this information stay with you.
             </p>
           </div>
         </section>

--- a/src/app/score/ScoreClient.tsx
+++ b/src/app/score/ScoreClient.tsx
@@ -1505,8 +1505,7 @@ export default function ScoreClient() {
         <div className="mt-12 rounded-lg border border-zinc-500 bg-zinc-900/50 p-4">
           <p className="text-xs text-zinc-400">
             This score is an educational tool based on 10 critical defense
-            milestones identified across thousands of criminal cases &mdash; informed by the procedural standards established by defense methodologists. This is not legal advice. Every case is different. Your attorney remains the final authority on strategy decisions
-            specific to your situation.
+            milestones identified across thousands of criminal cases &mdash; informed by the procedural standards established by defense methodologists. This is not legal advice. Every case is different. Decisions about how to use this information stay with you.
           </p>
         </div>
       </div>

--- a/src/app/score/results/[token]/page.tsx
+++ b/src/app/score/results/[token]/page.tsx
@@ -165,8 +165,7 @@ export default async function ScoreResultPage({
           multiple-choice answers &mdash; not an attorney&apos;s evaluation,
           not a case analysis, not a legal opinion. It does not create an
           attorney-client relationship and does not constitute legal advice.
-          Every case is different. Your attorney remains the final authority
-          on strategy decisions specific to your situation. ImNotAnAttorney
+          Every case is different. Decisions about how to use this information stay with you. ImNotAnAttorney
           provides legal information, not legal advice.
         </p>
       </div>

--- a/src/app/services/[slug]/page.tsx
+++ b/src/app/services/[slug]/page.tsx
@@ -684,8 +684,7 @@ export default async function ProductLandingPage({ params }: Props) {
 
         {/* Disclaimer */}
         <p className="mt-6 text-xs text-zinc-400">
-          This report provides legal INFORMATION, not legal ADVICE. Your
-          attorney remains the final authority on strategy decisions.
+          This report provides legal INFORMATION, not legal ADVICE. Decisions about how to use this information stay with you.
         </p>
       </div>
     </div>

--- a/src/app/similar-cases-analyzer/page.tsx
+++ b/src/app/similar-cases-analyzer/page.tsx
@@ -51,7 +51,7 @@ const faqItems = [
   {
     question: "Is this legal advice?",
     answer:
-      "No. This is legal INFORMATION, verified court data compiled for your review. Your attorney remains the final authority on strategy decisions.",
+      "No. This is legal INFORMATION, verified court data compiled for your review. Decisions about how to use this information stay with you.",
   },
   {
     question: "How fast do I get it?",
@@ -417,8 +417,8 @@ export default function SimilarCasesAnalyzerPage() {
             </div>
             <p className="mt-6 text-xs text-zinc-400">
               This product provides legal information, verified court data
-              compiled for your review. It is not legal advice. Your attorney
-              remains the final authority on all strategy decisions.
+              compiled for your review. It is not legal advice. Decisions
+              about how to use this information stay with you.
             </p>
             <p className="mt-3 text-sm text-zinc-400">
               Questions before you buy?{" "}

--- a/src/lib/intelligence-brief/prompts.ts
+++ b/src/lib/intelligence-brief/prompts.ts
@@ -45,7 +45,7 @@ These are not soft guidelines. A single occurrence of any banned phrase in repor
 
 const METHODOLOGY_NOTE = `
 METHODOLOGY NOTE (include at section end):
-This analysis draws on methods developed by elite defense attorneys, applied specifically to your case details. Your attorney remains the final authority on strategy decisions.`;
+This analysis draws on methods developed by elite defense attorneys, applied specifically to your case details. Decisions about how to use this information stay with you.`;
 
 const LEGAL_ACCURACY_RULES = `
 JURISDICTION-SPECIFIC CHARGE TERMINOLOGY:

--- a/src/lib/intelligence-brief/render.ts
+++ b/src/lib/intelligence-brief/render.ts
@@ -376,12 +376,12 @@ export function renderIntelligenceBriefHtml(
   ${meta.expertNames ? `<blockquote class="blockquote" style="margin: 20px 0; padding: 12px 16px;">
     <p class="body-text"><strong class="bold-text">METHODOLOGY NOTE</strong></p>
     <p class="body-text">Every question and framework in this report traces to documented winning methods from elite criminal defense attorneys. Your report draws on ${escapeHtml(meta.expertNames)}, selected for ${escapeHtml(meta.charges)} cases. Expert attributions appear throughout.</p>
-    <p class="body-text"><strong class="bold-text">Important:</strong> This report provides legal INFORMATION, not legal ADVICE. The analysis draws on methods developed by elite defense attorneys, applied specifically to your case details. Your attorney remains the final authority on strategy decisions.</p>
+    <p class="body-text"><strong class="bold-text">Important:</strong> This report provides legal INFORMATION, not legal ADVICE. The analysis draws on methods developed by elite defense attorneys, applied specifically to your case details. Decisions about how to use this information stay with you.</p>
   </blockquote>` : ""}
   ${bodyHtml}
   <div class="footer-disclaimer">
     <p class="footer-disclaimer-text">
-      <strong class="footer-disclaimer-label">Important:</strong> This report provides legal INFORMATION, not legal ADVICE. The analysis draws on methods developed by elite defense attorneys, applied specifically to your case details. Your attorney remains the final authority on strategy decisions.
+      <strong class="footer-disclaimer-label">Important:</strong> This report provides legal INFORMATION, not legal ADVICE. The analysis draws on methods developed by elite defense attorneys, applied specifically to your case details. Decisions about how to use this information stay with you.
     </p>
   </div>
   <div class="copyright-block">

--- a/src/lib/playbook-configs.ts
+++ b/src/lib/playbook-configs.ts
@@ -204,7 +204,7 @@ const DUI_FIRST_OFFENSE: PlaybookConfig = {
     ],
   },
   methodologyText:
-    "This report provides legal INFORMATION \u2014 not legal ADVICE. The analysis draws on methods developed by elite defense attorneys, applied to common DUI first offense patterns. Your attorney remains the final authority on strategy decisions.",
+    "This report provides legal INFORMATION \u2014 not legal ADVICE. The analysis draws on methods developed by elite defense attorneys, applied to common DUI first offense patterns. Decisions about how to use this information stay with you.",
   urgency: {
     headline: "Time-sensitive deadlines in your DUI case",
     items: [
@@ -364,7 +364,7 @@ const DRUG_POSSESSION: PlaybookConfig = {
     ],
   },
   methodologyText:
-    "This report provides legal INFORMATION \u2014 not legal ADVICE. The analysis draws on methods developed by elite defense attorneys, applied to common drug possession patterns. Your attorney remains the final authority on strategy decisions.",
+    "This report provides legal INFORMATION \u2014 not legal ADVICE. The analysis draws on methods developed by elite defense attorneys, applied to common drug possession patterns. Decisions about how to use this information stay with you.",
   urgency: {
     headline: "Time-sensitive deadlines in your drug case",
     items: [
@@ -529,7 +529,7 @@ const PROBATION_VIOLATION: PlaybookConfig = {
     ],
   },
   methodologyText:
-    "This report provides legal INFORMATION \u2014 not legal ADVICE. The analysis draws on methods developed by elite defense attorneys and landmark Supreme Court decisions (Gagnon v. Scarpelli, Bearden v. Georgia), applied to common probation violation patterns. Your attorney remains the final authority on strategy decisions.",
+    "This report provides legal INFORMATION \u2014 not legal ADVICE. The analysis draws on methods developed by elite defense attorneys and landmark Supreme Court decisions (Gagnon v. Scarpelli, Bearden v. Georgia), applied to common probation violation patterns. Decisions about how to use this information stay with you.",
   urgency: {
     headline: "Time-sensitive deadlines in your violation case",
     items: [
@@ -694,7 +694,7 @@ const WHITE_COLLAR: PlaybookConfig = {
     ],
   },
   methodologyText:
-    "This report provides legal INFORMATION \u2014 not legal ADVICE. The analysis draws on methods developed by elite defense attorneys, applied to common white collar and fraud defense patterns. Your attorney remains the final authority on strategy decisions.",
+    "This report provides legal INFORMATION \u2014 not legal ADVICE. The analysis draws on methods developed by elite defense attorneys, applied to common white collar and fraud defense patterns. Decisions about how to use this information stay with you.",
   urgency: {
     headline: "Time-sensitive deadlines in your white collar case",
     items: [
@@ -859,7 +859,7 @@ const SEX_OFFENSE: PlaybookConfig = {
     ],
   },
   methodologyText:
-    "This report provides legal INFORMATION \u2014 not legal ADVICE. The analysis draws on methods developed by elite defense attorneys, applied to common sex offense defense patterns. Your attorney remains the final authority on strategy decisions.",
+    "This report provides legal INFORMATION \u2014 not legal ADVICE. The analysis draws on methods developed by elite defense attorneys, applied to common sex offense defense patterns. Decisions about how to use this information stay with you.",
   urgency: {
     headline: "Time-sensitive actions in your case",
     items: [
@@ -1024,7 +1024,7 @@ const FEDERAL_CRIMINAL: PlaybookConfig = {
     ],
   },
   methodologyText:
-    "This report provides legal INFORMATION \u2014 not legal ADVICE. The analysis draws on methods developed by elite defense attorneys, applied to common federal criminal defense patterns. Your attorney remains the final authority on strategy decisions.",
+    "This report provides legal INFORMATION \u2014 not legal ADVICE. The analysis draws on methods developed by elite defense attorneys, applied to common federal criminal defense patterns. Decisions about how to use this information stay with you.",
   urgency: {
     headline: "Time-sensitive actions in your case",
     items: [
@@ -1189,7 +1189,7 @@ const DRUG_TRAFFICKING: PlaybookConfig = {
     ],
   },
   methodologyText:
-    "This report provides legal INFORMATION \u2014 not legal ADVICE. The analysis draws on methods developed by elite defense attorneys, applied to common drug trafficking defense patterns. Your attorney remains the final authority on strategy decisions.",
+    "This report provides legal INFORMATION \u2014 not legal ADVICE. The analysis draws on methods developed by elite defense attorneys, applied to common drug trafficking defense patterns. Decisions about how to use this information stay with you.",
   urgency: {
     headline: "Time-sensitive actions in your case",
     items: [

--- a/src/lib/products.ts
+++ b/src/lib/products.ts
@@ -1226,14 +1226,10 @@ export const STANDALONE_PRODUCTS: Record<string, StandaloneProduct> = {
       "Your Similar Cases Analyzer report is generated on demand from verified court records within 60 seconds.",
     description:
       "Similar case outcomes, sentencing distributions, plea discount data, and appellate trends for your charge and jurisdiction.",
-<<<<<<< HEAD
     // Required: chargeType, state. Optional (used to match against USSC FY14-24
     // federal sentencing distribution when supplied): priorConvictions,
     // citizenship, ageBucket.
     intakeFields: ["chargeType", "state", "priorConvictions", "citizenship", "ageBucket", "district"],
-=======
-    intakeFields: ["chargeType", "state", "district"],
->>>>>>> f3c042d (fix(tools): adversarial-walkthrough findings on /tools/sentencing-calculator)
     stripePriceId: null,
     upsellTier: "case-decoder",
     upsellText:

--- a/src/lib/report-renderer.ts
+++ b/src/lib/report-renderer.ts
@@ -169,7 +169,7 @@ export function renderReportHtml(markdown: string, meta: ReportMeta): string {
   ${meta.expertNames ? `<blockquote style="border-left: 3px solid #F59E0B; padding: 16px; margin: 24px 0; background: #1C1917; border-radius: 0 8px 8px 0;">
     <p style="margin: 0 0 12px; color: #F59E0B; font-weight: bold;">METHODOLOGY NOTE</p>
     <p style="margin: 0 0 12px; color: #A1A1AA;">Every question and framework in this report traces to documented winning methods from elite criminal defense attorneys. Your report draws on ${escapeHtml(meta.expertNames)}, selected for ${escapeHtml(meta.chargeType || meta.charges)} cases. Expert attributions appear throughout.</p>
-    <p style="margin: 0; color: #A1A1AA;"><strong style="color: white;">Important:</strong> This report provides legal INFORMATION, not legal ADVICE. The analysis draws on methods developed by elite defense attorneys, applied specifically to your case details. Your attorney remains the final authority on strategy decisions.</p>
+    <p style="margin: 0; color: #A1A1AA;"><strong style="color: white;">Important:</strong> This report provides legal INFORMATION, not legal ADVICE. The analysis draws on methods developed by elite defense attorneys, applied specifically to your case details. Decisions about how to use this information stay with you.</p>
   </blockquote>` : ""}
   ${html}
   <div style="background: #1C1917; padding: 16px; border-radius: 8px; margin-top: 40px; border-left: 4px solid #A1A1AA;">

--- a/src/lib/tier9-reports/render.ts
+++ b/src/lib/tier9-reports/render.ts
@@ -88,8 +88,7 @@ const UPL_DISCLAIMER = `
     <p style="color: #F59E0B; font-weight: bold; margin: 0 0 8px;">Legal Information, Not Legal Advice</p>
     <p style="color: #A1A1AA; font-size: 13px; margin: 0;">
       This report provides verified court record data compiled into a structured format.
-      It is legal INFORMATION, not legal ADVICE. Your attorney remains the final authority
-      on strategy decisions. All data points are sourced from public court records with
+      It is legal INFORMATION, not legal ADVICE. Decisions about how to use this information stay with you. All data points are sourced from public court records with
       verification URLs provided.
     </p>
   </div>


### PR DESCRIPTION
## Summary
Follow-up to #12 (Footer fix). 36 instances of the banned UPL pattern `"Your attorney remains the final authority on strategy decisions"` (and variants) across 23 files — violated `~/.claude/rules/no-hallucinated-legal-data.md` (the defendant is alone, no attorney will verify).

- Replaced site-wide with `"Decisions about how to use this information stay with you."`
- Exception: `src/app/arrested/page.tsx` kept "if you have counsel, talk it over with them" framing (subject was different)
- Fixed library generators (IB prompts, render, playbook-configs × 7, tier9, report-renderer) → propagates to every future customer-facing report
- Fixed 15 landing/intake/checkout pages
- Fixed 3 API-route JSON disclaimer strings
- Also resolved stale merge conflict markers in `products.ts:1229-1236` that survived the #12 rebase

## Test plan
- [x] `grep "remains the final authority" src/` → 0 hits
- [x] `npx tsc --noEmit --skipLibCheck` → exit 0
- [x] `npm run build` → exit 0, 425/425 static pages
- [ ] Vercel preview: `/checkout`, `/judge-report-card`, `/similar-cases-analyzer` disclaimer copy updated
- [ ] Generate a sample IB report → footer disclaimer no longer references "your attorney"

## Out of scope (tracked)
- `"verify with attorney"` pattern in MDX blog posts — content-sweep PR
- `products.ts:875` `"verification URLs your attorney can confirm"` — describes what the paid product includes, not the reader having an attorney. Kept.

Plan: `docs/plans/2026-04-21-upl-drift-global-sweep.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)