### PR TITLE
fix(scotus): pristine-or-nothing pass on PR #21 review findings

### DIFF
--- a/e2e/scotus-case-search.spec.ts
+++ b/e2e/scotus-case-search.spec.ts
@@ -1,19 +1,23 @@
 /**
  * E2E: /tools/scotus-case-search — free SCOTUS research tool.
  *
- * Covers:
- *   - API returns ranked results for "miranda warnings" with expected top case
- *   - API rejects invalid year_from
- *   - API respects year_from/year_to filter
- *   - Page renders form + results server-side (no JS dependency)
- *   - Page strips HTML from snippets (no visible <p> tags in DOM)
- *
  * Gate: BASE defaults to https://imnotanattorney.com but can be overridden
  * via E2E_BASE_URL. Skips when E2E_SKIP_LIVE=1.
  */
 import { test, expect } from "@playwright/test";
 
 const BASE = process.env.E2E_BASE_URL || "https://imnotanattorney.com";
+
+// Known-stable Oyez case IDs (see public.scotus_cases). Oyez IDs do NOT
+// change when walkerdb refreshes weekly — unlike name strings, which get
+// minor editorial edits.
+const CANONICAL_MIRANDA_IDS = new Set([
+  54850, // Dickerson v. United States (2000)
+  54086, // Withrow v. Williams (1993)
+  52850, // Berkemer v. McCarty (1984)
+  55645, // Florida v. Powell (2010)
+  55138, // United States v. Patane (2004)
+]);
 
 test.describe("SCOTUS Case Search E2E", () => {
   test.beforeEach(() => {
@@ -23,7 +27,7 @@ test.describe("SCOTUS Case Search E2E", () => {
     );
   });
 
-  test("API: 'miranda warnings' returns ranked results with expected top case", async ({ request }) => {
+  test("API: 'miranda warnings' returns ranked results with a canonical Oyez case in top 5", async ({ request }) => {
     const res = await request.get(
       `${BASE}/api/tools/scotus-case-search?q=${encodeURIComponent("miranda warnings")}&limit=5`,
     );
@@ -31,22 +35,18 @@ test.describe("SCOTUS Case Search E2E", () => {
     const body = await res.json();
     expect(Array.isArray(body.results)).toBe(true);
     expect(body.results.length).toBeGreaterThan(0);
-    const names: string[] = body.results.map((r: { name: string }) => r.name);
-    // Miranda doctrine jurisprudence should surface at least one of these
-    // canonical cases; the ranking shifts but the set is stable.
-    const canonical = ["Dickerson v. United States", "Withrow v. Williams", "Berkemer v. McCarty"];
-    expect(canonical.some((n) => names.includes(n))).toBe(true);
-    // Ranks must be sorted descending.
+    const ids = new Set(body.results.map((r: { case_id: number }) => r.case_id));
+    const hitCount = [...CANONICAL_MIRANDA_IDS].filter((id) => ids.has(id)).length;
+    expect(hitCount).toBeGreaterThan(0);
     const ranks: number[] = body.results.map((r: { rank: number }) => r.rank);
     for (let i = 1; i < ranks.length; i++) {
       expect(ranks[i - 1]).toBeGreaterThanOrEqual(ranks[i]);
     }
-    // Disclaimer + data source must be present for UPL / attribution.
     expect(body.dataSource).toMatch(/Oyez/);
     expect(body.disclaimer).toMatch(/legal INFORMATION/i);
   });
 
-  test("API: year-range filter narrows results", async ({ request }) => {
+  test("API: year-range filter narrows results numerically", async ({ request }) => {
     const res = await request.get(
       `${BASE}/api/tools/scotus-case-search?q=${encodeURIComponent("fourth amendment search")}&year_from=2000&year_to=2010&limit=10`,
     );
@@ -66,6 +66,13 @@ test.describe("SCOTUS Case Search E2E", () => {
     expect(res.status()).toBe(400);
   });
 
+  test("API: year_from > year_to returns 400 (sane-range guard)", async ({ request }) => {
+    const res = await request.get(
+      `${BASE}/api/tools/scotus-case-search?q=test&year_from=2020&year_to=2000`,
+    );
+    expect(res.status()).toBe(400);
+  });
+
   test("API: invalid limit (over cap) returns 400", async ({ request }) => {
     const res = await request.get(
       `${BASE}/api/tools/scotus-case-search?q=test&limit=500`,
@@ -78,21 +85,30 @@ test.describe("SCOTUS Case Search E2E", () => {
     const page = await ctx.newPage();
     await page.goto(`${BASE}/tools/scotus-case-search?q=miranda`);
 
-    await expect(page.getByRole("heading", { name: /SCOTUS Case Search/i })).toBeVisible();
+    await expect(page.getByRole("heading", { name: /SCOTUS Case Search/i, level: 1 })).toBeVisible();
     await expect(page.locator('input[name="q"]')).toHaveValue("miranda");
-    // At least one Miranda result should render server-side.
-    const mirandaCount = await page.getByText(/Miranda/).count();
-    expect(mirandaCount).toBeGreaterThan(0);
+    // Scope to the results section so the form's preserved input value
+    // doesn't false-positive the count.
+    const resultCards = page.locator('section[aria-label="Search results"] article');
+    const mirandaCards = resultCards.filter({ hasText: /Miranda/i });
+    expect(await mirandaCards.count()).toBeGreaterThan(0);
     await ctx.close();
   });
 
   test("Page: snippets have no raw HTML tags leaking into the DOM", async ({ page }) => {
+    // React escapes text nodes, so the RPC's regex-strip is display-only (not
+    // a security boundary). This assertion guards against a regression that
+    // would leak literal "<p>" strings visible to the user.
     await page.goto(`${BASE}/tools/scotus-case-search?q=miranda`);
-    // The Oyez text has <p> tags; the RPC strips them before returning. If
-    // they ever leak back in (e.g., a regex drop or render bug), the literal
-    // "<p>" string would appear in the text content.
     const bodyText = await page.locator("main").innerText();
     expect(bodyText).not.toContain("<p>");
     expect(bodyText).not.toContain("</p>");
+  });
+
+  test("Page: empty query renders empty-state without hitting DB", async ({ page }) => {
+    await page.goto(`${BASE}/tools/scotus-case-search`);
+    const cards = page.locator('section[aria-label="Search results"] article');
+    expect(await cards.count()).toBe(0);
+    await expect(page.getByText(/Type a query above to search/i)).toBeVisible();
   });
 });

--- a/scripts/ingest/walkerdb-scotus-cases.mjs
+++ b/scripts/ingest/walkerdb-scotus-cases.mjs
@@ -18,6 +18,7 @@
  */
 
 import fs from 'node:fs';
+import fsp from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import dotenv from 'dotenv';
@@ -76,22 +77,29 @@ function jsonb(v) {
 
 function firstString(v) {
   if (v === null || v === undefined) return null;
-  if (typeof v === 'string') return v.trim() || null;
-  return String(v);
+  // Trim non-string inputs too (numeric citation fields sometimes come
+  // through as Number). Prevents "0" leaking when Oyez returns numeric 0.
+  const s = typeof v === 'string' ? v : String(v);
+  const trimmed = s.trim();
+  return trimmed || null;
 }
 
 function decidedDateFromTimeline(timeline) {
   if (!Array.isArray(timeline)) return { unix: null, date: null };
+  // Pick the LAST 'Decided' event in the timeline. Cases with rehearings or
+  // remand-then-decided show multiple Decided events; the final one is the
+  // operative decision (code-review finding #33).
+  let chosen = null;
   for (const ev of timeline) {
     if (ev && ev.event === 'Decided' && Array.isArray(ev.dates) && ev.dates.length > 0) {
       const unix = Number(ev.dates[0]);
-      if (!Number.isFinite(unix)) return { unix: null, date: null };
-      const d = new Date(unix * 1000);
-      if (isNaN(d.getTime())) return { unix, date: null };
-      return { unix, date: d.toISOString().slice(0, 10) };
+      if (Number.isFinite(unix)) chosen = unix;
     }
   }
-  return { unix: null, date: null };
+  if (chosen === null) return { unix: null, date: null };
+  const d = new Date(chosen * 1000);
+  if (isNaN(d.getTime())) return { unix: chosen, date: null };
+  return { unix: chosen, date: d.toISOString().slice(0, 10) };
 }
 
 function caseToRow(rec) {
@@ -153,7 +161,9 @@ async function* readCasesAsRows(files) {
   for (const f of files) {
     let rec;
     try {
-      rec = JSON.parse(fs.readFileSync(f, 'utf8'));
+      // Non-blocking read so the event loop stays responsive while COPY
+      // consumes the async iterable.
+      rec = JSON.parse(await fsp.readFile(f, 'utf8'));
     } catch (err) {
       skipped++;
       continue;

--- a/scripts/lib/pg-bulk-defaults.mjs
+++ b/scripts/lib/pg-bulk-defaults.mjs
@@ -11,11 +11,6 @@
  *   - COPY FROM STDIN helpers (`bulkCopyCsv`, `bulkCopyRows`) to replace
  *     per-row INSERT loops (rule #18 / hook enforcement).
  *
- * Environment:
- *   Reads SUPABASE_DB_URL from the caller project's .env.local. The
- *   connection string can point at either port 6543 (pooler txn mode) or
- *   port 5432 (session mode) — the helper rewrites to 5432 for safety.
- *
  * Usage:
  *   import { createBulkClient, bulkCopyCsv, bulkCopyRows } from './lib/pg-bulk-defaults.mjs';
  *   const { client, cleanup } = await createBulkClient();
@@ -39,6 +34,14 @@ function rewriteToSessionPort(urlStr) {
   }
 }
 
+/**
+ * Open a pg.Client tuned for bulk operations.
+ *
+ * Session parameters are batched into a single simple-query round trip
+ * (code-review finding #15 — Supabase runs in us-west-2, so individual
+ * SET statements cost ~150ms each from Windows; batching saves ~1s of
+ * startup latency).
+ */
 export async function createBulkClient(opts = {}) {
   const {
     workMemMB = 256,
@@ -54,19 +57,28 @@ export async function createBulkClient(opts = {}) {
 
   const client = new pg.Client({
     connectionString: rewriteToSessionPort(connectionString),
+    // Supabase's pooler uses a cert chain that Node's default CA bundle
+    // accepts, but `db.<ref>.supabase.co:5432` direct-host sessions can
+    // present a cert that trips `self-signed certificate in certificate
+    // chain` on some Node builds. Matches the repo-wide convention from
+    // scripts/lib/db.mjs + every CL-bulk loader. The connection is still
+    // TLS-encrypted — this only disables chain verification.
     ssl: { rejectUnauthorized: false },
     application_name: 'inaa-bulk-loader',
   });
 
   await client.connect();
 
-  await client.query(`SET work_mem = '${workMemMB}MB'`);
-  await client.query(`SET maintenance_work_mem = '${maintWorkMemMB}MB'`);
-  await client.query(`SET statement_timeout = '${statementTimeout}'`);
-  await client.query(`SET idle_in_transaction_session_timeout = '${idleTxTimeout}'`);
-  await client.query(`SET tcp_keepalives_idle = 60`);
-  await client.query(`SET tcp_keepalives_interval = 10`);
-  await client.query(`SET tcp_keepalives_count = 6`);
+  const settings = [
+    `SET work_mem = '${workMemMB}MB'`,
+    `SET maintenance_work_mem = '${maintWorkMemMB}MB'`,
+    `SET statement_timeout = '${statementTimeout}'`,
+    `SET idle_in_transaction_session_timeout = '${idleTxTimeout}'`,
+    `SET tcp_keepalives_idle = 60`,
+    `SET tcp_keepalives_interval = 10`,
+    `SET tcp_keepalives_count = 6`,
+  ];
+  await client.query(settings.join('; '));
 
   return {
     client,
@@ -76,6 +88,15 @@ export async function createBulkClient(opts = {}) {
   };
 }
 
+/**
+ * Stream a CSV file to COPY FROM STDIN.
+ *
+ * Note: NULL marker '\\N' is the repo-wide convention. Caller-provided CSVs
+ * (Marshall, USSC subsets) use empty-string-as-null and never contain literal
+ * `\N` text, so this is safe.
+ *
+ * Returns { rowCount, durationMs }.
+ */
 export async function bulkCopyCsv(client, table, columns, csvPath) {
   if (!fs.existsSync(csvPath)) {
     throw new Error(`bulkCopyCsv: CSV not found: ${csvPath}`);
@@ -92,6 +113,9 @@ export async function bulkCopyCsv(client, table, columns, csvPath) {
   return { rowCount: pgStream.rowCount ?? null, durationMs };
 }
 
+const NUL = String.fromCharCode(0);
+const NUL_RE = new RegExp(NUL, 'g');
+
 function csvEscape(value) {
   if (value === null || value === undefined) return '\\N';
   if (typeof value === 'boolean') return value ? 't' : 'f';
@@ -101,13 +125,26 @@ function csvEscape(value) {
   }
   if (typeof value === 'bigint') return value.toString();
   if (value instanceof Date) return value.toISOString();
-  const s = typeof value === 'object' ? JSON.stringify(value) : String(value);
+  let s = typeof value === 'object' ? JSON.stringify(value) : String(value);
+  // Postgres COPY rejects NULL bytes in text columns:
+  //   "invalid byte sequence for encoding UTF8: 0x00"
+  // Oyez OCR text occasionally contains them — strip before encoding.
+  if (s.indexOf(NUL) !== -1) s = s.replace(NUL_RE, '');
   if (/[",\n\r]/.test(s)) {
     return '"' + s.replace(/"/g, '""') + '"';
   }
   return s;
 }
 
+/**
+ * Stream an async iterable of row-arrays to COPY FROM STDIN.
+ *
+ *   await bulkCopyRows(client, 'my_table', ['a','b','c'], async function*() {
+ *     for (const r of source) yield [r.a, r.b, r.c];
+ *   }());
+ *
+ * Returns { rowCount, durationMs }.
+ */
 export async function bulkCopyRows(client, table, columns, rowsIterable) {
   const colList = columns.map((c) => `"${c}"`).join(', ');
   const copySql = `COPY ${table} (${colList}) FROM STDIN WITH (FORMAT CSV, NULL '\\N')`;
@@ -129,3 +166,6 @@ export async function bulkCopyRows(client, table, columns, rowsIterable) {
 
   return { rowCount: pgStream.rowCount ?? null, durationMs };
 }
+
+// Exported for unit testing only.
+export const _internals = { csvEscape };

--- a/src/app/api/tools/scotus-case-search/route.ts
+++ b/src/app/api/tools/scotus-case-search/route.ts
@@ -8,7 +8,7 @@
  *   limit      1..50 (default 20)
  *
  * Response:
- *   { results: SearchResult[], query: { q, year_from, year_to, limit } }
+ *   { query, count, results, dataSource, sourceUrl, disclaimer }
  *
  * Data: public.scotus_cases (8,411 Oyez-sourced SCOTUS cases). See plan at
  * ImNotAnAttorney/docs/plans/2026-04-21-walkerdb-scotus-ingest.md.
@@ -20,6 +20,12 @@ import { NextRequest, NextResponse } from "next/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { checkRateLimit } from "@/lib/rate-limit";
 import { getClientIp } from "@/lib/request";
+
+// Mark dynamic: the route reads req.url for query params + the Cache-Control
+// header hints at CDN caching, but Vercel's edge treats query-variant routes
+// as dynamic (see gotcha_vercel_strips_smaxage_on_dynamic_routes). Explicit
+// flag documents the intent + avoids accidental static generation.
+export const dynamic = "force-dynamic";
 
 const MAX_LIMIT = 50;
 const DEFAULT_LIMIT = 20;
@@ -43,13 +49,17 @@ export type ScotusSearchResult = {
   rank: number;
 };
 
-function parseInputs(req: NextRequest): {
-  ok: true;
-  q: string;
-  year_from: string | null;
-  year_to: string | null;
-  limit: number;
-} | { ok: false; error: string } {
+export type ParseResult =
+  | {
+      ok: true;
+      q: string;
+      year_from: string | null;
+      year_to: string | null;
+      limit: number;
+    }
+  | { ok: false; error: string };
+
+export function parseInputs(req: NextRequest): ParseResult {
   const url = new URL(req.url);
   const rawQ = (url.searchParams.get("q") ?? "").trim();
   const rawYearFrom = url.searchParams.get("year_from");
@@ -57,7 +67,7 @@ function parseInputs(req: NextRequest): {
   const rawLimit = url.searchParams.get("limit");
 
   if (rawQ.length > 300) {
-    return { ok: false, error: "q must be ≤ 300 characters" };
+    return { ok: false, error: "q must be 300 characters or fewer" };
   }
   if (rawYearFrom !== null && rawYearFrom !== "" && !YEAR_RE.test(rawYearFrom)) {
     return { ok: false, error: "year_from must be a 4-digit year" };
@@ -75,13 +85,16 @@ function parseInputs(req: NextRequest): {
     limit = parsed;
   }
 
-  return {
-    ok: true,
-    q: rawQ,
-    year_from: rawYearFrom && YEAR_RE.test(rawYearFrom) ? rawYearFrom : null,
-    year_to: rawYearTo && YEAR_RE.test(rawYearTo) ? rawYearTo : null,
-    limit,
-  };
+  const yFrom = rawYearFrom && YEAR_RE.test(rawYearFrom) ? rawYearFrom : null;
+  const yTo = rawYearTo && YEAR_RE.test(rawYearTo) ? rawYearTo : null;
+
+  // Reject nonsensical ranges — the RPC would silently return zero rows,
+  // which is a worse UX than a clear 400.
+  if (yFrom && yTo && Number(yFrom) > Number(yTo)) {
+    return { ok: false, error: "year_from must be less than or equal to year_to" };
+  }
+
+  return { ok: true, q: rawQ, year_from: yFrom, year_to: yTo, limit };
 }
 
 export async function GET(req: NextRequest) {

--- a/src/app/tools/scotus-case-search/page.tsx
+++ b/src/app/tools/scotus-case-search/page.tsx
@@ -9,22 +9,32 @@
  * (information), never advice. Every result links to the authoritative
  * opinion on Justia.
  *
+ * Rate limiting: this page rate-limits the same bucket as the API route
+ * (PR #21 code-review finding #1) so a crawler hitting /tools/...?q=X
+ * repeatedly can't bypass the API's 60/5min guard by targeting the page.
+ *
  * See plan at ImNotAnAttorney/docs/plans/2026-04-21-walkerdb-scotus-ingest.md.
  */
 import type { Metadata } from "next";
+import { headers } from "next/headers";
 import Link from "next/link";
 import { createAdminClient } from "@/lib/supabase/admin";
+import { checkRateLimit } from "@/lib/rate-limit";
 import type { ScotusSearchResult } from "@/app/api/tools/scotus-case-search/route";
 
 export const metadata: Metadata = {
   title: "SCOTUS Case Search — Free Tool | ImNotAnAttorney",
   description:
     "Search 8,400+ Supreme Court cases by issue, party, or keyword. Facts, questions, and holdings in plain English — sourced from Oyez.",
+  alternates: {
+    canonical: "/tools/scotus-case-search",
+  },
   openGraph: {
     title: "Free SCOTUS Case Search",
     description:
       "Search 8,400+ Supreme Court cases. Facts, questions, holdings — in plain English.",
     type: "website",
+    url: "/tools/scotus-case-search",
   },
 };
 
@@ -39,29 +49,64 @@ interface PageProps {
 const YEAR_RE = /^\d{4}$/;
 const DEFAULT_LIMIT = 20;
 
+function getIpFromHeaders(h: Headers): string {
+  return (
+    h.get("x-real-ip") ||
+    h.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+    h.get("cf-connecting-ip") ||
+    "unknown"
+  );
+}
+
 export default async function ScotusCaseSearchPage({ searchParams }: PageProps) {
   const { q = "", year_from = "", year_to = "" } = await searchParams;
 
   const trimmedQ = q.trim().slice(0, 300);
   const validYearFrom = YEAR_RE.test(year_from) ? year_from : null;
   const validYearTo = YEAR_RE.test(year_to) ? year_to : null;
+  const yearRangeInvalid =
+    !!(validYearFrom && validYearTo) && Number(validYearFrom) > Number(validYearTo);
 
+  // Rate limit: the page bypasses the API route's rate limiter if we hit the
+  // RPC directly. Mirror the same bucket + limit so a crawler can't abuse the
+  // page URL to flood Supabase with FTS queries (code-review finding #1).
+  const h = await headers();
+  const ip = getIpFromHeaders(h);
   const supabase = createAdminClient();
-  const { data, error } = await supabase.rpc("scotus_case_search", {
-    q: trimmedQ === "" ? null : trimmedQ,
-    year_from: validYearFrom,
-    year_to: validYearTo,
-    result_limit: DEFAULT_LIMIT,
-  });
+  const { limited } = await checkRateLimit(supabase, `scotus-search-page:${ip}`, 60, 300);
 
-  const results: ScotusSearchResult[] = ((data ?? []) as ScotusSearchResult[]) ?? [];
-  const errorMessage = error ? "Search temporarily unavailable. Try again in a moment." : null;
+  const results: ScotusSearchResult[] = [];
+  let errorMessage: string | null = null;
+  let rateLimited = false;
+
+  if (limited) {
+    rateLimited = true;
+    errorMessage = "You've hit the search rate limit. Try again in a minute.";
+  } else if (yearRangeInvalid) {
+    errorMessage = "From year must be less than or equal to To year.";
+  } else if (trimmedQ === "" && !validYearFrom && !validYearTo) {
+    // No query + no filters → don't touch the DB. Empty state instead.
+    // (code-review finding #10: rank=0 + limit 20 otherwise returns 20
+    // year-sorted cases that the page hides anyway.)
+  } else {
+    const { data, error } = await supabase.rpc("scotus_case_search", {
+      q: trimmedQ === "" ? null : trimmedQ,
+      year_from: validYearFrom,
+      year_to: validYearTo,
+      result_limit: DEFAULT_LIMIT,
+    });
+    if (error) {
+      errorMessage = "Search temporarily unavailable. Try again in a moment.";
+    } else if (data) {
+      results.push(...(data as ScotusSearchResult[]));
+    }
+  }
 
   return (
     <main className="min-h-screen bg-zinc-950 text-zinc-100">
       <div className="mx-auto max-w-4xl px-4 py-12">
         <header className="mb-8">
-          <h1 className="text-3xl md:text-4xl font-bold tracking-tight mb-3">
+          <h1 id="page-title" className="text-3xl md:text-4xl font-bold tracking-tight mb-3">
             SCOTUS Case Search
           </h1>
           <p className="text-zinc-300">
@@ -74,6 +119,7 @@ export default async function ScotusCaseSearchPage({ searchParams }: PageProps) 
           method="GET"
           action="/tools/scotus-case-search"
           className="mb-8 grid grid-cols-1 md:grid-cols-[1fr_auto_auto_auto] gap-3 items-end"
+          aria-labelledby="page-title"
         >
           <div>
             <label htmlFor="q" className="block text-sm text-zinc-300 mb-1">
@@ -86,6 +132,7 @@ export default async function ScotusCaseSearchPage({ searchParams }: PageProps) 
               defaultValue={trimmedQ}
               maxLength={300}
               placeholder="miranda warnings"
+              autoComplete="off"
               className="w-full rounded-md bg-zinc-900 border border-zinc-700 text-zinc-100 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-emerald-500"
             />
           </div>
@@ -98,9 +145,9 @@ export default async function ScotusCaseSearchPage({ searchParams }: PageProps) 
               id="year_from"
               name="year_from"
               inputMode="numeric"
-              pattern="\d{4}"
               defaultValue={validYearFrom ?? ""}
               placeholder="2000"
+              autoComplete="off"
               className="w-24 rounded-md bg-zinc-900 border border-zinc-700 text-zinc-100 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-emerald-500"
             />
           </div>
@@ -113,9 +160,9 @@ export default async function ScotusCaseSearchPage({ searchParams }: PageProps) 
               id="year_to"
               name="year_to"
               inputMode="numeric"
-              pattern="\d{4}"
               defaultValue={validYearTo ?? ""}
               placeholder="2025"
+              autoComplete="off"
               className="w-24 rounded-md bg-zinc-900 border border-zinc-700 text-zinc-100 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-emerald-500"
             />
           </div>
@@ -128,32 +175,43 @@ export default async function ScotusCaseSearchPage({ searchParams }: PageProps) 
         </form>
 
         {errorMessage ? (
-          <p className="rounded-md bg-red-950 border border-red-700 text-red-200 p-4 mb-6">
+          <p
+            role={rateLimited ? "status" : "alert"}
+            className="rounded-md bg-red-950 border border-red-700 text-red-200 p-4 mb-6"
+          >
             {errorMessage}
           </p>
         ) : null}
 
-        <section aria-label="results" className="space-y-6">
+        <section aria-label="Search results">
+          <h2 className="sr-only">Search results</h2>
           {results.length === 0 && !errorMessage ? (
-            <p className="text-zinc-400">
-              {trimmedQ
-                ? `No cases matched "${trimmedQ}" in the selected year range.`
-                : "Type a query above to search."}
-            </p>
+            trimmedQ ? (
+              <p className="text-zinc-400">
+                No cases matched <q>{trimmedQ}</q> in the selected year range.
+              </p>
+            ) : (
+              <p className="text-zinc-400">Type a query above to search.</p>
+            )
           ) : null}
-          {results.map((r) => (
-            <ScotusResultCard key={r.case_id} r={r} />
-          ))}
+          <ul className="space-y-6 list-none p-0">
+            {results.map((r) => (
+              <li key={r.case_id}>
+                <ScotusResultCard r={r} />
+              </li>
+            ))}
+          </ul>
         </section>
 
         <footer className="mt-16 border-t border-zinc-800 pt-6 text-xs text-zinc-400 space-y-2">
+          <h2 className="sr-only">Attribution and disclaimer</h2>
           <p>
             Sourced from{" "}
             <a
               href="https://www.oyez.org/"
               className="text-emerald-400 hover:underline"
               target="_blank"
-              rel="noreferrer"
+              rel="noopener noreferrer"
             >
               Oyez
             </a>{" "}
@@ -162,7 +220,7 @@ export default async function ScotusCaseSearchPage({ searchParams }: PageProps) 
               href="https://github.com/walkerdb/supreme_court_transcripts"
               className="text-emerald-400 hover:underline"
               target="_blank"
-              rel="noreferrer"
+              rel="noopener noreferrer"
             >
               walkerdb/supreme_court_transcripts
             </a>{" "}
@@ -181,6 +239,26 @@ export default async function ScotusCaseSearchPage({ searchParams }: PageProps) 
   );
 }
 
+const OYEZ_CANONICAL_HOSTS = new Set(["api.oyez.org", "www.oyez.org", "oyez.org"]);
+
+function safeOyezUrl(href: string | null): string | null {
+  if (!href) return null;
+  try {
+    const u = new URL(href);
+    if (!OYEZ_CANONICAL_HOSTS.has(u.hostname)) return null;
+    // Rewrite the API host to the public-facing site without relying on
+    // naive string replace (code-review finding #8 — avoids open-redirect
+    // if Oyez ever returns a host like api.oyez.org.evil.example).
+    const rewritten = new URL(u.toString());
+    if (rewritten.hostname === "api.oyez.org") {
+      rewritten.hostname = "www.oyez.org";
+    }
+    return rewritten.toString();
+  } catch {
+    return null;
+  }
+}
+
 function ScotusResultCard({ r }: { r: ScotusSearchResult }) {
   const citation =
     r.citation_volume && r.citation_page
@@ -189,12 +267,14 @@ function ScotusResultCard({ r }: { r: ScotusSearchResult }) {
         ? `(${r.citation_year})`
         : null;
 
+  const oyezUrl = safeOyezUrl(r.oyez_href);
+
   return (
     <article className="rounded-lg border border-zinc-800 bg-zinc-900/50 p-5">
       <header className="mb-3">
-        <h2 className="text-xl font-semibold text-zinc-100">
+        <h3 className="text-xl font-semibold text-zinc-100">
           {r.name ?? "(unnamed case)"}
-        </h2>
+        </h3>
         {citation ? (
           <p className="text-sm text-zinc-400 mt-1">{citation}</p>
         ) : null}
@@ -202,9 +282,9 @@ function ScotusResultCard({ r }: { r: ScotusSearchResult }) {
 
       {r.question_snippet ? (
         <div className="mb-3">
-          <h3 className="text-xs uppercase tracking-wider text-emerald-400 mb-1">
+          <h4 className="text-xs uppercase tracking-wider text-emerald-400 mb-1">
             Question
-          </h3>
+          </h4>
           <p className="text-sm text-zinc-200 whitespace-pre-wrap">
             {r.question_snippet}
           </p>
@@ -213,9 +293,9 @@ function ScotusResultCard({ r }: { r: ScotusSearchResult }) {
 
       {r.facts_snippet ? (
         <div className="mb-3">
-          <h3 className="text-xs uppercase tracking-wider text-emerald-400 mb-1">
+          <h4 className="text-xs uppercase tracking-wider text-emerald-400 mb-1">
             Facts
-          </h3>
+          </h4>
           <p className="text-sm text-zinc-200 whitespace-pre-wrap">
             {r.facts_snippet}
           </p>
@@ -224,9 +304,9 @@ function ScotusResultCard({ r }: { r: ScotusSearchResult }) {
 
       {r.conclusion_snippet ? (
         <div className="mb-3">
-          <h3 className="text-xs uppercase tracking-wider text-emerald-400 mb-1">
+          <h4 className="text-xs uppercase tracking-wider text-emerald-400 mb-1">
             Holding / conclusion
-          </h3>
+          </h4>
           <p className="text-sm text-zinc-200 whitespace-pre-wrap">
             {r.conclusion_snippet}
           </p>
@@ -238,17 +318,17 @@ function ScotusResultCard({ r }: { r: ScotusSearchResult }) {
           <a
             href={r.justia_url}
             target="_blank"
-            rel="noreferrer"
+            rel="noopener noreferrer"
             className="text-emerald-400 hover:underline"
           >
             Read full opinion (Justia) →
           </a>
         ) : null}
-        {r.oyez_href ? (
+        {oyezUrl ? (
           <a
-            href={r.oyez_href.replace("api.oyez.org", "www.oyez.org")}
+            href={oyezUrl}
             target="_blank"
-            rel="noreferrer"
+            rel="noopener noreferrer"
             className="text-emerald-400 hover:underline"
           >
             Oyez page →

--- a/supabase/migrations/20260421195414_scotus_cases.sql
+++ b/supabase/migrations/20260421195414_scotus_cases.sql
@@ -1,10 +1,13 @@
 -- SCOTUS cases from walkerdb/supreme_court_transcripts (Oyez-sourced)
 -- Plan: ImNotAnAttorney/docs/plans/2026-04-21-walkerdb-scotus-ingest.md
 --
--- 8,415 Supreme Court cases with metadata + full-text facts/question/conclusion.
--- Per-turn oral-argument transcripts are deferred to a follow-up ingest.
+-- 8,415 upstream Oyez cases → 8,411 loaded (4 skipped: invalid ID / JSON
+-- parse error in source). Per-turn oral-argument transcripts are deferred
+-- to a follow-up ingest.
 --
 -- Data source: https://github.com/walkerdb/supreme_court_transcripts (Oyez API mirror, weekly refresh)
+
+BEGIN;
 
 CREATE TABLE IF NOT EXISTS public.scotus_cases (
   case_id                     BIGINT PRIMARY KEY,
@@ -45,7 +48,7 @@ CREATE TABLE IF NOT EXISTS public.scotus_cases (
 );
 
 COMMENT ON TABLE public.scotus_cases IS
-  'SCOTUS cases from walkerdb/supreme_court_transcripts (Oyez mirror). 8,415 cases, metadata + facts/question/conclusion. Transcripts separate.';
+  'SCOTUS cases from walkerdb/supreme_court_transcripts (Oyez mirror). 8,411 loaded (from 8,415 upstream; 4 skipped for missing ID / JSON parse errors). Transcripts in a separate table (deferred).';
 
 CREATE INDEX IF NOT EXISTS scotus_cases_term_idx
   ON public.scotus_cases (term);
@@ -77,3 +80,5 @@ CREATE EXTENSION IF NOT EXISTS pg_trgm;
 CREATE INDEX IF NOT EXISTS scotus_cases_name_trgm_idx
   ON public.scotus_cases
   USING GIN (name gin_trgm_ops);
+
+COMMIT;

--- a/supabase/migrations/20260421200000_scotus_case_search_rpc.sql
+++ b/supabase/migrations/20260421200000_scotus_case_search_rpc.sql
@@ -1,9 +1,23 @@
 -- RPC: ranked SCOTUS case search with year-range filter + HTML-stripped snippets.
--- Consumed by /api/tools/scotus-case-search.
+-- Consumed by /api/tools/scotus-case-search and the /tools/scotus-case-search page.
 --
 -- Plan: ImNotAnAttorney/docs/plans/2026-04-21-walkerdb-scotus-ingest.md
+--
+-- Security hardening (PR #21 code-review response):
+--   * DROP FUNCTION IF EXISTS so CREATE can change arg types without overload hazard
+--   * SET search_path so a malicious schema can't shadow to_tsvector / ts_rank / etc
+--   * REVOKE EXECUTE from anon+authenticated — Supabase auto-grants on public.* functions,
+--     we gate access through API-layer rate limiting + service-role-only admin client.
+--   * Year filter uses ~ '^\d{4}$' guard + numeric cast — citation_year is TEXT and
+--     lexicographic comparison silently misclassifies 3-digit or non-digit Oyez values.
+--   * tsvector + numeric year materialized once in a CTE (reused by WHERE / SELECT /
+--     ORDER BY) so the row isn't traversed three times.
 
-CREATE OR REPLACE FUNCTION public.scotus_case_search(
+BEGIN;
+
+DROP FUNCTION IF EXISTS public.scotus_case_search(TEXT, TEXT, TEXT, INT);
+
+CREATE FUNCTION public.scotus_case_search(
   q TEXT,
   year_from TEXT DEFAULT NULL,
   year_to TEXT DEFAULT NULL,
@@ -28,61 +42,87 @@ RETURNS TABLE(
 )
 LANGUAGE SQL
 STABLE
+SET search_path = pg_catalog, public
 AS $$
+  -- The tsvector expression below MUST match the GIN index predicate exactly
+  -- (scotus_cases_fts_idx in the schema migration) or the WHERE clause won't
+  -- hit the index. Keep these in lockstep.
   WITH query_vec AS (
-    SELECT CASE
-      WHEN q IS NULL OR btrim(q) = '' THEN NULL
-      ELSE websearch_to_tsquery('english', q)
-    END AS tsq
+    SELECT
+      CASE
+        WHEN q IS NULL OR btrim(q) = '' THEN NULL
+        ELSE websearch_to_tsquery('english', q)
+      END AS tsq,
+      CASE WHEN year_from ~ '^\d{4}$' THEN year_from::int END AS yfrom_int,
+      CASE WHEN year_to   ~ '^\d{4}$' THEN year_to::int   END AS yto_int
+  ),
+  ranked AS (
+    SELECT
+      c.case_id,
+      c.name,
+      c.term,
+      c.citation_year,
+      c.citation_volume,
+      c.citation_page,
+      c.first_party,
+      c.second_party,
+      c.facts_of_the_case,
+      c.question,
+      c.conclusion,
+      c.justia_url,
+      c.oyez_href,
+      c.decided_date,
+      to_tsvector(
+        'english',
+        COALESCE(c.name, '')               || ' ' ||
+        COALESCE(c.first_party, '')        || ' ' ||
+        COALESCE(c.second_party, '')       || ' ' ||
+        COALESCE(c.question, '')           || ' ' ||
+        COALESCE(c.facts_of_the_case, '')  || ' ' ||
+        COALESCE(c.conclusion, '')         || ' ' ||
+        COALESCE(c.description, '')
+      ) AS tsv,
+      CASE WHEN c.citation_year ~ '^\d{4}$' THEN c.citation_year::int END AS year_int
+    FROM public.scotus_cases c
   )
   SELECT
-    c.case_id,
-    c.name,
-    c.term,
-    c.citation_year,
-    c.citation_volume,
-    c.citation_page,
-    c.first_party,
-    c.second_party,
-    LEFT(regexp_replace(COALESCE(c.facts_of_the_case, ''), '<[^>]+>', '', 'g'), 500) AS facts_snippet,
-    LEFT(regexp_replace(COALESCE(c.question, ''),          '<[^>]+>', '', 'g'), 500) AS question_snippet,
-    LEFT(regexp_replace(COALESCE(c.conclusion, ''),        '<[^>]+>', '', 'g'), 500) AS conclusion_snippet,
-    c.justia_url,
-    c.oyez_href,
-    c.decided_date,
+    r.case_id,
+    r.name,
+    r.term,
+    r.citation_year,
+    r.citation_volume,
+    r.citation_page,
+    r.first_party,
+    r.second_party,
+    -- HTML tags stripped for visual cleanliness only (React text-node escaping
+    -- is the XSS boundary). The strip handles well-formed <p>, <em> etc.
+    LEFT(regexp_replace(COALESCE(r.facts_of_the_case, ''), '<[^>]+>', '', 'g'), 500) AS facts_snippet,
+    LEFT(regexp_replace(COALESCE(r.question, ''),          '<[^>]+>', '', 'g'), 500) AS question_snippet,
+    LEFT(regexp_replace(COALESCE(r.conclusion, ''),        '<[^>]+>', '', 'g'), 500) AS conclusion_snippet,
+    r.justia_url,
+    r.oyez_href,
+    r.decided_date,
     CASE
       WHEN qv.tsq IS NULL THEN 0.0::real
-      ELSE ts_rank(
-        to_tsvector('english',
-          COALESCE(c.name, '')               || ' ' ||
-          COALESCE(c.first_party, '')        || ' ' ||
-          COALESCE(c.second_party, '')       || ' ' ||
-          COALESCE(c.question, '')           || ' ' ||
-          COALESCE(c.facts_of_the_case, '')  || ' ' ||
-          COALESCE(c.conclusion, '')         || ' ' ||
-          COALESCE(c.description, '')
-        ),
-        qv.tsq
-      )
+      ELSE ts_rank(r.tsv, qv.tsq)
     END AS rank
-  FROM public.scotus_cases c
+  FROM ranked r
   CROSS JOIN query_vec qv
   WHERE
-    (qv.tsq IS NULL
-     OR to_tsvector('english',
-          COALESCE(c.name, '')              || ' ' ||
-          COALESCE(c.first_party, '')       || ' ' ||
-          COALESCE(c.second_party, '')      || ' ' ||
-          COALESCE(c.question, '')          || ' ' ||
-          COALESCE(c.facts_of_the_case, '') || ' ' ||
-          COALESCE(c.conclusion, '')        || ' ' ||
-          COALESCE(c.description, '')
-        ) @@ qv.tsq)
-    AND (year_from IS NULL OR c.citation_year >= year_from)
-    AND (year_to   IS NULL OR c.citation_year <= year_to)
-  ORDER BY rank DESC, c.citation_year DESC NULLS LAST, c.name ASC
+    (qv.tsq IS NULL OR r.tsv @@ qv.tsq)
+    AND (qv.yfrom_int IS NULL OR (r.year_int IS NOT NULL AND r.year_int >= qv.yfrom_int))
+    AND (qv.yto_int   IS NULL OR (r.year_int IS NOT NULL AND r.year_int <= qv.yto_int))
+  ORDER BY
+    rank DESC,
+    r.year_int DESC NULLS LAST,
+    r.name ASC
   LIMIT LEAST(GREATEST(result_limit, 1), 100);
 $$;
 
 COMMENT ON FUNCTION public.scotus_case_search(TEXT, TEXT, TEXT, INT) IS
-  'Free-text ranked search over SCOTUS cases with year-range filter and HTML-stripped snippets.';
+  'Free-text ranked search over public.scotus_cases with year-range filter (guarded numeric cast) and HTML-stripped snippets. anon/authenticated roles revoked — access through API.';
+
+REVOKE EXECUTE ON FUNCTION public.scotus_case_search(TEXT, TEXT, TEXT, INT)
+  FROM anon, authenticated, PUBLIC;
+
+COMMIT;

--- a/tests/api/scotus-case-search.test.ts
+++ b/tests/api/scotus-case-search.test.ts
@@ -1,15 +1,6 @@
 /**
  * Integration tests for GET /api/tools/scotus-case-search.
  *
- * Verifies:
- *   - Empty query returns most recent cases (q=null)
- *   - Query string passes through to RPC
- *   - Year filters validate + pass through
- *   - Invalid limit/year → 400
- *   - Rate limiting returns 429
- *   - RPC error returns 500
- *   - Cache-Control is short-lived + SWR
- *
  * Mocks `supabase.rpc("scotus_case_search", ...)`.
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
@@ -148,5 +139,37 @@ describe("GET /api/tools/scotus-case-search", () => {
     rpcRows = [];
     await GET(buildReq("?q=test"));
     expect(lastRpcArgs?.result_limit).toBe(20);
+  });
+
+  it("rejects year_from > year_to (sane range)", async () => {
+    const res = await GET(buildReq("?q=test&year_from=2020&year_to=2000"));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/year_from.*less than or equal/i);
+  });
+
+  it("whitespace-only q is null-coerced (not sent as string)", async () => {
+    rpcRows = [];
+    await GET(buildReq("?q=%20%20%20"));
+    expect(lastRpcArgs?.q).toBeNull();
+  });
+
+  it("websearch-to-tsquery syntax in q passes through unescaped (the RPC sanitizes)", async () => {
+    // SQL-injection attempt against RPC — Supabase param-binding + the RPC's
+    // use of websearch_to_tsquery should sanitize it. This test documents the
+    // contract: the route does not reject arbitrary q content below the length cap.
+    rpcRows = [];
+    const inj = `"); DROP TABLE scotus_cases; --`;
+    await GET(buildReq(`?q=${encodeURIComponent(inj)}`));
+    expect(lastRpcArgs?.q).toBe(inj);
+  });
+
+  it("Cache-Control specifies exact max-age + SWR window", async () => {
+    rpcRows = [];
+    const res = await GET(buildReq("?q=test"));
+    const cc = res.headers.get("Cache-Control") || "";
+    expect(cc).toMatch(/public/);
+    expect(cc).toMatch(/max-age=300\b/);
+    expect(cc).toMatch(/stale-while-revalidate=3600\b/);
   });
 });


### PR DESCRIPTION
## Summary

Applies all CRITICAL + WARNING + actionable SUGGESTION fixes from the PR #21 code review. Per project Pristine-Or-Nothing rule.

### Fixed

- **6/6 CRITICAL**: page rate-limit bypass, RPC REVOKE/search_path, year lexicographic comparison, canonical metadata, HTML-strip claim rephrased.
- **16/17 WARNING**: reflected-query quoting, oyez_href URL-parse (SSRF), FTS recomputation via CTE, empty-query short-circuit, year_from>year_to validation, DROP FUNCTION IF EXISTS, firstString trim, async readFile, batched session SET, NUL-byte strip in csvEscape, migration BEGIN/COMMIT, ASCII error string, E2E case_id stability, COMMENT count. (1 deferred: stylistic test-mock hoist, no functional impact.)
- **11/17 SUGGESTION + 3 non-findings + 3 deferred**: sr-only headings, aria-labelledby, autoComplete, rel noopener, dynamic flag, decidedDate last-event, extra tests (injection, whitespace, exact Cache-Control, year_from>year_to), E2E scoping, empty-state test. Deferred with reason: TRUNCATE-CTAS swap (#34 — low-traffic table, out-of-scope refactor); csv-bulk-checked marker (#35 — passes hook); CTA gating by query (#40 — polish, out-of-scope).

### Verification

- `tsc --noEmit --skipLibCheck`: clean
- `vitest run tests/api/scotus-case-search.test.ts`: 16/16 pass (up from 12)
- RPC re-applied against prod Supabase: proacl restricted to service_role, search_path set, year-range numeric filtering validated.

### Build note

`next build` failed on an unrelated `/blog/federal-investigation-what-to-expect/opengraph-image` prerender error (concurrent work). SKIP_BUILD=1 used on push per pre-push hook's documented bypass. The failure is unrelated to the SCOTUS changes in this PR.

## Test plan

- [x] tsc clean
- [x] vitest scotus file 16/16 pass
- [x] RPC security changes verified on prod DB
- [ ] CI green
- [ ] E2E against prod after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)