### PR TITLE
feat(partner-deep-link): coverage-check link to /judge-report-card

### DIFF
--- a/src/app/judge-report-card/page.tsx
+++ b/src/app/judge-report-card/page.tsx
@@ -124,7 +124,7 @@ export default function JudgeReportCardPage() {
           <p className="mt-2 text-sm text-zinc-300">
             Based on verified court records with source URLs
           </p>
-          <div className="mt-6">
+          <div id="availability" className="mt-6 scroll-mt-24">
             <AvailabilityChecker
               slug="judge-report-card"
               productName="Judge Report Card"

--- a/src/app/r/[code]/[product]/page.tsx
+++ b/src/app/r/[code]/[product]/page.tsx
@@ -65,6 +65,19 @@ const SUBHEADLINES: Partial<Record<TierSlug, string>> = {
 // Adversarial-walkthrough skeptical-buyer R1/R2/R4: flagged "every bullet
 // assumes YOUR ATTORNEY" as a close-the-tab signal for the 60%+ of criminal
 // defendants whose public defender isn't assigned until arraignment.
+// Tiers whose value prop includes judge-level intelligence. Coverage-check
+// link only renders for these — case-decoder focuses on charge decode and
+// does not depend on the 15,386-judge index. Ships as Phase 4 Option A per
+// docs/plans/2026-04-22-coverage-lookup.md: link-out to /judge-report-card
+// (which already embeds AvailabilityChecker) before committing to an inline
+// coverage form on the deep-link page itself.
+const TIERS_WITH_JUDGE_COVERAGE: ReadonlySet<TierSlug> = new Set<TierSlug>([
+  "intelligence-brief",
+  "x-ray",
+  "war-room",
+  "situation-room",
+]);
+
 const NO_ATTORNEY_YET: Partial<Record<TierSlug, string>> = {
   "case-decoder":
     "No attorney yet? The decode still works — it's the first file your public defender sees at intake, or the one you hand to whoever you hire.",
@@ -291,13 +304,31 @@ export default async function DeepLinkProductPage({ params, searchParams }: Page
             anchors (15,386 judges / 33K opinions / every citation verified)
             hit the reader before any claim does. Same walkthrough flagged
             the prior position as hidden behind the cookie banner on mobile. */}
-        <div className="flex flex-wrap justify-center gap-x-4 gap-y-1 text-xs text-zinc-500 mb-8">
+        <div className="flex flex-wrap justify-center gap-x-4 gap-y-1 text-xs text-zinc-500 mb-2">
           <span>15,386 judges indexed</span>
           <span>&bull;</span>
           <span>33,000+ opinions classified</span>
           <span>&bull;</span>
           <span>Every citation verified to source</span>
         </div>
+
+        {/* Coverage-check link. Answers the silent "is MY judge in the 15,386?"
+            objection before the buyer commits $897+. Links to the free
+            Judge Report Card availability checker (AvailabilityChecker
+            component already in prod). Gated to judge-intel tiers only —
+            case-decoder value prop doesn't depend on the judge index.
+            Phase 4 Option A per docs/plans/2026-04-22-coverage-lookup.md. */}
+        {TIERS_WITH_JUDGE_COVERAGE.has(tierSlug) && (
+          <p className="text-center text-xs text-zinc-500 mb-8">
+            <Link
+              href="/judge-report-card#availability"
+              className="text-zinc-400 underline decoration-zinc-600 hover:text-amber-400 hover:decoration-amber-400"
+            >
+              Check if your judge is covered
+            </Link>{" "}
+            &mdash; free, before you commit.
+          </p>
+        )}
 
         {/* Scene + competitive alternatives. Adversarial-walkthrough R2
             (2026-04-21) flagged the prior "commonly measured in years of


### PR DESCRIPTION
## Summary
- Add subtle "Check if your judge is covered — free, before you commit." link directly below the proof strip on partner deep-link pages
- Gated to judge-intel tiers only (Intelligence Brief / X-Ray / War Room / Situation Room); case-decoder skipped (charge decode doesn't depend on the 15,386-judge index)
- Link destination: `/judge-report-card#availability` — the `AvailabilityChecker` component already wired there captures email on miss for waitlist
- Add `id="availability"` + `scroll-mt-24` to the existing checker wrapper so the hash scrolls the buyer directly to the checker, not to page top

## Why
Adversarial-walkthrough R1 + R4 skeptical-buyer: proof strip advertises "15,386 judges indexed" but buyer can't verify THEIR judge is in the index before committing \$897+. Close-tab trigger on every judge-intel tier.

Ships as **Option A** per `docs/plans/2026-04-22-coverage-lookup.md`. Option B (embed `AvailabilityChecker` inline on the deep-link page) promotes only if Option A click-through ≥ 8% over 14 days. Option C (bespoke route) rejected — violates bootstrap + steal-before-building.

## Phase 4 of 5 — final phase in the adversarial-walkthrough R5+ remediation.
Prior phases: #29 (whole-dollar prices), #50 (downsell below UPL), #51 (no-attorney-yet copy), #52 (copy polish).

## Test plan
- [x] `npx tsc --noEmit --skipLibCheck` — clean
- [x] `npm run build` — clean (pre-push gate)
- [ ] Post-deploy: curl `/r/E2EREFE/intelligence-brief`, confirm coverage-check link visible below proof strip
- [ ] Post-deploy: click link → confirm hash scrolls to `AvailabilityChecker` section on `/judge-report-card`
- [ ] Post-deploy: curl `/r/E2EREFE/case-decoder`, confirm coverage-check link **absent** (CD has no judge-intel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)