### PR TITLE
fix(build): enable local next build on Windows — webpack + compile-only + scotus export fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "build:local": "next build --webpack --experimental-build-mode compile",
     "start": "next start",
     "lint": "eslint",
     "check-tiers": "node scripts/check-tiers.mjs",

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -51,8 +51,17 @@ if ! echo "$changed" | grep -qE '^(src/|package\.json|tsconfig|next\.config|midd
   exit 0
 fi
 
-echo "[pre-push] src/ changes detected — running npm run build..."
-if ! npm run build; then
+echo "[pre-push] src/ changes detected — running npm run build:local (webpack compile-only)..."
+# Local pre-push uses webpack + --experimental-build-mode=compile. Two reasons:
+# 1. Turbopack on Windows breaks opengraph-image prerender (satori XML parse
+#    "data: -" across all OG routes).
+# 2. Even on webpack, Windows libvips OOMs during 733-page parallel OG
+#    prerender (memory allocation failures / STATUS_ACCESS_VIOLATION).
+# Compile-only mode validates TypeScript + bundles + route exports — catches
+# the 80% of failures that would kill Vercel — while skipping the prerender
+# stage Windows can't handle at scale. Vercel CI still does full prerender
+# via default `next build` in the Vercel pipeline.
+if ! npm run build:local; then
   echo ""
   echo "[pre-push] BLOCKED: next build failed. Fix before pushing."
   echo "[pre-push] Emergency bypass: SKIP_BUILD=1 git push ..."

--- a/src/app/api/tools/scotus-case-search/route.ts
+++ b/src/app/api/tools/scotus-case-search/route.ts
@@ -59,7 +59,7 @@ export type ParseResult =
     }
   | { ok: false; error: string };
 
-export function parseInputs(req: NextRequest): ParseResult {
+function parseInputs(req: NextRequest): ParseResult {
   const url = new URL(req.url);
   const rawQ = (url.searchParams.get("q") ?? "").trim();
   const rawYearFrom = url.searchParams.get("year_from");


### PR DESCRIPTION
## Summary
Fixes three independent root causes that broke `npm run build` locally on Windows while leaving Vercel CI untouched. Pre-push hook now reliably gates TypeScript / route / bundle errors on developer machines instead of silently failing.

## Root causes (all pre-existing, surfaced this session)

### 1. Turbopack on Windows breaks opengraph-image prerender
- satori fetches brand PNG → sharp/libvips crashes with `Input buffer has corrupt header: glib: XML parse error: data: -`
- Hits EVERY `/opengraph-image` route (blog, state, service, partner)
- Known issue: [vercel/next.js#86431](https://github.com/vercel/next.js/issues/86431), [#87322](https://github.com/vercel/next.js/issues/87322)

### 2. Even on webpack, libvips OOMs during parallel OG prerender
- `memory allocation of 1553658 bytes failed` / `STATUS_ACCESS_VIOLATION`
- 733 pages × 11 workers exceeds Windows libvips memory pool
- Vercel Linux handles same concurrency fine — full prerender must stay server-side

### 3. Latent: scotus-case-search route exports non-HTTP-method helper
- `export function parseInputs` violates Next's route validator
- Turbopack (Vercel) is looser and lets it through silently
- Webpack catches it; only `GET` is imported externally (tests)

## Changes
- `src/app/api/tools/scotus-case-search/route.ts` — unexport `parseInputs`
- `package.json` — add `build:local`: `next build --webpack --experimental-build-mode compile`
- `scripts/hooks/pre-push` — switch local gate from `npm run build` to `npm run build:local`; explanatory block

## What local gate still catches
- TypeScript errors (full next tsc — stricter than `tsc --noEmit`)
- Route handler export violations (exactly the scotus case above)
- Module resolution / bundle errors
- next.config / middleware issues

## What local gate no longer attempts
- Static opengraph-image prerender → Vercel's responsibility

## Verification
- `npm run build:local` completes clean in ~70s on this Windows machine (from "fails with OOM")
- Pre-push hook ran `build:local` for this PR's push — gated clean
- Vercel default `npm run build` unchanged — production pipeline identical

## Test plan
- [ ] Vercel preview deploys green (validates default Turbopack still works)
- [ ] No regression on /api/tools/scotus-case-search (parseInputs still callable internally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)