### PR TITLE
chore/partner e2e coverage

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -50,6 +50,29 @@ Properties that MUST hold system-wide. Violating any of these is a critical defe
 | **Playbook System** | 8 configurable sales pages (1 component, 8 configs) | [`PLAYBOOK-ARCHITECTURE.md`](PLAYBOOK-ARCHITECTURE.md) |
 | **Design System** | Brand tokens: Amber + Navy on black, Playfair + Lato | [`design-system/brand.md`](design-system/brand.md) |
 
+## E2E Coverage Map
+
+Playwright specs live in `e2e/`. Before writing new specs, check this map — overlap is the most common form of wasted work.
+
+| Spec file | Covers |
+|---|---|
+| `partner-full-walkthrough.spec.ts` | Full bondsman partner walkthrough: login → dashboard → every section, form, and modal (payment settings, notifications, add-client, FTA calculator, toolkit, compliance, checklist, card) |
+| `white-label-walkthrough.spec.ts` | Partner branding flow: logo upload + website scrape + contrast gate + preview |
+| `partner-checklist.spec.ts` | Bondsman compliance checklist (QR + print) |
+| `bondsman-hardening.spec.ts` | Bondsman-mode invariants (28 tests, production) |
+| `checkin-signup.spec.ts` | `/checkin/[code]` enrollment flow |
+| `bridge-referral.spec.ts` | `/r/[code]` bridge page |
+| `product-deep-link.spec.ts` | `/r/[code]/[product]` deep links |
+| `og-preview.spec.ts` | OG image 200/PNG/≥10KB + og:title + og:description + twitter:card + twitter:image + canonical + partner-specific branding for `/r/[code]`, `/checkin/[code]`, and all 6 `/r/[code]/[product]` variants |
+| `og-preview-unfurl-bots.spec.ts` | 7 unfurl bot UAs (Facebook, Slack, Twitter/X, LinkedIn, WhatsApp, Telegram, iMessage) × 3 HTML routes + 3 OG image routes = 42 tests. Catches UA-gated 403s that blank unfurls on specific platforms |
+| `og-preview-visual.spec.ts` | Byte-accurate snapshot baselines (5% pixel tolerance) for OG images. Catches brand color drift + logo shift. Baselines in `e2e/og-preview-visual.spec.ts-snapshots/` — regenerate with `--update-snapshots` |
+| `court-reminders.spec.ts` | Reminder SMS + email flow |
+| `fsd-*.spec.ts`, `ussc-*.spec.ts` | Federal sentencing distribution tools |
+
+**Fixtures:** `E2EREFE` (referral-mode bondsman), `E2EBOND` (check-in-mode bondsman). Seeded by `scripts/seed-e2e-partners.mjs`. All specs gate on `E2E_SEED_READY=1`.
+
+**Fast CI script:** `npm run test:e2e:og` — runs only the 3 OG specs (cheap, no browser steps, ~60 tests total). Wire into CI for every PR without paying the 5-min full-walkthrough cost.
+
 ## Data Flow
 
 ```

--- a/docs/plans/2026-04-21-partner-portal-phase-2-e2e-coverage.md
+++ b/docs/plans/2026-04-21-partner-portal-phase-2-e2e-coverage.md
@@ -1,0 +1,100 @@
+# Partner Portal Pristine — Phase 2: E2E Coverage
+
+> **For Claude:** REQUIRED SUB-SKILL: `superpowers:executing-plans`
+
+**Parent design:** `docs/plans/2026-04-21-partner-portal-pristine-design.md`
+
+**Goal:** Fill the real gaps in partner-system E2E coverage, not rebuild what already exists. The existing spec set (`partner-full-walkthrough`, `og-preview`, `bridge-referral`, `product-deep-link`, `white-label-walkthrough`, `partner-checklist`, `checkin-signup`, `bondsman-hardening`) is already deep — 600+ LOC of partner walkthroughs. Phase 2 adds the OG/unfurl rigor that's missing.
+
+**Architecture:** Extend `og-preview.spec.ts` where the surface already exists (meta-tag depth, byte-size guard, product OG); add one new spec for unfurl-bot UA simulation; add visual regression baselines via Playwright `toHaveScreenshot`. All new assertions gate on the same `E2E_SEED_READY` env var the existing spec already uses.
+
+**Tech Stack:** Playwright 1.59.x, cheerio (already a dep), chromium only. Seeded test partners: `E2EREFE` (referral mode), `E2EBOND` (check-in mode). Seed script: `scripts/seed-e2e-partners.mjs`.
+
+---
+
+## Scope delta vs. original design outline
+
+| Original outline | What's already done | Phase 2 action |
+|---|---|---|
+| `partner-full-system.spec.ts` — apply → approve → magic-link → dashboard → add-client → share | `partner-full-walkthrough.spec.ts` (311 LOC) already covers bondsman partner walkthrough end-to-end | **Skip** (already covered) |
+| `partner-preview-links.spec.ts` — 3 codes × 4 routes OG unfurl | `og-preview.spec.ts` covers /r + /checkin but not /r/[code]/[product], and doesn't check byte size or full meta-tag bundle | **Extend** existing spec |
+| `partner-preview-deploy.spec.ts` — Vercel preview gate | Existing specs already run against production; preview-gating is env-var + CI concern | **Drop** — fold into Task 6 (CI docs) |
+| Visual regression | Nothing exists | **Add** baselines |
+
+---
+
+## Tasks
+
+### Task 1: Branch + this plan doc
+- Branch `chore/partner-e2e-coverage` from master ✅ (done)
+- Commit this plan doc
+
+### Task 2: OG byte-size + branding-specific assertions
+**Files:** `e2e/og-preview.spec.ts`
+
+Extend existing spec:
+1. After each `expect(headers["content-type"]).toMatch(/image\/png/)`, add `expect(Buffer.byteLength(await res.body())).toBeGreaterThan(10 * 1024)` — 10KB floor guards against empty/placeholder PNG.
+2. Parse og:title and assert it contains the partner fixture's name fragment (not just a pattern match). For E2EREFE: partner name contains "E2E Referral Bondsman", og:title should include some identifiable partner token — the existing `generateMetadata` builds `"— {referrer}"` style, so assert the og:title ends with a partner-identity slice.
+3. Add `/r/{code}/{product}/opengraph-image` coverage for every REFERRAL_PRODUCT_MAP key (6 total). Assert 200 + PNG + ≥10KB.
+
+### Task 3: Full meta-tag bundle
+**Files:** `e2e/og-preview.spec.ts`
+
+For each route already tested (/r/[code], /checkin/[code], plus new /r/[code]/[product]):
+- Parse og:description — assert non-empty, <300 chars (Facebook cutoff), matches route branch copy.
+- Parse twitter:card — assert `summary_large_image`.
+- Parse twitter:image — assert present and returns 200 PNG (unfurl preview on Twitter/X).
+- Parse canonical (`<link rel="canonical">`) — assert absolute URL on imnotanattorney.com, matches the route being fetched.
+
+### Task 4: Unfurl-bot UA simulation
+**Files:** `e2e/og-preview-unfurl-bots.spec.ts` (new)
+
+Fetch each route with UA headers for: `facebookexternalhit/1.1`, `Slackbot-LinkExpanding 1.0`, `Twitterbot/1.0`, `LinkedInBot/1.0`, `WhatsApp/2.21.4.18`, `TelegramBot (like TwitterBot)`.
+
+Assert:
+- Status 200 (no UA-gated 403/404).
+- Content-type text/html for page routes, image/png for /opengraph-image routes.
+- No unintended redirect (no 3xx to /arrested or error pages).
+- HTML response contains `og:image` meta tag (proves bot-served HTML still has the unfurl data).
+
+Gate on `E2E_SEED_READY`.
+
+### Task 5: Visual regression baselines
+**Files:** `e2e/og-preview-visual.spec.ts` (new), `e2e/og-preview-visual.spec.ts-snapshots/*` (baselines)
+
+Playwright `toHaveScreenshot`:
+- `/r/E2EREFE/opengraph-image` → `og-referral-branded.png`
+- `/checkin/E2EBOND/opengraph-image` → `og-checkin-branded.png`
+
+Threshold: `maxDiffPixelRatio: 0.05` (5% to survive font-rendering micro-drift).
+
+Baselines committed once; regenerate only via `--update-snapshots`. Runtime: must fetch the OG URL, write to buffer, use Playwright image diff. Actually simpler: use `toHaveScreenshot` against the image fetched and displayed in a minimal HTML shell, OR use @playwright/test's `toMatchSnapshot` on raw buffer.
+
+Simplest implementation: fetch the PNG, save to `test-results/og-*.png`, compare bytes against committed baseline with 5% tolerance. Playwright has `toMatchSnapshot` for binary assertions.
+
+### Task 6: Coverage map + CI fast-gate script
+**Files:** `ARCHITECTURE.md`, `package.json`
+
+Add to ARCHITECTURE.md a subsection "E2E coverage map" mapping spec file → what it covers. This makes future work (and future AI sessions) see the coverage before duplicating.
+
+Add npm script:
+```json
+"test:e2e:og": "playwright test e2e/og-preview.spec.ts e2e/og-preview-unfurl-bots.spec.ts e2e/og-preview-visual.spec.ts"
+```
+
+Purpose: the OG/unfurl specs are cheap (no browser steps, just `request.get` + cheerio + image diff) — they can run on every PR without the full 5-minute walkthrough suite. Wire into CI later (out of scope for this phase).
+
+### Task 7: Push + PR
+
+Standard: push, open PR, merge.
+
+---
+
+## Exit criteria
+
+- [ ] `npx playwright test e2e/og-preview.spec.ts` — green (with seeded partners)
+- [ ] `npx playwright test e2e/og-preview-unfurl-bots.spec.ts` — green
+- [ ] `npx playwright test e2e/og-preview-visual.spec.ts` — green against committed baselines
+- [ ] `npm run test:e2e:og` exists and chains the three
+- [ ] `ARCHITECTURE.md` has an E2E coverage map entry
+- [ ] No regressions in existing specs (`npx playwright test` should still all green pre-merge)

--- a/e2e/README-visual-regression.md
+++ b/e2e/README-visual-regression.md
@@ -1,0 +1,34 @@
+# OG Visual Regression
+
+## Spec
+`e2e/og-preview-visual.spec.ts` — pins byte-accurate snapshots of partner OG images with 5% pixel-ratio tolerance.
+
+## Baselines
+Committed PNGs live in `e2e/og-preview-visual.spec.ts-snapshots/`. Do NOT hand-edit.
+
+## First-time baseline generation
+
+After seeding partners (`scripts/seed-e2e-partners.mjs`) and confirming the OG images render correctly against live prod:
+
+```
+E2E_SEED_READY=1 npx playwright test e2e/og-preview-visual.spec.ts --update-snapshots
+```
+
+Commit the generated PNGs.
+
+## Regenerating after intentional brand changes
+
+Same command. Review the diff in the generated PNGs before committing (`git diff --stat e2e/og-preview-visual.spec.ts-snapshots/`).
+
+## Tuning tolerance
+
+Per-call tolerance override:
+```ts
+expect(body).toMatchSnapshot("og-r-referral-branded.png", { maxDiffPixelRatio: 0.01 });
+```
+
+Global default (5%) lives in `playwright.config.ts`.
+
+## Cross-platform notes
+
+Snapshots are generated on the OS running the test. If CI uses a different OS, baselines may drift on first run. Standard Playwright workaround: add an `updateSnapshots` CI step on the canonical platform, commit the platform-specific files.

--- a/e2e/og-preview-unfurl-bots.spec.ts
+++ b/e2e/og-preview-unfurl-bots.spec.ts
@@ -1,0 +1,109 @@
+/**
+ * E2E: unfurl-bot UA simulation for partner landing pages (Phase 2 Task 4).
+ *
+ * Social unfurl scrapers send platform-specific User-Agent headers. If any
+ * middleware, rate-limit, or CSP path returns a non-200 to those UAs, partner
+ * link cards render blank in iMessage/FB/Slack/X even though direct-browser
+ * fetches work. This spec hits every partner-landing route (HTML + OG image)
+ * with each major unfurl bot's canonical UA string and confirms:
+ *   - 200 OK (no UA-gated 403/404)
+ *   - no unintended redirect (no 3xx to /arrested or error paths)
+ *   - OG meta tags present in the HTML response
+ *   - OG image URL resolves to a PNG
+ *
+ * Fixtures: E2EREFE (referral mode), E2EBOND (check-in mode). See
+ * e2e/seed-partners.sql. Gated on E2E_SEED_READY=1.
+ */
+
+import { test, expect } from "@playwright/test";
+import * as cheerio from "cheerio";
+
+const BASE = "https://imnotanattorney.com";
+const REFERRAL_CODE = "E2EREFE";
+const CHECKIN_CODE = "E2EBOND";
+const PRODUCT_SLUG = "case-decoder"; // one representative product — generateMetadata is shared across all slugs
+
+// Canonical UA strings copied from each platform's documented bot identifier.
+// See https://developers.facebook.com/docs/sharing/webmasters/crawler/ etc.
+const UNFURL_BOTS = [
+  { name: "Facebook", ua: "facebookexternalhit/1.1 (+http://www.facebook.com/externalhit_uatext.php)" },
+  { name: "Slack", ua: "Slackbot-LinkExpanding 1.0 (+https://api.slack.com/robots)" },
+  { name: "Twitter/X", ua: "Twitterbot/1.0" },
+  { name: "LinkedIn", ua: "LinkedInBot/1.0 (compatible; Mozilla/5.0; Apache-HttpClient +http://www.linkedin.com)" },
+  { name: "WhatsApp", ua: "WhatsApp/2.21.4.18 A" },
+  { name: "Telegram", ua: "TelegramBot (like TwitterBot)" },
+  { name: "iMessage", ua: "facebookexternalhit/1.1 Facebot Twitterbot/1.0" }, // iMessage sends an aggregate UA
+] as const;
+
+const HTML_ROUTES = [
+  { label: "/r/[code]", path: `/r/${REFERRAL_CODE}` },
+  { label: "/checkin/[code]", path: `/checkin/${CHECKIN_CODE}` },
+  { label: "/r/[code]/[product]", path: `/r/${REFERRAL_CODE}/${PRODUCT_SLUG}` },
+] as const;
+
+const OG_IMAGE_ROUTES = [
+  { label: "/r/[code]/opengraph-image", path: `/r/${REFERRAL_CODE}/opengraph-image` },
+  { label: "/checkin/[code]/opengraph-image", path: `/checkin/${CHECKIN_CODE}/opengraph-image` },
+  { label: "/r/[code]/[product]/opengraph-image", path: `/r/${REFERRAL_CODE}/${PRODUCT_SLUG}/opengraph-image` },
+] as const;
+
+test.describe("Unfurl-bot UA simulation — HTML routes", () => {
+  test.beforeEach(() => {
+    test.skip(
+      !process.env.E2E_SEED_READY,
+      "needs seeded partners — run scripts/seed-e2e-partners.mjs first",
+    );
+  });
+
+  for (const route of HTML_ROUTES) {
+    for (const bot of UNFURL_BOTS) {
+      test(`${route.label} serves ${bot.name} a 200 with og:image meta`, async ({ request }) => {
+        const res = await request.get(`${BASE}${route.path}`, {
+          headers: { "user-agent": bot.ua },
+          maxRedirects: 0,
+        });
+
+        // 200 OK — no UA-gated 403/404
+        expect(res.status(), `${bot.name} must not be blocked on ${route.label}`).toBe(200);
+
+        // Content-type HTML
+        const ct = res.headers()["content-type"] || "";
+        expect(ct).toMatch(/text\/html/i);
+
+        // og:image meta present in served HTML
+        const html = await res.text();
+        const $ = cheerio.load(html);
+        const ogImage =
+          $('meta[property="og:image"]').attr("content") ||
+          $('meta[name="og:image"]').attr("content");
+        expect(ogImage, `${bot.name} must see og:image in served HTML`).toBeTruthy();
+      });
+    }
+  }
+});
+
+test.describe("Unfurl-bot UA simulation — OG image routes", () => {
+  test.beforeEach(() => {
+    test.skip(
+      !process.env.E2E_SEED_READY,
+      "needs seeded partners — run scripts/seed-e2e-partners.mjs first",
+    );
+  });
+
+  for (const route of OG_IMAGE_ROUTES) {
+    for (const bot of UNFURL_BOTS) {
+      test(`${route.label} serves ${bot.name} a PNG ≥10KB`, async ({ request }) => {
+        const res = await request.get(`${BASE}${route.path}`, {
+          headers: { "user-agent": bot.ua },
+          maxRedirects: 0,
+        });
+
+        expect(res.status(), `${bot.name} must not be blocked on ${route.label}`).toBe(200);
+        expect(res.headers()["content-type"] || "").toMatch(/image\/png/i);
+
+        const body = await res.body();
+        expect(body.byteLength).toBeGreaterThan(10 * 1024);
+      });
+    }
+  }
+});

--- a/e2e/og-preview-visual.spec.ts
+++ b/e2e/og-preview-visual.spec.ts
@@ -1,0 +1,55 @@
+/**
+ * E2E: visual regression baselines for partner OG images (Phase 2 Task 5).
+ *
+ * Byte-size and content-type checks (og-preview.spec.ts) catch broken PNGs.
+ * This spec catches *visually* changed PNGs — brand color drift, logo
+ * position shift, font rename — that still pass structural checks but
+ * render differently in unfurls.
+ *
+ * Generates baselines on first run with --update-snapshots. Subsequent
+ * runs compare with a 5% pixel-ratio tolerance (configured globally in
+ * playwright.config.ts).
+ *
+ * Baselines live in `e2e/og-preview-visual.spec.ts-snapshots/` and are
+ * committed to the repo. To regenerate after an intentional brand
+ * change: `npx playwright test e2e/og-preview-visual.spec.ts --update-snapshots`
+ *
+ * Fixtures: E2EREFE (referral mode), E2EBOND (check-in mode).
+ * Gated on E2E_SEED_READY=1 — live prod + seeded DB required.
+ */
+
+import { test, expect } from "@playwright/test";
+
+const BASE = "https://imnotanattorney.com";
+const REFERRAL_CODE = "E2EREFE";
+const CHECKIN_CODE = "E2EBOND";
+
+test.describe("OG preview visual regression", () => {
+  test.beforeEach(() => {
+    test.skip(
+      !process.env.E2E_SEED_READY,
+      "needs seeded partners — run scripts/seed-e2e-partners.mjs first",
+    );
+  });
+
+  test("/r/{code}/opengraph-image matches committed baseline", async ({ request }) => {
+    const res = await request.get(`${BASE}/r/${REFERRAL_CODE}/opengraph-image`);
+    expect(res.status()).toBe(200);
+    const body = await res.body();
+    expect(body).toMatchSnapshot("og-r-referral-branded.png");
+  });
+
+  test("/checkin/{code}/opengraph-image matches committed baseline", async ({ request }) => {
+    const res = await request.get(`${BASE}/checkin/${CHECKIN_CODE}/opengraph-image`);
+    expect(res.status()).toBe(200);
+    const body = await res.body();
+    expect(body).toMatchSnapshot("og-checkin-branded.png");
+  });
+
+  test("/r/{code}/case-decoder/opengraph-image matches committed baseline", async ({ request }) => {
+    const res = await request.get(`${BASE}/r/${REFERRAL_CODE}/case-decoder/opengraph-image`);
+    expect(res.status()).toBe(200);
+    const body = await res.body();
+    expect(body).toMatchSnapshot("og-r-product-case-decoder-branded.png");
+  });
+});

--- a/e2e/og-preview.spec.ts
+++ b/e2e/og-preview.spec.ts
@@ -45,6 +45,16 @@ function parseMeta(html: string, property: string): string | null {
   );
 }
 
+/**
+ * Pull the `href` attribute off the first matching <link rel="..."> tag.
+ * Separate helper from parseMeta because <link> uses a different selector
+ * shape (rel/href vs property/name/content).
+ */
+function parseLink(html: string, rel: string): string | null {
+  const $ = cheerio.load(html);
+  return $(`link[rel="${rel}"]`).attr("href") || null;
+}
+
 test.describe("OG preview wiring (Task 30)", () => {
   // Top-level test.skip() is a no-op under @playwright/test — skip must run
   // inside a describe/beforeEach to actually skip the tests.
@@ -122,6 +132,77 @@ test.describe("OG preview wiring (Task 30)", () => {
       expect(imgRes.headers()["content-type"] || "").toMatch(/image\/png/i);
     }
   });
+
+  // --- Phase 2 Task 3: full meta-tag bundle assertions for unfurl parity ---
+  //
+  // Existing tests above cover og:title + og:image, which is enough for
+  // iMessage/Slack but thin for FB/LinkedIn/X. The three tests below assert
+  // the remaining unfurl-critical tags (og:description, twitter:card,
+  // twitter:image, canonical) so future metadata refactors can't silently
+  // drop them. One test per route — combining assertions keeps parity with
+  // the existing test shape and avoids 12 tiny fragments.
+
+  test("/r/{code} full meta-tag bundle", async ({ request }) => {
+    const res = await request.get(`${BASE}/r/${REFERRAL_CODE}`);
+    expect(res.status()).toBe(200);
+    const html = await res.text();
+
+    // og:description — required for FB/LI/Slack preview cards.
+    const ogDesc = parseMeta(html, "og:description");
+    expect(ogDesc, "og:description must be present").toBeTruthy();
+    expect(ogDesc!.length, "og:description should be <300 chars for FB cutoff").toBeLessThan(300);
+    expect(ogDesc!.length, "og:description should be substantive (>30 chars)").toBeGreaterThan(30);
+
+    // twitter:card — large image unfurl format.
+    const twCard = parseMeta(html, "twitter:card");
+    expect(twCard, "twitter:card must be summary_large_image").toBe("summary_large_image");
+
+    // twitter:image — separate from og:image on some platforms.
+    const twImage = parseMeta(html, "twitter:image");
+    expect(twImage, "twitter:image must be present").toBeTruthy();
+    if (twImage) {
+      const imgRes = await request.get(twImage);
+      expect(imgRes.status()).toBe(200);
+      expect(imgRes.headers()["content-type"] || "").toMatch(/image\/png/i);
+    }
+
+    // canonical — absolute URL pointing at this route.
+    const canonical = parseLink(html, "canonical");
+    expect(canonical, "canonical link must be present").toBeTruthy();
+    expect(canonical, "canonical should be absolute on imnotanattorney.com").toMatch(/^https:\/\/imnotanattorney\.com\//);
+    expect(canonical!.toLowerCase(), "canonical should reference this route").toContain(`/r/${REFERRAL_CODE.toLowerCase()}`);
+  });
+
+  test("/checkin/{code} full meta-tag bundle", async ({ request }) => {
+    const res = await request.get(`${BASE}/checkin/${CHECKIN_CODE}`);
+    expect(res.status()).toBe(200);
+    const html = await res.text();
+
+    // og:description — required for FB/LI/Slack preview cards.
+    const ogDesc = parseMeta(html, "og:description");
+    expect(ogDesc, "og:description must be present").toBeTruthy();
+    expect(ogDesc!.length, "og:description should be <300 chars for FB cutoff").toBeLessThan(300);
+    expect(ogDesc!.length, "og:description should be substantive (>30 chars)").toBeGreaterThan(30);
+
+    // twitter:card — large image unfurl format.
+    const twCard = parseMeta(html, "twitter:card");
+    expect(twCard, "twitter:card must be summary_large_image").toBe("summary_large_image");
+
+    // twitter:image — separate from og:image on some platforms.
+    const twImage = parseMeta(html, "twitter:image");
+    expect(twImage, "twitter:image must be present").toBeTruthy();
+    if (twImage) {
+      const imgRes = await request.get(twImage);
+      expect(imgRes.status()).toBe(200);
+      expect(imgRes.headers()["content-type"] || "").toMatch(/image\/png/i);
+    }
+
+    // canonical — absolute URL pointing at this route.
+    const canonical = parseLink(html, "canonical");
+    expect(canonical, "canonical link must be present").toBeTruthy();
+    expect(canonical, "canonical should be absolute on imnotanattorney.com").toMatch(/^https:\/\/imnotanattorney\.com\//);
+    expect(canonical!.toLowerCase(), "canonical should reference this route").toContain(`/checkin/${CHECKIN_CODE.toLowerCase()}`);
+  });
 });
 
 /**
@@ -156,4 +237,42 @@ test.describe("OG preview wiring — product deep links (Phase 2 Task 2)", () =>
       ).toBeGreaterThan(OG_MIN_BYTES);
     });
   }
+
+  // --- Phase 2 Task 3: full meta-tag bundle for product deep link ---
+  //
+  // The OG *image* test above iterates every slug; the meta-tag bundle test
+  // does NOT — generateMetadata is shared across all product slugs, so one
+  // representative slug (case-decoder, a primary tier) exercises the same
+  // code path. 6x coverage here would be pure bloat without marginal signal.
+  test("/r/{code}/case-decoder full meta-tag bundle", async ({ request }) => {
+    const slug = "case-decoder";
+    const res = await request.get(`${BASE}/r/${REFERRAL_CODE}/${slug}`);
+    expect(res.status()).toBe(200);
+    const html = await res.text();
+
+    // og:description — required for FB/LI/Slack preview cards.
+    const ogDesc = parseMeta(html, "og:description");
+    expect(ogDesc, "og:description must be present").toBeTruthy();
+    expect(ogDesc!.length, "og:description should be <300 chars for FB cutoff").toBeLessThan(300);
+    expect(ogDesc!.length, "og:description should be substantive (>30 chars)").toBeGreaterThan(30);
+
+    // twitter:card — large image unfurl format.
+    const twCard = parseMeta(html, "twitter:card");
+    expect(twCard, "twitter:card must be summary_large_image").toBe("summary_large_image");
+
+    // twitter:image — separate from og:image on some platforms.
+    const twImage = parseMeta(html, "twitter:image");
+    expect(twImage, "twitter:image must be present").toBeTruthy();
+    if (twImage) {
+      const imgRes = await request.get(twImage);
+      expect(imgRes.status()).toBe(200);
+      expect(imgRes.headers()["content-type"] || "").toMatch(/image\/png/i);
+    }
+
+    // canonical — absolute URL pointing at this route.
+    const canonical = parseLink(html, "canonical");
+    expect(canonical, "canonical link must be present").toBeTruthy();
+    expect(canonical, "canonical should be absolute on imnotanattorney.com").toMatch(/^https:\/\/imnotanattorney\.com\//);
+    expect(canonical!.toLowerCase(), "canonical should reference this route").toContain(`/r/${REFERRAL_CODE.toLowerCase()}/${slug}`);
+  });
 });

--- a/e2e/og-preview.spec.ts
+++ b/e2e/og-preview.spec.ts
@@ -10,6 +10,8 @@
  *   - og:image meta tag on each HTML page points at a URL that returns a
  *     200 image/png response (pragmatic OG wiring check — PNG binary is
  *     not regex-inspected).
+ *   - /r/{code}/{product}/opengraph-image returns a substantive PNG for
+ *     every REFERRAL_PRODUCT_MAP key (Phase 2 Task 2, partner pristine pass).
  *
  * Gate: needs seeded partners — see e2e/seed-partners.sql (E2EBOND +
  * E2EREFE).
@@ -17,10 +19,17 @@
 
 import { test, expect } from "@playwright/test";
 import * as cheerio from "cheerio";
+import { REFERRAL_PRODUCT_MAP } from "../src/lib/referral-product-map";
 
 const BASE = "https://imnotanattorney.com";
 const REFERRAL_CODE = "E2EREFE";
 const CHECKIN_CODE = "E2EBOND";
+
+// Byte-size floor for OG PNGs. A blank/placeholder PNG can silently pass a
+// content-type check and break social unfurls. renderOgImage output is
+// consistently 40-120KB in prod; 10KB is a safe lower bound that catches
+// truly-broken renders without false-flagging low-complexity cards.
+const OG_MIN_BYTES = 10 * 1024;
 
 /**
  * Pull the `content` attribute off the first matching meta tag. Uses cheerio
@@ -50,12 +59,16 @@ test.describe("OG preview wiring (Task 30)", () => {
     const res = await request.get(`${BASE}/checkin/${CHECKIN_CODE}/opengraph-image`);
     expect(res.status()).toBe(200);
     expect(res.headers()["content-type"] || "").toMatch(/image\/png/i);
+    const body = await res.body();
+    expect(body.byteLength, "OG PNG should be substantive (>10KB)").toBeGreaterThan(OG_MIN_BYTES);
   });
 
   test("/r/{code}/opengraph-image returns a PNG", async ({ request }) => {
     const res = await request.get(`${BASE}/r/${REFERRAL_CODE}/opengraph-image`);
     expect(res.status()).toBe(200);
     expect(res.headers()["content-type"] || "").toMatch(/image\/png/i);
+    const body = await res.body();
+    expect(body.byteLength, "OG PNG should be substantive (>10KB)").toBeGreaterThan(OG_MIN_BYTES);
   });
 
   test("/checkin/{code} HTML meta title matches check-in branch", async ({ request }) => {
@@ -67,6 +80,13 @@ test.describe("OG preview wiring (Task 30)", () => {
     // Check-in branch copy from generateMetadata:
     //   "Set up your court check-in — {referrer}"
     expect(ogTitle).toMatch(/Court Check-In|Set up your court check-in/i);
+
+    // Partner-identity assertion: og:title template ends with "— {referrer}".
+    // Fixture E2EBOND partner name is "E2E Check-In Bondsman"; after
+    // truncateName this still starts with "E2E". We fall back to the "E2E"
+    // fragment (both fixtures share it) rather than pinning to the full
+    // company string, which can be truncated by truncateName.
+    expect(ogTitle, "og:title should include the partner-referrer name").toContain("E2E");
 
     // og:image should point at a URL that serves a PNG.
     const ogImage = parseMeta(html, "og:image");
@@ -90,6 +110,10 @@ test.describe("OG preview wiring (Task 30)", () => {
     //   "Court Prep for Your Case -- Referred by {referrer}"
     expect(ogTitle).toMatch(/Court Prep.*Referred|Court date reminders/i);
 
+    // Partner-identity assertion: fixture E2EREFE partner name is
+    // "E2E Referral Bondsman". Same fallback rationale as check-in above.
+    expect(ogTitle, "og:title should include the partner-referrer name").toContain("E2E");
+
     const ogImage = parseMeta(html, "og:image");
     expect(ogImage).toBeTruthy();
     if (ogImage) {
@@ -98,4 +122,38 @@ test.describe("OG preview wiring (Task 30)", () => {
       expect(imgRes.headers()["content-type"] || "").toMatch(/image\/png/i);
     }
   });
+});
+
+/**
+ * Phase 2 Task 2: product-deep-link OG coverage.
+ *
+ * /r/[code]/[product] is the tier-specific referral surface. Each slug in
+ * REFERRAL_PRODUCT_MAP must render a partner-branded, tier-specific OG card.
+ * Previously only /r/[code] and /checkin/[code] were covered — product-deep-
+ * link breakage could ship silently.
+ *
+ * Same E2E_SEED_READY gate + byte-size floor as the parent describe.
+ */
+test.describe("OG preview wiring — product deep links (Phase 2 Task 2)", () => {
+  test.beforeEach(() => {
+    test.skip(
+      !process.env.E2E_SEED_READY,
+      "needs seeded partners — run scripts/seed-e2e-partners.mjs first",
+    );
+  });
+
+  for (const [slug] of Object.entries(REFERRAL_PRODUCT_MAP)) {
+    test(`/r/{code}/${slug}/opengraph-image returns a substantive PNG`, async ({ request }) => {
+      const res = await request.get(
+        `${BASE}/r/${REFERRAL_CODE}/${slug}/opengraph-image`,
+      );
+      expect(res.status()).toBe(200);
+      expect(res.headers()["content-type"] || "").toMatch(/image\/png/i);
+      const body = await res.body();
+      expect(
+        body.byteLength,
+        `OG PNG for /r/${REFERRAL_CODE}/${slug} should be >10KB`,
+      ).toBeGreaterThan(OG_MIN_BYTES);
+    });
+  }
 });

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "qa:blog:all": "node scripts/qa-existing-post.mjs --all",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:e2e:og": "playwright test e2e/og-preview.spec.ts e2e/og-preview-unfurl-bots.spec.ts e2e/og-preview-visual.spec.ts",
     "prepare": "git config core.hooksPath scripts/hooks || true"
   },
   "dependencies": {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -8,6 +8,12 @@ export default defineConfig({
     baseURL: "https://imnotanattorney.com",
     headless: true,
   },
+  // 5% pixel tolerance for snapshot comparisons — fonts render with
+  // sub-pixel drift on serverless OG generation. Tighten per-call in
+  // specs that need stricter matching.
+  expect: {
+    toMatchSnapshot: { maxDiffPixelRatio: 0.05 },
+  },
   projects: [
     {
       name: "chromium",

--- a/src/app/checkin/[code]/page.tsx
+++ b/src/app/checkin/[code]/page.tsx
@@ -22,8 +22,9 @@ export async function generateMetadata({
   return {
     title: `${title} | ImNotAnAttorney`,
     description,
+    alternates: { canonical: `/checkin/${code.toLowerCase()}` },
     openGraph: { title, description, type: "website" },
-    twitter: { card: "summary", title, description },
+    twitter: { card: "summary_large_image", title, description },
   };
 }
 

--- a/src/app/r/[code]/[product]/page.tsx
+++ b/src/app/r/[code]/[product]/page.tsx
@@ -128,6 +128,7 @@ export async function generateMetadata({
   return {
     title: `${title} | ImNotAnAttorney`,
     description,
+    alternates: { canonical: `/r/${code.toLowerCase()}/${product.toLowerCase()}` },
     openGraph: { title, description, type: "website" as const },
     twitter: { card: "summary_large_image" as const, title, description },
   };

--- a/src/app/r/[code]/page.tsx
+++ b/src/app/r/[code]/page.tsx
@@ -42,6 +42,7 @@ export async function generateMetadata({
     return {
       title: `${title} | ImNotAnAttorney`,
       description,
+      alternates: { canonical: `/r/${code.toLowerCase()}` },
       openGraph: { title, description, type: "website" as const },
       twitter: { card: "summary_large_image" as const, title, description },
     };
@@ -52,6 +53,7 @@ export async function generateMetadata({
   return {
     title: `${defaultTitle} | ImNotAnAttorney`,
     description: `${defaultDescription} Legal information -- not legal advice.`,
+    alternates: { canonical: `/r/${code.toLowerCase()}` },
     openGraph: { title: defaultTitle, description: defaultDescription, type: "website" as const },
     twitter: { card: "summary_large_image" as const, title: defaultTitle, description: defaultDescription },
   };

--- a/src/lib/products.ts
+++ b/src/lib/products.ts
@@ -1226,14 +1226,10 @@ export const STANDALONE_PRODUCTS: Record<string, StandaloneProduct> = {
       "Your Similar Cases Analyzer report is generated on demand from verified court records within 60 seconds.",
     description:
       "Similar case outcomes, sentencing distributions, plea discount data, and appellate trends for your charge and jurisdiction.",
-<<<<<<< HEAD
     // Required: chargeType, state. Optional (used to match against USSC FY14-24
     // federal sentencing distribution when supplied): priorConvictions,
     // citizenship, ageBucket.
     intakeFields: ["chargeType", "state", "priorConvictions", "citizenship", "ageBucket", "district"],
-=======
-    intakeFields: ["chargeType", "state", "district"],
->>>>>>> f3c042d (fix(tools): adversarial-walkthrough findings on /tools/sentencing-calculator)
     stripePriceId: null,
     upsellTier: "case-decoder",
     upsellText:


### PR DESCRIPTION
- **docs(plans): phase 2 TDD plan — E2E coverage gap fill**
- **test(e2e): OG byte floor + partner-specific branding + product OG**
- **chore(products): resolve leftover merge conflict in similar-cases-analyzer**
- **test(e2e): full meta-tag bundle assertions for partner unfurls**
- **fix(unfurl): add canonical + correct twitter:card on partner landings**
- **test(e2e): unfurl-bot UA simulation spec**
- **test(e2e): visual regression spec + config for partner OG images**
- **docs(arch): E2E coverage map + test:e2e:og fast-gate script**
