### PR TITLE
fix/partner followups round 5

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -67,6 +67,7 @@ Playwright specs live in `e2e/`. Before writing new specs, check this map — ov
 | `og-preview-unfurl-bots.spec.ts` | 7 unfurl bot UAs (Facebook, Slack, Twitter/X, LinkedIn, WhatsApp, Telegram, iMessage) × 3 HTML routes + 3 OG image routes = 42 tests. Catches UA-gated 403s that blank unfurls on specific platforms |
 | `og-preview-visual.spec.ts` | Byte-accurate snapshot baselines (5% pixel tolerance) for OG images. Catches brand color drift + logo shift. Baselines in `e2e/og-preview-visual.spec.ts-snapshots/` — regenerate with `--update-snapshots` |
 | `court-reminders.spec.ts` | Reminder SMS + email flow |
+| `a11y-partner-routes.spec.ts` | axe-core WCAG 2.1 AA audit on 5 partner-facing routes (/partner/login, /r/[code], /r/[code]/reminders, /r/[code]/[product], /checkin/[code]). Fails on critical/serious; warns on moderate/minor. Authenticated dashboard routes out of scope (follow-up). |
 | `fsd-*.spec.ts`, `ussc-*.spec.ts` | Federal sentencing distribution tools |
 
 **Fixtures:** `E2EREFE` (referral-mode bondsman), `E2EBOND` (check-in-mode bondsman). Seeded by `scripts/seed-e2e-partners.mjs`. All specs gate on `E2E_SEED_READY=1`.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -73,6 +73,78 @@ Playwright specs live in `e2e/`. Before writing new specs, check this map — ov
 
 **Fast CI script:** `npm run test:e2e:og` — runs only the 3 OG specs (cheap, no browser steps, ~60 tests total). Wire into CI for every PR without paying the 5-min full-walkthrough cost.
 
+## Partner System Operational Inventories
+
+Audit snapshot from 2026-04-21 (Phase 3 hardening). Inventory-only — gaps below
+each table become follow-up PRs. Re-run the inventory when adding a new
+`/api/partner/*` route or partner-system env dependency.
+
+Rate-limit helper: `src/lib/rate-limit.ts` → `checkRateLimit(supabase, key, maxRequests, windowSeconds)`.
+Backed by Postgres RPC `check_rate_limit` with in-memory fail-closed fallback
+(`MEMORY_MAX_REQUESTS=3` per 60s) when Supabase is unreachable. Middleware
+(`src/middleware.ts`) enforces cookie-exists auth on `/api/partner/*` but does
+NOT apply any rate limits of its own — all limiting is per-route.
+
+### Rate limits — /api/partner/* + /api/partners/*
+
+| Route | Method | Rate-limited | Key | Limit | Gap notes |
+|---|---|---|---|---|---|
+| `/api/partners/apply` | POST | Yes | `partner-apply:{ip}` | 3 / hour | OK |
+| `/api/partner/magic-link` | POST | Yes (2 keys) | `partner-magic:{email}` + `partner-magic-ip:{ip}` | 3/hr email · 10/hr IP | OK |
+| `/api/partner/magic-link/verify` | POST | Yes | `partner-verify:{ip}` | 10 / 5 min | OK |
+| `/api/partner/logout` | POST | Yes | `partner-logout:{ip}` | 10 / 5 min | OK |
+| `/api/partner/track-event` | POST | Yes (2 keys) | `partner-event-ip:{ip}` + `partner-event:{promo_code}` | 10/min IP · 10/min code | OK |
+| `/api/partner/branding/save` | PATCH | Yes | `partner-branding-save:{partner.id}` | 30 / hour | OK |
+| `/api/partner/branding/upload` | POST | Yes | `partner-branding-upload:{partner.id}` | 10 / hour | OK |
+| `/api/partner/branding/fetch-website` | POST | Yes | `partner-branding-fetch-website:{partner.id}` | 20 / hour | OK |
+| `/api/partner/dashboard` | GET | No | — | — | Authenticated read, low-risk. No limit — Supabase connection-pool is the implicit ceiling. Optional: add `partner-dashboard:{partner.id}` 60/min as DoS guard. |
+| `/api/partner/settings` | PATCH | No | — | — | Authenticated write. **GAP**: no per-partner cap; brute-force-able by authed attacker. Add `partner-settings:{partner.id}` 20/hour. |
+| `/api/partner/add-client` | POST | No | — | — | Authenticated write accepting PII (name, email, phone). **GAP**: no per-partner cap; compromised partner session could spam client-enrollment emails/SMS. Add `partner-add-client:{partner.id}` 30/hour. |
+| `/api/partner/notification-prefs` | GET · PATCH | No | — | — | Low-risk read + toggle write. Optional PATCH cap `partner-notifs:{partner.id}` 20/hour. |
+| `/api/partner/clients/[id]/schedule` | PATCH | No | — | — | Authenticated write that triggers email + SMS to client. **GAP**: no per-partner cap; compromised partner session could spam outbound reminders. Add `partner-schedule:{partner.id}` 30/hour. |
+| `/api/partner/compliance-report` | GET | No | — | — | Authenticated read, low-risk. No limit needed. |
+
+**Gaps flagged as follow-up:**
+- [ ] `/api/partner/settings` (PATCH): add `partner-settings:{partner.id}` 20/hour — authed write, no cap.
+- [ ] `/api/partner/add-client` (POST): add `partner-add-client:{partner.id}` 30/hour — authed write sends email/SMS to third-party clients.
+- [ ] `/api/partner/clients/[id]/schedule` (PATCH): add `partner-schedule:{partner.id}` 30/hour — authed write sends email/SMS per call.
+- [ ] `/api/partner/notification-prefs` (PATCH): optional `partner-notifs:{partner.id}` 20/hour DoS guard.
+- [ ] `/api/partner/dashboard` (GET): optional `partner-dashboard:{partner.id}` 60/min DoS guard (currently protected only by Supabase pool ceiling).
+- [ ] Durable-store fallback: in-memory fallback gives `MEMORY_MAX_REQUESTS * N_isolates` effective limit on Vercel. Consider Vercel KV / Upstash for magic-link (3/hr) where Supabase outage would otherwise relax the limit.
+
+### Env vars — partner system
+
+Scope legend: **Public** = `NEXT_PUBLIC_*`, ships in client bundle. **Secret** = server-only, must be on Vercel prod never committed. **Runtime** = Node-provided (no Vercel config).
+
+| Env var | Required? | Where read | Scope |
+|---|---|---|---|
+| `NEXT_PUBLIC_SUPABASE_URL` | Required | `src/lib/supabase/admin.ts:46`, `src/middleware.ts:92,249` (CSP connect-src), `src/lib/partner-branding/url-guard.ts:307` | Public |
+| `SUPABASE_SERVICE_ROLE_KEY` | Required | `src/lib/supabase/admin.ts:47` (every partner route via `createAdminClient()`) | Secret |
+| `RESEND_API_KEY` | Required | `src/lib/email.ts:50` (magic-link, add-client, schedule, all partner emails) + `src/lib/sms.ts:45` (SMS-via-email-gateway for partner-client reminders) | Secret |
+| `RESEND_FROM_EMAIL` | Optional | `src/lib/email.ts:54` (defaults to `noreply@imnotanattorney.com`) | Secret |
+| `NEXT_PUBLIC_SITE_URL` | Optional | `src/lib/email.ts:178` (magic-link URLs, partner dashboard links; defaults to `https://imnotanattorney.com`) | Public |
+| `OPERATOR_EMAIL` | Optional | `src/app/api/partners/apply/route.ts:25` (apply-notification recipient), `src/lib/email.ts:217,298` (reply-to + admin digests) | Secret |
+| `ADMIN_PASSWORD` | Required (admin routes) | `src/middleware.ts:134` — not read by `/api/partner/*` but gates partner-adjacent admin surfaces | Secret |
+| `OPERATOR_SECRET` | Required (generate/evaluate) | `src/middleware.ts:154` — not read by `/api/partner/*` but gates report generation used by partner tiers | Secret |
+| `CRON_AUTH_TOKEN` | Required (partner crons) | `src/middleware.ts:171` — gates `/api/cron/partner-drip`, `/api/cron/partner-cleanup`, `/api/cron/partner-monthly-summary`, `/api/cron/court-reminders`, `/api/cron/check-in-prompt`, `/api/cron/sms-health-check` | Secret |
+| `NEXT_PUBLIC_PARTNER_BRANDING_ENABLED` | Optional (feature flag) | `src/lib/partner-branding/feature-flag.ts:2` — gates white-label branding UI + `/api/partner/branding/*` routes | Public |
+| `NEXT_PUBLIC_CHECKIN_TOGGLE_ENABLED` | Optional (feature flag) | `src/app/partner/dashboard/page.tsx:158`, `src/app/partner/card/page.tsx:69,106`, `src/app/partner/checklist/page.tsx:72,257`, `src/app/r/[code]/page.tsx:99`, `src/app/r/[code]/opengraph-image.tsx:37`, `src/app/checkin/[code]/page.tsx:13,37`, `src/app/checkin/[code]/opengraph-image.tsx:13` — gates bondsman mode toggle + `/checkin/[code]` surface | Public |
+| `SMS_HEALTH_TEST_PHONE` | Optional | `src/app/api/cron/sms-health-check/route.ts:20` — if unset, SMS-leg of health probe skipped | Secret |
+| `TELEGRAM_BOT_TOKEN_LEGAL` | Optional | `src/app/api/cron/sms-health-check/route.ts:110` — alerting when SMS health probe fails | Secret |
+| `TELEGRAM_CHAT_ID` | Optional | `src/app/api/cron/sms-health-check/route.ts:111` — paired with Telegram bot token | Secret |
+| `NODE_ENV` | Runtime | `src/middleware.ts:104,117` + `src/app/api/partner/logout/route.ts:33` + `src/app/api/partner/magic-link/verify/route.ts:79` — gates cookie `secure` flag | Runtime |
+
+**Gaps flagged as follow-up (Vercel prod verification needed on project `imnotanattorney` / `prj_zqxNgG9xcM235bnKRoEgP5kBOEEr`):**
+- [ ] Verify `NEXT_PUBLIC_SUPABASE_URL` present — blast radius: every partner route + middleware CSP.
+- [ ] Verify `SUPABASE_SERVICE_ROLE_KEY` present — blast radius: every partner route (all use `createAdminClient`).
+- [ ] Verify `RESEND_API_KEY` present — blast radius: magic-link login, add-client, schedule, all partner email + SMS.
+- [ ] Verify `CRON_AUTH_TOKEN` present — blast radius: 6 partner-adjacent crons (`partner-drip`, `partner-cleanup`, `partner-monthly-summary`, `court-reminders`, `check-in-prompt`, `sms-health-check`).
+- [ ] Verify `OPERATOR_EMAIL` present — partner-apply notification silently falls back to hard-coded default if missing; document the fallback address in onboarding runbook.
+- [ ] Verify `NEXT_PUBLIC_PARTNER_BRANDING_ENABLED` state (true in prod? test only?) — white-label routes silently 404-equivalent if false.
+- [ ] Verify `NEXT_PUBLIC_CHECKIN_TOGGLE_ENABLED` state — `/checkin/[code]` surface is gated; wrong value = bondsman mode invisible in prod.
+- [ ] Consider promoting `OPERATOR_EMAIL` and `RESEND_FROM_EMAIL` from Optional → Required; the hard-coded fallbacks (`rahim0kapadia@gmail.com`, `noreply@imnotanattorney.com`) should not ship silently.
+- [ ] Document `TELEGRAM_BOT_TOKEN_LEGAL` + `TELEGRAM_CHAT_ID` in the alerting runbook — without both, SMS health probe failures are silent.
+
 ## Data Flow
 
 ```

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -106,7 +106,7 @@ NOT apply any rate limits of its own — all limiting is per-route.
 | `/api/partner/compliance-report` | GET | No | — | — | Authenticated read, low-risk. No limit needed. |
 
 **Remaining gaps:**
-- [ ] Durable-store fallback: in-memory fallback gives `MEMORY_MAX_REQUESTS * N_isolates` effective limit on Vercel. Consider Vercel KV / Upstash for magic-link (3/hr) where Supabase outage would otherwise relax the limit.
+- [~] 2026-04-21: abstract durable-store contract shipped (`src/lib/rate-limit-durable/`). Magic-link opted in via `checkRateLimit(..., { durable: true })`. No provider wired yet — set `DURABLE_RL_PROVIDER=upstash` or `vercel-kv` and implement the sibling class to activate. Without a provider, behavior is unchanged (in-memory fallback). See `src/lib/rate-limit-durable/README.md`.
 
 ### Env vars — partner system
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -138,7 +138,7 @@ Scope legend: **Public** = `NEXT_PUBLIC_*`, ships in client bundle. **Secret** =
 - [ ] Verify `OPERATOR_EMAIL` present — partner-apply notification silently falls back to hard-coded default if missing; document the fallback address in onboarding runbook.
 - [ ] Verify `NEXT_PUBLIC_PARTNER_BRANDING_ENABLED` state (true in prod? test only?) — white-label routes silently 404-equivalent if false.
 - [ ] Verify `NEXT_PUBLIC_CHECKIN_TOGGLE_ENABLED` state — `/checkin/[code]` surface is gated; wrong value = bondsman mode invisible in prod.
-- [ ] Consider promoting `OPERATOR_EMAIL` and `RESEND_FROM_EMAIL` from Optional → Required; the hard-coded fallbacks (`rahim0kapadia@gmail.com`, `noreply@imnotanattorney.com`) should not ship silently.
+- [x] 2026-04-21: `OPERATOR_EMAIL` and `RESEND_FROM_EMAIL` now use `envWithWarn()` — in production, falling back to the hardcoded default emits a `[ENV-MISSING]` console.warn once per process. Grep Vercel logs for `ENV-MISSING` to detect drift. Source: `src/lib/env-check.ts`.
 - [ ] Document `TELEGRAM_BOT_TOKEN_LEGAL` + `TELEGRAM_CHAT_ID` in the alerting runbook — without both, SMS health probe failures are silent.
 
 ## Data Flow

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -50,6 +50,29 @@ Properties that MUST hold system-wide. Violating any of these is a critical defe
 | **Playbook System** | 8 configurable sales pages (1 component, 8 configs) | [`PLAYBOOK-ARCHITECTURE.md`](PLAYBOOK-ARCHITECTURE.md) |
 | **Design System** | Brand tokens: Amber + Navy on black, Playfair + Lato | [`design-system/brand.md`](design-system/brand.md) |
 
+## E2E Coverage Map
+
+Playwright specs live in `e2e/`. Before writing new specs, check this map — overlap is the most common form of wasted work.
+
+| Spec file | Covers |
+|---|---|
+| `partner-full-walkthrough.spec.ts` | Full bondsman partner walkthrough: login → dashboard → every section, form, and modal (payment settings, notifications, add-client, FTA calculator, toolkit, compliance, checklist, card) |
+| `white-label-walkthrough.spec.ts` | Partner branding flow: logo upload + website scrape + contrast gate + preview |
+| `partner-checklist.spec.ts` | Bondsman compliance checklist (QR + print) |
+| `bondsman-hardening.spec.ts` | Bondsman-mode invariants (28 tests, production) |
+| `checkin-signup.spec.ts` | `/checkin/[code]` enrollment flow |
+| `bridge-referral.spec.ts` | `/r/[code]` bridge page |
+| `product-deep-link.spec.ts` | `/r/[code]/[product]` deep links |
+| `og-preview.spec.ts` | OG image 200/PNG/≥10KB + og:title + og:description + twitter:card + twitter:image + canonical + partner-specific branding for `/r/[code]`, `/checkin/[code]`, and all 6 `/r/[code]/[product]` variants |
+| `og-preview-unfurl-bots.spec.ts` | 7 unfurl bot UAs (Facebook, Slack, Twitter/X, LinkedIn, WhatsApp, Telegram, iMessage) × 3 HTML routes + 3 OG image routes = 42 tests. Catches UA-gated 403s that blank unfurls on specific platforms |
+| `og-preview-visual.spec.ts` | Byte-accurate snapshot baselines (5% pixel tolerance) for OG images. Catches brand color drift + logo shift. Baselines in `e2e/og-preview-visual.spec.ts-snapshots/` — regenerate with `--update-snapshots` |
+| `court-reminders.spec.ts` | Reminder SMS + email flow |
+| `fsd-*.spec.ts`, `ussc-*.spec.ts` | Federal sentencing distribution tools |
+
+**Fixtures:** `E2EREFE` (referral-mode bondsman), `E2EBOND` (check-in-mode bondsman). Seeded by `scripts/seed-e2e-partners.mjs`. All specs gate on `E2E_SEED_READY=1`.
+
+**Fast CI script:** `npm run test:e2e:og` — runs only the 3 OG specs (cheap, no browser steps, ~60 tests total). Wire into CI for every PR without paying the 5-min full-walkthrough cost.
+
 ## Data Flow
 
 ```

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -106,7 +106,7 @@ NOT apply any rate limits of its own — all limiting is per-route.
 | `/api/partner/compliance-report` | GET | No | — | — | Authenticated read, low-risk. No limit needed. |
 
 **Remaining gaps:**
-- [~] 2026-04-21: abstract durable-store contract shipped (`src/lib/rate-limit-durable/`). Magic-link opted in via `checkRateLimit(..., { durable: true })`. No provider wired yet — set `DURABLE_RL_PROVIDER=upstash` or `vercel-kv` and implement the sibling class to activate. Without a provider, behavior is unchanged (in-memory fallback). See `src/lib/rate-limit-durable/README.md`.
+- [x] 2026-04-21: durable-store fallback ACTIVATED via Upstash Redis. Contract + implementation live at `src/lib/rate-limit-durable/`. Magic-link opted in via `checkRateLimit(..., { durable: true })`. To provision + wire Upstash on prod: `node scripts/setup-durable-rate-limit.mjs` (needs UPSTASH_EMAIL, UPSTASH_API_KEY, VERCEL_TOKEN envs locally). Dormant until `DURABLE_RL_PROVIDER=upstash` is set on Vercel; setup script writes that env.
 
 ### Env vars — partner system
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -131,13 +131,7 @@ Scope legend: **Public** = `NEXT_PUBLIC_*`, ships in client bundle. **Secret** =
 | `NODE_ENV` | Runtime | `src/middleware.ts:104,117` + `src/app/api/partner/logout/route.ts:33` + `src/app/api/partner/magic-link/verify/route.ts:79` — gates cookie `secure` flag | Runtime |
 
 **Gaps flagged as follow-up (Vercel prod verification needed on project `imnotanattorney` / `prj_zqxNgG9xcM235bnKRoEgP5kBOEEr`):**
-- [ ] Verify `NEXT_PUBLIC_SUPABASE_URL` present — blast radius: every partner route + middleware CSP.
-- [ ] Verify `SUPABASE_SERVICE_ROLE_KEY` present — blast radius: every partner route (all use `createAdminClient`).
-- [ ] Verify `RESEND_API_KEY` present — blast radius: magic-link login, add-client, schedule, all partner email + SMS.
-- [ ] Verify `CRON_AUTH_TOKEN` present — blast radius: 6 partner-adjacent crons (`partner-drip`, `partner-cleanup`, `partner-monthly-summary`, `court-reminders`, `check-in-prompt`, `sms-health-check`).
-- [ ] Verify `OPERATOR_EMAIL` present — partner-apply notification silently falls back to hard-coded default if missing; document the fallback address in onboarding runbook.
-- [ ] Verify `NEXT_PUBLIC_PARTNER_BRANDING_ENABLED` state (true in prod? test only?) — white-label routes silently 404-equivalent if false.
-- [ ] Verify `NEXT_PUBLIC_CHECKIN_TOGGLE_ENABLED` state — `/checkin/[code]` surface is gated; wrong value = bondsman mode invisible in prod.
+- [x] 2026-04-21: `GET /api/admin/env-presence` + `node scripts/check-partner-envs.mjs` report presence of all 15 partner-system env vars in the running deploy. Use before/after deploys to catch drift. Extend `PARTNER_SYSTEM_ENVS` in the route when adding a new env dependency (keep inventory table + endpoint array in lockstep).
 - [x] 2026-04-21: `OPERATOR_EMAIL` and `RESEND_FROM_EMAIL` now use `envWithWarn()` — in production, falling back to the hardcoded default emits a `[ENV-MISSING]` console.warn once per process. Grep Vercel logs for `ENV-MISSING` to detect drift. Source: `src/lib/env-check.ts`.
 - [ ] Document `TELEGRAM_BOT_TOKEN_LEGAL` + `TELEGRAM_CHAT_ID` in the alerting runbook — without both, SMS health probe failures are silent.
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -98,19 +98,14 @@ NOT apply any rate limits of its own — all limiting is per-route.
 | `/api/partner/branding/save` | PATCH | Yes | `partner-branding-save:{partner.id}` | 30 / hour | OK |
 | `/api/partner/branding/upload` | POST | Yes | `partner-branding-upload:{partner.id}` | 10 / hour | OK |
 | `/api/partner/branding/fetch-website` | POST | Yes | `partner-branding-fetch-website:{partner.id}` | 20 / hour | OK |
-| `/api/partner/dashboard` | GET | No | — | — | Authenticated read, low-risk. No limit — Supabase connection-pool is the implicit ceiling. Optional: add `partner-dashboard:{partner.id}` 60/min as DoS guard. |
-| `/api/partner/settings` | PATCH | No | — | — | Authenticated write. **GAP**: no per-partner cap; brute-force-able by authed attacker. Add `partner-settings:{partner.id}` 20/hour. |
-| `/api/partner/add-client` | POST | No | — | — | Authenticated write accepting PII (name, email, phone). **GAP**: no per-partner cap; compromised partner session could spam client-enrollment emails/SMS. Add `partner-add-client:{partner.id}` 30/hour. |
-| `/api/partner/notification-prefs` | GET · PATCH | No | — | — | Low-risk read + toggle write. Optional PATCH cap `partner-notifs:{partner.id}` 20/hour. |
-| `/api/partner/clients/[id]/schedule` | PATCH | No | — | — | Authenticated write that triggers email + SMS to client. **GAP**: no per-partner cap; compromised partner session could spam outbound reminders. Add `partner-schedule:{partner.id}` 30/hour. |
+| `/api/partner/dashboard` | GET | Yes | `partner-dashboard:{partner.id}` | 60 / min | OK (DoS guard added 2026-04-21) |
+| `/api/partner/settings` | PATCH | Yes | `partner-settings:{partner.id}` | 20 / hour | OK (added 2026-04-21) |
+| `/api/partner/add-client` | POST | Yes | `partner-add-client:{partner.id}` | 30 / hour | OK (added 2026-04-21) |
+| `/api/partner/notification-prefs` | GET · PATCH | PATCH yes | `partner-notifs:{partner.id}` | 20 / hour | OK (added 2026-04-21) |
+| `/api/partner/clients/[id]/schedule` | PATCH | Yes | `partner-schedule:{partner.id}` | 30 / hour | OK (added 2026-04-21) |
 | `/api/partner/compliance-report` | GET | No | — | — | Authenticated read, low-risk. No limit needed. |
 
-**Gaps flagged as follow-up:**
-- [ ] `/api/partner/settings` (PATCH): add `partner-settings:{partner.id}` 20/hour — authed write, no cap.
-- [ ] `/api/partner/add-client` (POST): add `partner-add-client:{partner.id}` 30/hour — authed write sends email/SMS to third-party clients.
-- [ ] `/api/partner/clients/[id]/schedule` (PATCH): add `partner-schedule:{partner.id}` 30/hour — authed write sends email/SMS per call.
-- [ ] `/api/partner/notification-prefs` (PATCH): optional `partner-notifs:{partner.id}` 20/hour DoS guard.
-- [ ] `/api/partner/dashboard` (GET): optional `partner-dashboard:{partner.id}` 60/min DoS guard (currently protected only by Supabase pool ceiling).
+**Remaining gaps:**
 - [ ] Durable-store fallback: in-memory fallback gives `MEMORY_MAX_REQUESTS * N_isolates` effective limit on Vercel. Consider Vercel KV / Upstash for magic-link (3/hr) where Supabase outage would otherwise relax the limit.
 
 ### Env vars — partner system

--- a/docs/plans/2026-04-21-partner-portal-phase-2-e2e-coverage.md
+++ b/docs/plans/2026-04-21-partner-portal-phase-2-e2e-coverage.md
@@ -1,0 +1,100 @@
+# Partner Portal Pristine — Phase 2: E2E Coverage
+
+> **For Claude:** REQUIRED SUB-SKILL: `superpowers:executing-plans`
+
+**Parent design:** `docs/plans/2026-04-21-partner-portal-pristine-design.md`
+
+**Goal:** Fill the real gaps in partner-system E2E coverage, not rebuild what already exists. The existing spec set (`partner-full-walkthrough`, `og-preview`, `bridge-referral`, `product-deep-link`, `white-label-walkthrough`, `partner-checklist`, `checkin-signup`, `bondsman-hardening`) is already deep — 600+ LOC of partner walkthroughs. Phase 2 adds the OG/unfurl rigor that's missing.
+
+**Architecture:** Extend `og-preview.spec.ts` where the surface already exists (meta-tag depth, byte-size guard, product OG); add one new spec for unfurl-bot UA simulation; add visual regression baselines via Playwright `toHaveScreenshot`. All new assertions gate on the same `E2E_SEED_READY` env var the existing spec already uses.
+
+**Tech Stack:** Playwright 1.59.x, cheerio (already a dep), chromium only. Seeded test partners: `E2EREFE` (referral mode), `E2EBOND` (check-in mode). Seed script: `scripts/seed-e2e-partners.mjs`.
+
+---
+
+## Scope delta vs. original design outline
+
+| Original outline | What's already done | Phase 2 action |
+|---|---|---|
+| `partner-full-system.spec.ts` — apply → approve → magic-link → dashboard → add-client → share | `partner-full-walkthrough.spec.ts` (311 LOC) already covers bondsman partner walkthrough end-to-end | **Skip** (already covered) |
+| `partner-preview-links.spec.ts` — 3 codes × 4 routes OG unfurl | `og-preview.spec.ts` covers /r + /checkin but not /r/[code]/[product], and doesn't check byte size or full meta-tag bundle | **Extend** existing spec |
+| `partner-preview-deploy.spec.ts` — Vercel preview gate | Existing specs already run against production; preview-gating is env-var + CI concern | **Drop** — fold into Task 6 (CI docs) |
+| Visual regression | Nothing exists | **Add** baselines |
+
+---
+
+## Tasks
+
+### Task 1: Branch + this plan doc
+- Branch `chore/partner-e2e-coverage` from master ✅ (done)
+- Commit this plan doc
+
+### Task 2: OG byte-size + branding-specific assertions
+**Files:** `e2e/og-preview.spec.ts`
+
+Extend existing spec:
+1. After each `expect(headers["content-type"]).toMatch(/image\/png/)`, add `expect(Buffer.byteLength(await res.body())).toBeGreaterThan(10 * 1024)` — 10KB floor guards against empty/placeholder PNG.
+2. Parse og:title and assert it contains the partner fixture's name fragment (not just a pattern match). For E2EREFE: partner name contains "E2E Referral Bondsman", og:title should include some identifiable partner token — the existing `generateMetadata` builds `"— {referrer}"` style, so assert the og:title ends with a partner-identity slice.
+3. Add `/r/{code}/{product}/opengraph-image` coverage for every REFERRAL_PRODUCT_MAP key (6 total). Assert 200 + PNG + ≥10KB.
+
+### Task 3: Full meta-tag bundle
+**Files:** `e2e/og-preview.spec.ts`
+
+For each route already tested (/r/[code], /checkin/[code], plus new /r/[code]/[product]):
+- Parse og:description — assert non-empty, <300 chars (Facebook cutoff), matches route branch copy.
+- Parse twitter:card — assert `summary_large_image`.
+- Parse twitter:image — assert present and returns 200 PNG (unfurl preview on Twitter/X).
+- Parse canonical (`<link rel="canonical">`) — assert absolute URL on imnotanattorney.com, matches the route being fetched.
+
+### Task 4: Unfurl-bot UA simulation
+**Files:** `e2e/og-preview-unfurl-bots.spec.ts` (new)
+
+Fetch each route with UA headers for: `facebookexternalhit/1.1`, `Slackbot-LinkExpanding 1.0`, `Twitterbot/1.0`, `LinkedInBot/1.0`, `WhatsApp/2.21.4.18`, `TelegramBot (like TwitterBot)`.
+
+Assert:
+- Status 200 (no UA-gated 403/404).
+- Content-type text/html for page routes, image/png for /opengraph-image routes.
+- No unintended redirect (no 3xx to /arrested or error pages).
+- HTML response contains `og:image` meta tag (proves bot-served HTML still has the unfurl data).
+
+Gate on `E2E_SEED_READY`.
+
+### Task 5: Visual regression baselines
+**Files:** `e2e/og-preview-visual.spec.ts` (new), `e2e/og-preview-visual.spec.ts-snapshots/*` (baselines)
+
+Playwright `toHaveScreenshot`:
+- `/r/E2EREFE/opengraph-image` → `og-referral-branded.png`
+- `/checkin/E2EBOND/opengraph-image` → `og-checkin-branded.png`
+
+Threshold: `maxDiffPixelRatio: 0.05` (5% to survive font-rendering micro-drift).
+
+Baselines committed once; regenerate only via `--update-snapshots`. Runtime: must fetch the OG URL, write to buffer, use Playwright image diff. Actually simpler: use `toHaveScreenshot` against the image fetched and displayed in a minimal HTML shell, OR use @playwright/test's `toMatchSnapshot` on raw buffer.
+
+Simplest implementation: fetch the PNG, save to `test-results/og-*.png`, compare bytes against committed baseline with 5% tolerance. Playwright has `toMatchSnapshot` for binary assertions.
+
+### Task 6: Coverage map + CI fast-gate script
+**Files:** `ARCHITECTURE.md`, `package.json`
+
+Add to ARCHITECTURE.md a subsection "E2E coverage map" mapping spec file → what it covers. This makes future work (and future AI sessions) see the coverage before duplicating.
+
+Add npm script:
+```json
+"test:e2e:og": "playwright test e2e/og-preview.spec.ts e2e/og-preview-unfurl-bots.spec.ts e2e/og-preview-visual.spec.ts"
+```
+
+Purpose: the OG/unfurl specs are cheap (no browser steps, just `request.get` + cheerio + image diff) — they can run on every PR without the full 5-minute walkthrough suite. Wire into CI later (out of scope for this phase).
+
+### Task 7: Push + PR
+
+Standard: push, open PR, merge.
+
+---
+
+## Exit criteria
+
+- [ ] `npx playwright test e2e/og-preview.spec.ts` — green (with seeded partners)
+- [ ] `npx playwright test e2e/og-preview-unfurl-bots.spec.ts` — green
+- [ ] `npx playwright test e2e/og-preview-visual.spec.ts` — green against committed baselines
+- [ ] `npm run test:e2e:og` exists and chains the three
+- [ ] `ARCHITECTURE.md` has an E2E coverage map entry
+- [ ] No regressions in existing specs (`npx playwright test` should still all green pre-merge)

--- a/docs/plans/2026-04-21-partner-portal-phase-3-hardening.md
+++ b/docs/plans/2026-04-21-partner-portal-phase-3-hardening.md
@@ -1,0 +1,117 @@
+# Partner Portal Pristine — Phase 3: Hardening
+
+> **For Claude:** REQUIRED SUB-SKILL: `superpowers:executing-plans`
+
+**Parent design:** `docs/plans/2026-04-21-partner-portal-pristine-design.md`
+
+**Base:** `chore/partner-e2e-coverage` (Phase 2) — inherits canonical links, twitter:card fix, products.ts conflict resolution, and E2E coverage map. Phase 3 PR depends on Phase 2 merging first (or rebase if master shifts).
+
+**Goal:** Ship the hardening items that are both valuable and completable without live-prod write access. Narrows the original design doc's audit list to what's achievable in this session; the rest is documented as follow-up.
+
+## Scope — what we're shipping vs. deferring
+
+| Item | Phase 3 action |
+|---|---|
+| RLS audit (full, every partner table, policy review, doc to SCHEMA.md) | **Defer** — needs Supabase project admin access for a proper audit; out of scope |
+| zod schemas for all 8 `/api/partner/*` routes | **Narrow** — ship schemas for 3 top-risk routes (add-client, magic-link, settings) that accept rich user input. Others follow-up. |
+| Auth-boundary audit test | **Ship** — structural source-text test asserting every route validates session at top + doesn't accept `partner_id` from body/query |
+| Rate-limit audit | **Narrow** — inventory current limits in ARCHITECTURE.md; flag gaps as follow-up rather than fixing in this PR |
+| Observability (Sentry + Telegram alerts) | **Defer** — needs external config access |
+| Perf (cold-start, N+1 hunting) | **Defer** — needs production profiling, not a pure code change |
+| Dead code grep | **Ship** — mechanical, low-risk |
+| Env-var audit | **Ship (document only)** — list every env var the partner system reads, flag any missing from Vercel prod as follow-up |
+| CSP `img-src` audit for partner logos | **Ship** — static review + doc |
+| CV probe INNA-H12 (partner-preview-integrity) | **Narrow** — write the probe script in this repo; wiring it into `~/projects/continuous-verification/verify.mjs` is the user's follow-up |
+| ?preview=1 sentinel on /r/[code]/* | **Ship** — feature add, moderate scope |
+
+## Tasks
+
+### Task 1: Plan commit ✅ (this doc)
+
+### Task 2: zod schemas for 3 top-risk partner routes
+**Files:** `src/lib/partner-schemas.ts` (new), `src/lib/__tests__/partner-schemas.test.ts` (new), 3 route handlers modified.
+
+Routes in scope:
+1. `POST /api/partner/add-client` — bondsman submits defendant data (name, phone, email, court date, charge type, county/state)
+2. `POST /api/partner/magic-link` — email lookup + sends magic link
+3. `POST /api/partner/settings` — partner updates payment/notification prefs
+
+Each schema:
+- Strict (no `.passthrough()` — extra fields rejected)
+- Length caps on strings (names, emails, phones)
+- Enum for known values (charge_type, payment_method)
+- PII fields trimmed + normalized
+
+Wire: at route entry, `const body = await req.json(); const parsed = SCHEMA.safeParse(body); if (!parsed.success) return NextResponse.json({ error: "..." }, { status: 400 });`.
+
+Tests: unit-test each schema with valid + invalid inputs. Cover boundary conditions.
+
+### Task 3: Auth-boundary structural audit test
+**Files:** `tests/auth/partner-api-boundary.test.ts` (new).
+
+Read source text for every file in `src/app/api/partner/**/route.ts`. Assert:
+- Each file imports and calls `requirePartnerAuth` OR `validatePartnerSession`.
+- Auth check appears BEFORE any business logic (heuristic: first function-local statement in `GET`/`POST`/`PUT`/`DELETE` export is the auth check).
+- NO file contains `req.json()` destructuring that pulls `partner_id` or `partnerId` from the body (regex guard).
+- NO file reads `partner_id` from `req.nextUrl.searchParams`.
+
+### Task 4: Rate-limit inventory (document in ARCHITECTURE.md)
+**Files:** `ARCHITECTURE.md` (edit).
+
+Read every `/api/partner/*` route, find calls to `rateLimit` helper (or absence). Produce a table in ARCHITECTURE.md:
+
+| Route | Current limit | Scope key | Gap? |
+|---|---|---|---|
+| ... | ... | ... | ... |
+
+Don't fix gaps in this PR — each gap becomes a follow-up PR. This doc table is the working list.
+
+### Task 5: Dead code grep
+**Files:** Delete as needed; or document none found.
+
+`grep -r` for exported symbols in `src/lib/partner-*.ts` and check `src/` for consumer references. Delete anything unreferenced. Commit only if deletions found.
+
+### Task 6: Env-var audit (document in ARCHITECTURE.md)
+**Files:** `ARCHITECTURE.md` (edit).
+
+List every `process.env.X` reference under partner system code. Cross-ref against `.env.example` if present. Document in ARCHITECTURE.md. Flag missing-in-Vercel items as follow-up (we can't verify Vercel from this session).
+
+### Task 7: CSP img-src audit
+**Files:** `src/middleware.ts` (review), `ARCHITECTURE.md` (edit, if gap).
+
+Read `buildCsp()`; verify `img-src` allows Supabase Storage (`*.supabase.co`) and partner-scraped domains. Document the current state + any hardening opportunity.
+
+### Task 8: CV probe INNA-H12 partner-preview-integrity (local script only)
+**Files:** `scripts/verify-partner-preview-integrity.mjs` (new), `scripts/CONTEXT.md` (edit).
+
+Fetch `/r/[CODE]/opengraph-image` for the top-3 active partner codes. Assert 200 + PNG + ≥10KB. Exit 0 on all pass; non-zero on any fail. User wires into `~/projects/continuous-verification/verify.mjs` separately.
+
+Query "top-3 active partners": `SELECT promo_code FROM partners WHERE status='approved' ORDER BY total_referrals DESC LIMIT 3;`
+
+### Task 9: ?preview=1 sentinel on /r/[code]/*
+**Files:** `src/app/r/[code]/page.tsx` (edit), `src/app/r/[code]/[product]/page.tsx` (edit), `src/app/checkin/[code]/page.tsx` (edit), `src/components/PreviewBanner.tsx` (new), `src/components/shells/PartnerBrandedShell.tsx` (edit to accept a preview-mode prop), `src/app/partner/dashboard/page.tsx` (edit to add "Preview my link" affordance), tests.
+
+When `?preview=1` is present on a partner route:
+- Skip the `after()` telemetry event (no `partner_events` row inserted).
+- Skip referral cookie set in middleware.
+- Render a `<PreviewBanner>` at the top of the page: "You're previewing what defendants see. Attribution is paused on this view."
+
+The partner can share the preview URL with teammates or verify the page without polluting analytics.
+
+Tests: unit-test the skip-telemetry behavior + banner render gate.
+
+### Task 10: Push + PR
+
+Standard push. PR body should note Phase 3 depends on Phase 2 merging first.
+
+## Exit criteria
+
+- [ ] `npx tsc --noEmit --skipLibCheck` — clean
+- [ ] `npx vitest run` — green (existing + new schema tests + auth-boundary test + preview-sentinel tests)
+- [ ] zod schemas cover add-client, magic-link, settings
+- [ ] Auth-boundary test passes (proves all 8+ partner API routes gated)
+- [ ] Rate-limit inventory + env-var inventory committed to ARCHITECTURE.md
+- [ ] CV probe script exists in repo, runnable via `node scripts/verify-partner-preview-integrity.mjs`
+- [ ] ?preview=1 behavior works (render test) and skips attribution
+
+Phase 3 PR waits on Phase 2 merge. Phase 4 (copy/UX polish) branches from Phase 3 tip.

--- a/docs/plans/2026-04-21-partner-portal-phase-4-polish.md
+++ b/docs/plans/2026-04-21-partner-portal-phase-4-polish.md
@@ -1,0 +1,58 @@
+# Partner Portal Pristine — Phase 4: Copy/UX Polish
+
+> **For Claude:** REQUIRED SUB-SKILL: `superpowers:executing-plans`
+
+**Parent design:** `docs/plans/2026-04-21-partner-portal-pristine-design.md`
+
+**Base:** `fix/partner-hardening` (Phase 3) — inherits zod, auth-boundary test, CV probe, rate-limit + env-var inventories. Phase 4 PR merges last.
+
+## Scope — polish we can mechanize
+
+Copy/UX polish is inherently subjective and often needs live-browser review. Phase 4 ships what can be **mechanized as tests + audits**, leaving the live-browser adversarial-walkthrough pass for a manual user-driven session.
+
+| Item | Phase 4 action |
+|---|---|
+| Adversarial walkthrough (7-agent swarm on live URL) | **Defer** — needs live staging URL + screenshot review + subjective judgment calls. User-driven, not auto-mode. |
+| axe-core accessibility audit (AA violations per partner route) | **Ship** — adds a Playwright spec using `@axe-core/playwright`. Gated on `E2E_SEED_READY`. |
+| UPL scan — static source-text test on defendant-facing copy | **Ship** — structural grep-test asserts no "legal advice", no "ask your attorney to verify", no outcome guarantees on `/r/[code]/*` + `/checkin/[code]`. |
+| Brand-voice review (Atti voice across partner-facing pages) | **Defer** — requires judgment + line-by-line rewrites. User-driven. |
+| Mobile-scannable audit (375px viewport) | **Defer** — needs live-browser visual review. |
+
+## Tasks
+
+### Task 1: Plan commit ✅ (this doc)
+
+### Task 2: axe-core a11y audit spec
+**Files:** `e2e/a11y-partner-routes.spec.ts` (new), `package.json` (add `@axe-core/playwright` dep)
+
+Playwright + axe-core run automated WCAG AA checks against every partner-facing route. Fails on critical/serious violations; warnings on moderate. Gated on `E2E_SEED_READY=1`.
+
+Routes covered: `/partner/login`, `/partner/dashboard`, `/partner/dashboard/branding`, `/r/[code]`, `/r/[code]/reminders`, `/r/[code]/[product]`, `/checkin/[code]`.
+
+On first CI run against a seeded + live environment, any failures become real follow-up work. For now: spec exists + compiles; baseline is "whatever the site currently emits" (not hardened here).
+
+### Task 3: UPL structural scan test
+**Files:** `tests/compliance/upl-partner-copy.test.ts` (new)
+
+Read the source text of every defendant-facing partner page (`src/app/r/**/page.tsx`, `src/app/checkin/[code]/page.tsx`) and assert NONE of these phrases appear in the text content (JSX children + string literals):
+- "legal advice" (except in the permitted "legal information, not legal advice" disclaimer — exempt that exact substring)
+- "ask your attorney to verify"
+- "your attorney can confirm"
+- Outcome guarantees: "will win", "guaranteed", "dismissal", "not guilty" (in promising tone — context-aware scan, flag for review, don't hard-fail)
+
+The test is rigid for the first two (zero tolerance); soft for outcome-guarantee phrases (print warnings, let the user triage).
+
+Per `.claude/rules/no-hallucinated-legal-data.md` + `.claude/rules/brand-voice.md`: UPL exposure is a real risk + the brand rule is "never put burden back on the defendant." Ask-your-attorney framing violates this.
+
+### Task 4: Push + PR
+
+Final verification. Push. Open PR.
+
+## Exit criteria
+
+- [ ] `npx tsc --noEmit --skipLibCheck` — clean
+- [ ] `npx vitest run tests/compliance/upl-partner-copy.test.ts` — green
+- [ ] `npx playwright test --list e2e/a11y-partner-routes.spec.ts` — shows expected test count, no config errors
+- [ ] ARCHITECTURE.md updated (add a11y spec + UPL scan to E2E Coverage Map)
+
+Phase 4 PR closes the pristine pass. Remaining live-browser adversarial walkthrough, brand-voice line-edits, and mobile-scannable review are user-driven follow-ups.

--- a/e2e/README-visual-regression.md
+++ b/e2e/README-visual-regression.md
@@ -1,0 +1,34 @@
+# OG Visual Regression
+
+## Spec
+`e2e/og-preview-visual.spec.ts` — pins byte-accurate snapshots of partner OG images with 5% pixel-ratio tolerance.
+
+## Baselines
+Committed PNGs live in `e2e/og-preview-visual.spec.ts-snapshots/`. Do NOT hand-edit.
+
+## First-time baseline generation
+
+After seeding partners (`scripts/seed-e2e-partners.mjs`) and confirming the OG images render correctly against live prod:
+
+```
+E2E_SEED_READY=1 npx playwright test e2e/og-preview-visual.spec.ts --update-snapshots
+```
+
+Commit the generated PNGs.
+
+## Regenerating after intentional brand changes
+
+Same command. Review the diff in the generated PNGs before committing (`git diff --stat e2e/og-preview-visual.spec.ts-snapshots/`).
+
+## Tuning tolerance
+
+Per-call tolerance override:
+```ts
+expect(body).toMatchSnapshot("og-r-referral-branded.png", { maxDiffPixelRatio: 0.01 });
+```
+
+Global default (5%) lives in `playwright.config.ts`.
+
+## Cross-platform notes
+
+Snapshots are generated on the OS running the test. If CI uses a different OS, baselines may drift on first run. Standard Playwright workaround: add an `updateSnapshots` CI step on the canonical platform, commit the platform-specific files.

--- a/e2e/a11y-partner-routes.spec.ts
+++ b/e2e/a11y-partner-routes.spec.ts
@@ -1,0 +1,83 @@
+/**
+ * E2E: axe-core accessibility audit on every partner-facing route (Phase 4 Task 3).
+ *
+ * Runs axe-core (WCAG 2.1 AA ruleset) against each route. Fails on critical
+ * or serious violations; logs moderate + minor as warnings.
+ *
+ * Baseline = whatever the current site emits. Violations surfaced by the first
+ * run are real follow-up work, NOT Phase 4 fix list. This spec exists so that
+ * future regressions (a new component with missing aria-labels, a color that
+ * drops below AA contrast) fail the CI gate instead of silently landing.
+ *
+ * Routes covered:
+ *   /partner/login
+ *   /r/[code]           (referral mode — requires partner-branded shell)
+ *   /r/[code]/reminders
+ *   /r/[code]/case-decoder  (one product deep-link representative)
+ *   /checkin/[code]     (check-in mode)
+ *
+ * Note: /partner/dashboard and /partner/dashboard/branding require an
+ * authenticated session — out of scope for this basic spec. When
+ * partner-full-walkthrough.spec.ts's authentication helper is exposed, a
+ * follow-up can add authenticated a11y coverage.
+ *
+ * Fixtures: E2EREFE (referral mode), E2EBOND (check-in mode).
+ * Gated on E2E_SEED_READY=1.
+ */
+
+import { test, expect } from "@playwright/test";
+import AxeBuilder from "@axe-core/playwright";
+
+const BASE = "https://imnotanattorney.com";
+const REFERRAL_CODE = "E2EREFE";
+const CHECKIN_CODE = "E2EBOND";
+
+const ROUTES = [
+  { label: "/partner/login", path: "/partner/login" },
+  { label: "/r/[code]", path: `/r/${REFERRAL_CODE}` },
+  { label: "/r/[code]/reminders", path: `/r/${REFERRAL_CODE}/reminders` },
+  { label: "/r/[code]/[product]", path: `/r/${REFERRAL_CODE}/case-decoder` },
+  { label: "/checkin/[code]", path: `/checkin/${CHECKIN_CODE}` },
+] as const;
+
+test.describe("a11y — partner-facing routes", () => {
+  test.beforeEach(() => {
+    test.skip(
+      !process.env.E2E_SEED_READY,
+      "needs seeded partners — run scripts/seed-e2e-partners.mjs first",
+    );
+  });
+
+  for (const route of ROUTES) {
+    test(`${route.label} has no critical or serious axe violations`, async ({ page }) => {
+      await page.goto(`${BASE}${route.path}`, { waitUntil: "networkidle" });
+
+      const results = await new AxeBuilder({ page })
+        .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])
+        .analyze();
+
+      const critical = results.violations.filter((v) => v.impact === "critical");
+      const serious = results.violations.filter((v) => v.impact === "serious");
+      const moderate = results.violations.filter((v) => v.impact === "moderate");
+      const minor = results.violations.filter((v) => v.impact === "minor");
+
+      // Warnings (non-failing) — surfaced in test output for triage.
+      if (moderate.length > 0 || minor.length > 0) {
+        console.warn(
+          `[a11y ${route.label}] ${moderate.length} moderate + ${minor.length} minor violations — triage:`,
+          [...moderate, ...minor].map((v) => ({ id: v.id, help: v.help, nodes: v.nodes.length })),
+        );
+      }
+
+      // Hard assertion — any critical or serious is a failing violation.
+      expect(
+        critical,
+        `${route.label} has ${critical.length} CRITICAL a11y violations: ${critical.map((v) => v.id).join(", ")}`,
+      ).toHaveLength(0);
+      expect(
+        serious,
+        `${route.label} has ${serious.length} SERIOUS a11y violations: ${serious.map((v) => v.id).join(", ")}`,
+      ).toHaveLength(0);
+    });
+  }
+});

--- a/e2e/og-preview-unfurl-bots.spec.ts
+++ b/e2e/og-preview-unfurl-bots.spec.ts
@@ -1,0 +1,109 @@
+/**
+ * E2E: unfurl-bot UA simulation for partner landing pages (Phase 2 Task 4).
+ *
+ * Social unfurl scrapers send platform-specific User-Agent headers. If any
+ * middleware, rate-limit, or CSP path returns a non-200 to those UAs, partner
+ * link cards render blank in iMessage/FB/Slack/X even though direct-browser
+ * fetches work. This spec hits every partner-landing route (HTML + OG image)
+ * with each major unfurl bot's canonical UA string and confirms:
+ *   - 200 OK (no UA-gated 403/404)
+ *   - no unintended redirect (no 3xx to /arrested or error paths)
+ *   - OG meta tags present in the HTML response
+ *   - OG image URL resolves to a PNG
+ *
+ * Fixtures: E2EREFE (referral mode), E2EBOND (check-in mode). See
+ * e2e/seed-partners.sql. Gated on E2E_SEED_READY=1.
+ */
+
+import { test, expect } from "@playwright/test";
+import * as cheerio from "cheerio";
+
+const BASE = "https://imnotanattorney.com";
+const REFERRAL_CODE = "E2EREFE";
+const CHECKIN_CODE = "E2EBOND";
+const PRODUCT_SLUG = "case-decoder"; // one representative product — generateMetadata is shared across all slugs
+
+// Canonical UA strings copied from each platform's documented bot identifier.
+// See https://developers.facebook.com/docs/sharing/webmasters/crawler/ etc.
+const UNFURL_BOTS = [
+  { name: "Facebook", ua: "facebookexternalhit/1.1 (+http://www.facebook.com/externalhit_uatext.php)" },
+  { name: "Slack", ua: "Slackbot-LinkExpanding 1.0 (+https://api.slack.com/robots)" },
+  { name: "Twitter/X", ua: "Twitterbot/1.0" },
+  { name: "LinkedIn", ua: "LinkedInBot/1.0 (compatible; Mozilla/5.0; Apache-HttpClient +http://www.linkedin.com)" },
+  { name: "WhatsApp", ua: "WhatsApp/2.21.4.18 A" },
+  { name: "Telegram", ua: "TelegramBot (like TwitterBot)" },
+  { name: "iMessage", ua: "facebookexternalhit/1.1 Facebot Twitterbot/1.0" }, // iMessage sends an aggregate UA
+] as const;
+
+const HTML_ROUTES = [
+  { label: "/r/[code]", path: `/r/${REFERRAL_CODE}` },
+  { label: "/checkin/[code]", path: `/checkin/${CHECKIN_CODE}` },
+  { label: "/r/[code]/[product]", path: `/r/${REFERRAL_CODE}/${PRODUCT_SLUG}` },
+] as const;
+
+const OG_IMAGE_ROUTES = [
+  { label: "/r/[code]/opengraph-image", path: `/r/${REFERRAL_CODE}/opengraph-image` },
+  { label: "/checkin/[code]/opengraph-image", path: `/checkin/${CHECKIN_CODE}/opengraph-image` },
+  { label: "/r/[code]/[product]/opengraph-image", path: `/r/${REFERRAL_CODE}/${PRODUCT_SLUG}/opengraph-image` },
+] as const;
+
+test.describe("Unfurl-bot UA simulation — HTML routes", () => {
+  test.beforeEach(() => {
+    test.skip(
+      !process.env.E2E_SEED_READY,
+      "needs seeded partners — run scripts/seed-e2e-partners.mjs first",
+    );
+  });
+
+  for (const route of HTML_ROUTES) {
+    for (const bot of UNFURL_BOTS) {
+      test(`${route.label} serves ${bot.name} a 200 with og:image meta`, async ({ request }) => {
+        const res = await request.get(`${BASE}${route.path}`, {
+          headers: { "user-agent": bot.ua },
+          maxRedirects: 0,
+        });
+
+        // 200 OK — no UA-gated 403/404
+        expect(res.status(), `${bot.name} must not be blocked on ${route.label}`).toBe(200);
+
+        // Content-type HTML
+        const ct = res.headers()["content-type"] || "";
+        expect(ct).toMatch(/text\/html/i);
+
+        // og:image meta present in served HTML
+        const html = await res.text();
+        const $ = cheerio.load(html);
+        const ogImage =
+          $('meta[property="og:image"]').attr("content") ||
+          $('meta[name="og:image"]').attr("content");
+        expect(ogImage, `${bot.name} must see og:image in served HTML`).toBeTruthy();
+      });
+    }
+  }
+});
+
+test.describe("Unfurl-bot UA simulation — OG image routes", () => {
+  test.beforeEach(() => {
+    test.skip(
+      !process.env.E2E_SEED_READY,
+      "needs seeded partners — run scripts/seed-e2e-partners.mjs first",
+    );
+  });
+
+  for (const route of OG_IMAGE_ROUTES) {
+    for (const bot of UNFURL_BOTS) {
+      test(`${route.label} serves ${bot.name} a PNG ≥10KB`, async ({ request }) => {
+        const res = await request.get(`${BASE}${route.path}`, {
+          headers: { "user-agent": bot.ua },
+          maxRedirects: 0,
+        });
+
+        expect(res.status(), `${bot.name} must not be blocked on ${route.label}`).toBe(200);
+        expect(res.headers()["content-type"] || "").toMatch(/image\/png/i);
+
+        const body = await res.body();
+        expect(body.byteLength).toBeGreaterThan(10 * 1024);
+      });
+    }
+  }
+});

--- a/e2e/og-preview-visual.spec.ts
+++ b/e2e/og-preview-visual.spec.ts
@@ -1,0 +1,55 @@
+/**
+ * E2E: visual regression baselines for partner OG images (Phase 2 Task 5).
+ *
+ * Byte-size and content-type checks (og-preview.spec.ts) catch broken PNGs.
+ * This spec catches *visually* changed PNGs — brand color drift, logo
+ * position shift, font rename — that still pass structural checks but
+ * render differently in unfurls.
+ *
+ * Generates baselines on first run with --update-snapshots. Subsequent
+ * runs compare with a 5% pixel-ratio tolerance (configured globally in
+ * playwright.config.ts).
+ *
+ * Baselines live in `e2e/og-preview-visual.spec.ts-snapshots/` and are
+ * committed to the repo. To regenerate after an intentional brand
+ * change: `npx playwright test e2e/og-preview-visual.spec.ts --update-snapshots`
+ *
+ * Fixtures: E2EREFE (referral mode), E2EBOND (check-in mode).
+ * Gated on E2E_SEED_READY=1 — live prod + seeded DB required.
+ */
+
+import { test, expect } from "@playwright/test";
+
+const BASE = "https://imnotanattorney.com";
+const REFERRAL_CODE = "E2EREFE";
+const CHECKIN_CODE = "E2EBOND";
+
+test.describe("OG preview visual regression", () => {
+  test.beforeEach(() => {
+    test.skip(
+      !process.env.E2E_SEED_READY,
+      "needs seeded partners — run scripts/seed-e2e-partners.mjs first",
+    );
+  });
+
+  test("/r/{code}/opengraph-image matches committed baseline", async ({ request }) => {
+    const res = await request.get(`${BASE}/r/${REFERRAL_CODE}/opengraph-image`);
+    expect(res.status()).toBe(200);
+    const body = await res.body();
+    expect(body).toMatchSnapshot("og-r-referral-branded.png");
+  });
+
+  test("/checkin/{code}/opengraph-image matches committed baseline", async ({ request }) => {
+    const res = await request.get(`${BASE}/checkin/${CHECKIN_CODE}/opengraph-image`);
+    expect(res.status()).toBe(200);
+    const body = await res.body();
+    expect(body).toMatchSnapshot("og-checkin-branded.png");
+  });
+
+  test("/r/{code}/case-decoder/opengraph-image matches committed baseline", async ({ request }) => {
+    const res = await request.get(`${BASE}/r/${REFERRAL_CODE}/case-decoder/opengraph-image`);
+    expect(res.status()).toBe(200);
+    const body = await res.body();
+    expect(body).toMatchSnapshot("og-r-product-case-decoder-branded.png");
+  });
+});

--- a/e2e/og-preview.spec.ts
+++ b/e2e/og-preview.spec.ts
@@ -45,6 +45,16 @@ function parseMeta(html: string, property: string): string | null {
   );
 }
 
+/**
+ * Pull the `href` attribute off the first matching <link rel="..."> tag.
+ * Separate helper from parseMeta because <link> uses a different selector
+ * shape (rel/href vs property/name/content).
+ */
+function parseLink(html: string, rel: string): string | null {
+  const $ = cheerio.load(html);
+  return $(`link[rel="${rel}"]`).attr("href") || null;
+}
+
 test.describe("OG preview wiring (Task 30)", () => {
   // Top-level test.skip() is a no-op under @playwright/test — skip must run
   // inside a describe/beforeEach to actually skip the tests.
@@ -122,6 +132,77 @@ test.describe("OG preview wiring (Task 30)", () => {
       expect(imgRes.headers()["content-type"] || "").toMatch(/image\/png/i);
     }
   });
+
+  // --- Phase 2 Task 3: full meta-tag bundle assertions for unfurl parity ---
+  //
+  // Existing tests above cover og:title + og:image, which is enough for
+  // iMessage/Slack but thin for FB/LinkedIn/X. The three tests below assert
+  // the remaining unfurl-critical tags (og:description, twitter:card,
+  // twitter:image, canonical) so future metadata refactors can't silently
+  // drop them. One test per route — combining assertions keeps parity with
+  // the existing test shape and avoids 12 tiny fragments.
+
+  test("/r/{code} full meta-tag bundle", async ({ request }) => {
+    const res = await request.get(`${BASE}/r/${REFERRAL_CODE}`);
+    expect(res.status()).toBe(200);
+    const html = await res.text();
+
+    // og:description — required for FB/LI/Slack preview cards.
+    const ogDesc = parseMeta(html, "og:description");
+    expect(ogDesc, "og:description must be present").toBeTruthy();
+    expect(ogDesc!.length, "og:description should be <300 chars for FB cutoff").toBeLessThan(300);
+    expect(ogDesc!.length, "og:description should be substantive (>30 chars)").toBeGreaterThan(30);
+
+    // twitter:card — large image unfurl format.
+    const twCard = parseMeta(html, "twitter:card");
+    expect(twCard, "twitter:card must be summary_large_image").toBe("summary_large_image");
+
+    // twitter:image — separate from og:image on some platforms.
+    const twImage = parseMeta(html, "twitter:image");
+    expect(twImage, "twitter:image must be present").toBeTruthy();
+    if (twImage) {
+      const imgRes = await request.get(twImage);
+      expect(imgRes.status()).toBe(200);
+      expect(imgRes.headers()["content-type"] || "").toMatch(/image\/png/i);
+    }
+
+    // canonical — absolute URL pointing at this route.
+    const canonical = parseLink(html, "canonical");
+    expect(canonical, "canonical link must be present").toBeTruthy();
+    expect(canonical, "canonical should be absolute on imnotanattorney.com").toMatch(/^https:\/\/imnotanattorney\.com\//);
+    expect(canonical!.toLowerCase(), "canonical should reference this route").toContain(`/r/${REFERRAL_CODE.toLowerCase()}`);
+  });
+
+  test("/checkin/{code} full meta-tag bundle", async ({ request }) => {
+    const res = await request.get(`${BASE}/checkin/${CHECKIN_CODE}`);
+    expect(res.status()).toBe(200);
+    const html = await res.text();
+
+    // og:description — required for FB/LI/Slack preview cards.
+    const ogDesc = parseMeta(html, "og:description");
+    expect(ogDesc, "og:description must be present").toBeTruthy();
+    expect(ogDesc!.length, "og:description should be <300 chars for FB cutoff").toBeLessThan(300);
+    expect(ogDesc!.length, "og:description should be substantive (>30 chars)").toBeGreaterThan(30);
+
+    // twitter:card — large image unfurl format.
+    const twCard = parseMeta(html, "twitter:card");
+    expect(twCard, "twitter:card must be summary_large_image").toBe("summary_large_image");
+
+    // twitter:image — separate from og:image on some platforms.
+    const twImage = parseMeta(html, "twitter:image");
+    expect(twImage, "twitter:image must be present").toBeTruthy();
+    if (twImage) {
+      const imgRes = await request.get(twImage);
+      expect(imgRes.status()).toBe(200);
+      expect(imgRes.headers()["content-type"] || "").toMatch(/image\/png/i);
+    }
+
+    // canonical — absolute URL pointing at this route.
+    const canonical = parseLink(html, "canonical");
+    expect(canonical, "canonical link must be present").toBeTruthy();
+    expect(canonical, "canonical should be absolute on imnotanattorney.com").toMatch(/^https:\/\/imnotanattorney\.com\//);
+    expect(canonical!.toLowerCase(), "canonical should reference this route").toContain(`/checkin/${CHECKIN_CODE.toLowerCase()}`);
+  });
 });
 
 /**
@@ -156,4 +237,42 @@ test.describe("OG preview wiring — product deep links (Phase 2 Task 2)", () =>
       ).toBeGreaterThan(OG_MIN_BYTES);
     });
   }
+
+  // --- Phase 2 Task 3: full meta-tag bundle for product deep link ---
+  //
+  // The OG *image* test above iterates every slug; the meta-tag bundle test
+  // does NOT — generateMetadata is shared across all product slugs, so one
+  // representative slug (case-decoder, a primary tier) exercises the same
+  // code path. 6x coverage here would be pure bloat without marginal signal.
+  test("/r/{code}/case-decoder full meta-tag bundle", async ({ request }) => {
+    const slug = "case-decoder";
+    const res = await request.get(`${BASE}/r/${REFERRAL_CODE}/${slug}`);
+    expect(res.status()).toBe(200);
+    const html = await res.text();
+
+    // og:description — required for FB/LI/Slack preview cards.
+    const ogDesc = parseMeta(html, "og:description");
+    expect(ogDesc, "og:description must be present").toBeTruthy();
+    expect(ogDesc!.length, "og:description should be <300 chars for FB cutoff").toBeLessThan(300);
+    expect(ogDesc!.length, "og:description should be substantive (>30 chars)").toBeGreaterThan(30);
+
+    // twitter:card — large image unfurl format.
+    const twCard = parseMeta(html, "twitter:card");
+    expect(twCard, "twitter:card must be summary_large_image").toBe("summary_large_image");
+
+    // twitter:image — separate from og:image on some platforms.
+    const twImage = parseMeta(html, "twitter:image");
+    expect(twImage, "twitter:image must be present").toBeTruthy();
+    if (twImage) {
+      const imgRes = await request.get(twImage);
+      expect(imgRes.status()).toBe(200);
+      expect(imgRes.headers()["content-type"] || "").toMatch(/image\/png/i);
+    }
+
+    // canonical — absolute URL pointing at this route.
+    const canonical = parseLink(html, "canonical");
+    expect(canonical, "canonical link must be present").toBeTruthy();
+    expect(canonical, "canonical should be absolute on imnotanattorney.com").toMatch(/^https:\/\/imnotanattorney\.com\//);
+    expect(canonical!.toLowerCase(), "canonical should reference this route").toContain(`/r/${REFERRAL_CODE.toLowerCase()}/${slug}`);
+  });
 });

--- a/e2e/og-preview.spec.ts
+++ b/e2e/og-preview.spec.ts
@@ -10,6 +10,8 @@
  *   - og:image meta tag on each HTML page points at a URL that returns a
  *     200 image/png response (pragmatic OG wiring check — PNG binary is
  *     not regex-inspected).
+ *   - /r/{code}/{product}/opengraph-image returns a substantive PNG for
+ *     every REFERRAL_PRODUCT_MAP key (Phase 2 Task 2, partner pristine pass).
  *
  * Gate: needs seeded partners — see e2e/seed-partners.sql (E2EBOND +
  * E2EREFE).
@@ -17,10 +19,17 @@
 
 import { test, expect } from "@playwright/test";
 import * as cheerio from "cheerio";
+import { REFERRAL_PRODUCT_MAP } from "../src/lib/referral-product-map";
 
 const BASE = "https://imnotanattorney.com";
 const REFERRAL_CODE = "E2EREFE";
 const CHECKIN_CODE = "E2EBOND";
+
+// Byte-size floor for OG PNGs. A blank/placeholder PNG can silently pass a
+// content-type check and break social unfurls. renderOgImage output is
+// consistently 40-120KB in prod; 10KB is a safe lower bound that catches
+// truly-broken renders without false-flagging low-complexity cards.
+const OG_MIN_BYTES = 10 * 1024;
 
 /**
  * Pull the `content` attribute off the first matching meta tag. Uses cheerio
@@ -50,12 +59,16 @@ test.describe("OG preview wiring (Task 30)", () => {
     const res = await request.get(`${BASE}/checkin/${CHECKIN_CODE}/opengraph-image`);
     expect(res.status()).toBe(200);
     expect(res.headers()["content-type"] || "").toMatch(/image\/png/i);
+    const body = await res.body();
+    expect(body.byteLength, "OG PNG should be substantive (>10KB)").toBeGreaterThan(OG_MIN_BYTES);
   });
 
   test("/r/{code}/opengraph-image returns a PNG", async ({ request }) => {
     const res = await request.get(`${BASE}/r/${REFERRAL_CODE}/opengraph-image`);
     expect(res.status()).toBe(200);
     expect(res.headers()["content-type"] || "").toMatch(/image\/png/i);
+    const body = await res.body();
+    expect(body.byteLength, "OG PNG should be substantive (>10KB)").toBeGreaterThan(OG_MIN_BYTES);
   });
 
   test("/checkin/{code} HTML meta title matches check-in branch", async ({ request }) => {
@@ -67,6 +80,13 @@ test.describe("OG preview wiring (Task 30)", () => {
     // Check-in branch copy from generateMetadata:
     //   "Set up your court check-in — {referrer}"
     expect(ogTitle).toMatch(/Court Check-In|Set up your court check-in/i);
+
+    // Partner-identity assertion: og:title template ends with "— {referrer}".
+    // Fixture E2EBOND partner name is "E2E Check-In Bondsman"; after
+    // truncateName this still starts with "E2E". We fall back to the "E2E"
+    // fragment (both fixtures share it) rather than pinning to the full
+    // company string, which can be truncated by truncateName.
+    expect(ogTitle, "og:title should include the partner-referrer name").toContain("E2E");
 
     // og:image should point at a URL that serves a PNG.
     const ogImage = parseMeta(html, "og:image");
@@ -90,6 +110,10 @@ test.describe("OG preview wiring (Task 30)", () => {
     //   "Court Prep for Your Case -- Referred by {referrer}"
     expect(ogTitle).toMatch(/Court Prep.*Referred|Court date reminders/i);
 
+    // Partner-identity assertion: fixture E2EREFE partner name is
+    // "E2E Referral Bondsman". Same fallback rationale as check-in above.
+    expect(ogTitle, "og:title should include the partner-referrer name").toContain("E2E");
+
     const ogImage = parseMeta(html, "og:image");
     expect(ogImage).toBeTruthy();
     if (ogImage) {
@@ -98,4 +122,38 @@ test.describe("OG preview wiring (Task 30)", () => {
       expect(imgRes.headers()["content-type"] || "").toMatch(/image\/png/i);
     }
   });
+});
+
+/**
+ * Phase 2 Task 2: product-deep-link OG coverage.
+ *
+ * /r/[code]/[product] is the tier-specific referral surface. Each slug in
+ * REFERRAL_PRODUCT_MAP must render a partner-branded, tier-specific OG card.
+ * Previously only /r/[code] and /checkin/[code] were covered — product-deep-
+ * link breakage could ship silently.
+ *
+ * Same E2E_SEED_READY gate + byte-size floor as the parent describe.
+ */
+test.describe("OG preview wiring — product deep links (Phase 2 Task 2)", () => {
+  test.beforeEach(() => {
+    test.skip(
+      !process.env.E2E_SEED_READY,
+      "needs seeded partners — run scripts/seed-e2e-partners.mjs first",
+    );
+  });
+
+  for (const [slug] of Object.entries(REFERRAL_PRODUCT_MAP)) {
+    test(`/r/{code}/${slug}/opengraph-image returns a substantive PNG`, async ({ request }) => {
+      const res = await request.get(
+        `${BASE}/r/${REFERRAL_CODE}/${slug}/opengraph-image`,
+      );
+      expect(res.status()).toBe(200);
+      expect(res.headers()["content-type"] || "").toMatch(/image\/png/i);
+      const body = await res.body();
+      expect(
+        body.byteLength,
+        `OG PNG for /r/${REFERRAL_CODE}/${slug} should be >10KB`,
+      ).toBeGreaterThan(OG_MIN_BYTES);
+    });
+  }
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@anthropic-ai/sdk": "^0.82.0",
         "@supabase/supabase-js": "^2.97.0",
+        "@upstash/redis": "^1.37.0",
         "@vercel/analytics": "^1.6.1",
         "cheerio": "^1.2.0",
         "dotenv": "^17.4.1",
@@ -2742,6 +2743,15 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@upstash/redis": {
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.37.0.tgz",
+      "integrity": "sha512-LqOJ3+XWPLSZ2rGSed5DYG3ixybxb8EhZu3yQqF7MdZX1wLBG/FRcI6xcUZXHy/SS7mmXWyadrud0HJHkOc+uw==",
+      "license": "MIT",
+      "dependencies": {
+        "uncrypto": "^0.1.3"
+      }
     },
     "node_modules/@vercel/analytics": {
       "version": "1.6.1",
@@ -9576,6 +9586,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/uncrypto": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
     },
     "node_modules/undici": {
       "version": "7.24.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,8 @@
         "react-dom": "19.2.3",
         "reading-time": "^1.5.0",
         "sanitize-html": "^2.17.1",
-        "stripe": "^20.3.1"
+        "stripe": "^20.3.1",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@playwright/test": "^1.59.1",
@@ -108,6 +109,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -323,28 +325,6 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -1345,6 +1325,7 @@
       "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "playwright": "1.59.1"
       },
@@ -2137,6 +2118,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2221,6 +2203,7 @@
       "integrity": "sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.0",
         "@typescript-eslint/types": "8.58.0",
@@ -2902,6 +2885,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3284,6 +3268,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4244,6 +4229,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4429,6 +4415,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -7426,6 +7413,7 @@
       "resolved": "https://registry.npmjs.org/next/-/next-16.2.2.tgz",
       "integrity": "sha512-i6AJdyVa4oQjyvX/6GeER8dpY/xlIV+4NMv/svykcLtURJSy/WzDnnUk/TM4d0uewFHK7xSQz4TbIwPgjky+3A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@next/env": "16.2.2",
         "@swc/helpers": "0.5.15",
@@ -7905,6 +7893,7 @@
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -8237,6 +8226,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8246,6 +8236,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -9320,6 +9311,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9518,6 +9510,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9823,6 +9816,7 @@
       "integrity": "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -10601,8 +10595,8 @@
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "zod": "^4.3.6"
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.11.2",
         "@playwright/test": "^1.59.1",
         "@tailwindcss/postcss": "^4",
         "@types/node": "^20",
@@ -77,6 +78,19 @@
         "zod": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.2.tgz",
+      "integrity": "sha512-iP6hfNl9G0j/SEUSo8M7D80RbcDo9KRAAfDP4IT5OHB+Wm6zUHIrm8Y51BKI+Oyqduvipf9u1hcRy57zCBKzWQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.11.3"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3173,9 +3187,9 @@
       }
     },
     "node_modules/axe-core": {
-      "version": "4.11.1",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.1.tgz",
-      "integrity": "sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==",
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.3.tgz",
+      "integrity": "sha512-zBQouZixDTbo3jMGqHKyePxYxr1e5W8UdTmBQ7sNtaA9M2bE32daxxPLS/jojhKOHxQ7LWwPjfiwf/fhaJWzlg==",
       "dev": true,
       "license": "MPL-2.0",
       "engines": {
@@ -8029,6 +8043,7 @@
       "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "playwright-core": "cli.js"
       },

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.82.0",
     "@supabase/supabase-js": "^2.97.0",
+    "@upstash/redis": "^1.37.0",
     "@vercel/analytics": "^1.6.1",
     "cheerio": "^1.2.0",
     "dotenv": "^17.4.1",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "qa:blog:all": "node scripts/qa-existing-post.mjs --all",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:e2e:og": "playwright test e2e/og-preview.spec.ts e2e/og-preview-unfurl-bots.spec.ts e2e/og-preview-visual.spec.ts",
     "prepare": "git config core.hooksPath scripts/hooks || true"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.11.2",
     "@playwright/test": "^1.59.1",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "react-dom": "19.2.3",
     "reading-time": "^1.5.0",
     "sanitize-html": "^2.17.1",
-    "stripe": "^20.3.1"
+    "stripe": "^20.3.1",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@playwright/test": "^1.59.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -8,6 +8,12 @@ export default defineConfig({
     baseURL: "https://imnotanattorney.com",
     headless: true,
   },
+  // 5% pixel tolerance for snapshot comparisons — fonts render with
+  // sub-pixel drift on serverless OG generation. Tighten per-call in
+  // specs that need stricter matching.
+  expect: {
+    toMatchSnapshot: { maxDiffPixelRatio: 0.05 },
+  },
   projects: [
     {
       name: "chromium",

--- a/scripts/CONTEXT.md
+++ b/scripts/CONTEXT.md
@@ -77,6 +77,11 @@ The full multi-source verification cascade (Harvard CAP, GovInfo, eCFR, Cornell 
 | `test-inclusion-flow.mjs` | Tier inclusion logic (parent_order_id, is_included_deliverable) |
 | `verify-download-flow.mjs` | Download token flow for all 8 playbooks. Options: `, skip-cleanup`, `, skip-api` |
 
+### Continuous Verification Probes
+| File | Purpose |
+|------|---------|
+| `verify-partner-preview-integrity.mjs` | CV probe INNA-H12. Fetches top-3 partner OG images, asserts 200 + PNG + =10KB. JSON-lines output. Exits 0/1. Usage: `node scripts/verify-partner-preview-integrity.mjs`. Wire into `~/projects/continuous-verification/verify.mjs` as hypothesis H12 |
+
 ### Content & Marketing
 | File | Purpose |
 |------|---------|

--- a/scripts/CONTEXT.md
+++ b/scripts/CONTEXT.md
@@ -17,6 +17,7 @@
 | File | Purpose |
 |------|---------|
 | `check-tiers.mjs` | Verifies tier names/prices in `src/lib/tiers.ts` match across docs (CLAUDE.md, PRD, SERVICES). Catches pricing drift |
+| `brand-voice-scan.mjs` | Heuristic flagger for partner-surface copy. Outputs ranked candidates with file:line references. 10 rules (6 hard, 4 soft) per `.claude/rules/brand-voice.md` + `no-hallucinated-legal-data.md`. Never rewrites. Usage: `node scripts/brand-voice-scan.mjs` or `--json` for tooling. Exits 0 regardless of findings; exit 2 on tool error |
 
 ### Report Generation
 | File | Purpose |

--- a/scripts/brand-voice-scan.mjs
+++ b/scripts/brand-voice-scan.mjs
@@ -1,0 +1,266 @@
+#!/usr/bin/env node
+/**
+ * Brand-voice heuristic flagger for partner-surface copy.
+ *
+ * NOT an auto-fixer. Output is advisory — ranked candidates with reasons
+ * and file:line references. User triages which to fix.
+ *
+ * Usage:
+ *   node scripts/brand-voice-scan.mjs           # default paths, colorized summary
+ *   node scripts/brand-voice-scan.mjs --json    # JSON lines for tooling
+ *   node scripts/brand-voice-scan.mjs path/foo.tsx path/bar.tsx
+ *
+ * Exits 0 always (flags are advisory, not failures). Emit exit code 2 on
+ * read/parse errors so CI can distinguish tool failure from clean output.
+ *
+ * Rules enforced: see docs/plans/2026-04-21-partner-portal-phase-3-hardening.md
+ * + .claude/rules/brand-voice.md.
+ */
+
+import { readFileSync, readdirSync, statSync, existsSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const REPO_ROOT = path.resolve(__dirname, "..");
+
+function dirname(p) {
+  const i = p.replace(/\\/g, "/").lastIndexOf("/");
+  return i < 0 ? "." : p.slice(0, i);
+}
+
+// ── Rule catalog ─────────────────────────────────────────────────────
+// Each rule has: id, severity, reason, and one of:
+//   - pattern: RegExp (case-insensitive, global)
+//   - fn: (line) => boolean (heuristic check per line)
+//
+// Severity: "hard" (should not appear), "soft" (flag for review).
+
+const RULES = [
+  // Hard
+  {
+    id: "speed-sell",
+    severity: "hard",
+    reason: "Speed-selling — brand forbids selling on speed/time. Quality is the hook.",
+    pattern: /\b(?:fast|quick|quickly|instantly|instant|rapid|in\s+minutes|under\s+60\s+seconds|within\s+an\s+hour|same-day|blazing|lightning)\b/gi,
+  },
+  {
+    id: "burden-on-defendant",
+    severity: "hard",
+    reason: "Burden-back-on-defendant. Brand rule: 'We Research, You Ask' — never 'You Do'.",
+    pattern: /\b(?:you\s+ask\b|you\s+do\b|your\s+job\s+is|you\s+need\s+to|you\s+have\s+to\b)/gi,
+  },
+  {
+    id: "corporate-lawyer",
+    severity: "hard",
+    reason: "Corporate-lawyer voice. Brand is insider-defendant, not corporate legal.",
+    pattern: /\b(?:hereby|pursuant\s+to|hereinafter|aforementioned|wherein|notwithstanding)\b/gi,
+  },
+  {
+    id: "outcome-guarantee",
+    severity: "hard",
+    reason: "Outcome guarantee. UPL risk + brand ban.",
+    pattern: /\b(?:we\s+guarantee|guaranteed\s+(?:dismissal|acquittal|outcome|win)|will\s+win|will\s+prevail|ensures?\s+(?:a|your)\s+(?:dismissal|acquittal))\b/gi,
+  },
+  {
+    id: "gavel-cliche",
+    severity: "hard",
+    reason: "Gavel / scales-of-justice visual cliché. Brand rule explicitly bans.",
+    pattern: /\b(?:gavel|scales\s+of\s+justice)\b/gi,
+  },
+  {
+    id: "attorney-verification",
+    severity: "hard",
+    reason: "Attorney-verification framing. Defendants have no attorney to verify anything.",
+    pattern: /\b(?:ask\s+your\s+attorney\s+to\s+verify|verify\s+with\s+your\s+attorney|your\s+attorney\s+can\s+confirm|have\s+your\s+attorney\s+verify)\b/gi,
+  },
+
+  // Soft
+  {
+    id: "we-are-attorneys",
+    severity: "soft",
+    reason: "Co-occurrence of 'we/our' + 'attorney' — brand rule forbids implying we ARE attorneys.",
+    fn: (line) => {
+      const lower = line.toLowerCase();
+      if (!/\bour\s+attorneys?\b/.test(lower)) return false;
+      return true;
+    },
+  },
+  {
+    id: "passive-voice",
+    severity: "soft",
+    reason: "Passive voice in sales copy — active voice is stronger.",
+    pattern: /\b(?:is|are|was|were|be|been|being)\s+(?:guaranteed|processed|sent|delivered|provided)\s+(?:by|within|at|in)\b/gi,
+  },
+  {
+    id: "high-adjective-density",
+    severity: "soft",
+    reason: "Adjective density > 20% — copy-smell, marketing puffery.",
+    fn: (line) => {
+      // Rough adjective heuristic: count -ly-less words ending in common
+      // adj suffixes, divided by total words. Skip short lines (<8 words).
+      const words = line.replace(/<[^>]+>/g, " ").match(/\b\w+\b/g) ?? [];
+      if (words.length < 8) return false;
+      const adjSuffixes = /(?:ive|ful|ous|able|ible|al|ic|ant|ent|ish|less|like|y|est)$/i;
+      const adjExcluded = /(?:very|only|really|just|also|then|even|still)$/i;
+      let adjCount = 0;
+      for (const w of words) {
+        if (w.length < 4) continue;
+        if (adjExcluded.test(w)) continue;
+        if (adjSuffixes.test(w)) adjCount++;
+      }
+      return adjCount / words.length > 0.2;
+    },
+  },
+  {
+    id: "you-we-imbalance",
+    severity: "soft",
+    reason: "'you' outnumbers 'we' > 2:1 — brand imbalance (We Research carries more verbs).",
+    fn: (line) => {
+      const lower = line.toLowerCase();
+      const words = lower.match(/\b\w+\b/g) ?? [];
+      if (words.length < 15) return false;
+      const you = words.filter((w) => w === "you" || w === "your" || w === "you're").length;
+      const we = words.filter((w) => w === "we" || w === "our" || w === "we're" || w === "us").length;
+      if (you < 3) return false;
+      return we === 0 ? you >= 3 : you / we > 2;
+    },
+  },
+];
+
+// ── Default target list ──────────────────────────────────────────────
+
+const DEFAULT_TARGETS = [
+  "src/app/r/[code]/page.tsx",
+  "src/app/r/[code]/[product]/page.tsx",
+  "src/app/r/[code]/quiz/page.tsx",
+  "src/app/r/[code]/reminders/page.tsx",
+  "src/app/checkin/[code]/page.tsx",
+  "src/components/BridgePage.tsx",
+];
+
+// Partner-facing pages — glob if the dir exists.
+function discoverPartnerPages() {
+  const base = path.join(REPO_ROOT, "src", "app", "partner");
+  if (!existsSync(base)) return [];
+  const out = [];
+  function walk(dir) {
+    for (const name of readdirSync(dir)) {
+      const full = path.join(dir, name);
+      const s = statSync(full);
+      if (s.isDirectory()) walk(full);
+      else if (/^page\.tsx$/.test(name)) out.push(path.relative(REPO_ROOT, full));
+    }
+  }
+  walk(base);
+  return out;
+}
+
+// ── Main scan ────────────────────────────────────────────────────────
+
+const args = process.argv.slice(2);
+const outputJson = args.includes("--json");
+const explicitTargets = args.filter((a) => !a.startsWith("--"));
+const targets = explicitTargets.length > 0
+  ? explicitTargets
+  : [...DEFAULT_TARGETS, ...discoverPartnerPages()];
+
+function scanFile(relPath) {
+  const full = path.isAbsolute(relPath) ? relPath : path.join(REPO_ROOT, relPath);
+  if (!existsSync(full)) {
+    return { file: relPath, findings: [], error: "not found" };
+  }
+  const source = readFileSync(full, "utf8");
+  const lines = source.split(/\r?\n/);
+  const findings = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (!line.trim()) continue;
+    // Skip lines that are pure imports / JSX-attribute noise / comments
+    if (/^\s*(?:import |\/\/|\*|\/\*)/.test(line)) continue;
+
+    for (const rule of RULES) {
+      if (rule.pattern) {
+        const re = new RegExp(rule.pattern.source, rule.pattern.flags);
+        const matches = [...line.matchAll(re)];
+        for (const m of matches) {
+          findings.push({
+            rule: rule.id,
+            severity: rule.severity,
+            line: i + 1,
+            column: (m.index ?? 0) + 1,
+            match: m[0],
+            context: line.trim().slice(0, 160),
+            reason: rule.reason,
+          });
+        }
+      } else if (rule.fn) {
+        if (rule.fn(line)) {
+          findings.push({
+            rule: rule.id,
+            severity: rule.severity,
+            line: i + 1,
+            context: line.trim().slice(0, 160),
+            reason: rule.reason,
+          });
+        }
+      }
+    }
+  }
+
+  return { file: relPath, findings };
+}
+
+const results = targets.map(scanFile);
+
+if (outputJson) {
+  for (const r of results) {
+    for (const f of r.findings) {
+      console.log(JSON.stringify({ ...f, file: r.file }));
+    }
+  }
+} else {
+  const GREEN = "\x1b[32m";
+  const YELLOW = "\x1b[33m";
+  const RED = "\x1b[31m";
+  const DIM = "\x1b[2m";
+  const RESET = "\x1b[0m";
+  const BOLD = "\x1b[1m";
+
+  let hardCount = 0;
+  let softCount = 0;
+  for (const r of results) {
+    if (r.findings.length === 0) continue;
+    const hard = r.findings.filter((f) => f.severity === "hard").length;
+    const soft = r.findings.filter((f) => f.severity === "soft").length;
+    hardCount += hard;
+    softCount += soft;
+    console.log(`${BOLD}${r.file}${RESET}  ${RED}${hard} hard${RESET}  ${YELLOW}${soft} soft${RESET}`);
+    // Sort: hard first, then by line
+    const sorted = [...r.findings].sort((a, b) => {
+      if (a.severity !== b.severity) return a.severity === "hard" ? -1 : 1;
+      return a.line - b.line;
+    });
+    for (const f of sorted) {
+      const color = f.severity === "hard" ? RED : YELLOW;
+      const lineRef = `${r.file}:${f.line}${f.column ? ":" + f.column : ""}`;
+      console.log(`  ${color}${f.severity.toUpperCase()}${RESET}  ${f.rule.padEnd(24)}  ${DIM}${lineRef}${RESET}`);
+      console.log(`         ${f.reason}`);
+      if (f.match) console.log(`         ${DIM}match: "${f.match}"${RESET}`);
+      console.log(`         ${DIM}${f.context}${RESET}`);
+      console.log("");
+    }
+    console.log("");
+  }
+
+  console.log(`${BOLD}Summary${RESET}: ${RED}${hardCount} hard${RESET}, ${YELLOW}${softCount} soft${RESET} across ${results.filter((r) => r.findings.length).length} files.`);
+  if (hardCount === 0 && softCount === 0) {
+    console.log(`${GREEN}Clean.${RESET} All scanned files pass every heuristic.`);
+  } else {
+    console.log(`Review is advisory. Fix hard findings first; soft findings are triage candidates.`);
+  }
+}
+
+process.exit(0);

--- a/scripts/brand-voice-scan.mjs
+++ b/scripts/brand-voice-scan.mjs
@@ -166,6 +166,45 @@ const targets = explicitTargets.length > 0
   ? explicitTargets
   : [...DEFAULT_TARGETS, ...discoverPartnerPages()];
 
+// Heuristic: does this line contain enough code-syntax to NOT be prose?
+// Soft rules (high-adjective-density, you-we-imbalance) produce garbage on
+// JSX/TS lines because identifiers like onChange / className / submitLabel
+// carry adjective suffixes, and ternaries / JSX attrs skew pronoun counts.
+// Hard rules (speed-sell, guarantees, UPL) are also suspect on code lines
+// — if a variable is named `quickCheck` we don't care about the "quick"
+// substring.
+//
+// Signal: any of these tokens on the line strongly suggests non-prose:
+//   {  }  =>  </  />  classname=  onchange=  onclick=  <[a-z]...=
+// Also: lines matching a JSDoc/hashtag/etc. structural cue.
+//
+// Note: this is intentionally conservative — we'd rather under-flag on the
+// edge cases (a prose line embedded in a JSX expression) than drown the
+// real findings in JSX noise. If a real prose line with code-chars somehow
+// slips through unflagged, the hard-rule regex still runs as a backstop.
+function looksLikeCode(line) {
+  const trimmed = line.trim();
+  // Pure code-structure lines
+  if (/[{}]|=>|<\/|\/>/.test(trimmed)) return true;
+  if (/^(const|let|var|function|return|import|export|type|interface|enum)\b/.test(trimmed)) return true;
+  // JSX attribute lines ("  className="..."" or "  onChange={fn}")
+  if (/^\s*(className|onChange|onClick|onSubmit|onKeyDown|style|href|src|alt|rel|target|aria-|data-|type|name|id|value|placeholder|checked|disabled|required|defaultValue)[\s:=]/i.test(line)) return true;
+  // Opening/closing JSX element on its own line: <Tag  or  Tag>
+  if (/^\s*<[A-Za-z][\w.]*\s*$/.test(line) || /^\s*\/?>$/.test(trimmed)) return true;
+  // Template-literal embed lines with ${...}
+  if (/\$\{/.test(trimmed)) return true;
+  // CSS style-object shape: 2+ `key: "value"` or `key: number` patterns
+  // on one line. Catches inline style objects slipping past the { filter
+  // (which only fires when braces are ON the current line).
+  const styleKvCount = (trimmed.match(/\b[a-z][a-zA-Z]+\s*:\s*["'0-9]/g) ?? []).length;
+  if (styleKvCount >= 2) return true;
+  // HTML-entity density: lines with 2+ &name; entities are disclaimer /
+  // divider text nodes, not prose. Tokenizer miscounts entities as words.
+  const entityCount = (trimmed.match(/&[a-z]+;/gi) ?? []).length;
+  if (entityCount >= 2) return true;
+  return false;
+}
+
 function scanFile(relPath) {
   const full = path.isAbsolute(relPath) ? relPath : path.join(REPO_ROOT, relPath);
   if (!existsSync(full)) {
@@ -181,7 +220,20 @@ function scanFile(relPath) {
     // Skip lines that are pure imports / JSX-attribute noise / comments
     if (/^\s*(?:import |\/\/|\*|\/\*)/.test(line)) continue;
 
+    // Skip lines that are clearly code, not prose. Prose lives in JSX text
+    // nodes (between > and <) or in bare string literals — both keep their
+    // prose-ness by containing words + punctuation without {}, =>, etc.
+    const isCode = looksLikeCode(line);
+
     for (const rule of RULES) {
+      // Soft rules (heuristics) are meaningless on code lines — skip.
+      if (isCode && rule.severity === "soft") continue;
+      // Hard rules also skip obvious code — a "quick" in a variable name
+      // isn't a brand-voice issue. Exception: hard rules still run on code
+      // lines that contain string-literal content (heuristic: has quoted
+      // text), since prose often lives inside quotes on same line as JSX.
+      if (isCode && rule.severity === "hard" && !/["'`][^"'`]*(?:\s\w+){2,}[^"'`]*["'`]/.test(line)) continue;
+
       if (rule.pattern) {
         const re = new RegExp(rule.pattern.source, rule.pattern.flags);
         const matches = [...line.matchAll(re)];

--- a/scripts/check-partner-envs.mjs
+++ b/scripts/check-partner-envs.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+/**
+ * Local script: queries /api/admin/env-presence and pretty-prints which
+ * partner-system env vars are set on the deploy.
+ *
+ * Usage:
+ *   ADMIN_PASSWORD=... node scripts/check-partner-envs.mjs
+ *   ADMIN_PASSWORD=... BASE_URL=https://imnotanattorney.com node scripts/check-partner-envs.mjs
+ *
+ * Env:
+ *   ADMIN_PASSWORD  — required; matches the ADMIN_PASSWORD env on Vercel
+ *   BASE_URL        — optional; defaults to https://imnotanattorney.com
+ *
+ * Exits 0 if all env vars are present, 1 if any are missing (useful as a
+ * CI smoke step: `node scripts/check-partner-envs.mjs || echo "envs drifted"`).
+ */
+
+import { config as loadEnv } from "dotenv";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+loadEnv({ path: resolve(__dirname, "..", ".env.local") });
+
+const BASE_URL = process.env.BASE_URL || "https://imnotanattorney.com";
+const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD;
+
+if (!ADMIN_PASSWORD) {
+  console.error("ERROR: ADMIN_PASSWORD env var required.");
+  console.error("Usage: ADMIN_PASSWORD=... node scripts/check-partner-envs.mjs");
+  process.exit(2);
+}
+
+const url = `${BASE_URL}/api/admin/env-presence`;
+
+let res;
+try {
+  res = await fetch(url, {
+    headers: { "x-admin-password": ADMIN_PASSWORD },
+  });
+} catch (err) {
+  console.error(`ERROR: fetch ${url} failed: ${err?.message ?? err}`);
+  process.exit(1);
+}
+
+if (res.status !== 200) {
+  console.error(`ERROR: ${url} returned ${res.status}.`);
+  if (res.status === 401) {
+    console.error("  (ADMIN_PASSWORD did not match — check the env var.)");
+  }
+  process.exit(1);
+}
+
+const body = await res.json();
+const { envs, missing_count, present_count, checked_at } = body;
+
+const GREEN = "\x1b[32m";
+const RED = "\x1b[31m";
+const RESET = "\x1b[0m";
+const BOLD = "\x1b[1m";
+
+console.log(`${BOLD}Partner-system env presence on ${BASE_URL}${RESET}`);
+console.log(`Checked at: ${checked_at}`);
+console.log(`Present: ${GREEN}${present_count}${RESET}   Missing: ${missing_count > 0 ? RED : GREEN}${missing_count}${RESET}`);
+console.log("");
+
+const keys = Object.keys(envs).sort();
+const maxLen = Math.max(...keys.map((k) => k.length));
+for (const key of keys) {
+  const present = envs[key];
+  const icon = present ? `${GREEN}✓${RESET}` : `${RED}✗${RESET}`;
+  const status = present ? `${GREEN}SET${RESET}` : `${RED}MISSING${RESET}`;
+  console.log(`  ${icon}  ${key.padEnd(maxLen)}  ${status}`);
+}
+
+process.exit(missing_count > 0 ? 1 : 0);

--- a/scripts/setup-durable-rate-limit.mjs
+++ b/scripts/setup-durable-rate-limit.mjs
@@ -1,0 +1,198 @@
+#!/usr/bin/env node
+/**
+ * Reusable setup script for durable rate-limit fallback via Upstash Redis.
+ *
+ * Provisions a dedicated Upstash Redis DB for this project's rate-limiting,
+ * then writes three envs to Vercel prod:
+ *   - UPSTASH_REDIS_REST_URL
+ *   - UPSTASH_REDIS_REST_TOKEN
+ *   - DURABLE_RL_PROVIDER=upstash
+ *
+ * After the script exits, the next Vercel deploy (any git push, or a
+ * manual redeploy) will pick up the envs + wired factory.
+ *
+ * Usage:
+ *   UPSTASH_EMAIL=you@domain.com \
+ *   UPSTASH_API_KEY=... \
+ *   VERCEL_TOKEN=... \
+ *   node scripts/setup-durable-rate-limit.mjs
+ *
+ * Optional:
+ *   DB_NAME=inna-web-rate-limit      # default based on package.json name
+ *   REGION=us-east-1                 # default us-east-1
+ *   VERCEL_PROJECT=imnotanattorney   # default from CLAUDE.md
+ *
+ * Idempotent: if a DB with the chosen name already exists on your Upstash
+ * account, the script fetches its credentials and re-writes the same envs
+ * (safe to re-run after a lockfile change or a new teammate pulling down).
+ *
+ * Security: this script reads tokens from YOUR env only. No tokens are
+ * logged, emitted to stdout, or persisted. The Vercel env write uses the
+ * Vercel REST API v9 with your VERCEL_TOKEN — the token never leaves this
+ * process.
+ *
+ * Reusable across projects: copy this file into any Next.js repo on Vercel,
+ * change the DB_NAME default, run. The DurableRateLimitStore contract +
+ * factory + upstash impl lift cleanly into any project with the abstraction.
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { config as loadEnv } from "dotenv";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+loadEnv({ path: resolve(__dirname, "..", ".env.local") });
+
+const GREEN = "\x1b[32m";
+const RED = "\x1b[31m";
+const YELLOW = "\x1b[33m";
+const DIM = "\x1b[2m";
+const RESET = "\x1b[0m";
+const BOLD = "\x1b[1m";
+
+function die(msg) {
+  console.error(`${RED}ERROR:${RESET} ${msg}`);
+  process.exit(1);
+}
+
+function info(msg) {
+  console.log(`${DIM}${msg}${RESET}`);
+}
+
+function ok(msg) {
+  console.log(`${GREEN}✓${RESET} ${msg}`);
+}
+
+function warn(msg) {
+  console.warn(`${YELLOW}! ${msg}${RESET}`);
+}
+
+// Load repo package.json for default DB name
+const pkg = JSON.parse(
+  readFileSync(resolve(__dirname, "..", "package.json"), "utf8"),
+);
+
+const UPSTASH_EMAIL = process.env.UPSTASH_EMAIL;
+const UPSTASH_API_KEY = process.env.UPSTASH_API_KEY;
+const VERCEL_TOKEN = process.env.VERCEL_TOKEN;
+const DB_NAME = process.env.DB_NAME || `${pkg.name}-rate-limit`;
+const REGION = process.env.REGION || "us-east-1";
+const VERCEL_PROJECT = process.env.VERCEL_PROJECT || "imnotanattorney";
+
+if (!UPSTASH_EMAIL) die("UPSTASH_EMAIL env var required. Get from console.upstash.com/account.");
+if (!UPSTASH_API_KEY) die("UPSTASH_API_KEY env var required. Generate at console.upstash.com/account/api.");
+if (!VERCEL_TOKEN) die("VERCEL_TOKEN env var required. Generate at vercel.com/account/tokens (scope: your team, full access OR env-write).");
+
+console.log(`${BOLD}Durable rate-limit setup${RESET}`);
+console.log(`  DB name:        ${DB_NAME}`);
+console.log(`  Region:         ${REGION}`);
+console.log(`  Vercel project: ${VERCEL_PROJECT}`);
+console.log("");
+
+const upstashAuth = "Basic " + Buffer.from(`${UPSTASH_EMAIL}:${UPSTASH_API_KEY}`).toString("base64");
+
+// Step 1: Look up existing DB or create a new one
+info("1. Checking Upstash for existing DB...");
+const listRes = await fetch("https://api.upstash.com/v2/redis/databases", {
+  headers: { Authorization: upstashAuth },
+});
+if (!listRes.ok) {
+  die(`Upstash list DBs failed: ${listRes.status} ${await listRes.text()}`);
+}
+const existingDbs = await listRes.json();
+let db = Array.isArray(existingDbs) ? existingDbs.find((d) => d.database_name === DB_NAME) : null;
+
+if (db) {
+  ok(`Found existing DB "${DB_NAME}" (id: ${db.database_id}). Reusing.`);
+} else {
+  info("   No existing DB. Creating...");
+  const createRes = await fetch("https://api.upstash.com/v2/redis/database", {
+    method: "POST",
+    headers: {
+      Authorization: upstashAuth,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      name: DB_NAME,
+      region: REGION,
+      tls: true,
+    }),
+  });
+  if (!createRes.ok) {
+    die(`Upstash create DB failed: ${createRes.status} ${await createRes.text()}`);
+  }
+  db = await createRes.json();
+  ok(`Created DB "${DB_NAME}" (id: ${db.database_id}).`);
+}
+
+// Step 2: Fetch REST credentials for the DB (list response doesn't always include rest_token)
+info("2. Fetching REST credentials...");
+const detailRes = await fetch(`https://api.upstash.com/v2/redis/database/${db.database_id}`, {
+  headers: { Authorization: upstashAuth },
+});
+if (!detailRes.ok) {
+  die(`Upstash fetch DB details failed: ${detailRes.status} ${await detailRes.text()}`);
+}
+const detail = await detailRes.json();
+const restUrl = detail.endpoint ? `https://${detail.endpoint}` : detail.rest_url;
+const restToken = detail.rest_token;
+if (!restUrl || !restToken) {
+  die(`Upstash DB details missing rest_url/rest_token. Full response: ${JSON.stringify(detail)}`);
+}
+ok(`Got REST credentials.`);
+
+// Step 3: Write envs to Vercel prod
+info("3. Writing envs to Vercel project " + VERCEL_PROJECT + " (production)...");
+
+// Vercel API: look up project id from slug
+const projRes = await fetch(`https://api.vercel.com/v9/projects/${VERCEL_PROJECT}`, {
+  headers: { Authorization: `Bearer ${VERCEL_TOKEN}` },
+});
+if (!projRes.ok) {
+  die(`Vercel project lookup failed: ${projRes.status} ${await projRes.text()}`);
+}
+const project = await projRes.json();
+ok(`Found Vercel project "${VERCEL_PROJECT}" (id: ${project.id}).`);
+
+async function upsertEnv(key, value) {
+  // Vercel API v10 env upsert: the create endpoint supports "upsert=true".
+  // Target "production" only — preview/development still use in-memory.
+  const res = await fetch(
+    `https://api.vercel.com/v10/projects/${project.id}/env?upsert=true`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${VERCEL_TOKEN}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        key,
+        value,
+        type: "encrypted",
+        target: ["production"],
+      }),
+    },
+  );
+  if (!res.ok) {
+    const body = await res.text();
+    die(`Vercel env upsert for ${key} failed: ${res.status} ${body}`);
+  }
+  ok(`Wrote ${key} to Vercel prod.`);
+}
+
+await upsertEnv("UPSTASH_REDIS_REST_URL", restUrl);
+await upsertEnv("UPSTASH_REDIS_REST_TOKEN", restToken);
+await upsertEnv("DURABLE_RL_PROVIDER", "upstash");
+
+console.log("");
+console.log(`${GREEN}${BOLD}Done.${RESET}`);
+console.log("");
+console.log("Next steps:");
+console.log(`  1. Redeploy (git push or ${DIM}vercel --prod${RESET} / dashboard redeploy)`);
+console.log(`  2. Verify: ${DIM}ADMIN_PASSWORD=... node scripts/check-partner-envs.mjs${RESET}`);
+console.log(`     Should show UPSTASH_REDIS_REST_URL + UPSTASH_REDIS_REST_TOKEN + DURABLE_RL_PROVIDER all SET.`);
+console.log(`  3. Magic-link 3/hour is now durable across Vercel isolates.`);
+console.log("");
+console.log(`${DIM}To undo: delete the DB from console.upstash.com and remove the 3 envs from Vercel.${RESET}`);

--- a/scripts/verify-partner-preview-integrity.mjs
+++ b/scripts/verify-partner-preview-integrity.mjs
@@ -1,0 +1,203 @@
+#!/usr/bin/env node
+/**
+ * CV probe: partner preview link integrity (INNA-H12).
+ *
+ * Validates that the top-3 active partners (by total_referrals) serve a
+ * working OG image on imnotanattorney.com. Detects silent breakages in
+ * CDN / Supabase storage / the opengraph-image route that partners
+ * would otherwise only notice when their shared links render blank in
+ * iMessage/FB/Slack.
+ *
+ * Contract for each probed partner:
+ *   - GET https://imnotanattorney.com/r/{CODE}/opengraph-image
+ *   - Status 200
+ *   - Content-Type matches image/png
+ *   - Body byteLength > 10KB
+ *
+ * Output: JSON-lines, one line per probe result. Exits 0 if all pass,
+ * 1 if any fail. Intended to be wired into
+ *   ~/projects/continuous-verification/verify.mjs as hypothesis H12.
+ *
+ * Usage:
+ *   node scripts/verify-partner-preview-integrity.mjs
+ *
+ * Env vars required:
+ *   NEXT_PUBLIC_SUPABASE_URL        supabase project URL
+ *   SUPABASE_SERVICE_ROLE_KEY       service role key (bypasses RLS)
+ *
+ * Optional:
+ *   INNA_H12_BASE_URL               override https://imnotanattorney.com
+ *   INNA_H12_MIN_BYTES              override 10240 byte floor
+ *   INNA_H12_TIMEOUT_MS             override 10000ms fetch timeout
+ */
+
+import { createClient } from "@supabase/supabase-js";
+import { config as loadEnv } from "dotenv";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+// Load .env.local from repo root if present  allows local runs without
+// having to pre-export. Silently no-ops if the file is absent.
+loadEnv({ path: resolve(__dirname, "..", ".env.local") });
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const BASE_URL = process.env.INNA_H12_BASE_URL || "https://imnotanattorney.com";
+const MIN_BYTES = Number(process.env.INNA_H12_MIN_BYTES) || 10 * 1024;
+const TIMEOUT_MS = Number(process.env.INNA_H12_TIMEOUT_MS) || 10_000;
+
+function emit(result) {
+  // JSON-lines  each result is its own line, aggregator-friendly.
+  console.log(JSON.stringify(result));
+}
+
+if (!SUPABASE_URL || !SERVICE_KEY) {
+  emit({
+    hypothesis: "INNA-H12",
+    status: "ERROR",
+    reason: "missing env: NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY",
+  });
+  process.exit(1);
+}
+
+const sb = createClient(SUPABASE_URL, SERVICE_KEY, {
+  auth: { autoRefreshToken: false, persistSession: false },
+});
+
+/**
+ * Fetch the top-3 approved partners by total_referrals. Ties broken by
+ * promo_code alphabetically (deterministic). Partners with 0 referrals
+ * still count  a brand-new partner's preview should also work.
+ */
+async function fetchTopPartners() {
+  const { data, error } = await sb
+    .from("partners")
+    .select("promo_code, name, total_referrals")
+    .eq("status", "approved")
+    .not("promo_code", "is", null)
+    .order("total_referrals", { ascending: false })
+    .order("promo_code", { ascending: true })
+    .limit(3);
+
+  if (error) throw new Error(`supabase query failed: ${error.message}`);
+  return data ?? [];
+}
+
+async function probePartner(partner) {
+  const code = (partner.promo_code ?? "").toUpperCase();
+  const url = `${BASE_URL}/r/${code}/opengraph-image`;
+  const start = Date.now();
+
+  const ctrl = new AbortController();
+  const timeoutId = setTimeout(() => ctrl.abort(), TIMEOUT_MS);
+
+  try {
+    const res = await fetch(url, { signal: ctrl.signal, redirect: "manual" });
+    const status = res.status;
+    const contentType = res.headers.get("content-type") || "";
+
+    if (status !== 200) {
+      return {
+        hypothesis: "INNA-H12",
+        status: "FAIL",
+        partner_code: code,
+        partner_name: partner.name,
+        reason: `status ${status} (expected 200)`,
+        url,
+        latency_ms: Date.now() - start,
+      };
+    }
+
+    if (!/image\/png/i.test(contentType)) {
+      return {
+        hypothesis: "INNA-H12",
+        status: "FAIL",
+        partner_code: code,
+        partner_name: partner.name,
+        reason: `content-type "${contentType}" (expected image/png)`,
+        url,
+        latency_ms: Date.now() - start,
+      };
+    }
+
+    const buf = await res.arrayBuffer();
+    const bytes = buf.byteLength;
+    if (bytes < MIN_BYTES) {
+      return {
+        hypothesis: "INNA-H12",
+        status: "FAIL",
+        partner_code: code,
+        partner_name: partner.name,
+        reason: `body ${bytes} bytes (expected > ${MIN_BYTES})`,
+        url,
+        latency_ms: Date.now() - start,
+      };
+    }
+
+    return {
+      hypothesis: "INNA-H12",
+      status: "PASS",
+      partner_code: code,
+      partner_name: partner.name,
+      bytes,
+      url,
+      latency_ms: Date.now() - start,
+    };
+  } catch (err) {
+    const reason = err?.name === "AbortError"
+      ? `fetch timeout after ${TIMEOUT_MS}ms`
+      : `fetch error: ${err?.message ?? err}`;
+    return {
+      hypothesis: "INNA-H12",
+      status: "FAIL",
+      partner_code: code,
+      partner_name: partner.name,
+      reason,
+      url,
+      latency_ms: Date.now() - start,
+    };
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+async function main() {
+  let partners;
+  try {
+    partners = await fetchTopPartners();
+  } catch (err) {
+    emit({
+      hypothesis: "INNA-H12",
+      status: "ERROR",
+      reason: err?.message ?? String(err),
+    });
+    process.exit(1);
+  }
+
+  if (partners.length === 0) {
+    emit({
+      hypothesis: "INNA-H12",
+      status: "SKIP",
+      reason: "no approved partners with promo_code found",
+    });
+    process.exit(0);
+  }
+
+  const results = await Promise.all(partners.map(probePartner));
+  for (const r of results) emit(r);
+
+  const anyFail = results.some((r) => r.status !== "PASS");
+  process.exit(anyFail ? 1 : 0);
+}
+
+main().catch((err) => {
+  emit({
+    hypothesis: "INNA-H12",
+    status: "ERROR",
+    reason: err?.message ?? String(err),
+  });
+  process.exit(1);
+});

--- a/src/app/api/admin/env-presence/route.ts
+++ b/src/app/api/admin/env-presence/route.ts
@@ -1,0 +1,52 @@
+/**
+ * GET /api/admin/env-presence — diagnostic reporter for partner-system env vars.
+ *
+ * Returns { envs: { [KEY]: boolean } } indicating presence (not values).
+ * Auth: admin password via x-admin-password header (middleware enforces).
+ *
+ * Purpose: lets an operator verify every partner-system env var is actually
+ * set on Vercel prod without logging into the Vercel dashboard. Closes the
+ * Phase 3 Operational Inventory follow-up list for env-var verification.
+ *
+ * Extending this list: when a new partner-system env var is added to
+ * ARCHITECTURE.md § Partner System Operational Inventories → Env vars, add
+ * it to PARTNER_SYSTEM_ENVS below in the same PR. The inventory + this route
+ * should stay in lockstep.
+ */
+
+import { NextResponse } from "next/server";
+
+// Source of truth: every env var read anywhere in the partner system. Keep
+// in lockstep with ARCHITECTURE.md § Partner System Operational Inventories.
+const PARTNER_SYSTEM_ENVS = [
+  "NEXT_PUBLIC_SUPABASE_URL",
+  "SUPABASE_SERVICE_ROLE_KEY",
+  "RESEND_API_KEY",
+  "RESEND_FROM_EMAIL",
+  "NEXT_PUBLIC_SITE_URL",
+  "OPERATOR_EMAIL",
+  "ADMIN_PASSWORD",
+  "OPERATOR_SECRET",
+  "CRON_AUTH_TOKEN",
+  "NEXT_PUBLIC_PARTNER_BRANDING_ENABLED",
+  "NEXT_PUBLIC_CHECKIN_TOGGLE_ENABLED",
+  "SMS_HEALTH_TEST_PHONE",
+  "TELEGRAM_BOT_TOKEN_LEGAL",
+  "TELEGRAM_CHAT_ID",
+  "NODE_ENV",
+] as const;
+
+export async function GET() {
+  const envs: Record<string, boolean> = {};
+  for (const key of PARTNER_SYSTEM_ENVS) {
+    const value = process.env[key];
+    envs[key] = typeof value === "string" && value.trim().length > 0;
+  }
+
+  return NextResponse.json({
+    checked_at: new Date().toISOString(),
+    envs,
+    missing_count: Object.values(envs).filter((v) => !v).length,
+    present_count: Object.values(envs).filter((v) => v).length,
+  });
+}

--- a/src/app/api/partner/add-client/route.ts
+++ b/src/app/api/partner/add-client/route.ts
@@ -10,48 +10,32 @@ import { createAdminClient } from "@/lib/supabase/admin";
 import { requirePartnerAuth } from "@/lib/partner-helpers";
 import { sendEmail, escapeHtml } from "@/lib/email";
 import { SITE_URL } from "@/lib/site";
-import { CHARGE_DISPLAY_NAMES } from "@/lib/court-reminders";
+import { AddClientSchema } from "@/lib/partner-schemas";
 import { randomUUID } from "crypto";
-
-interface AddClientBody {
-  first_name: string;
-  email: string;
-  charge_type: string;
-  county_state: string;
-  court_date: string;
-  last_name?: string;
-  indemnitor_name?: string;
-  indemnitor_email?: string;
-}
 
 export async function POST(req: NextRequest) {
   const { partner, error: authError } = await requirePartnerAuth(req);
   if (authError) return authError;
 
-  let body: AddClientBody;
-  try {
-    body = await req.json();
-  } catch {
-    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  const parsed = AddClientSchema.safeParse(await req.json().catch(() => null));
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: parsed.error.issues[0]?.message ?? "Invalid request" },
+      { status: 400 },
+    );
   }
+  const {
+    first_name,
+    last_name,
+    email,
+    charge_type,
+    county_state,
+    court_date,
+    indemnitor_name,
+    indemnitor_email,
+  } = parsed.data;
 
-  const { first_name, email, charge_type, county_state, court_date, last_name, indemnitor_name, indemnitor_email } = body;
-  if (!first_name?.trim() || !email?.trim() || !charge_type?.trim() || !county_state?.trim() || !court_date?.trim()) {
-    return NextResponse.json({ error: "All fields are required" }, { status: 400 });
-  }
-
-  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
-    return NextResponse.json({ error: "Invalid email address" }, { status: 400 });
-  }
-
-  if (indemnitor_email?.trim() && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(indemnitor_email.trim())) {
-    return NextResponse.json({ error: "Invalid co-signer email address" }, { status: 400 });
-  }
-
-  if (!CHARGE_DISPLAY_NAMES[charge_type]) {
-    return NextResponse.json({ error: "Invalid charge type" }, { status: 400 });
-  }
-
+  // future-date check (needs runtime today, kept in route)
   const courtDateObj = new Date(court_date + "T00:00:00");
   const today = new Date();
   today.setHours(0, 0, 0, 0);

--- a/src/app/api/partner/add-client/route.ts
+++ b/src/app/api/partner/add-client/route.ts
@@ -11,11 +11,27 @@ import { requirePartnerAuth } from "@/lib/partner-helpers";
 import { sendEmail, escapeHtml } from "@/lib/email";
 import { SITE_URL } from "@/lib/site";
 import { AddClientSchema } from "@/lib/partner-schemas";
+import { checkRateLimit } from "@/lib/rate-limit";
 import { randomUUID } from "crypto";
 
 export async function POST(req: NextRequest) {
   const { partner, error: authError } = await requirePartnerAuth(req);
   if (authError) return authError;
+
+  const supabase = createAdminClient();
+
+  const { limited } = await checkRateLimit(
+    supabase,
+    `partner-add-client:${partner.id}`,
+    30,
+    60 * 60,
+  );
+  if (limited) {
+    return NextResponse.json(
+      { error: "Too many client add attempts. Try again later." },
+      { status: 429 },
+    );
+  }
 
   const parsed = AddClientSchema.safeParse(await req.json().catch(() => null));
   if (!parsed.success) {
@@ -44,7 +60,6 @@ export async function POST(req: NextRequest) {
   }
 
   const token = randomUUID();
-  const supabase = createAdminClient();
 
   const { error: insertErr } = await supabase.from("court_reminders").insert({
     token,

--- a/src/app/api/partner/clients/[id]/schedule/route.ts
+++ b/src/app/api/partner/clients/[id]/schedule/route.ts
@@ -12,6 +12,7 @@
 import { NextRequest, NextResponse, after } from "next/server";
 import { requirePartnerAuth } from "@/lib/partner-helpers";
 import { createAdminClient } from "@/lib/supabase/admin";
+import { checkRateLimit } from "@/lib/rate-limit";
 import { validateCheckInDays, formatDaysDisplay, sortCheckInDays } from "@/lib/check-in-schedule";
 import { sendEmail, escapeHtml } from "@/lib/email";
 import { sendSMS, capSMS } from "@/lib/sms";
@@ -28,6 +29,20 @@ export async function PATCH(
 
   if (!partner.promo_code) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const supabaseLimiter = createAdminClient();
+  const { limited } = await checkRateLimit(
+    supabaseLimiter,
+    `partner-schedule:${partner.id}`,
+    30,
+    60 * 60,
+  );
+  if (limited) {
+    return NextResponse.json(
+      { error: "Too many schedule updates. Try again later." },
+      { status: 429 },
+    );
   }
 
   // Task 7 (bondsman-modes v2): block schedule writes for referral-mode partners.

--- a/src/app/api/partner/dashboard/route.ts
+++ b/src/app/api/partner/dashboard/route.ts
@@ -9,6 +9,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { requirePartnerAuth, paginatedQuery, batchedInQuery } from "@/lib/partner-helpers";
 import { sumProtectedExposureCents } from "@/lib/bond-exposure";
+import { checkRateLimit } from "@/lib/rate-limit";
 
 interface CourtClient {
   id: string;
@@ -34,6 +35,19 @@ export async function GET(req: NextRequest) {
   if (authError) return authError;
 
   const supabase = createAdminClient();
+
+  const { limited } = await checkRateLimit(
+    supabase,
+    `partner-dashboard:${partner.id}`,
+    60,
+    60,
+  );
+  if (limited) {
+    return NextResponse.json(
+      { error: "Too many dashboard requests. Try again in a moment." },
+      { status: 429 },
+    );
+  }
 
   try {
     // Fetch recent referrals (no PII, just tier, date, commission)

--- a/src/app/api/partner/magic-link/route.ts
+++ b/src/app/api/partner/magic-link/route.ts
@@ -38,7 +38,8 @@ export async function POST(req: NextRequest) {
       supabase,
       `partner-magic:${normalizedEmail}`,
       3,
-      3600
+      3600,
+      { durable: true }
     );
     if (limited) {
       return NextResponse.json(
@@ -52,7 +53,8 @@ export async function POST(req: NextRequest) {
       supabase,
       `partner-magic-ip:${ip}`,
       10,
-      3600
+      3600,
+      { durable: true }
     );
     if (ipLimited) {
       return NextResponse.json(

--- a/src/app/api/partner/notification-prefs/route.ts
+++ b/src/app/api/partner/notification-prefs/route.ts
@@ -4,6 +4,7 @@ import { createAdminClient } from "@/lib/supabase/admin";
 import { requirePartnerAuth } from "@/lib/partner-helpers";
 import type { PartnerNotificationPrefs } from "@/lib/notification-prefs";
 import { PARTNER_DEFAULTS, getPartnerPrefs } from "@/lib/notification-prefs";
+import { checkRateLimit } from "@/lib/rate-limit";
 
 const VALID_CHANNELS = new Set(["email", "sms", "both"]);
 const VALID_KEYS = new Set(Object.keys(PARTNER_DEFAULTS));
@@ -19,6 +20,21 @@ export async function GET(req: NextRequest) {
 export async function PATCH(req: NextRequest) {
   const { partner, error: authError } = await requirePartnerAuth(req);
   if (authError) return authError;
+
+  const supabase = createAdminClient();
+
+  const { limited } = await checkRateLimit(
+    supabase,
+    `partner-notifs:${partner.id}`,
+    20,
+    60 * 60,
+  );
+  if (limited) {
+    return NextResponse.json(
+      { error: "Too many notification updates. Try again later." },
+      { status: 429 },
+    );
+  }
 
   let body: Partial<PartnerNotificationPrefs>;
   try { body = await req.json(); } catch {
@@ -38,7 +54,6 @@ export async function PATCH(req: NextRequest) {
   const existing = partner.notification_prefs || {};
   const updated = { ...existing, ...body };
 
-  const supabase = createAdminClient();
   const { error: updateErr } = await supabase
     .from("partners")
     .update({ notification_prefs: updated })

--- a/src/app/api/partner/settings/route.ts
+++ b/src/app/api/partner/settings/route.ts
@@ -9,10 +9,23 @@ import { createAdminClient } from "@/lib/supabase/admin";
 import { requirePartnerAuth } from "@/lib/partner-helpers";
 import { VALID_PAYMENT_METHODS } from "@/lib/partner-data";
 import { validateCheckInDays } from "@/lib/check-in-schedule";
+import { checkRateLimit } from "@/lib/rate-limit";
 
 export async function PATCH(req: NextRequest) {
   const { partner, error: authError } = await requirePartnerAuth(req);
   if (authError) return authError;
+
+  const supabase = createAdminClient();
+
+  const { limited } = await checkRateLimit(
+    supabase,
+    `partner-settings:${partner.id}`,
+    20,
+    60 * 60,
+  );
+  if (limited) {
+    return NextResponse.json({ error: "Too many settings updates. Try again later." }, { status: 429 });
+  }
 
   let body;
   try {
@@ -96,8 +109,6 @@ export async function PATCH(req: NextRequest) {
   if (default_check_in_days !== undefined) {
     updates.default_check_in_days = default_check_in_days;
   }
-
-  const supabase = createAdminClient();
 
   // Mode flip: atomic stamp. Scope the flip UPDATE to the OPPOSITE current
   // value so flip_at is only bumped when the row actually transitions. If

--- a/src/app/api/partners/apply/route.ts
+++ b/src/app/api/partners/apply/route.ts
@@ -20,9 +20,9 @@ import { normalizeEmail, isValidEmail, OPERATOR_EMAIL_FALLBACK, SITE_URL } from 
 import { createPartnerPromoCode, sanitizePromoCode } from "@/lib/referral";
 import { generateMagicLink } from "@/lib/partner-auth";
 import { partnerWelcomeEmail } from "@/lib/partner-emails";
+import { envWithWarn } from "@/lib/env-check";
 
-const OPERATOR_EMAIL =
-  process.env.OPERATOR_EMAIL || OPERATOR_EMAIL_FALLBACK;
+const OPERATOR_EMAIL = envWithWarn("OPERATOR_EMAIL", OPERATOR_EMAIL_FALLBACK);
 
 const VALID_SOURCES = [
   "bondsman",

--- a/src/app/checkin/[code]/page.tsx
+++ b/src/app/checkin/[code]/page.tsx
@@ -22,8 +22,9 @@ export async function generateMetadata({
   return {
     title: `${title} | ImNotAnAttorney`,
     description,
+    alternates: { canonical: `/checkin/${code.toLowerCase()}` },
     openGraph: { title, description, type: "website" },
-    twitter: { card: "summary", title, description },
+    twitter: { card: "summary_large_image", title, description },
   };
 }
 

--- a/src/app/partner/dashboard/page.tsx
+++ b/src/app/partner/dashboard/page.tsx
@@ -351,7 +351,7 @@ export default function PartnerDashboard() {
         <div className="bg-zinc-900 rounded-xl border border-zinc-700 p-4">
           <h3 className="font-bold text-amber-400 mb-2">How your link works</h3>
           <p className="text-sm text-zinc-300">
-            When clients use your link, they take a quick quiz and get a product recommendation.
+            When clients use your link, they take a short quiz and get a product recommendation.
             They can also set up free court prep, date reminders + what to expect at their hearing.
             You earn commission whether they buy now or later through a reminder.
           </p>

--- a/src/app/r/[code]/[product]/page.tsx
+++ b/src/app/r/[code]/[product]/page.tsx
@@ -128,6 +128,7 @@ export async function generateMetadata({
   return {
     title: `${title} | ImNotAnAttorney`,
     description,
+    alternates: { canonical: `/r/${code.toLowerCase()}/${product.toLowerCase()}` },
     openGraph: { title, description, type: "website" as const },
     twitter: { card: "summary_large_image" as const, title, description },
   };

--- a/src/app/r/[code]/page.tsx
+++ b/src/app/r/[code]/page.tsx
@@ -42,6 +42,7 @@ export async function generateMetadata({
     return {
       title: `${title} | ImNotAnAttorney`,
       description,
+      alternates: { canonical: `/r/${code.toLowerCase()}` },
       openGraph: { title, description, type: "website" as const },
       twitter: { card: "summary_large_image" as const, title, description },
     };
@@ -52,6 +53,7 @@ export async function generateMetadata({
   return {
     title: `${defaultTitle} | ImNotAnAttorney`,
     description: `${defaultDescription} Legal information -- not legal advice.`,
+    alternates: { canonical: `/r/${code.toLowerCase()}` },
     openGraph: { title: defaultTitle, description: defaultDescription, type: "website" as const },
     twitter: { card: "summary_large_image" as const, title: defaultTitle, description: defaultDescription },
   };

--- a/src/app/r/[code]/reminders/page.tsx
+++ b/src/app/r/[code]/reminders/page.tsx
@@ -129,6 +129,9 @@ export default async function CourtRemindersPage({ params, searchParams }: PageP
               </Link>
             </aside>
           </FadeInUp>
+          <p className="mt-8 text-center text-xs text-zinc-500">
+            Legal information, not legal advice.
+          </p>
         </div>
       </div>
     </div>

--- a/src/components/BridgePage.tsx
+++ b/src/components/BridgePage.tsx
@@ -115,6 +115,9 @@ export function BridgePage({ partnerName, company, city, promoCode, checkInEnabl
             <p className="text-zinc-400 text-sm mt-8">
               We give you questions. We don&apos;t give you advice. Your attorney does that.
             </p>
+            <p className="text-zinc-500 text-xs mt-2">
+              Legal information, not legal advice.
+            </p>
           </FadeInUp>
         </div>
       </div>

--- a/src/lib/__tests__/env-check.test.ts
+++ b/src/lib/__tests__/env-check.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import { envWithWarn, __resetEnvWarnCache } from "../env-check";
+
+describe("envWithWarn", () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+  const KEY = "__TEST_ENV_WARN_KEY";
+
+  beforeEach(() => {
+    delete process.env[KEY];
+    __resetEnvWarnCache();
+  });
+
+  afterEach(() => {
+    delete process.env[KEY];
+    if (originalNodeEnv === undefined) {
+      delete (process.env as Record<string, string | undefined>).NODE_ENV;
+    } else {
+      (process.env as Record<string, string | undefined>).NODE_ENV = originalNodeEnv;
+    }
+  });
+
+  it("returns the env var value when set", () => {
+    process.env[KEY] = "real-value";
+    expect(envWithWarn(KEY, "fallback")).toBe("real-value");
+  });
+
+  it("returns the fallback when env var is unset", () => {
+    expect(envWithWarn(KEY, "fallback")).toBe("fallback");
+  });
+
+  it("returns the fallback when env var is empty string", () => {
+    process.env[KEY] = "";
+    expect(envWithWarn(KEY, "fallback")).toBe("fallback");
+  });
+
+  it("returns the fallback when env var is whitespace only", () => {
+    process.env[KEY] = "   ";
+    expect(envWithWarn(KEY, "fallback")).toBe("fallback");
+  });
+
+  it("warns once in production when env is missing", () => {
+    (process.env as Record<string, string | undefined>).NODE_ENV = "production";
+    const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    envWithWarn(KEY, "fallback");
+    envWithWarn(KEY, "fallback");
+    envWithWarn(KEY, "fallback");
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy.mock.calls[0][0]).toContain("ENV-MISSING");
+    expect(spy.mock.calls[0][0]).toContain(KEY);
+    expect(spy.mock.calls[0][0]).toContain("fallback");
+    spy.mockRestore();
+  });
+
+  it("does not warn in development even when env is missing", () => {
+    (process.env as Record<string, string | undefined>).NODE_ENV = "development";
+    const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    envWithWarn(KEY, "fallback");
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it("does not warn when env var IS set, even in production", () => {
+    (process.env as Record<string, string | undefined>).NODE_ENV = "production";
+    process.env[KEY] = "real-value";
+    const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    envWithWarn(KEY, "fallback");
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});

--- a/src/lib/__tests__/partner-schemas.test.ts
+++ b/src/lib/__tests__/partner-schemas.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { AddClientSchema } from "../partner-schemas";
+
+const VALID_BODY = {
+  first_name: "John",
+  email: "john@example.com",
+  charge_type: "dui-first-offense",
+  county_state: "Pinellas County, FL",
+  court_date: "2030-06-09",
+};
+
+describe("AddClientSchema", () => {
+  it("accepts valid minimal body", () => {
+    const r = AddClientSchema.safeParse(VALID_BODY);
+    expect(r.success, r.success ? "" : JSON.stringify(r.error.issues)).toBe(true);
+  });
+
+  it("accepts optional fields", () => {
+    const r = AddClientSchema.safeParse({
+      ...VALID_BODY,
+      last_name: "Smith",
+      indemnitor_name: "Jane",
+      indemnitor_email: "jane@example.com",
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it("rejects missing first_name", () => {
+    const r = AddClientSchema.safeParse({ ...VALID_BODY, first_name: "" });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects invalid email", () => {
+    const r = AddClientSchema.safeParse({ ...VALID_BODY, email: "not-an-email" });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects unknown charge_type", () => {
+    const r = AddClientSchema.safeParse({ ...VALID_BODY, charge_type: "not-a-real-charge" });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects non-ISO court_date", () => {
+    const r = AddClientSchema.safeParse({ ...VALID_BODY, court_date: "06/09/2030" });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects unknown body fields (strict mode)", () => {
+    const r = AddClientSchema.safeParse({ ...VALID_BODY, partner_id: "leak-attempt" });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects 10KB name (length cap guards garbage injection)", () => {
+    const r = AddClientSchema.safeParse({ ...VALID_BODY, first_name: "A".repeat(10_000) });
+    expect(r.success).toBe(false);
+  });
+
+  it("accepts empty-string indemnitor_email (form-common pattern)", () => {
+    const r = AddClientSchema.safeParse({ ...VALID_BODY, indemnitor_email: "" });
+    expect(r.success).toBe(true);
+  });
+
+  it("lowercases email on parse", () => {
+    const r = AddClientSchema.safeParse({ ...VALID_BODY, email: "John@Example.COM" });
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data.email).toBe("john@example.com");
+  });
+});

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -16,6 +16,8 @@
  * throwing, so callers do not need try/catch around missing config.
  */
 
+import { envWithWarn } from "@/lib/env-check";
+
 // ============================================================
 // HTML ESCAPING
 // ============================================================
@@ -50,8 +52,10 @@ export function escapeHtml(str: string): string {
 const RESEND_API_KEY = process.env.RESEND_API_KEY;
 
 /** Sender address shown in the "From" field of all outbound emails. */
-const FROM_EMAIL =
-  process.env.RESEND_FROM_EMAIL || "noreply@imnotanattorney.com";
+const FROM_EMAIL = envWithWarn(
+  "RESEND_FROM_EMAIL",
+  "noreply@imnotanattorney.com",
+);
 
 // PHYSICAL_ADDRESS imported from @/lib/site (CAN-SPAM compliance).
 // Also duplicated in supabase/functions/generate-report (Deno can't import Next.js modules).
@@ -214,7 +218,7 @@ export async function sendEmail(
         from: FROM_EMAIL,
         to: [params.to],
         subject: params.subject,
-        reply_to: process.env.OPERATOR_EMAIL || "rahim0kapadia@gmail.com",
+        reply_to: envWithWarn("OPERATOR_EMAIL", "rahim0kapadia@gmail.com"),
         headers: Object.keys(headers).length > 0 ? headers : undefined,
         html: `
           <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; background: #0C0A09; color: #D4D4D8; padding: 32px;">
@@ -294,8 +298,7 @@ export async function sendEmailWithRetry(
 // SEND EMAIL WITH OPERATOR ALERT ON FAILURE
 // ============================================================
 
-const OPERATOR_EMAIL =
-  process.env.OPERATOR_EMAIL || "rahim0kapadia@gmail.com";
+const OPERATOR_EMAIL = envWithWarn("OPERATOR_EMAIL", "rahim0kapadia@gmail.com");
 
 /**
  * Sends an email with one retry, then alerts the operator if both fail.

--- a/src/lib/env-check.ts
+++ b/src/lib/env-check.ts
@@ -1,0 +1,49 @@
+/**
+ * Env-var presence checker — warns loudly when optional-with-fallback
+ * env vars are missing in production.
+ *
+ * Problem: Several env vars (OPERATOR_EMAIL, RESEND_FROM_EMAIL, etc.) ship
+ * with hardcoded fallback values. Missing the env var silently means emails
+ * go from a personal Gmail or an anonymous no-reply — bad enough to
+ * investigate, not bad enough to crash the app.
+ *
+ * This module exports `envWithWarn(key, fallback)`. In production, if the
+ * env var is unset, it logs a distinctive warning that shows up in Vercel
+ * logs + monitoring. In dev, it silently returns the fallback (local work
+ * doesn't need the warning noise).
+ *
+ * Usage:
+ *   const FROM_EMAIL = envWithWarn("RESEND_FROM_EMAIL", "noreply@imnotanattorney.com");
+ *
+ * See ARCHITECTURE.md § "Partner System Operational Inventories" — this closes
+ * the "consider promoting Optional → Required" follow-up without hard-crashing
+ * the boot path.
+ */
+
+const warned = new Set<string>();
+
+export function envWithWarn(key: string, fallback: string): string {
+  const value = process.env[key];
+  if (value && value.trim().length > 0) {
+    return value;
+  }
+
+  // Only warn once per key per process — Vercel warm lambdas re-import
+  // modules; we don't want one log line per request.
+  if (process.env.NODE_ENV === "production" && !warned.has(key)) {
+    warned.add(key);
+    console.warn(
+      `[ENV-MISSING] ${key} not set in production — falling back to hard-coded default "${fallback}". Set the env var on Vercel (project: imnotanattorney).`,
+    );
+  }
+
+  return fallback;
+}
+
+/**
+ * Test-only helper: reset the one-time-warn cache so a fresh warn fires.
+ * NOT called from application code.
+ */
+export function __resetEnvWarnCache(): void {
+  warned.clear();
+}

--- a/src/lib/partner-schemas.ts
+++ b/src/lib/partner-schemas.ts
@@ -1,0 +1,81 @@
+/**
+ * Zod schemas for partner API request bodies.
+ *
+ * Why: manual validation inside route handlers silently ignores unknown
+ * fields, lacks length caps, and duplicates "required field" logic across
+ * routes. Centralizing here gives strict parsing (unknown fields rejected),
+ * type-safe parsed.data, and one place to evolve the shape.
+ *
+ * Usage in a route handler:
+ *
+ *   const parsed = AddClientSchema.safeParse(await req.json());
+ *   if (!parsed.success) {
+ *     return NextResponse.json(
+ *       { error: parsed.error.issues[0]?.message ?? "Invalid body" },
+ *       { status: 400 },
+ *     );
+ *   }
+ *   // parsed.data is typed
+ */
+
+import { z } from "zod";
+import { CHARGE_DISPLAY_NAMES } from "./court-reminders";
+
+// Length caps — chosen to allow reasonable human names / emails / city names,
+// reject 10KB-of-garbage injection attempts.
+const MAX_NAME = 120;
+const MAX_EMAIL = 254; // RFC 5321
+const MAX_CITY_STATE = 100;
+const MAX_CHARGE_TYPE = 80;
+
+// Email regex — same shape as the existing manual check in add-client/route.ts
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+/**
+ * Schema for POST /api/partner/add-client.
+ *
+ * Strict mode: unknown fields are rejected. If you add a new optional
+ * field to the route, add it here first.
+ */
+export const AddClientSchema = z
+  .object({
+    first_name: z
+      .string()
+      .trim()
+      .min(1, "First name is required")
+      .max(MAX_NAME),
+    last_name: z.string().trim().max(MAX_NAME).optional(),
+    email: z
+      .string()
+      .trim()
+      .toLowerCase()
+      .max(MAX_EMAIL)
+      .regex(EMAIL_RE, "Invalid email address"),
+    charge_type: z
+      .string()
+      .trim()
+      .max(MAX_CHARGE_TYPE)
+      .refine(
+        (v) => Object.prototype.hasOwnProperty.call(CHARGE_DISPLAY_NAMES, v),
+        { message: "Invalid charge type" },
+      ),
+    county_state: z.string().trim().min(1).max(MAX_CITY_STATE),
+    court_date: z
+      .string()
+      .trim()
+      // Accept YYYY-MM-DD (ISO date) — the existing route parses via `new Date(court_date + "T00:00:00")`.
+      // Enforce the shape here; future-date check stays in the route (needs runtime "today").
+      .regex(/^\d{4}-\d{2}-\d{2}$/, "Court date must be YYYY-MM-DD"),
+    indemnitor_name: z.string().trim().max(MAX_NAME).optional(),
+    indemnitor_email: z
+      .string()
+      .trim()
+      .toLowerCase()
+      .max(MAX_EMAIL)
+      .regex(EMAIL_RE, "Invalid co-signer email")
+      .optional()
+      .or(z.literal("")),
+  })
+  .strict();
+
+export type AddClientInput = z.infer<typeof AddClientSchema>;

--- a/src/lib/products.ts
+++ b/src/lib/products.ts
@@ -1226,14 +1226,10 @@ export const STANDALONE_PRODUCTS: Record<string, StandaloneProduct> = {
       "Your Similar Cases Analyzer report is generated on demand from verified court records within 60 seconds.",
     description:
       "Similar case outcomes, sentencing distributions, plea discount data, and appellate trends for your charge and jurisdiction.",
-<<<<<<< HEAD
     // Required: chargeType, state. Optional (used to match against USSC FY14-24
     // federal sentencing distribution when supplied): priorConvictions,
     // citizenship, ageBucket.
     intakeFields: ["chargeType", "state", "priorConvictions", "citizenship", "ageBucket", "district"],
-=======
-    intakeFields: ["chargeType", "state", "district"],
->>>>>>> f3c042d (fix(tools): adversarial-walkthrough findings on /tools/sentencing-calculator)
     stripePriceId: null,
     upsellTier: "case-decoder",
     upsellText:

--- a/src/lib/rate-limit-durable/README.md
+++ b/src/lib/rate-limit-durable/README.md
@@ -1,0 +1,63 @@
+# Durable rate-limit fallback
+
+The primary rate limiter is Supabase RPC (`check_rate_limit`). When that's
+unreachable, `src/lib/rate-limit.ts` falls back to an in-memory store.
+On Vercel's serverless runtime, in-memory is per-isolate — N warm lambdas
+means an N-fold effective limit during a Supabase outage.
+
+For high-sensitivity keys (magic-link 3/hour, password-reset-style flows),
+that's too loose. This directory holds the abstract contract for a durable
+cross-isolate fallback. Pick a provider and implement.
+
+## Contract
+
+`DurableRateLimitStore.increment(key, windowSeconds)` — atomically
+increment a counter keyed by `key` within a `windowSeconds` window, return
+the post-increment count. Cross-isolate atomicity is the whole point;
+Redis `INCR` + `EXPIRE` (on first set) is the canonical implementation.
+
+## To wire Upstash Redis
+
+1. `npm install @upstash/redis`
+2. Add envs to Vercel: `UPSTASH_REDIS_REST_URL`, `UPSTASH_REDIS_REST_TOKEN`, `DURABLE_RL_PROVIDER=upstash`
+3. Create `src/lib/rate-limit-durable/upstash.ts`:
+
+   ```ts
+   import { Redis } from "@upstash/redis";
+   import type { DurableRateLimitStore } from "./types";
+
+   export class UpstashDurableRateLimitStore implements DurableRateLimitStore {
+     private redis = Redis.fromEnv();
+
+     async increment(key: string, windowSeconds: number): Promise<number> {
+       const count = await this.redis.incr(key);
+       if (count === 1) {
+         await this.redis.expire(key, windowSeconds);
+       }
+       return count;
+     }
+   }
+   ```
+
+4. In `factory.ts`, swap the `"upstash"` case from throw to:
+
+   ```ts
+   case "upstash": {
+     const { UpstashDurableRateLimitStore } = await import("./upstash");
+     cached = new UpstashDurableRateLimitStore();
+     return cached;
+   }
+   ```
+
+   (the factory signature becomes async; `checkRateLimit` needs an `await` too)
+
+## To wire Vercel KV
+
+Same shape; `npm install @vercel/kv`, envs `KV_URL` / `KV_REST_API_URL` / `KV_REST_API_TOKEN`, `DURABLE_RL_PROVIDER=vercel-kv`, implement `vercel-kv.ts` with the same contract.
+
+## Why ship the abstraction before a provider?
+
+Ships the call-site change (`checkRateLimit({ durable: true })`) today so
+magic-link is marked for durable-fallback as soon as a provider is wired.
+Prevents a future "wire the provider but now find every call-site that
+should opt in" sweep.

--- a/src/lib/rate-limit-durable/README.md
+++ b/src/lib/rate-limit-durable/README.md
@@ -16,40 +16,27 @@ increment a counter keyed by `key` within a `windowSeconds` window, return
 the post-increment count. Cross-isolate atomicity is the whole point;
 Redis `INCR` + `EXPIRE` (on first set) is the canonical implementation.
 
-## To wire Upstash Redis
+## To wire Upstash Redis (automated)
 
-1. `npm install @upstash/redis`
-2. Add envs to Vercel: `UPSTASH_REDIS_REST_URL`, `UPSTASH_REDIS_REST_TOKEN`, `DURABLE_RL_PROVIDER=upstash`
-3. Create `src/lib/rate-limit-durable/upstash.ts`:
-
-   ```ts
-   import { Redis } from "@upstash/redis";
-   import type { DurableRateLimitStore } from "./types";
-
-   export class UpstashDurableRateLimitStore implements DurableRateLimitStore {
-     private redis = Redis.fromEnv();
-
-     async increment(key: string, windowSeconds: number): Promise<number> {
-       const count = await this.redis.incr(key);
-       if (count === 1) {
-         await this.redis.expire(key, windowSeconds);
-       }
-       return count;
-     }
-   }
+1. Create Upstash account: console.upstash.com
+2. Generate management API key: console.upstash.com/account/api
+3. Generate Vercel token: vercel.com/account/tokens (scope: your team)
+4. Run:
    ```
-
-4. In `factory.ts`, swap the `"upstash"` case from throw to:
-
-   ```ts
-   case "upstash": {
-     const { UpstashDurableRateLimitStore } = await import("./upstash");
-     cached = new UpstashDurableRateLimitStore();
-     return cached;
-   }
+   UPSTASH_EMAIL=you@domain.com \
+   UPSTASH_API_KEY=... \
+   VERCEL_TOKEN=... \
+   node scripts/setup-durable-rate-limit.mjs
    ```
+5. Redeploy (git push or manual).
 
-   (the factory signature becomes async; `checkRateLimit` needs an `await` too)
+Script is idempotent — safe to re-run. See script header for optional env
+overrides (DB_NAME, REGION, VERCEL_PROJECT).
+
+To provision + wire on another Next.js-on-Vercel project: copy
+`scripts/setup-durable-rate-limit.mjs` + the
+`src/lib/rate-limit-durable/` directory, install `@upstash/redis`,
+change the DB_NAME default in the script, run.
 
 ## To wire Vercel KV
 

--- a/src/lib/rate-limit-durable/__tests__/factory.test.ts
+++ b/src/lib/rate-limit-durable/__tests__/factory.test.ts
@@ -36,10 +36,18 @@ describe("getDurableRateLimitStore", () => {
     expect(store).toBeInstanceOf(NoopDurableRateLimitStore);
   });
 
-  it("throws with wiring instructions when upstash is configured but not implemented", () => {
+  it("returns UpstashDurableRateLimitStore when upstash is configured", async () => {
     process.env.DURABLE_RL_PROVIDER = "upstash";
-    expect(() => getDurableRateLimitStore()).toThrow(/upstash/i);
-    expect(() => getDurableRateLimitStore()).toThrow(/not.*implemented|src\/lib\/rate-limit-durable/i);
+    // Minimal mock env so Redis.fromEnv() inside the store doesn't throw
+    process.env.UPSTASH_REDIS_REST_URL = "https://test.upstash.io";
+    process.env.UPSTASH_REDIS_REST_TOKEN = "test-token";
+
+    const { UpstashDurableRateLimitStore } = await import("../upstash");
+    const store = getDurableRateLimitStore();
+    expect(store).toBeInstanceOf(UpstashDurableRateLimitStore);
+
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
   });
 
   it("throws with wiring instructions when vercel-kv is configured but not implemented", () => {

--- a/src/lib/rate-limit-durable/__tests__/factory.test.ts
+++ b/src/lib/rate-limit-durable/__tests__/factory.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { getDurableRateLimitStore, __resetDurableStoreCache } from "../factory";
+import { NoopDurableRateLimitStore } from "../noop";
+
+describe("getDurableRateLimitStore", () => {
+  const originalProvider = process.env.DURABLE_RL_PROVIDER;
+
+  beforeEach(() => {
+    __resetDurableStoreCache();
+    delete process.env.DURABLE_RL_PROVIDER;
+  });
+
+  afterEach(() => {
+    __resetDurableStoreCache();
+    if (originalProvider === undefined) {
+      delete process.env.DURABLE_RL_PROVIDER;
+    } else {
+      process.env.DURABLE_RL_PROVIDER = originalProvider;
+    }
+  });
+
+  it("returns no-op when env is unset", () => {
+    const store = getDurableRateLimitStore();
+    expect(store).toBeInstanceOf(NoopDurableRateLimitStore);
+  });
+
+  it("returns no-op when env is 'none'", () => {
+    process.env.DURABLE_RL_PROVIDER = "none";
+    const store = getDurableRateLimitStore();
+    expect(store).toBeInstanceOf(NoopDurableRateLimitStore);
+  });
+
+  it("is case-insensitive + trim-tolerant on provider name", () => {
+    process.env.DURABLE_RL_PROVIDER = "  NONE  ";
+    const store = getDurableRateLimitStore();
+    expect(store).toBeInstanceOf(NoopDurableRateLimitStore);
+  });
+
+  it("throws with wiring instructions when upstash is configured but not implemented", () => {
+    process.env.DURABLE_RL_PROVIDER = "upstash";
+    expect(() => getDurableRateLimitStore()).toThrow(/upstash/i);
+    expect(() => getDurableRateLimitStore()).toThrow(/not.*implemented|src\/lib\/rate-limit-durable/i);
+  });
+
+  it("throws with wiring instructions when vercel-kv is configured but not implemented", () => {
+    process.env.DURABLE_RL_PROVIDER = "vercel-kv";
+    expect(() => getDurableRateLimitStore()).toThrow(/vercel-kv/i);
+  });
+
+  it("throws with clear error on unknown provider", () => {
+    process.env.DURABLE_RL_PROVIDER = "memcached";
+    expect(() => getDurableRateLimitStore()).toThrow(/not a known value/i);
+  });
+
+  it("no-op's increment throws the NOOP_DURABLE_STORE sentinel", async () => {
+    const store = new NoopDurableRateLimitStore();
+    await expect(store.increment("k", 60)).rejects.toThrow("NOOP_DURABLE_STORE");
+  });
+});

--- a/src/lib/rate-limit-durable/__tests__/upstash.test.ts
+++ b/src/lib/rate-limit-durable/__tests__/upstash.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock @upstash/redis's Redis class — we don't want the tests to hit a real
+// Redis instance, and Redis.fromEnv() would throw on missing env in CI.
+const incrMock = vi.fn();
+const expireMock = vi.fn();
+
+vi.mock("@upstash/redis", () => ({
+  Redis: class MockRedis {
+    static fromEnv() {
+      return new MockRedis();
+    }
+    incr(...args: unknown[]) {
+      return incrMock(...args);
+    }
+    expire(...args: unknown[]) {
+      return expireMock(...args);
+    }
+  },
+}));
+
+import { UpstashDurableRateLimitStore } from "../upstash";
+
+describe("UpstashDurableRateLimitStore", () => {
+  beforeEach(() => {
+    incrMock.mockReset();
+    expireMock.mockReset();
+  });
+
+  it("returns the post-increment count from INCR", async () => {
+    incrMock.mockResolvedValueOnce(2);
+    const store = new UpstashDurableRateLimitStore();
+    const count = await store.increment("partner-magic:test@example.com", 3600);
+    expect(count).toBe(2);
+    expect(incrMock).toHaveBeenCalledTimes(1);
+    expect(incrMock).toHaveBeenCalledWith("partner-magic:test@example.com");
+  });
+
+  it("stamps TTL on first set (INCR returns 1)", async () => {
+    incrMock.mockResolvedValueOnce(1);
+    const store = new UpstashDurableRateLimitStore();
+    await store.increment("partner-magic:test@example.com", 3600);
+    expect(expireMock).toHaveBeenCalledTimes(1);
+    expect(expireMock).toHaveBeenCalledWith("partner-magic:test@example.com", 3600);
+  });
+
+  it("does NOT stamp TTL on subsequent sets (INCR returns > 1)", async () => {
+    incrMock.mockResolvedValueOnce(2);
+    const store = new UpstashDurableRateLimitStore();
+    await store.increment("partner-magic:test@example.com", 3600);
+    expect(expireMock).not.toHaveBeenCalled();
+  });
+
+  it("propagates Upstash errors to the caller", async () => {
+    incrMock.mockRejectedValueOnce(new Error("Upstash down"));
+    const store = new UpstashDurableRateLimitStore();
+    await expect(
+      store.increment("partner-magic:test@example.com", 3600),
+    ).rejects.toThrow("Upstash down");
+  });
+});

--- a/src/lib/rate-limit-durable/factory.ts
+++ b/src/lib/rate-limit-durable/factory.ts
@@ -1,0 +1,59 @@
+/**
+ * Factory that returns the configured DurableRateLimitStore based on the
+ * DURABLE_RL_PROVIDER env var.
+ *
+ *   unset / "none" / empty      → no-op (falls through to in-memory)
+ *   "upstash"                   → throws until implemented (see README)
+ *   "vercel-kv"                 → throws until implemented (see README)
+ *
+ * Called by `checkRateLimit` only when `{ durable: true }` opts in AND
+ * the primary Supabase RPC errored.
+ *
+ * To implement a provider: add `src/lib/rate-limit-durable/upstash.ts`
+ * (or `vercel-kv.ts`) exporting a class that implements
+ * DurableRateLimitStore, then swap the corresponding `throw` below for
+ * `return new YourImpl(...)`. See README.md in this directory for detail.
+ */
+
+import type { DurableRateLimitStore } from "./types";
+import { NoopDurableRateLimitStore } from "./noop";
+
+let cached: DurableRateLimitStore | null = null;
+
+export function getDurableRateLimitStore(): DurableRateLimitStore {
+  if (cached) return cached;
+
+  const provider = (process.env.DURABLE_RL_PROVIDER ?? "").trim().toLowerCase();
+
+  switch (provider) {
+    case "":
+    case "none":
+      cached = new NoopDurableRateLimitStore();
+      return cached;
+
+    case "upstash":
+      throw new Error(
+        "DURABLE_RL_PROVIDER=upstash but provider is not implemented. " +
+          "Install @upstash/redis, create src/lib/rate-limit-durable/upstash.ts, " +
+          "and wire it in this factory. See src/lib/rate-limit-durable/README.md.",
+      );
+
+    case "vercel-kv":
+      throw new Error(
+        "DURABLE_RL_PROVIDER=vercel-kv but provider is not implemented. " +
+          "Install @vercel/kv, create src/lib/rate-limit-durable/vercel-kv.ts, " +
+          "and wire it in this factory. See src/lib/rate-limit-durable/README.md.",
+      );
+
+    default:
+      throw new Error(
+        `DURABLE_RL_PROVIDER="${provider}" is not a known value. ` +
+          `Valid: unset, "none", "upstash", "vercel-kv".`,
+      );
+  }
+}
+
+/** Test-only: reset the cached store so a new factory call re-evaluates env. */
+export function __resetDurableStoreCache(): void {
+  cached = null;
+}

--- a/src/lib/rate-limit-durable/factory.ts
+++ b/src/lib/rate-limit-durable/factory.ts
@@ -17,6 +17,7 @@
 
 import type { DurableRateLimitStore } from "./types";
 import { NoopDurableRateLimitStore } from "./noop";
+import { UpstashDurableRateLimitStore } from "./upstash";
 
 let cached: DurableRateLimitStore | null = null;
 
@@ -31,12 +32,14 @@ export function getDurableRateLimitStore(): DurableRateLimitStore {
       cached = new NoopDurableRateLimitStore();
       return cached;
 
-    case "upstash":
-      throw new Error(
-        "DURABLE_RL_PROVIDER=upstash but provider is not implemented. " +
-          "Install @upstash/redis, create src/lib/rate-limit-durable/upstash.ts, " +
-          "and wire it in this factory. See src/lib/rate-limit-durable/README.md.",
-      );
+    case "upstash": {
+      // Static import at the top of this file is safe because @upstash/redis
+      // is a regular dep (installed in Round 4). When DURABLE_RL_PROVIDER is
+      // unset or "none" this class is never instantiated, so the dep is
+      // dead-code at runtime in the default config.
+      cached = new UpstashDurableRateLimitStore();
+      return cached;
+    }
 
     case "vercel-kv":
       throw new Error(

--- a/src/lib/rate-limit-durable/noop.ts
+++ b/src/lib/rate-limit-durable/noop.ts
@@ -1,0 +1,16 @@
+/**
+ * No-op durable store — signals "no durable fallback configured; use
+ * in-memory." The checkRateLimit helper detects a no-op and routes to
+ * the in-memory fallback as before, so behavior is unchanged.
+ *
+ * The `increment` throws a sentinel error the caller uses to fall through
+ * rather than returning a meaningless number.
+ */
+
+import type { DurableRateLimitStore } from "./types";
+
+export class NoopDurableRateLimitStore implements DurableRateLimitStore {
+  async increment(_key: string, _windowSeconds: number): Promise<number> {
+    throw new Error("NOOP_DURABLE_STORE");
+  }
+}

--- a/src/lib/rate-limit-durable/types.ts
+++ b/src/lib/rate-limit-durable/types.ts
@@ -1,0 +1,31 @@
+/**
+ * Contract for durable rate-limit stores used as a last-resort fallback when
+ * the primary (Supabase RPC `check_rate_limit`) is unreachable.
+ *
+ * Why durable? The default in-memory fallback in `src/lib/rate-limit.ts` is
+ * per-isolate. On Vercel, N warm lambdas means N independent counters, so a
+ * 3/hour limit becomes effectively 3×N/hour during a Supabase outage — bad
+ * for magic-link and other authenticated-abuse-attractive keys.
+ *
+ * Implementations supply a single `increment(key, windowSeconds)` that
+ * atomically increments a counter keyed by `key` and returns the
+ * post-increment count. Implementations are responsible for TTL / window
+ * expiry.
+ *
+ * No provider is shipped by default. Pick Upstash or Vercel KV, add the
+ * dep, and implement this contract in a sibling file (e.g.
+ * `src/lib/rate-limit-durable/upstash.ts`).
+ */
+
+export interface DurableRateLimitStore {
+  /**
+   * Atomically increment the counter for `key` within a sliding or tumbling
+   * `windowSeconds`-second window. Return the post-increment count. The
+   * caller compares the count against its own max-requests threshold.
+   *
+   * Implementations MUST guarantee cross-isolate atomicity (that's the
+   * whole point of this contract). A basic Redis INCR + EXPIRE (on first
+   * set) is sufficient.
+   */
+  increment(key: string, windowSeconds: number): Promise<number>;
+}

--- a/src/lib/rate-limit-durable/upstash.ts
+++ b/src/lib/rate-limit-durable/upstash.ts
@@ -1,0 +1,42 @@
+/**
+ * Upstash Redis implementation of DurableRateLimitStore.
+ *
+ * Uses the Upstash REST SDK (@upstash/redis). Reads env vars at construction
+ * time:
+ *   - UPSTASH_REDIS_REST_URL
+ *   - UPSTASH_REDIS_REST_TOKEN
+ *
+ * Redis semantics: INCR key, then EXPIRE key windowSeconds the FIRST time
+ * the key's counter hits 1. Standard sliding-window rate-limit pattern.
+ * Atomic across all Vercel isolates.
+ *
+ * Activated by setting DURABLE_RL_PROVIDER=upstash on the deploy. Without
+ * that env (or with it unset), the no-op store is used and this class is
+ * never instantiated — so the @upstash/redis dep is dead-code at request
+ * time when durable rate-limiting is off.
+ */
+
+import { Redis } from "@upstash/redis";
+import type { DurableRateLimitStore } from "./types";
+
+export class UpstashDurableRateLimitStore implements DurableRateLimitStore {
+  private readonly redis: Redis;
+
+  constructor() {
+    // Redis.fromEnv() reads UPSTASH_REDIS_REST_URL + UPSTASH_REDIS_REST_TOKEN.
+    // If either is missing it throws at construction time — the factory
+    // surfaces that as a clear config error rather than a request-time 500.
+    this.redis = Redis.fromEnv();
+  }
+
+  async increment(key: string, windowSeconds: number): Promise<number> {
+    // INCR returns the post-increment count. On first set (count === 1),
+    // stamp the TTL so the counter expires at window end. Subsequent INCRs
+    // within the window reuse the existing TTL.
+    const count = await this.redis.incr(key);
+    if (count === 1) {
+      await this.redis.expire(key, windowSeconds);
+    }
+    return count;
+  }
+}

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -15,6 +15,7 @@
  */
 
 import { SupabaseClient } from "@supabase/supabase-js";
+import { getDurableRateLimitStore } from "./rate-limit-durable/factory";
 
 // ── In-memory fallback when Supabase is unavailable ─────────────────
 // LIMITATION: On serverless platforms (Vercel), each isolate has its own
@@ -63,13 +64,23 @@ function memoryRateLimit(key: string): boolean {
  * @param key - Rate limit key (e.g., "subscribe:1.2.3.4")
  * @param maxRequests - Maximum requests allowed in the window
  * @param windowSeconds - Window duration in seconds
+ * @param options - Optional flags
+ * @param options.durable - When true, the Supabase-RPC-error branch routes to the
+ *   durable-store factory (cross-isolate) before falling through to in-memory. Use
+ *   for high-sensitivity keys where an N-fold effective limit across warm lambdas
+ *   during a Supabase outage is unacceptable (e.g., magic-link, password reset).
+ *   Without a provider wired (`DURABLE_RL_PROVIDER` unset or `"none"`), the factory
+ *   returns a no-op and the caller falls through to the in-memory store — so
+ *   opting in today is safe and becomes durable the moment a provider is wired.
+ *   See `src/lib/rate-limit-durable/README.md`.
  * @returns { limited: boolean } - true if the request should be blocked
  */
 export async function checkRateLimit(
   supabase: SupabaseClient,
   key: string,
   maxRequests: number,
-  windowSeconds: number
+  windowSeconds: number,
+  options?: { durable?: boolean }
 ): Promise<{ limited: boolean }> {
   const { data, error } = await supabase.rpc("check_rate_limit", {
     p_key: key,
@@ -78,8 +89,26 @@ export async function checkRateLimit(
   });
 
   if (error) {
-    // Fail closed with in-memory fallback, don't allow unlimited requests
-    console.error("[RateLimit] RPC error, using in-memory fallback:", error.message);
+    // Fail closed with fallback, don't allow unlimited requests
+    console.error("[RateLimit] RPC error, using fallback:", error.message);
+
+    if (options?.durable) {
+      try {
+        const store = getDurableRateLimitStore();
+        const count = await store.increment(key, windowSeconds);
+        return { limited: count > maxRequests };
+      } catch (durableErr) {
+        if ((durableErr as Error)?.message === "NOOP_DURABLE_STORE") {
+          // No provider wired — fall through to in-memory
+        } else {
+          console.error(
+            "[RateLimit] durable store error, falling back to in-memory:",
+            (durableErr as Error)?.message,
+          );
+        }
+      }
+    }
+
     const isLimited = memoryRateLimit(key);
     return { limited: isLimited };
   }

--- a/tests/api/partner-schedule-403.test.ts
+++ b/tests/api/partner-schedule-403.test.ts
@@ -93,6 +93,12 @@ vi.mock("@/lib/supabase/admin", () => ({
   createAdminClient: () => ({ from: (t: string) => makeChain(t) }),
 }));
 
+// Phase-3 rate-limit guard is out of scope for this spec — short-circuit
+// to "not limited" so the route proceeds to the business logic under test.
+vi.mock("@/lib/rate-limit", () => ({
+  checkRateLimit: async () => ({ limited: false }),
+}));
+
 vi.mock("@/lib/partner-helpers", async () => {
   const actual = await vi.importActual<typeof import("@/lib/partner-helpers")>("@/lib/partner-helpers");
   return {

--- a/tests/api/partner-settings-flip-at.test.ts
+++ b/tests/api/partner-settings-flip-at.test.ts
@@ -85,6 +85,12 @@ vi.mock("@/lib/supabase/admin", () => ({
   createAdminClient: () => ({ from: (t: string) => makeChain(t) }),
 }));
 
+// Phase-3 rate-limit guard is out of scope for this spec — short-circuit
+// to "not limited" so the route proceeds to the business logic under test.
+vi.mock("@/lib/rate-limit", () => ({
+  checkRateLimit: async () => ({ limited: false }),
+}));
+
 vi.mock("@/lib/partner-helpers", async () => {
   const actual = await vi.importActual<typeof import("@/lib/partner-helpers")>("@/lib/partner-helpers");
   return {

--- a/tests/auth/partner-api-boundary.test.ts
+++ b/tests/auth/partner-api-boundary.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Structural audit: every /api/partner/** route MUST validate the session
+ * before doing anything else, and MUST NOT read partner_id from the request
+ * body or query — the partner identity comes exclusively from the
+ * session-validated partner object.
+ *
+ * A prior WIP tried to drop auth checks from a route during a refactor.
+ * This test reads route source files as text and asserts the contract
+ * structurally. Runs fast, no mocks, no live DB.
+ *
+ * Failure signals to act on:
+ *  - "no auth call": the route is ungated — anyone on the internet can hit it.
+ *  - "partner_id in body/query": the route trusts client-supplied identity.
+ *  - "auth NOT at top": business logic may run before the auth check.
+ *
+ * PUBLIC routes (intentionally unauthenticated, called out in PUBLIC_ROUTES
+ * below): login (magic-link + verify), logout (clears cookie by design),
+ * and track-event (public analytics identified by promo_code + rate-limited).
+ * The partner_id-in-body/query guard still applies to these routes.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+
+const PARTNER_API_DIR = path.resolve(__dirname, "..", "..", "src", "app", "api", "partner");
+
+// Routes that MUST remain public — login/logout can't require a session.
+// track-event is a public analytics endpoint identified by promo_code,
+// rate-limited, with a whitelisted event shape (see route source).
+const PUBLIC_ROUTES = new Set(
+  [
+    "src/app/api/partner/magic-link/route.ts",
+    "src/app/api/partner/magic-link/verify/route.ts",
+    "src/app/api/partner/logout/route.ts",
+    "src/app/api/partner/track-event/route.ts",
+  ].map((p) => p.split("/").join(path.sep)),
+);
+
+function findRouteFiles(dir: string): string[] {
+  const entries = readdirSync(dir);
+  const files: string[] = [];
+  for (const e of entries) {
+    const full = path.join(dir, e);
+    if (statSync(full).isDirectory()) {
+      files.push(...findRouteFiles(full));
+    } else if (e === "route.ts" || e === "route.tsx") {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+const AUTH_CALL_RE = /(requirePartnerAuth\s*\(|validatePartnerSession\s*\()/;
+const BODY_PARTNER_ID_RE = /body\s*\.\s*partner_?[Ii]d|const\s*\{\s*[^}]*partner_?[Ii]d[^}]*\}\s*=/;
+const QUERY_PARTNER_ID_RE = /searchParams\s*\.\s*get\s*\(\s*["']partner_?[Ii]d["']\s*\)/;
+
+const routeFiles = findRouteFiles(PARTNER_API_DIR);
+const repoRoot = path.resolve(__dirname, "..", "..");
+
+describe("partner API auth boundary", () => {
+  it("finds at least one route file", () => {
+    expect(routeFiles.length).toBeGreaterThan(0);
+  });
+
+  for (const file of routeFiles) {
+    const rel = path.relative(repoRoot, file);
+    const source = readFileSync(file, "utf8");
+    const isPublic = PUBLIC_ROUTES.has(rel);
+
+    if (!isPublic) {
+      it(`${rel} calls requirePartnerAuth or validatePartnerSession`, () => {
+        expect(
+          AUTH_CALL_RE.test(source),
+          `${rel} must gate on requirePartnerAuth or validatePartnerSession`,
+        ).toBe(true);
+      });
+    }
+
+    it(`${rel} does not read partner_id from body`, () => {
+      expect(
+        BODY_PARTNER_ID_RE.test(source),
+        `${rel} must not accept partner_id from request body — identity comes from the session`,
+      ).toBe(false);
+    });
+
+    it(`${rel} does not read partner_id from query`, () => {
+      expect(
+        QUERY_PARTNER_ID_RE.test(source),
+        `${rel} must not accept partner_id from query params — identity comes from the session`,
+      ).toBe(false);
+    });
+  }
+});

--- a/tests/compliance/upl-partner-copy.test.ts
+++ b/tests/compliance/upl-partner-copy.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Static UPL compliance audit on defendant-facing partner page source.
+ *
+ * The INAA brand rule (per .claude/rules/no-hallucinated-legal-data.md +
+ * .claude/rules/brand-voice.md) is strict:
+ *   - We provide LEGAL INFORMATION, not LEGAL ADVICE.
+ *   - Defendants are alone; no attorney "verifies" anything we output.
+ *   - No outcome guarantees ("will win", "guaranteed dismissal", "not guilty").
+ *
+ * This test reads partner page + BridgePage source text and asserts none
+ * of the UPL-problematic substrings appear. Exempts the permitted disclaimer
+ * "legal information, not legal advice" (case-insensitive substring match
+ * stripped before scanning).
+ *
+ * Failure surface: the test fails if a copy change introduces an
+ * UPL-problematic phrase — caught at PR time, before a customer sees it.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync, existsSync } from "node:fs";
+import path from "node:path";
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..");
+
+// Every defendant-facing partner page source file, PLUS the BridgePage
+// component (rendered inside /r/[code]/page.tsx — most prose lives here).
+const FILES = [
+  "src/app/r/[code]/page.tsx",
+  "src/app/r/[code]/[product]/page.tsx",
+  "src/app/r/[code]/quiz/page.tsx",
+  "src/app/r/[code]/reminders/page.tsx",
+  "src/app/checkin/[code]/page.tsx",
+  "src/components/BridgePage.tsx",
+];
+
+// Hard-fail phrases. Match is case-insensitive. One phrase present = test fails.
+// Every phrase listed here violates a specific rule in
+// .claude/rules/no-hallucinated-legal-data.md or .claude/rules/brand-voice.md.
+const UPL_HARD_FAIL = [
+  "ask your attorney to verify",
+  "ask an attorney to verify",
+  "your attorney can confirm",
+  "have your attorney verify",
+  "verify with your attorney",
+  "verify with an attorney",
+  "verify with attorney",
+];
+
+// Phrases that are USUALLY UPL violations but have a permitted exception.
+// Remove the permitted substrings from the source text before scanning.
+// - "legal advice" is permitted ONLY as part of "legal information, not
+//    legal advice" (or the hyphenated variant) — the disclaimer line.
+const PERMITTED_DISCLAIMER_RE = /legal information[, ]+not legal advice/gi;
+const PERMITTED_DISCLAIMER_RE_ALT = /legal information.*?not legal advice/gi;
+
+const UPL_CONDITIONAL_FAIL = [
+  "legal advice",
+];
+
+// Soft-warn phrases (outcome guarantees). Don't fail, but log to stderr
+// so a grep of CI output surfaces them for manual review. Some legitimate
+// uses exist (e.g. quoting case law, describing prosecution strategy).
+const OUTCOME_GUARANTEE_WARN = [
+  "will win",
+  "guaranteed dismissal",
+  "guaranteed acquittal",
+  "promise you won",
+  "promise to win",
+  "we guarantee",
+];
+
+describe("UPL compliance — defendant-facing partner pages", () => {
+  for (const relPath of FILES) {
+    const full = path.join(REPO_ROOT, relPath);
+
+    it(`${relPath} exists and can be read`, () => {
+      expect(existsSync(full), `${relPath} must exist`).toBe(true);
+    });
+
+    if (!existsSync(full)) continue;
+    const raw = readFileSync(full, "utf8");
+    // Strip the permitted disclaimer in both spellings before scanning for
+    // conditional-fail phrases.
+    const scrubbed = raw
+      .replace(PERMITTED_DISCLAIMER_RE, "[[DISCLAIMER]]")
+      .replace(PERMITTED_DISCLAIMER_RE_ALT, "[[DISCLAIMER]]");
+    const lower = scrubbed.toLowerCase();
+
+    for (const bad of UPL_HARD_FAIL) {
+      it(`${relPath} does not contain hard-fail phrase "${bad}"`, () => {
+        expect(
+          lower.includes(bad.toLowerCase()),
+          `${relPath} contains UPL-problematic phrase "${bad}" — .claude/rules/no-hallucinated-legal-data.md bans this. Remove or rephrase.`,
+        ).toBe(false);
+      });
+    }
+
+    for (const bad of UPL_CONDITIONAL_FAIL) {
+      it(`${relPath} does not use "${bad}" outside the permitted disclaimer`, () => {
+        expect(
+          lower.includes(bad.toLowerCase()),
+          `${relPath} contains "${bad}" outside the permitted "legal information, not legal advice" disclaimer. Rephrase.`,
+        ).toBe(false);
+      });
+    }
+
+    it(`${relPath} outcome-guarantee soft-warn`, () => {
+      const hits = OUTCOME_GUARANTEE_WARN.filter((p) => lower.includes(p.toLowerCase()));
+      if (hits.length > 0) {
+        // Emit to stderr so CI logs show it — but don't hard fail.
+        console.warn(
+          `[UPL SOFT-WARN] ${relPath} contains outcome-guarantee phrases: ${hits.join(", ")} — review in context.`,
+        );
+      }
+      // Always passes — soft-warn is a signal, not a gate.
+      expect(true).toBe(true);
+    });
+  }
+});


### PR DESCRIPTION
- **docs(plans): phase 2 TDD plan — E2E coverage gap fill**
- **test(e2e): OG byte floor + partner-specific branding + product OG**
- **chore(products): resolve leftover merge conflict in similar-cases-analyzer**
- **test(e2e): full meta-tag bundle assertions for partner unfurls**
- **fix(unfurl): add canonical + correct twitter:card on partner landings**
- **test(e2e): unfurl-bot UA simulation spec**
- **test(e2e): visual regression spec + config for partner OG images**
- **docs(arch): E2E coverage map + test:e2e:og fast-gate script**
- **docs(plans): phase 3 TDD plan — hardening with realistic scope**
- **feat(partner): zod schema for add-client + length caps + strict mode**
- **test(partner): structural auth-boundary audit for /api/partner/***
- **docs(arch): partner system rate-limit + env-var operational inventories**
- **feat(cv): INNA-H12 probe - partner preview link integrity**
- **docs(plans): phase 4 TDD plan — mechanized polish (a11y + UPL)**
- **test(e2e): axe-core a11y audit on partner-facing routes**
- **test(compliance): UPL static scan on defendant-facing partner pages**
- **fix(partner): rate limits on 5 previously-uncapped routes**
- **feat(upl): visible 'Legal information, not legal advice' disclaimer**
- **feat(env-check): envWithWarn helper — warn when optional-fallback envs are missing in prod**
- **test(api): stub checkRateLimit in partner-schedule + partner-settings specs**
- **feat(admin): env-presence diagnostic endpoint + check script**
- **feat(rate-limit): durable-store fallback contract + magic-link opt-in**
- **feat(brand-voice): heuristic candidate flagger — scripts/brand-voice-scan.mjs**
- **fix(brand-voice): 'quick quiz' -> 'short quiz' on partner dashboard**
- **feat(rate-limit): Upstash Redis provider + reusable setup script**
- **refactor(brand-voice): tighten scanner — skip code lines, halve false positives**
