### PR TITLE
feat(scotus): walkerdb SCOTUS cases ingest + free search tool

### DIFF
--- a/e2e/scotus-case-search.spec.ts
+++ b/e2e/scotus-case-search.spec.ts
@@ -1,0 +1,98 @@
+/**
+ * E2E: /tools/scotus-case-search — free SCOTUS research tool.
+ *
+ * Covers:
+ *   - API returns ranked results for "miranda warnings" with expected top case
+ *   - API rejects invalid year_from
+ *   - API respects year_from/year_to filter
+ *   - Page renders form + results server-side (no JS dependency)
+ *   - Page strips HTML from snippets (no visible <p> tags in DOM)
+ *
+ * Gate: BASE defaults to https://imnotanattorney.com but can be overridden
+ * via E2E_BASE_URL. Skips when E2E_SKIP_LIVE=1.
+ */
+import { test, expect } from "@playwright/test";
+
+const BASE = process.env.E2E_BASE_URL || "https://imnotanattorney.com";
+
+test.describe("SCOTUS Case Search E2E", () => {
+  test.beforeEach(() => {
+    test.skip(
+      process.env.E2E_SKIP_LIVE === "1",
+      "E2E_SKIP_LIVE=1 — this spec hits live API + page",
+    );
+  });
+
+  test("API: 'miranda warnings' returns ranked results with expected top case", async ({ request }) => {
+    const res = await request.get(
+      `${BASE}/api/tools/scotus-case-search?q=${encodeURIComponent("miranda warnings")}&limit=5`,
+    );
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    expect(Array.isArray(body.results)).toBe(true);
+    expect(body.results.length).toBeGreaterThan(0);
+    const names: string[] = body.results.map((r: { name: string }) => r.name);
+    // Miranda doctrine jurisprudence should surface at least one of these
+    // canonical cases; the ranking shifts but the set is stable.
+    const canonical = ["Dickerson v. United States", "Withrow v. Williams", "Berkemer v. McCarty"];
+    expect(canonical.some((n) => names.includes(n))).toBe(true);
+    // Ranks must be sorted descending.
+    const ranks: number[] = body.results.map((r: { rank: number }) => r.rank);
+    for (let i = 1; i < ranks.length; i++) {
+      expect(ranks[i - 1]).toBeGreaterThanOrEqual(ranks[i]);
+    }
+    // Disclaimer + data source must be present for UPL / attribution.
+    expect(body.dataSource).toMatch(/Oyez/);
+    expect(body.disclaimer).toMatch(/legal INFORMATION/i);
+  });
+
+  test("API: year-range filter narrows results", async ({ request }) => {
+    const res = await request.get(
+      `${BASE}/api/tools/scotus-case-search?q=${encodeURIComponent("fourth amendment search")}&year_from=2000&year_to=2010&limit=10`,
+    );
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    for (const r of body.results as Array<{ citation_year: string | null }>) {
+      if (r.citation_year === null) continue;
+      expect(Number(r.citation_year)).toBeGreaterThanOrEqual(2000);
+      expect(Number(r.citation_year)).toBeLessThanOrEqual(2010);
+    }
+  });
+
+  test("API: invalid year_from returns 400", async ({ request }) => {
+    const res = await request.get(
+      `${BASE}/api/tools/scotus-case-search?q=test&year_from=abcd`,
+    );
+    expect(res.status()).toBe(400);
+  });
+
+  test("API: invalid limit (over cap) returns 400", async ({ request }) => {
+    const res = await request.get(
+      `${BASE}/api/tools/scotus-case-search?q=test&limit=500`,
+    );
+    expect(res.status()).toBe(400);
+  });
+
+  test("Page: form + server-rendered results (no-JS fallback works)", async ({ browser }) => {
+    const ctx = await browser.newContext({ javaScriptEnabled: false });
+    const page = await ctx.newPage();
+    await page.goto(`${BASE}/tools/scotus-case-search?q=miranda`);
+
+    await expect(page.getByRole("heading", { name: /SCOTUS Case Search/i })).toBeVisible();
+    await expect(page.locator('input[name="q"]')).toHaveValue("miranda");
+    // At least one Miranda result should render server-side.
+    const mirandaCount = await page.getByText(/Miranda/).count();
+    expect(mirandaCount).toBeGreaterThan(0);
+    await ctx.close();
+  });
+
+  test("Page: snippets have no raw HTML tags leaking into the DOM", async ({ page }) => {
+    await page.goto(`${BASE}/tools/scotus-case-search?q=miranda`);
+    // The Oyez text has <p> tags; the RPC strips them before returning. If
+    // they ever leak back in (e.g., a regex drop or render bug), the literal
+    // "<p>" string would appear in the text content.
+    const bodyText = await page.locator("main").innerText();
+    expect(bodyText).not.toContain("<p>");
+    expect(bodyText).not.toContain("</p>");
+  });
+});

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "lucide-react": "^1.7.0",
     "next": "^16.2.2",
     "next-mdx-remote": "^6.0.0",
+    "pg-copy-streams": "^7.0.0",
     "qrcode": "^1.5.4",
     "react": "19.2.3",
     "react-dom": "19.2.3",

--- a/scripts/ingest/walkerdb-scotus-cases.mjs
+++ b/scripts/ingest/walkerdb-scotus-cases.mjs
@@ -1,0 +1,252 @@
+/**
+ * walkerdb-scotus-cases.mjs
+ *
+ * Loads the walkerdb/supreme_court_transcripts dataset (Oyez-mirrored SCOTUS cases)
+ * into public.scotus_cases. 8,415 case JSON files, ~80MB table, COPY-loaded.
+ *
+ * Per-turn oral-argument transcripts are NOT loaded here — separate followup.
+ *
+ * Plan: ImNotAnAttorney/docs/plans/2026-04-21-walkerdb-scotus-ingest.md
+ *
+ * Template: scripts/marshall-covid-prisons-ingest.mjs (bulkCopyRows pattern)
+ * Expert: cl-bulk-data-defensive #17 + #18 (COPY FROM STDIN, session defenses)
+ * csv-bulk-checked: github bulk via shallow clone of walkerdb/supreme_court_transcripts; no Oyez API fetches in this script
+ *
+ * Usage:
+ *   REPO_PATH=D:/inaa-bulk/walkerdb/repo node scripts/ingest/walkerdb-scotus-cases.mjs
+ *   # defaults REPO_PATH to D:/inaa-bulk/walkerdb/repo
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import dotenv from 'dotenv';
+import { createBulkClient, bulkCopyRows } from '../lib/pg-bulk-defaults.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT = path.resolve(__dirname, '..', '..');
+dotenv.config({ path: path.join(PROJECT_ROOT, '.env.local') });
+
+const REPO_PATH = process.env.REPO_PATH || 'D:/inaa-bulk/walkerdb/repo';
+const CASES_DIR = path.join(REPO_PATH, 'oyez', 'cases');
+
+const TABLE = 'public.scotus_cases';
+
+const COLUMNS = [
+  'case_id',
+  'oyez_href',
+  'name',
+  'term',
+  'docket_number',
+  'additional_docket_numbers',
+  'citation_volume',
+  'citation_page',
+  'citation_year',
+  'first_party',
+  'first_party_label',
+  'second_party',
+  'second_party_label',
+  'facts_of_the_case',
+  'question',
+  'conclusion',
+  'description',
+  'manner_of_jurisdiction',
+  'location_json',
+  'lower_court_json',
+  'decided_by_json',
+  'heard_by_json',
+  'advocates_json',
+  'decisions_json',
+  'related_cases_json',
+  'written_opinion_json',
+  'opinion_announcement_json',
+  'oral_argument_audio_json',
+  'argument2_url',
+  'justia_url',
+  'timeline_json',
+  'decided_unix',
+  'decided_date',
+  'view_count',
+];
+
+function jsonb(v) {
+  if (v === null || v === undefined) return null;
+  return v;
+}
+
+function firstString(v) {
+  if (v === null || v === undefined) return null;
+  if (typeof v === 'string') return v.trim() || null;
+  return String(v);
+}
+
+function decidedDateFromTimeline(timeline) {
+  if (!Array.isArray(timeline)) return { unix: null, date: null };
+  for (const ev of timeline) {
+    if (ev && ev.event === 'Decided' && Array.isArray(ev.dates) && ev.dates.length > 0) {
+      const unix = Number(ev.dates[0]);
+      if (!Number.isFinite(unix)) return { unix: null, date: null };
+      const d = new Date(unix * 1000);
+      if (isNaN(d.getTime())) return { unix, date: null };
+      return { unix, date: d.toISOString().slice(0, 10) };
+    }
+  }
+  return { unix: null, date: null };
+}
+
+function caseToRow(rec) {
+  const citation = rec.citation && typeof rec.citation === 'object' ? rec.citation : {};
+  const timeline = rec.timeline;
+  const decided = decidedDateFromTimeline(timeline);
+  const caseId = Number(rec.ID);
+  if (!Number.isFinite(caseId)) return null;
+
+  return [
+    caseId,
+    firstString(rec.href),
+    firstString(rec.name),
+    firstString(rec.term),
+    firstString(rec.docket_number),
+    jsonb(rec.additional_docket_numbers),
+    firstString(citation.volume),
+    firstString(citation.page),
+    firstString(citation.year),
+    firstString(rec.first_party),
+    firstString(rec.first_party_label),
+    firstString(rec.second_party),
+    firstString(rec.second_party_label),
+    firstString(rec.facts_of_the_case),
+    firstString(rec.question),
+    firstString(rec.conclusion),
+    firstString(rec.description),
+    firstString(rec.manner_of_jurisdiction),
+    jsonb(rec.location),
+    jsonb(rec.lower_court),
+    jsonb(rec.decided_by),
+    jsonb(rec.heard_by),
+    jsonb(rec.advocates),
+    jsonb(rec.decisions),
+    jsonb(rec.related_cases),
+    jsonb(rec.written_opinion),
+    jsonb(rec.opinion_announcement),
+    jsonb(rec.oral_argument_audio),
+    firstString(rec.argument2_url),
+    firstString(rec.justia_url),
+    jsonb(timeline),
+    decided.unix,
+    decided.date,
+    Number.isFinite(Number(rec.view_count)) ? Number(rec.view_count) : null,
+  ];
+}
+
+function listCaseFiles(dir) {
+  const all = fs.readdirSync(dir);
+  return all
+    .filter((f) => f.endsWith('.json') && !/-t\d+\.json$/.test(f))
+    .map((f) => path.join(dir, f));
+}
+
+async function* readCasesAsRows(files) {
+  let skipped = 0;
+  let loaded = 0;
+  const seen = new Set();
+  for (const f of files) {
+    let rec;
+    try {
+      rec = JSON.parse(fs.readFileSync(f, 'utf8'));
+    } catch (err) {
+      skipped++;
+      continue;
+    }
+    const row = caseToRow(rec);
+    if (!row) { skipped++; continue; }
+    const id = row[0];
+    if (seen.has(id)) { skipped++; continue; }
+    seen.add(id);
+    loaded++;
+    yield row;
+    if (loaded % 1000 === 0) {
+      console.log(`  ${loaded}/${files.length} rows streamed...`);
+    }
+  }
+  console.log(`  done: loaded=${loaded}, skipped=${skipped}, total-files=${files.length}`);
+}
+
+async function main() {
+  if (!fs.existsSync(CASES_DIR)) {
+    throw new Error(
+      `Cases dir not found: ${CASES_DIR}\n` +
+      `Clone the repo first:\n  git clone --depth=1 https://github.com/walkerdb/supreme_court_transcripts.git ${path.dirname(CASES_DIR).replace(/\\/g,'/')}`
+    );
+  }
+
+  const files = listCaseFiles(CASES_DIR);
+  console.log(`case files: ${files.length}`);
+  if (files.length < 1000) {
+    throw new Error(`expected >1000 case files, got ${files.length} — repo path may be wrong`);
+  }
+
+  const { client, cleanup } = await createBulkClient({
+    workMemMB: 256,
+    maintWorkMemMB: 1024,
+    statementTimeout: '30min',
+  });
+
+  try {
+    console.log(`truncating ${TABLE}...`);
+    await client.query(`TRUNCATE TABLE ${TABLE}`);
+
+    console.log(`COPY loading ${files.length} rows...`);
+    const result = await bulkCopyRows(client, TABLE, COLUMNS, readCasesAsRows(files));
+    console.log(`loaded ${result.rowCount} rows in ${(result.durationMs / 1000).toFixed(1)}s`);
+
+    const countRes = await client.query(`SELECT COUNT(*)::int AS n FROM ${TABLE}`);
+    console.log(`verified row count: ${countRes.rows[0].n}`);
+
+    const fieldsRes = await client.query(`
+      SELECT
+        COUNT(*)                                             AS total,
+        COUNT(facts_of_the_case) FILTER (WHERE facts_of_the_case <> '') AS with_facts,
+        COUNT(question)          FILTER (WHERE question <> '')          AS with_question,
+        COUNT(conclusion)        FILTER (WHERE conclusion <> '')        AS with_conclusion,
+        MIN(citation_year)                                   AS oldest_year,
+        MAX(citation_year)                                   AS newest_year
+      FROM ${TABLE}
+    `);
+    console.log('coverage:', fieldsRes.rows[0]);
+
+    const sampleRes = await client.query(`
+      SELECT name, citation_year, left(conclusion, 120) AS conclusion_snip
+      FROM ${TABLE}
+      WHERE name ILIKE 'Miranda v. Arizona%'
+      LIMIT 2
+    `);
+    console.log('Miranda sample:', sampleRes.rows);
+
+    const ftsRes = await client.query(`
+      SELECT name, citation_year,
+             ts_rank(
+               to_tsvector('english',
+                 COALESCE(name,'') || ' ' || COALESCE(question,'') || ' ' ||
+                 COALESCE(facts_of_the_case,'') || ' ' || COALESCE(conclusion,'')),
+               plainto_tsquery('english','fourth amendment unreasonable search')
+             ) AS rank
+      FROM ${TABLE}
+      WHERE to_tsvector('english',
+              COALESCE(name,'') || ' ' || COALESCE(question,'') || ' ' ||
+              COALESCE(facts_of_the_case,'') || ' ' || COALESCE(conclusion,''))
+            @@ plainto_tsquery('english','fourth amendment unreasonable search')
+      ORDER BY rank DESC
+      LIMIT 5
+    `);
+    console.log('FTS test — top 5 for "fourth amendment unreasonable search":');
+    for (const r of ftsRes.rows) console.log(`  ${r.rank.toFixed(3)}  ${r.name} (${r.citation_year})`);
+  } finally {
+    await cleanup();
+  }
+}
+
+main().catch((err) => {
+  console.error('FAILED:', err && err.message ? err.message : err);
+  process.exit(1);
+});

--- a/scripts/lib/pg-bulk-defaults.mjs
+++ b/scripts/lib/pg-bulk-defaults.mjs
@@ -1,0 +1,131 @@
+/**
+ * scripts/lib/pg-bulk-defaults.mjs
+ *
+ * Shared bulk-load client for Supabase-backed ingest scripts. Centralizes
+ * the defensive session settings from `cl-bulk-data-defensive.md` (gotchas
+ * #7, #14, #17, #18) so every loader script gets the same guarantees:
+ *   - session-mode pooler port 5432 (multi-statement scripts safe)
+ *   - work_mem / maintenance_work_mem tuned per tier (default Supabase Pro)
+ *   - statement_timeout + idle_in_transaction_session_timeout bounded
+ *   - tcp_keepalives configured so orphan backends self-terminate
+ *   - COPY FROM STDIN helpers (`bulkCopyCsv`, `bulkCopyRows`) to replace
+ *     per-row INSERT loops (rule #18 / hook enforcement).
+ *
+ * Environment:
+ *   Reads SUPABASE_DB_URL from the caller project's .env.local. The
+ *   connection string can point at either port 6543 (pooler txn mode) or
+ *   port 5432 (session mode) — the helper rewrites to 5432 for safety.
+ *
+ * Usage:
+ *   import { createBulkClient, bulkCopyCsv, bulkCopyRows } from './lib/pg-bulk-defaults.mjs';
+ *   const { client, cleanup } = await createBulkClient();
+ *   try { await bulkCopyCsv(client, 'my_table', ['a','b'], 'data.csv'); }
+ *   finally { await cleanup(); }
+ */
+
+import { pipeline } from 'node:stream/promises';
+import { Readable } from 'node:stream';
+import fs from 'node:fs';
+import pg from 'pg';
+import { from as copyFrom } from 'pg-copy-streams';
+
+function rewriteToSessionPort(urlStr) {
+  try {
+    const u = new URL(urlStr);
+    u.port = '5432';
+    return u.toString();
+  } catch {
+    return urlStr;
+  }
+}
+
+export async function createBulkClient(opts = {}) {
+  const {
+    workMemMB = 256,
+    maintWorkMemMB = 1024,
+    statementTimeout = '30min',
+    idleTxTimeout = '5min',
+    connectionString = process.env.SUPABASE_DB_URL,
+  } = opts;
+
+  if (!connectionString) {
+    throw new Error('createBulkClient: missing SUPABASE_DB_URL (pass connectionString or set env)');
+  }
+
+  const client = new pg.Client({
+    connectionString: rewriteToSessionPort(connectionString),
+    ssl: { rejectUnauthorized: false },
+    application_name: 'inaa-bulk-loader',
+  });
+
+  await client.connect();
+
+  await client.query(`SET work_mem = '${workMemMB}MB'`);
+  await client.query(`SET maintenance_work_mem = '${maintWorkMemMB}MB'`);
+  await client.query(`SET statement_timeout = '${statementTimeout}'`);
+  await client.query(`SET idle_in_transaction_session_timeout = '${idleTxTimeout}'`);
+  await client.query(`SET tcp_keepalives_idle = 60`);
+  await client.query(`SET tcp_keepalives_interval = 10`);
+  await client.query(`SET tcp_keepalives_count = 6`);
+
+  return {
+    client,
+    cleanup: async () => {
+      try { await client.end(); } catch {}
+    },
+  };
+}
+
+export async function bulkCopyCsv(client, table, columns, csvPath) {
+  if (!fs.existsSync(csvPath)) {
+    throw new Error(`bulkCopyCsv: CSV not found: ${csvPath}`);
+  }
+  const colList = columns.map((c) => `"${c}"`).join(', ');
+  const copySql = `COPY ${table} (${colList}) FROM STDIN WITH (FORMAT CSV, NULL '\\N', HEADER true)`;
+
+  const started = Date.now();
+  const pgStream = client.query(copyFrom(copySql));
+  const fileStream = fs.createReadStream(csvPath);
+  await pipeline(fileStream, pgStream);
+  const durationMs = Date.now() - started;
+
+  return { rowCount: pgStream.rowCount ?? null, durationMs };
+}
+
+function csvEscape(value) {
+  if (value === null || value === undefined) return '\\N';
+  if (typeof value === 'boolean') return value ? 't' : 'f';
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) return '\\N';
+    return String(value);
+  }
+  if (typeof value === 'bigint') return value.toString();
+  if (value instanceof Date) return value.toISOString();
+  const s = typeof value === 'object' ? JSON.stringify(value) : String(value);
+  if (/[",\n\r]/.test(s)) {
+    return '"' + s.replace(/"/g, '""') + '"';
+  }
+  return s;
+}
+
+export async function bulkCopyRows(client, table, columns, rowsIterable) {
+  const colList = columns.map((c) => `"${c}"`).join(', ');
+  const copySql = `COPY ${table} (${colList}) FROM STDIN WITH (FORMAT CSV, NULL '\\N')`;
+
+  const started = Date.now();
+  const pgStream = client.query(copyFrom(copySql));
+
+  async function* encode() {
+    for await (const row of rowsIterable) {
+      if (!Array.isArray(row) || row.length !== columns.length) {
+        throw new Error(`bulkCopyRows: expected array of length ${columns.length}, got ${row && row.length}`);
+      }
+      yield row.map(csvEscape).join(',') + '\n';
+    }
+  }
+
+  await pipeline(Readable.from(encode(), { objectMode: false }), pgStream);
+  const durationMs = Date.now() - started;
+
+  return { rowCount: pgStream.rowCount ?? null, durationMs };
+}

--- a/src/app/api/tools/scotus-case-search/route.ts
+++ b/src/app/api/tools/scotus-case-search/route.ts
@@ -1,0 +1,134 @@
+/**
+ * @fileoverview GET /api/tools/scotus-case-search — free SCOTUS case search.
+ *
+ * Query params:
+ *   q          text query — websearch_to_tsquery syntax (quotes, OR, -negation)
+ *   year_from  4-digit year lower bound on citation_year (optional)
+ *   year_to    4-digit year upper bound on citation_year (optional)
+ *   limit      1..50 (default 20)
+ *
+ * Response:
+ *   { results: SearchResult[], query: { q, year_from, year_to, limit } }
+ *
+ * Data: public.scotus_cases (8,411 Oyez-sourced SCOTUS cases). See plan at
+ * ImNotAnAttorney/docs/plans/2026-04-21-walkerdb-scotus-ingest.md.
+ *
+ * UPL-safe — returns information (case facts, questions, holdings) and
+ * source links (Oyez, Justia). Never advice.
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { checkRateLimit } from "@/lib/rate-limit";
+import { getClientIp } from "@/lib/request";
+
+const MAX_LIMIT = 50;
+const DEFAULT_LIMIT = 20;
+const YEAR_RE = /^\d{4}$/;
+
+export type ScotusSearchResult = {
+  case_id: number;
+  name: string | null;
+  term: string | null;
+  citation_year: string | null;
+  citation_volume: string | null;
+  citation_page: string | null;
+  first_party: string | null;
+  second_party: string | null;
+  facts_snippet: string | null;
+  question_snippet: string | null;
+  conclusion_snippet: string | null;
+  justia_url: string | null;
+  oyez_href: string | null;
+  decided_date: string | null;
+  rank: number;
+};
+
+function parseInputs(req: NextRequest): {
+  ok: true;
+  q: string;
+  year_from: string | null;
+  year_to: string | null;
+  limit: number;
+} | { ok: false; error: string } {
+  const url = new URL(req.url);
+  const rawQ = (url.searchParams.get("q") ?? "").trim();
+  const rawYearFrom = url.searchParams.get("year_from");
+  const rawYearTo = url.searchParams.get("year_to");
+  const rawLimit = url.searchParams.get("limit");
+
+  if (rawQ.length > 300) {
+    return { ok: false, error: "q must be ≤ 300 characters" };
+  }
+  if (rawYearFrom !== null && rawYearFrom !== "" && !YEAR_RE.test(rawYearFrom)) {
+    return { ok: false, error: "year_from must be a 4-digit year" };
+  }
+  if (rawYearTo !== null && rawYearTo !== "" && !YEAR_RE.test(rawYearTo)) {
+    return { ok: false, error: "year_to must be a 4-digit year" };
+  }
+
+  let limit = DEFAULT_LIMIT;
+  if (rawLimit !== null) {
+    const parsed = Number(rawLimit);
+    if (!Number.isInteger(parsed) || parsed < 1 || parsed > MAX_LIMIT) {
+      return { ok: false, error: `limit must be an integer 1..${MAX_LIMIT}` };
+    }
+    limit = parsed;
+  }
+
+  return {
+    ok: true,
+    q: rawQ,
+    year_from: rawYearFrom && YEAR_RE.test(rawYearFrom) ? rawYearFrom : null,
+    year_to: rawYearTo && YEAR_RE.test(rawYearTo) ? rawYearTo : null,
+    limit,
+  };
+}
+
+export async function GET(req: NextRequest) {
+  const ip = getClientIp(req);
+  const supabase = createAdminClient();
+
+  const { limited } = await checkRateLimit(supabase, `scotus-search:${ip}`, 60, 300);
+  if (limited) {
+    return NextResponse.json({ error: "Too many requests" }, { status: 429 });
+  }
+
+  const parsed = parseInputs(req);
+  if (!parsed.ok) {
+    return NextResponse.json({ error: parsed.error }, { status: 400 });
+  }
+
+  const { q, year_from, year_to, limit } = parsed;
+
+  const { data, error } = await supabase.rpc("scotus_case_search", {
+    q: q === "" ? null : q,
+    year_from,
+    year_to,
+    result_limit: limit,
+  });
+
+  if (error) {
+    console.error("[scotus-case-search] RPC error:", error);
+    return NextResponse.json({ error: "Search failed" }, { status: 500 });
+  }
+
+  const results: ScotusSearchResult[] = (data ?? []) as ScotusSearchResult[];
+
+  return NextResponse.json(
+    {
+      query: { q, year_from, year_to, limit },
+      count: results.length,
+      results,
+      dataSource:
+        "Oyez API via walkerdb/supreme_court_transcripts (8,411 SCOTUS cases, 1793-2025).",
+      sourceUrl: "https://github.com/walkerdb/supreme_court_transcripts",
+      disclaimer:
+        "This search returns legal INFORMATION about Supreme Court cases — not legal advice. Oyez summaries reflect their editorial interpretation; the underlying opinion (linked via Justia) is the authoritative source.",
+    },
+    {
+      headers: {
+        "Cache-Control": "public, max-age=300, stale-while-revalidate=3600",
+      },
+    },
+  );
+}

--- a/src/app/tools/scotus-case-search/page.tsx
+++ b/src/app/tools/scotus-case-search/page.tsx
@@ -1,0 +1,276 @@
+/**
+ * @fileoverview /tools/scotus-case-search — free SCOTUS research tool.
+ *
+ * Server-rendered search over 8,411 SCOTUS cases (Oyez source via walkerdb).
+ * Free, ungated. Generates MOFU organic traffic that feeds into paid tiers
+ * (Similar Cases Analyzer, Federal Sentencing Distribution, etc.).
+ *
+ * UPL-safe per content rules: returns Oyez facts / questions / holdings
+ * (information), never advice. Every result links to the authoritative
+ * opinion on Justia.
+ *
+ * See plan at ImNotAnAttorney/docs/plans/2026-04-21-walkerdb-scotus-ingest.md.
+ */
+import type { Metadata } from "next";
+import Link from "next/link";
+import { createAdminClient } from "@/lib/supabase/admin";
+import type { ScotusSearchResult } from "@/app/api/tools/scotus-case-search/route";
+
+export const metadata: Metadata = {
+  title: "SCOTUS Case Search — Free Tool | ImNotAnAttorney",
+  description:
+    "Search 8,400+ Supreme Court cases by issue, party, or keyword. Facts, questions, and holdings in plain English — sourced from Oyez.",
+  openGraph: {
+    title: "Free SCOTUS Case Search",
+    description:
+      "Search 8,400+ Supreme Court cases. Facts, questions, holdings — in plain English.",
+    type: "website",
+  },
+};
+
+interface PageProps {
+  searchParams: Promise<{
+    q?: string;
+    year_from?: string;
+    year_to?: string;
+  }>;
+}
+
+const YEAR_RE = /^\d{4}$/;
+const DEFAULT_LIMIT = 20;
+
+export default async function ScotusCaseSearchPage({ searchParams }: PageProps) {
+  const { q = "", year_from = "", year_to = "" } = await searchParams;
+
+  const trimmedQ = q.trim().slice(0, 300);
+  const validYearFrom = YEAR_RE.test(year_from) ? year_from : null;
+  const validYearTo = YEAR_RE.test(year_to) ? year_to : null;
+
+  const supabase = createAdminClient();
+  const { data, error } = await supabase.rpc("scotus_case_search", {
+    q: trimmedQ === "" ? null : trimmedQ,
+    year_from: validYearFrom,
+    year_to: validYearTo,
+    result_limit: DEFAULT_LIMIT,
+  });
+
+  const results: ScotusSearchResult[] = ((data ?? []) as ScotusSearchResult[]) ?? [];
+  const errorMessage = error ? "Search temporarily unavailable. Try again in a moment." : null;
+
+  return (
+    <main className="min-h-screen bg-zinc-950 text-zinc-100">
+      <div className="mx-auto max-w-4xl px-4 py-12">
+        <header className="mb-8">
+          <h1 className="text-3xl md:text-4xl font-bold tracking-tight mb-3">
+            SCOTUS Case Search
+          </h1>
+          <p className="text-zinc-300">
+            Search 8,400+ Supreme Court cases. Facts, questions, and holdings in plain English,
+            sourced from Oyez. Free. No email required.
+          </p>
+        </header>
+
+        <form
+          method="GET"
+          action="/tools/scotus-case-search"
+          className="mb-8 grid grid-cols-1 md:grid-cols-[1fr_auto_auto_auto] gap-3 items-end"
+        >
+          <div>
+            <label htmlFor="q" className="block text-sm text-zinc-300 mb-1">
+              Search terms
+            </label>
+            <input
+              type="text"
+              id="q"
+              name="q"
+              defaultValue={trimmedQ}
+              maxLength={300}
+              placeholder="miranda warnings"
+              className="w-full rounded-md bg-zinc-900 border border-zinc-700 text-zinc-100 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-emerald-500"
+            />
+          </div>
+          <div>
+            <label htmlFor="year_from" className="block text-sm text-zinc-300 mb-1">
+              From year
+            </label>
+            <input
+              type="text"
+              id="year_from"
+              name="year_from"
+              inputMode="numeric"
+              pattern="\d{4}"
+              defaultValue={validYearFrom ?? ""}
+              placeholder="2000"
+              className="w-24 rounded-md bg-zinc-900 border border-zinc-700 text-zinc-100 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-emerald-500"
+            />
+          </div>
+          <div>
+            <label htmlFor="year_to" className="block text-sm text-zinc-300 mb-1">
+              To year
+            </label>
+            <input
+              type="text"
+              id="year_to"
+              name="year_to"
+              inputMode="numeric"
+              pattern="\d{4}"
+              defaultValue={validYearTo ?? ""}
+              placeholder="2025"
+              className="w-24 rounded-md bg-zinc-900 border border-zinc-700 text-zinc-100 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-emerald-500"
+            />
+          </div>
+          <button
+            type="submit"
+            className="rounded-md bg-emerald-500 hover:bg-emerald-400 text-zinc-900 font-semibold px-5 py-2"
+          >
+            Search
+          </button>
+        </form>
+
+        {errorMessage ? (
+          <p className="rounded-md bg-red-950 border border-red-700 text-red-200 p-4 mb-6">
+            {errorMessage}
+          </p>
+        ) : null}
+
+        <section aria-label="results" className="space-y-6">
+          {results.length === 0 && !errorMessage ? (
+            <p className="text-zinc-400">
+              {trimmedQ
+                ? `No cases matched "${trimmedQ}" in the selected year range.`
+                : "Type a query above to search."}
+            </p>
+          ) : null}
+          {results.map((r) => (
+            <ScotusResultCard key={r.case_id} r={r} />
+          ))}
+        </section>
+
+        <footer className="mt-16 border-t border-zinc-800 pt-6 text-xs text-zinc-400 space-y-2">
+          <p>
+            Sourced from{" "}
+            <a
+              href="https://www.oyez.org/"
+              className="text-emerald-400 hover:underline"
+              target="_blank"
+              rel="noreferrer"
+            >
+              Oyez
+            </a>{" "}
+            via{" "}
+            <a
+              href="https://github.com/walkerdb/supreme_court_transcripts"
+              className="text-emerald-400 hover:underline"
+              target="_blank"
+              rel="noreferrer"
+            >
+              walkerdb/supreme_court_transcripts
+            </a>{" "}
+            (8,411 cases, 1793-2025).
+          </p>
+          <p>
+            This tool returns legal INFORMATION, not legal advice. Oyez
+            summaries reflect their editorial interpretation; the authoritative
+            source for any holding is the underlying opinion (linked to Justia).
+            Decisions about how to use this information stay with you and your
+            attorney.
+          </p>
+        </footer>
+      </div>
+    </main>
+  );
+}
+
+function ScotusResultCard({ r }: { r: ScotusSearchResult }) {
+  const citation =
+    r.citation_volume && r.citation_page
+      ? `${r.citation_volume} U.S. ${r.citation_page}${r.citation_year ? ` (${r.citation_year})` : ""}`
+      : r.citation_year
+        ? `(${r.citation_year})`
+        : null;
+
+  return (
+    <article className="rounded-lg border border-zinc-800 bg-zinc-900/50 p-5">
+      <header className="mb-3">
+        <h2 className="text-xl font-semibold text-zinc-100">
+          {r.name ?? "(unnamed case)"}
+        </h2>
+        {citation ? (
+          <p className="text-sm text-zinc-400 mt-1">{citation}</p>
+        ) : null}
+      </header>
+
+      {r.question_snippet ? (
+        <div className="mb-3">
+          <h3 className="text-xs uppercase tracking-wider text-emerald-400 mb-1">
+            Question
+          </h3>
+          <p className="text-sm text-zinc-200 whitespace-pre-wrap">
+            {r.question_snippet}
+          </p>
+        </div>
+      ) : null}
+
+      {r.facts_snippet ? (
+        <div className="mb-3">
+          <h3 className="text-xs uppercase tracking-wider text-emerald-400 mb-1">
+            Facts
+          </h3>
+          <p className="text-sm text-zinc-200 whitespace-pre-wrap">
+            {r.facts_snippet}
+          </p>
+        </div>
+      ) : null}
+
+      {r.conclusion_snippet ? (
+        <div className="mb-3">
+          <h3 className="text-xs uppercase tracking-wider text-emerald-400 mb-1">
+            Holding / conclusion
+          </h3>
+          <p className="text-sm text-zinc-200 whitespace-pre-wrap">
+            {r.conclusion_snippet}
+          </p>
+        </div>
+      ) : null}
+
+      <footer className="mt-4 flex flex-wrap gap-3 text-sm">
+        {r.justia_url ? (
+          <a
+            href={r.justia_url}
+            target="_blank"
+            rel="noreferrer"
+            className="text-emerald-400 hover:underline"
+          >
+            Read full opinion (Justia) →
+          </a>
+        ) : null}
+        {r.oyez_href ? (
+          <a
+            href={r.oyez_href.replace("api.oyez.org", "www.oyez.org")}
+            target="_blank"
+            rel="noreferrer"
+            className="text-emerald-400 hover:underline"
+          >
+            Oyez page →
+          </a>
+        ) : null}
+      </footer>
+
+      <CtaRow />
+    </article>
+  );
+}
+
+function CtaRow() {
+  return (
+    <div className="mt-4 pt-4 border-t border-zinc-800 text-xs text-zinc-400">
+      Researching a federal case?{" "}
+      <Link
+        href="/intake/standalone/federal-sentencing-distribution"
+        className="text-emerald-400 hover:underline"
+      >
+        Get a Federal Sentencing Distribution Report →
+      </Link>
+    </div>
+  );
+}

--- a/supabase/migrations/20260421195414_scotus_cases.sql
+++ b/supabase/migrations/20260421195414_scotus_cases.sql
@@ -1,0 +1,79 @@
+-- SCOTUS cases from walkerdb/supreme_court_transcripts (Oyez-sourced)
+-- Plan: ImNotAnAttorney/docs/plans/2026-04-21-walkerdb-scotus-ingest.md
+--
+-- 8,415 Supreme Court cases with metadata + full-text facts/question/conclusion.
+-- Per-turn oral-argument transcripts are deferred to a follow-up ingest.
+--
+-- Data source: https://github.com/walkerdb/supreme_court_transcripts (Oyez API mirror, weekly refresh)
+
+CREATE TABLE IF NOT EXISTS public.scotus_cases (
+  case_id                     BIGINT PRIMARY KEY,
+  oyez_href                   TEXT,
+  name                        TEXT,
+  term                        TEXT,
+  docket_number               TEXT,
+  additional_docket_numbers   JSONB,
+  citation_volume             TEXT,
+  citation_page               TEXT,
+  citation_year               TEXT,
+  first_party                 TEXT,
+  first_party_label           TEXT,
+  second_party                TEXT,
+  second_party_label          TEXT,
+  facts_of_the_case           TEXT,
+  question                    TEXT,
+  conclusion                  TEXT,
+  description                 TEXT,
+  manner_of_jurisdiction      TEXT,
+  location_json               JSONB,
+  lower_court_json            JSONB,
+  decided_by_json             JSONB,
+  heard_by_json               JSONB,
+  advocates_json              JSONB,
+  decisions_json              JSONB,
+  related_cases_json          JSONB,
+  written_opinion_json        JSONB,
+  opinion_announcement_json   JSONB,
+  oral_argument_audio_json    JSONB,
+  argument2_url               TEXT,
+  justia_url                  TEXT,
+  timeline_json               JSONB,
+  decided_unix                BIGINT,
+  decided_date                DATE,
+  view_count                  INTEGER,
+  loaded_at                   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON TABLE public.scotus_cases IS
+  'SCOTUS cases from walkerdb/supreme_court_transcripts (Oyez mirror). 8,415 cases, metadata + facts/question/conclusion. Transcripts separate.';
+
+CREATE INDEX IF NOT EXISTS scotus_cases_term_idx
+  ON public.scotus_cases (term);
+
+CREATE INDEX IF NOT EXISTS scotus_cases_citation_year_idx
+  ON public.scotus_cases (citation_year);
+
+CREATE INDEX IF NOT EXISTS scotus_cases_decided_date_idx
+  ON public.scotus_cases (decided_date);
+
+-- FTS index over narrative fields. coalesce handles NULL (older cases
+-- often lack facts/question/conclusion but always have name).
+CREATE INDEX IF NOT EXISTS scotus_cases_fts_idx
+  ON public.scotus_cases
+  USING GIN (
+    to_tsvector(
+      'english',
+      COALESCE(name, '') || ' ' ||
+      COALESCE(first_party, '') || ' ' ||
+      COALESCE(second_party, '') || ' ' ||
+      COALESCE(question, '') || ' ' ||
+      COALESCE(facts_of_the_case, '') || ' ' ||
+      COALESCE(conclusion, '') || ' ' ||
+      COALESCE(description, '')
+    )
+  );
+
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+CREATE INDEX IF NOT EXISTS scotus_cases_name_trgm_idx
+  ON public.scotus_cases
+  USING GIN (name gin_trgm_ops);

--- a/supabase/migrations/20260421200000_scotus_case_search_rpc.sql
+++ b/supabase/migrations/20260421200000_scotus_case_search_rpc.sql
@@ -1,0 +1,88 @@
+-- RPC: ranked SCOTUS case search with year-range filter + HTML-stripped snippets.
+-- Consumed by /api/tools/scotus-case-search.
+--
+-- Plan: ImNotAnAttorney/docs/plans/2026-04-21-walkerdb-scotus-ingest.md
+
+CREATE OR REPLACE FUNCTION public.scotus_case_search(
+  q TEXT,
+  year_from TEXT DEFAULT NULL,
+  year_to TEXT DEFAULT NULL,
+  result_limit INT DEFAULT 20
+)
+RETURNS TABLE(
+  case_id            BIGINT,
+  name               TEXT,
+  term               TEXT,
+  citation_year      TEXT,
+  citation_volume    TEXT,
+  citation_page      TEXT,
+  first_party        TEXT,
+  second_party       TEXT,
+  facts_snippet      TEXT,
+  question_snippet   TEXT,
+  conclusion_snippet TEXT,
+  justia_url         TEXT,
+  oyez_href          TEXT,
+  decided_date       DATE,
+  rank               REAL
+)
+LANGUAGE SQL
+STABLE
+AS $$
+  WITH query_vec AS (
+    SELECT CASE
+      WHEN q IS NULL OR btrim(q) = '' THEN NULL
+      ELSE websearch_to_tsquery('english', q)
+    END AS tsq
+  )
+  SELECT
+    c.case_id,
+    c.name,
+    c.term,
+    c.citation_year,
+    c.citation_volume,
+    c.citation_page,
+    c.first_party,
+    c.second_party,
+    LEFT(regexp_replace(COALESCE(c.facts_of_the_case, ''), '<[^>]+>', '', 'g'), 500) AS facts_snippet,
+    LEFT(regexp_replace(COALESCE(c.question, ''),          '<[^>]+>', '', 'g'), 500) AS question_snippet,
+    LEFT(regexp_replace(COALESCE(c.conclusion, ''),        '<[^>]+>', '', 'g'), 500) AS conclusion_snippet,
+    c.justia_url,
+    c.oyez_href,
+    c.decided_date,
+    CASE
+      WHEN qv.tsq IS NULL THEN 0.0::real
+      ELSE ts_rank(
+        to_tsvector('english',
+          COALESCE(c.name, '')               || ' ' ||
+          COALESCE(c.first_party, '')        || ' ' ||
+          COALESCE(c.second_party, '')       || ' ' ||
+          COALESCE(c.question, '')           || ' ' ||
+          COALESCE(c.facts_of_the_case, '')  || ' ' ||
+          COALESCE(c.conclusion, '')         || ' ' ||
+          COALESCE(c.description, '')
+        ),
+        qv.tsq
+      )
+    END AS rank
+  FROM public.scotus_cases c
+  CROSS JOIN query_vec qv
+  WHERE
+    (qv.tsq IS NULL
+     OR to_tsvector('english',
+          COALESCE(c.name, '')              || ' ' ||
+          COALESCE(c.first_party, '')       || ' ' ||
+          COALESCE(c.second_party, '')      || ' ' ||
+          COALESCE(c.question, '')          || ' ' ||
+          COALESCE(c.facts_of_the_case, '') || ' ' ||
+          COALESCE(c.conclusion, '')        || ' ' ||
+          COALESCE(c.description, '')
+        ) @@ qv.tsq)
+    AND (year_from IS NULL OR c.citation_year >= year_from)
+    AND (year_to   IS NULL OR c.citation_year <= year_to)
+  ORDER BY rank DESC, c.citation_year DESC NULLS LAST, c.name ASC
+  LIMIT LEAST(GREATEST(result_limit, 1), 100);
+$$;
+
+COMMENT ON FUNCTION public.scotus_case_search(TEXT, TEXT, TEXT, INT) IS
+  'Free-text ranked search over SCOTUS cases with year-range filter and HTML-stripped snippets.';

--- a/tests/api/scotus-case-search.test.ts
+++ b/tests/api/scotus-case-search.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Integration tests for GET /api/tools/scotus-case-search.
+ *
+ * Verifies:
+ *   - Empty query returns most recent cases (q=null)
+ *   - Query string passes through to RPC
+ *   - Year filters validate + pass through
+ *   - Invalid limit/year → 400
+ *   - Rate limiting returns 429
+ *   - RPC error returns 500
+ *   - Cache-Control is short-lived + SWR
+ *
+ * Mocks `supabase.rpc("scotus_case_search", ...)`.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+let lastRpcArgs: Record<string, unknown> | null = null;
+let rpcRows: unknown[] = [];
+let rpcError: Error | null = null;
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: () => ({
+    rpc: async (fn: string, args: Record<string, unknown>) => {
+      if (fn !== "scotus_case_search") {
+        throw new Error(`unexpected rpc: ${fn}`);
+      }
+      lastRpcArgs = args;
+      if (rpcError) return { data: null, error: rpcError };
+      return { data: rpcRows, error: null };
+    },
+  }),
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  checkRateLimit: vi.fn(async () => ({ limited: false })),
+}));
+
+import { GET } from "@/app/api/tools/scotus-case-search/route";
+import { NextRequest } from "next/server";
+
+function buildReq(query: string): NextRequest {
+  return new NextRequest(`http://localhost/api/tools/scotus-case-search${query}`, {
+    headers: { "x-real-ip": "1.2.3.4" },
+  });
+}
+
+beforeEach(() => {
+  lastRpcArgs = null;
+  rpcRows = [];
+  rpcError = null;
+});
+
+describe("GET /api/tools/scotus-case-search", () => {
+  it("empty query → RPC called with q=null, default limit 20", async () => {
+    rpcRows = [
+      { case_id: 1, name: "Foo v. Bar", rank: 0, citation_year: "2020" },
+    ];
+    const res = await GET(buildReq(""));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.results).toHaveLength(1);
+    expect(body.count).toBe(1);
+    expect(lastRpcArgs).toEqual({
+      q: null,
+      year_from: null,
+      year_to: null,
+      result_limit: 20,
+    });
+    expect(body.dataSource).toMatch(/Oyez/);
+    expect(body.disclaimer).toMatch(/legal INFORMATION/i);
+  });
+
+  it("trims + passes non-empty query to RPC", async () => {
+    rpcRows = [];
+    await GET(buildReq("?q=%20miranda%20warnings%20"));
+    expect(lastRpcArgs?.q).toBe("miranda warnings");
+  });
+
+  it("accepts and passes through valid year filters", async () => {
+    rpcRows = [];
+    await GET(buildReq("?q=test&year_from=2000&year_to=2010&limit=5"));
+    expect(lastRpcArgs).toEqual({
+      q: "test",
+      year_from: "2000",
+      year_to: "2010",
+      result_limit: 5,
+    });
+  });
+
+  it("rejects invalid year_from (non-4-digit)", async () => {
+    const res = await GET(buildReq("?q=test&year_from=abcd"));
+    expect(res.status).toBe(400);
+    const res2 = await GET(buildReq("?q=test&year_from=123"));
+    expect(res2.status).toBe(400);
+    const res3 = await GET(buildReq("?q=test&year_from=12345"));
+    expect(res3.status).toBe(400);
+  });
+
+  it("rejects invalid year_to (non-4-digit)", async () => {
+    const res = await GET(buildReq("?q=test&year_to=xyz"));
+    expect(res.status).toBe(400);
+  });
+
+  it("ignores blank year_from / year_to query params", async () => {
+    rpcRows = [];
+    await GET(buildReq("?q=test&year_from=&year_to="));
+    expect(lastRpcArgs?.year_from).toBeNull();
+    expect(lastRpcArgs?.year_to).toBeNull();
+  });
+
+  it("rejects limit out of 1..50", async () => {
+    const res = await GET(buildReq("?q=test&limit=0"));
+    expect(res.status).toBe(400);
+    const res2 = await GET(buildReq("?q=test&limit=51"));
+    expect(res2.status).toBe(400);
+    const res3 = await GET(buildReq("?q=test&limit=abc"));
+    expect(res3.status).toBe(400);
+  });
+
+  it("rejects q longer than 300 chars (avoid pathological inputs)", async () => {
+    const longQ = "a".repeat(301);
+    const res = await GET(buildReq(`?q=${longQ}`));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 429 when rate-limited", async () => {
+    const { checkRateLimit } = await import("@/lib/rate-limit");
+    (checkRateLimit as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ limited: true });
+    const res = await GET(buildReq("?q=test"));
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 500 when RPC errors", async () => {
+    rpcError = new Error("db down");
+    const res = await GET(buildReq("?q=test"));
+    expect(res.status).toBe(500);
+  });
+
+  it("sets short-lived Cache-Control with SWR", async () => {
+    rpcRows = [];
+    const res = await GET(buildReq("?q=test"));
+    const cc = res.headers.get("Cache-Control") || "";
+    expect(cc).toMatch(/max-age=300/);
+    expect(cc).toMatch(/stale-while-revalidate/);
+  });
+
+  it("clamps limit default to 20", async () => {
+    rpcRows = [];
+    await GET(buildReq("?q=test"));
+    expect(lastRpcArgs?.result_limit).toBe(20);
+  });
+});


### PR DESCRIPTION
## Summary

Ships priority #4 from `docs/handoffs/2026-04-21-ussc-priorities-1-2-3-shipped.md` — ingests 8,411 Oyez-sourced SCOTUS cases into Supabase and exposes them via a free research page that feeds the paid funnel.

- **Data**: `public.scotus_cases` — 8,411 rows, 1793-2025, 44% with Oyez facts/question text, 41% with conclusion text.
- **RPC**: `public.scotus_case_search(q, year_from, year_to, result_limit)` — ranked FTS + HTML-stripped snippets.
- **API**: `GET /api/tools/scotus-case-search` — rate-limited (60/5min), validated, short-lived cache.
- **Page**: `/tools/scotus-case-search` — server-rendered, no-JS-fallback, UPL-safe framing, CTA to FSD $297 report.
- **Infrastructure**: `scripts/lib/pg-bulk-defaults.mjs` (helper that `marshall-covid-prisons-ingest.mjs` + `build-ussc-districts.mjs` already imported but never committed — unblocks them too).

## Scope decisions (expert-lens, not Rahim-ask)

- **Free page, not paid SKU**: SCOTUS oral-argument content is MOFU (informational). Dreyer BOFU-first + Hormozi value-equation both point at lead-gen over $97/$297 pricing. Data lives in shared Supabase so engine-repo War Room can consume later without re-ingest.
- **Cases-only this pass**: per-turn transcripts (~8,566 files) deferred to follow-up plan.
- **Priority #5 NRE Exonerations deferred**: confirmed Cloudflare-JS-gated via curl 403 + no GitHub mirror. Needs Rahim action (NRE bulk-CSV email) — blocker doc follows.

## Test plan

- [x] `npx tsc --noEmit --skipLibCheck` — clean
- [x] `npx vitest run` — 554 passed / 6 pre-existing skips / 0 regressions
- [x] Ingest smoke: 8,411 rows, FTS returns canonical Miranda/4A cases in expected rank order
- [ ] CI green on this PR
- [ ] E2E against prod after deploy: `npx playwright test e2e/scotus-case-search.spec.ts --project=chromium`
- [ ] Spot-check `/tools/scotus-case-search?q=miranda` on prod

## Plan

`C:/Users/email/projects/ImNotAnAttorney/docs/plans/2026-04-21-walkerdb-scotus-ingest.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)