### PR TITLE
feat(officer-bg): backfill GA NPI — 268,329 officers + 84,494 wandering

### DIFF
--- a/src/app/officer-background-check/page.tsx
+++ b/src/app/officer-background-check/page.tsx
@@ -38,7 +38,7 @@ const FEATURES = [
   "Discreditation history from other cases",
   "Testimony challenge patterns",
   "Procedural compliance track record",
-  "Employment history timeline (NPI officer-level: AZ, CA)",
+  "Employment history timeline (NPI officer-level: AZ, CA, GA)",
   "Wandering officer detection (terminated → rehired pattern)",
   "Agency incident data from Fatal Encounters database",
   "Prior complaints and disciplinary actions from court records",


### PR DESCRIPTION
## Summary
- PR #26 render fix discovered GA had 0 NPI officer-level rows — all 235 GA rows were \`fatal_encounters\` agency-only. Landing copy was pre-emptively corrected to "AZ, CA" there.
- Root: source data existed at \`data/external-intel/npi/us-post-data/db/data/output/ga/\` but \`ingest-npi.mjs\` had never been run against \`ga/\`. Fixed.
- Restores landing copy to "NPI officer-level: AZ, CA, GA".

## Ingest run
\`\`\`
node scripts/ingest-npi.mjs --state ga
\`\`\`
- \`ga-discipline-processed.csv.gz\` → 31,829 officers
- \`ga-processed.csv.gz\` → 236,500 officers
- Total upserted: **268,329** (26 in-batch duplicate ON CONFLICT skips per \`cl-bulk-data-defensive\` gotcha #11)
- Wandering officers detected: **84,494**

## Verification
\`scripts/verify-officer-render-ca-ga.mjs\` (landed in PR #26):
- CA: PASS 5/5 — 168,723 rows
- GA: PASS 5/5 — 268,329 rows (was 0 officer-level)
- AZ: PASS 5/5 — 41,300 rows

GA sample: John Law (33 jobs), Adam Knight (31), Ralph Langley (30), Eric Hadden (29), William Brackett (27) — all render end-to-end.

## Test plan
- [x] \`npx tsc --noEmit --skipLibCheck\` clean
- [x] Verification script — CA/GA/AZ 5/5 each
- [ ] Post-merge: live spot-check via Availability Checker for a GA officer and confirm Employment History rows render

🤖 Generated with [Claude Code](https://claude.com/claude-code)