### PR TITLE
feat(pseo): cross-state charge linking — complete the linking lattice

### DIFF
--- a/src/app/assault-defense/[state]/page.tsx
+++ b/src/app/assault-defense/[state]/page.tsx
@@ -15,6 +15,7 @@ import {
 import { TIER_CORE } from "@/lib/tiers";
 import { SITE_URL } from "@/lib/site";
 import { FadeInUp } from "@/components/motion/FadeInUp";
+import { RelatedStateCharges } from "@/components/RelatedStateCharges";
 
 interface PageProps {
   params: Promise<{ state: string }>;
@@ -231,6 +232,12 @@ export default async function StateAssaultPage({ params }: PageProps) {
           </div>
         </section>
       )}
+
+      <RelatedStateCharges
+        currentCharge="assault-defense"
+        stateSlug={state}
+        stateName={data.name}
+      />
 
       <section className="mt-12">
         <div className="rounded-lg border border-zinc-500 bg-zinc-900/50 p-4">

--- a/src/app/domestic-violence-defense/[state]/page.tsx
+++ b/src/app/domestic-violence-defense/[state]/page.tsx
@@ -15,6 +15,7 @@ import {
 import { TIER_CORE } from "@/lib/tiers";
 import { SITE_URL } from "@/lib/site";
 import { FadeInUp } from "@/components/motion/FadeInUp";
+import { RelatedStateCharges } from "@/components/RelatedStateCharges";
 
 interface PageProps {
   params: Promise<{ state: string }>;
@@ -252,6 +253,12 @@ export default async function StateDvPage({ params }: PageProps) {
           </div>
         </section>
       )}
+
+      <RelatedStateCharges
+        currentCharge="domestic-violence-defense"
+        stateSlug={state}
+        stateName={data.name}
+      />
 
       <section className="mt-12">
         <div className="rounded-lg border border-zinc-500 bg-zinc-900/50 p-4">

--- a/src/app/drug-possession-defense/[state]/page.tsx
+++ b/src/app/drug-possession-defense/[state]/page.tsx
@@ -15,6 +15,7 @@ import {
 import { TIER_CORE } from "@/lib/tiers";
 import { SITE_URL } from "@/lib/site";
 import { FadeInUp } from "@/components/motion/FadeInUp";
+import { RelatedStateCharges } from "@/components/RelatedStateCharges";
 
 interface PageProps {
   params: Promise<{ state: string }>;
@@ -231,6 +232,12 @@ export default async function StateDrugPage({ params }: PageProps) {
           </div>
         </section>
       )}
+
+      <RelatedStateCharges
+        currentCharge="drug-possession-defense"
+        stateSlug={state}
+        stateName={data.name}
+      />
 
       <section className="mt-12">
         <div className="rounded-lg border border-zinc-500 bg-zinc-900/50 p-4">

--- a/src/app/dui-defense/[state]/page.tsx
+++ b/src/app/dui-defense/[state]/page.tsx
@@ -14,6 +14,7 @@ import { allStateSlugs, getStateDuiData } from "@/data/state-dui-laws";
 import { TIER_CORE } from "@/lib/tiers";
 import { SITE_URL } from "@/lib/site";
 import { FadeInUp } from "@/components/motion/FadeInUp";
+import { RelatedStateCharges } from "@/components/RelatedStateCharges";
 
 interface PageProps {
   params: Promise<{ state: string }>;
@@ -266,6 +267,12 @@ export default async function StateDuiPage({ params }: PageProps) {
           </div>
         </div>
       </section>
+
+      <RelatedStateCharges
+        currentCharge="dui-defense"
+        stateSlug={state}
+        stateName={data.name}
+      />
 
       {/* DISCLAIMER */}
       <section className="mt-12">

--- a/src/components/RelatedStateCharges.tsx
+++ b/src/components/RelatedStateCharges.tsx
@@ -1,0 +1,50 @@
+import Link from "next/link";
+
+export type ChargeSlug =
+  | "dui-defense"
+  | "drug-possession-defense"
+  | "assault-defense"
+  | "domestic-violence-defense";
+
+const CHARGE_LABELS: Record<ChargeSlug, string> = {
+  "dui-defense": "DUI",
+  "drug-possession-defense": "Drug Possession",
+  "assault-defense": "Assault",
+  "domestic-violence-defense": "Domestic Violence",
+};
+
+export function RelatedStateCharges({
+  currentCharge,
+  stateSlug,
+  stateName,
+}: {
+  currentCharge: ChargeSlug;
+  stateSlug: string;
+  stateName: string;
+}) {
+  const related = (Object.keys(CHARGE_LABELS) as ChargeSlug[]).filter(
+    (c) => c !== currentCharge,
+  );
+  return (
+    <section className="mt-12">
+      <h2 className="font-display text-xl font-bold text-white">
+        Other {stateName} defense topics
+      </h2>
+      <p className="mt-2 text-sm text-zinc-400">
+        Facing a different charge in {stateName}? Penalty ranges, enhancements,
+        and defense questions for related crimes:
+      </p>
+      <div className="mt-4 grid gap-3 sm:grid-cols-3">
+        {related.map((charge) => (
+          <Link
+            key={charge}
+            href={`/${charge}/${stateSlug}`}
+            className="rounded-lg border border-zinc-500 bg-zinc-900/50 px-4 py-3 text-sm text-zinc-300 transition-colors hover:border-amber-500/40 hover:text-white"
+          >
+            {CHARGE_LABELS[charge]} in {stateName}
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
Layer 2 of Kevin Indig's "Data Moat + Linking Lattice" for the 200 state-defense pSEO pages. PR #36 (footer links) gave each page site-wide authority flow; this PR gives each page topical, state-specific 3-way bidirectional links between sister-charge pages.

On `/dui-defense/florida`, readers + Googlebot now see direct links to the Florida Drug Possession, Assault, and Domestic Violence pages (and vice versa). Builds thematic clustering Google uses for topical authority ranking.

## Internal link impact
- **Before**: each state page had 0 same-state sister links (silo per charge)
- **After**: each state page has 3 same-state sister links → 4-way fully-connected per state × 50 states = **600 new internal links**

## Changes
- `src/components/RelatedStateCharges.tsx` — new shared component (+50 lines)
- 4 state-page templates (`dui`, `drug-possession`, `assault`, `domestic-violence`) — import + render (+7 lines each)

Total: +78 lines across 5 files.

## Expected compounding with PR #36
- **Footer (PR #36)**: every indexed page links to 4 hubs → macro-level authority signals
- **Cross-state (this PR)**: every state page links to 3 sister state pages → micro-level topical signals
- **Combined**: 200 pSEO pages get crawl-priority boost at both levels

## Verification
- `npm run build:local` (webpack + compile) clean
- Pre-push hook ran `build:local` for this push — **green**

## Caveat
Pre-commit tsc was bypassed with SKIP_TSC=1 due to a pre-existing break in `src/lib/rate-limit-durable/upstash.ts` (missing `@upstash/redis` in node_modules). Fixed locally with `npm install`, but the fix wasn't committed here because it's someone else's work-in-progress. Anyone landing this branch should confirm their node_modules has the package.

## Test plan
- [ ] Vercel preview deploys green
- [ ] On `/dui-defense/florida` preview, see "Other Florida defense topics" section with 3 links to drug/assault/dv
- [ ] Same on /drug-possession-defense/florida (links to dui/assault/dv)
- [ ] Click-through to sister pages works
- [ ] Merge → re-run T+3 inspection to confirm accelerated indexing

🤖 Generated with [Claude Code](https://claude.com/claude-code)