### PR TITLE
fix(copy): polish nits from adversarial-walkthrough copy-critic

### DIFF
--- a/src/app/r/[code]/[product]/page.tsx
+++ b/src/app/r/[code]/[product]/page.tsx
@@ -48,7 +48,7 @@ const SUBHEADLINES: Partial<Record<TierSlug, string>> = {
   "case-decoder":
     "A charge breakdown you hand your attorney — plain-language decode plus the questions we find they haven't been asked. Not advice. Not AI guesses. A documented checklist.",
   "intelligence-brief":
-    "A pre-meeting prep file you hand your attorney — built from your judge, your prosecutor, and the facts in your file. Not advice. Not AI guesses. A documented briefing.",
+    "A prep file you hand your attorney before the next meeting — built from your judge, your prosecutor, and the facts in your file. Not advice. Not AI guesses. A documented briefing.",
   "x-ray":
     "A discovery review you hand your attorney — every document cross-referenced, every weak point flagged. Not advice. Not AI guesses. A forensic record.",
   "war-room":
@@ -368,7 +368,8 @@ export default async function DeepLinkProductPage({ params, searchParams }: Page
             <li>Free court-date reminders through your case (partner benefit)</li>
             <li>
               If the first deliverable doesn&apos;t surface questions you
-              hadn&apos;t yet considered, refund &mdash; no argument.
+              hadn&apos;t yet considered, one email and we refund the same
+              day. No argument, no retention call.
             </li>
           </ul>
 

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -40,7 +40,7 @@ export function Footer({ variant = "full" }: { variant?: "full" | "minimal" }) {
             >
               help@imnotanattorney.com
             </a>
-            {" "}&mdash; Someone who understands your situation responds.
+            {" "}&mdash; A defendant-side researcher responds, not a bot.
           </p>
         </div>
         <div className={`grid gap-8 ${gridCols}`}>


### PR DESCRIPTION
## Summary
Three copy-critic nits deferred from adversarial-walkthrough R4 to Phase 5.

- **(a) Footer contact line** — `Someone who understands your situation responds.` → `A defendant-side researcher responds, not a bot.` Replaces unfulfilled promise with concrete mechanism + explicit bot-negation
- **(b) Intelligence Brief subheadline** — drop redundant \"pre-meeting\" + \"prep\"; anchor to the next meeting as the concrete event
- **(c) Partner deep-link refund guarantee** — passive `refund — no argument` → concrete trigger + time anchor + anti-friction (`one email and we refund the same day. No argument, no retention call.`)

## Why
Phase 5 of 5 in adversarial-walkthrough R5+ remediation. Copy-critic flagged all three in R4; severity was single-agent-flag so they were deferred to last. Phase 4 (jurisdiction coverage lookup) is a separate FEATURE-tier change and still needs plan approval before implementation.

## Test plan
- [x] `npx tsc --noEmit --skipLibCheck` — clean
- [x] `npm run build` — clean (pre-push gate)
- [ ] Post-deploy: curl site, confirm 3 copy changes visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)