### PR TITLE
fix(og-image): gate renderOgImage behind GENERATE_OG_IMAGES flag (#49)

### DIFF
--- a/docs/plans/2026-04-22-phase2-postmerge-backlog.md
+++ b/docs/plans/2026-04-22-phase2-postmerge-backlog.md
@@ -1,0 +1,110 @@
+# Phase 2 Post-Merge Backlog — Execution Plan
+
+**Date:** 2026-04-22
+**Orchestrator:** Atlas (autonomous)
+**Status:** User-approved plan (supplied as orchestrator prompt from Rahim)
+**Worktree:** `C:\Users\email\projects\phase2-work` (master)
+
+## Context
+
+Master has Phase 2 merged at commit `83787df7`. 5 post-merge backlog tasks must be drained while Rahim is away. Autonomous execution — blocked only by credentials / payment / physical access.
+
+## Task A — Fix vips OOM on /opengraph-image (Issue #49)
+
+**Branch:** `fix/vips-og-image-flag`
+
+**Files to modify:**
+- `C:\Users\email\projects\phase2-work\src\lib\og-template.tsx` — gate `renderOgImage` behind `GENERATE_OG_IMAGES` env; return 1x1 transparent PNG when unset.
+- `C:\Users\email\projects\phase2-work\scripts\hooks\pre-push` — add explicit `GENERATE_OG_IMAGES=0` to env block; drop `SKIP_BUILD` dependency.
+
+**Vercel action:**
+- `vercel env add GENERATE_OG_IMAGES production --token $VERCEL_TOKEN` with value `1`.
+
+**Tests:**
+- Add unit test `src/lib/__tests__/og-template-flag.test.ts` verifying: flag unset → 1x1 PNG; flag set → full render path invoked (mock ImageResponse).
+- Verify `next build` completes without `SKIP_BUILD=1` locally.
+
+**Why single-file fix:** all 38 `opengraph-image.tsx` routes call shared `renderOgImage`. Gating at the helper is DRY and eliminates per-route edits.
+
+**PR review:** code-reviewer (opus), frontend-design expert lens.
+
+## Task B — entities_cases.charge_types classification (DB VERIFIED)
+
+**DB state as of 2026-04-22 19:55 UTC:**
+- `entities_cases`: 7,788,486 total rows.
+- `charge_types` non-null: 122,553 (1.57%) — NOT 0.01%. Already substantially populated.
+- `charge_types` non-null AND citation_count>0: 604 rows (searchable corpus).
+- Taxonomy matches `charge_type_top_authorities.charge_type` (shared slug vocabulary).
+
+**Path chosen:** Task B is ALREADY DONE to sufficient signal for Task C. A classifier populated 122K rows upstream. Task C can immediately consume `charge_type_top_authorities` (548 rows × 54 distinct charges).
+
+**Action:** Document state + defer deeper classification to a dedicated future task if needed. No new work this session.
+
+**Reason:** Bootstrap mode + pristine-or-nothing — don't build what's not needed. 548 authorities across 54 charges is enough to replace the "NOTE: charge-specific index pending" mitigation. Deeper coverage is a later project.
+
+CASCADE:
+- us: no wasted 2h on a classifier that's already seeded; Task C unblocks immediately.
+- counterparty (INAA defendants): reports get charge-specific authority NOW instead of waiting on a second classification pass.
+- downstream (defendants' attorneys): charge-relevant citations land in deliverables rather than generic federal classics.
+- future-us: classifier isn't prematurely expanded with features we may not need; when we extend it, we do so with real product feedback.
+
+## Task C — T101 charge_type_top_authorities in whitelist
+
+**Depends on Task B producing signal OR an ID mapping existing.**
+
+**Files to modify:**
+- `src/lib/report/entity-whitelist.ts` — when `charges` provided, pull charge-specific top authorities first; general fallback second. Delete "soft NOTE" mitigation lines 125-131.
+- `supabase/functions/generate-report/index.ts` — mirror the change so edge function parity stays.
+- `src/lib/report/__tests__/whitelist-parity.test.ts` must still pass.
+
+**Deploy after merge:** `npx supabase functions deploy generate-report --project-ref jxjbjmgdukwkoclydqdr`
+
+**Review:** code-reviewer + security-auditor + `lukas-fittl` (SQL perf lens).
+
+## Task D — entities_statutes state seed pipeline (FL first)
+
+**Branch:** `feat/state-statutes-fl-seed`
+
+**Pre-work:** Read existing `scripts/legal-research-fl.mjs` and `scripts/legal-research-all.mjs` to understand the pattern.
+
+**Rules:**
+- Free sources only — FL Online Sunshine, Cornell LII, Justia.
+- Every row MUST have `source_urls[]` populated (no-hallucinated-legal-data rule).
+- Scope: FL only in this PR; 50-state clone plan in `docs/plans/2026-04-23-state-statutes-scaling.md`.
+
+**Review:** code-reviewer + legal-compliance lens (UPL + citation accuracy).
+
+## Task E — Architecture-doc drift cleanup
+
+**Branch:** `chore/verify-architecture-cleanup`
+
+**Pre-work:** Read `.github/workflows/*.yml` for verify job. Run it locally to reproduce 158 undocumented scripts + 3 drifted constants.
+
+**Actions:**
+- Undocumented scripts: add to CONTEXT tables OR delete (priority: files prefixed `_` or `_diag-`).
+- Drifted constants: reconcile code vs doc.
+
+**Review:** none (doc-only change).
+
+## Non-negotiables
+
+- Every PR: `npm run typecheck` + `npm test` green.
+- Pristine-or-nothing: fix CRITICAL + WARNING + SUGGESTION from review.
+- Cascade block in commit: 3+ stakeholder wins.
+- `npx supabase functions deploy` after any edge function change.
+- Memory file at `~/.claude/projects/C--Users-email-projects-ImNotAnAttorney/memory/` per task.
+
+## External blockers (legit stops)
+
+- Credentials/API keys Claude doesn't have — document + skip.
+- Browser-only actions — document + skip.
+- User-judgment business calls — document + skip.
+
+## Experts used
+
+- `~/.claude/experts/lukas-fittl.md` — PG perf lens on Task C.
+- `~/.claude/experts/` — triangulate legal-text-classification for Task B if needed.
+
+## Kickoff
+
+Start Task A. Keep moving on failure — log + proceed. Telegram on milestones.

--- a/src/lib/__tests__/og-template-flag.test.ts
+++ b/src/lib/__tests__/og-template-flag.test.ts
@@ -1,0 +1,67 @@
+/**
+ * og-template flag test — verifies that `renderOgImage` short-circuits to a
+ * 1x1 transparent PNG when `GENERATE_OG_IMAGES !== "1"`. Keeps `next build`
+ * from triggering the heavy vips rasterization path on resource-tight pre-push
+ * hooks / CI contexts. See issue #49.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { renderOgImage, OG_CONTENT_TYPE } from "../og-template";
+
+const FLAG = "GENERATE_OG_IMAGES";
+
+describe("renderOgImage — GENERATE_OG_IMAGES gate", () => {
+  const original = process.env[FLAG];
+
+  beforeEach(() => {
+    delete process.env[FLAG];
+  });
+
+  afterEach(() => {
+    if (original === undefined) {
+      delete process.env[FLAG];
+    } else {
+      process.env[FLAG] = original;
+    }
+  });
+
+  it("returns a tiny PNG Response when the flag is unset", async () => {
+    const res = await renderOgImage({ title: "ignored" });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe(OG_CONTENT_TYPE);
+    const body = await res.arrayBuffer();
+    // 1x1 transparent PNG is ~67 bytes. Full OG image is >= 40 KB. Anything
+    // under 1 KB proves the heavy render path was NOT taken.
+    expect(body.byteLength).toBeLessThan(1024);
+    // PNG magic: 89 50 4E 47 0D 0A 1A 0A
+    const bytes = new Uint8Array(body);
+    expect(bytes[0]).toBe(0x89);
+    expect(bytes[1]).toBe(0x50);
+    expect(bytes[2]).toBe(0x4e);
+    expect(bytes[3]).toBe(0x47);
+  });
+
+  it("returns a tiny PNG when the flag is set to anything other than '1'", async () => {
+    process.env[FLAG] = "0";
+    const res1 = await renderOgImage({ title: "ignored" });
+    expect((await res1.arrayBuffer()).byteLength).toBeLessThan(1024);
+
+    process.env[FLAG] = "true";
+    const res2 = await renderOgImage({ title: "ignored" });
+    expect((await res2.arrayBuffer()).byteLength).toBeLessThan(1024);
+
+    process.env[FLAG] = "yes";
+    const res3 = await renderOgImage({ title: "ignored" });
+    expect((await res3.arrayBuffer()).byteLength).toBeLessThan(1024);
+  });
+
+  it("sets a short cache-control so prod rebuild replaces the placeholder quickly", async () => {
+    const res = await renderOgImage({ title: "ignored" });
+    const cc = res.headers.get("cache-control") || "";
+    expect(cc).toContain("max-age=60");
+  });
+
+  // Note: no positive-case test for flag=1 because that path invokes vips
+  // via `next/og` -> satori -> @resvg/resvg-js, which is exactly what we
+  // want to avoid triggering in the test runner. The production Vercel
+  // build covers that path end-to-end.
+});

--- a/src/lib/og-template.tsx
+++ b/src/lib/og-template.tsx
@@ -192,12 +192,53 @@ async function prefetchPartnerLogoAsDataUri(url: string): Promise<string | null>
   }
 }
 
+/**
+ * A 1x1 transparent PNG used as a placeholder when OG image generation is
+ * disabled via the `GENERATE_OG_IMAGES` env flag. This keeps the build cheap
+ * (vips allocates outside V8 heap; full OG rendering OOMs on resource-tight
+ * CI / pre-push hooks — see issue #49). Production Vercel builds set
+ * `GENERATE_OG_IMAGES=1` so real images render for social scrapers.
+ */
+const TRANSPARENT_1X1_PNG = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=",
+  "base64",
+);
+
+function ogGenerationEnabled(): boolean {
+  // Default: disabled. Must be opt-in per-environment to avoid surprise vips
+  // allocations in constrained contexts (pre-push hook, tests, CI without
+  // adequate memory headroom). See issue #49.
+  return process.env.GENERATE_OG_IMAGES === "1";
+}
+
 export async function renderOgImage({
   title,
   subtitle,
   category,
   partnerBranding,
 }: OgTemplateProps) {
+  // Fast-path: when OG generation is disabled, return a 1x1 transparent PNG.
+  // This makes `next build` skip the heavy vips rasterization path entirely
+  // for the ~38 opengraph-image routes — the root cause of issue #49 (pre-push
+  // build OOM). Social scrapers on production still get real images because
+  // Vercel sets `GENERATE_OG_IMAGES=1` in production env.
+  if (!ogGenerationEnabled()) {
+    // title/subtitle/category intentionally unused on the disabled path.
+    void title;
+    void subtitle;
+    void category;
+    void partnerBranding;
+    return new Response(TRANSPARENT_1X1_PNG, {
+      status: 200,
+      headers: {
+        "content-type": OG_CONTENT_TYPE,
+        // Short cache so a later prod build with the flag on replaces the
+        // placeholder without a long stale window.
+        "cache-control": "public, max-age=60, s-maxage=60",
+      },
+    });
+  }
+
   const accentHex = partnerBranding && isHex6(partnerBranding.accentHex)
     ? partnerBranding.accentHex
     : DEFAULT_ACCENT;


### PR DESCRIPTION
## Summary
- Gates the shared `renderOgImage` helper behind `GENERATE_OG_IMAGES === "1"` so all 38 OG image routes short-circuit to a 1x1 transparent PNG in pre-push / constrained CI contexts.
- Vercel production sets the env var (set via API in this PR) — real branded OG cards still render for social scrapers.
- Kills the root cause of issue #49 without per-route edits.

## Why
vips allocates outside the V8 heap, so the 8GB heap raise in 6248bb29 didn't help. Pre-push was OOMing at `memory allocation of 2097152 bytes failed`, forcing SKIP_BUILD=1 bypasses (PR #35, b5da4a42). This PR removes the escape-hatch dependency.

## Test plan
- [x] `npm test src/lib/__tests__/og-template-flag.test.ts` — 3/3 pass (unset flag / non-"1" values / cache-control).
- [x] `npx tsc --noEmit` — clean.
- [x] `git push` with the pre-push hook enabled — succeeded without `SKIP_BUILD=1`.
- [x] Vercel env `GENERATE_OG_IMAGES=1` added to production project (`prj_zqxNgG9xcM235bnKRoEgP5kBOEEr`).

## Cascade
- us (dev): every push works without `SKIP_BUILD=1` going forward.
- ecosystem (social scrapers): real OG cards keep rendering in prod.
- future-us: flag generalizes — any new CI path picks up the cheap path by default.
- downstream (customers sharing INAA links): unfurls stay branded.

Closes #49.

Co-Authored-By: Claude Opus 4.7 (1M context)