### PR TITLE
fix(partner-deep-link): whole-dollar price display on ≥$100 tiers

### DIFF
--- a/src/app/r/[code]/[product]/page.tsx
+++ b/src/app/r/[code]/[product]/page.tsx
@@ -200,12 +200,19 @@ export default async function DeepLinkProductPage({ params, searchParams }: Page
     "Questions built for your attorney, not generic legal information",
   ];
   // Stay in cents until the final display to avoid float drift for larger
-  // tiers (e.g. War Room 499700 cents).
-  const originalPrice = tier.price / 100;
-  const discountedPrice = Math.round(tier.price * 0.9) / 100;
+  // tiers (e.g. War Room 499700 cents). Display rule: >=$100 renders whole
+  // dollars (cents on a $897 crisis product read as haggling per
+  // adversarial-walkthrough skeptical-buyer R1+R4); sub-$100 SKUs keep
+  // .toFixed(2) so playbook-tier pricing stays honest.
+  const formatPrice = (cents: number): string => {
+    const dollars = cents / 100;
+    return dollars >= 100 ? String(Math.round(dollars)) : dollars.toFixed(2);
+  };
+  const originalPrice = formatPrice(tier.price);
+  const discountedPrice = formatPrice(Math.round(tier.price * 0.9));
   // Case Decoder anchor used in the "Not sure yet?" nudge below. Imported
   // from TIER_CORE per src/lib/PRICING-ARCHITECTURE.md — no hardcoded prices.
-  const caseDecoderDiscounted = Math.round(TIER_CORE["case-decoder"].price * 0.9) / 100;
+  const caseDecoderDiscounted = formatPrice(Math.round(TIER_CORE["case-decoder"].price * 0.9));
 
   // Fire-and-forget product_page_view telemetry. Wrapped so a CHECK
   // constraint violation doesn't break the page render.
@@ -318,7 +325,7 @@ export default async function DeepLinkProductPage({ params, searchParams }: Page
               ${originalPrice}
             </span>
             <span className="text-3xl font-bold text-white">
-              ${discountedPrice.toFixed(2)}
+              ${discountedPrice}
             </span>
             <span className="text-amber-400 text-sm font-medium">
               via {partnerDisplayName}
@@ -357,7 +364,7 @@ export default async function DeepLinkProductPage({ params, searchParams }: Page
             >
               Case Decoder
             </Link>{" "}
-            for ${caseDecoderDiscounted.toFixed(2)} &mdash; same refund rule: doesn&apos;t surface new questions, money back.
+            for ${caseDecoderDiscounted} &mdash; same refund rule: doesn&apos;t surface new questions, money back.
           </p>
         )}
 


### PR DESCRIPTION
## Summary
- Render $897 instead of $897.30 on Intelligence Brief, and $177 instead of $177.30 on Case Decoder downsell, for all partner deep-link pages where `tier.price >= $100`
- Sub-$100 SKUs (playbook tier) keep `.toFixed(2)` — honest sub-dollar pricing intact
- Layer 1 pricing architecture preserved: no hardcoded prices, values flow from `TIER_CORE` per `src/lib/PRICING-ARCHITECTURE.md`

## Why
Skeptical-buyer persona flagged cent-precision as "haggling" across R1 and R4 of the adversarial-walkthrough loop on `/r/E2EREFE/intelligence-brief`. Crisis buyers don't negotiate legal-defense prices in cents — the `.30` reads as discount-margin telegraphing, not professionalism.

## Scope
Phase 1 of 5 in the adversarial-walkthrough R5+ remediation backlog. Subsequent phases (downsell placement, no-attorney-yet copy, jurisdiction-coverage lookup, copy-critic polish) will ship on separate PRs.

See: `docs/audits/2026-04-21-adversarial-walkthrough-loop-summary.md`

## Test plan
- [x] `npx tsc --noEmit --skipLibCheck` — clean
- [x] `npm run build` — clean (Next.js 16.2.2, turbopack)
- [ ] Post-deploy: `curl https://imnotanattorney.com/r/E2EREFE/intelligence-brief | grep '\$897'` — expect `$897` (no `.30`)
- [ ] Post-deploy: `curl https://imnotanattorney.com/r/E2EREFE/case-decoder | grep '\$177'` — expect `$177` (no `.30`)
- [ ] Spot-check playbook tier ($47 / $97) renders with `.00` (sub-$100 branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)