### PR TITLE
feat(whitelist): wire charge-specific authority via entities_cases.charge_types (T101)

### DIFF
--- a/src/lib/report/__tests__/whitelist-parity.test.ts
+++ b/src/lib/report/__tests__/whitelist-parity.test.ts
@@ -47,18 +47,29 @@ interface FixtureAgency {
 
 function makeMockSupabase(fixtures: {
   cases: FixtureCase[];
+  // 2026-04-22 (T101): charge-specific cases can now be returned separately
+  // from general top-cited. The mock returns `casesByCharge` when
+  // `.overlaps('charge_types', ...)` is called, else falls back to `cases`.
+  casesByCharge?: FixtureCase[];
   statutes: FixtureStatute[];
   doctrines: FixtureDoctrine[];
   agencies: FixtureAgency[];
 }): SupabaseClient {
-  const make = (rows: unknown[]) => {
+  const make = (defaultRows: unknown[], chargeRows?: unknown[]) => {
     const q: any = {
-      _rows: rows,
+      _rows: defaultRows,
       select: () => q,
       gt: () => q,
       eq: () => q,
       order: () => q,
       limit: () => q,
+      // When the caller narrows by overlaps() we switch the row source. This
+      // reflects how the real builder splits the two queries (charge-specific
+      // first, general top-cited second).
+      overlaps: () => {
+        q._rows = chargeRows ?? [];
+        return q;
+      },
       then(cb: (v: { data: unknown[] }) => unknown) {
         return Promise.resolve(cb({ data: q._rows }));
       },
@@ -67,7 +78,7 @@ function makeMockSupabase(fixtures: {
   };
   const client: any = {
     from: (table: string) => {
-      if (table === "entities_cases") return make(fixtures.cases);
+      if (table === "entities_cases") return make(fixtures.cases, fixtures.casesByCharge);
       if (table === "entities_statutes") return make(fixtures.statutes);
       if (table === "entity_sources") return make(fixtures.doctrines);
       if (table === "entities_agencies") return make(fixtures.agencies);
@@ -80,6 +91,8 @@ function makeMockSupabase(fixtures: {
 describe("buildEntityWhitelist Node/Deno parity (S2)", () => {
   it("emits a deterministic whitelist with the documented structure", async () => {
     const fixtures = {
+      // General top-cited fallback. Intentionally includes case:terry twice
+      // (once here, once in casesByCharge) so we can prove dedupe.
       cases: [
         {
           canonical_id: "case:miranda",
@@ -88,6 +101,24 @@ describe("buildEntityWhitelist Node/Deno parity (S2)", () => {
           citation_count: 9999,
           date_filed: "1966-06-13",
         },
+        {
+          canonical_id: "case:terry",
+          case_name: "Terry v. Ohio",
+          primary_citation: "392 U.S. 1",
+          citation_count: 8000,
+          date_filed: "1968-06-10",
+        },
+      ],
+      // Charge-specific rows — served when overlaps('charge_types', …) runs.
+      casesByCharge: [
+        {
+          canonical_id: "case:schmerber",
+          case_name: "Schmerber v. California",
+          primary_citation: "384 U.S. 757",
+          citation_count: 500,
+          date_filed: "1966-06-20",
+        },
+        // Duplicate against `cases` to prove dedupe works.
         {
           canonical_id: "case:terry",
           case_name: "Terry v. Ohio",
@@ -128,15 +159,33 @@ describe("buildEntityWhitelist Node/Deno parity (S2)", () => {
     expect(wl.text).toContain("## Doctrines (type=doctrine)");
     expect(wl.text).toContain("## Agencies (type=agency)");
 
-    // L4 NOTE must appear when charges are supplied (mirror in Deno).
-    expect(wl.text).toContain("# NOTE: Charge-specific authority index pending");
-    expect(wl.text).toContain("[dui]");
+    // 2026-04-22 (T101): the "NOTE: charge-specific authority pending"
+    // disclaimer is GONE — the whitelist now carries real charge-specific
+    // cases first. Assert its absence so we don't silently regress.
+    expect(wl.text).not.toContain("# NOTE: Charge-specific authority index pending");
 
     // Cases render with canonical_id em-dash case_name (citation) format.
+    // Both charge-specific (schmerber) and general (miranda, terry) appear.
+    expect(wl.text).toContain(
+      "  case:schmerber — Schmerber v. California (384 U.S. 757)"
+    );
     expect(wl.text).toContain(
       "  case:miranda — Miranda v. Arizona (384 U.S. 436)"
     );
     expect(wl.text).toContain("  case:terry — Terry v. Ohio (392 U.S. 1)");
+
+    // Dedupe: case:terry appears in BOTH charge-specific and general
+    // fixtures. It must render exactly once.
+    const terryCount = (wl.text.match(/case:terry/g) ?? []).length;
+    expect(terryCount).toBe(1);
+
+    // Charge-specific cases must be listed BEFORE general top-cited so the
+    // model sees them first in the prompt.
+    const schmerberIdx = wl.text.indexOf("case:schmerber");
+    const mirandaIdx = wl.text.indexOf("case:miranda");
+    expect(schmerberIdx).toBeGreaterThan(0);
+    expect(mirandaIdx).toBeGreaterThan(0);
+    expect(schmerberIdx).toBeLessThan(mirandaIdx);
 
     // Doctrines strip the "doctrine:" prefix.
     expect(wl.text).toContain("  doct:1 — reasonable suspicion");
@@ -150,6 +199,7 @@ describe("buildEntityWhitelist Node/Deno parity (S2)", () => {
     // Valid IDs carry every canonical_id seen (except doctrine-less rows).
     expect(wl.validIds.has("case:miranda")).toBe(true);
     expect(wl.validIds.has("case:terry")).toBe(true);
+    expect(wl.validIds.has("case:schmerber")).toBe(true);
     expect(wl.validIds.has("statute:18-924c")).toBe(true);
     expect(wl.validIds.has("doct:1")).toBe(true);
     expect(wl.validIds.has("agency:dea")).toBe(true);

--- a/src/lib/report/entity-whitelist.ts
+++ b/src/lib/report/entity-whitelist.ts
@@ -94,54 +94,84 @@ export async function buildEntityWhitelist(
 
   // Cases — ordered by citation_count DESC, date_filed DESC.
   //
-  // History: the original query filtered `authority_score IS NOT NULL` and
-  // `charge_types && $charges`. DB audit 2026-04-22 (plan 2026-04-22-worry-
-  // phase2-residual-concerns.md, T1) showed `authority_score` is 0%
-  // populated across all 7.78M rows and `charge_types` is empty ({}) on all
-  // but ~677 rows. Result: the old query returned 0 cases for every report
-  // — the entire Phase 2 badge feature silently produced empty whitelists.
+  // 2026-04-22 (T101 — PR #56): charge-specific authority now wired.
+  // `entities_cases.charge_types` is populated on 122,553 rows (1.57 % of
+  // 7.78M); 604 of those have citation_count > 0. The overlaps('charge_types',
+  // $charges) path now returns real charge-relevant authority via the GIN
+  // index on the text[] column (measured ~500 ms for 2-charge lookup).
+  // General top-cited fallback still runs to keep the whitelist non-empty
+  // when charge_types hits nothing (new or rare charges).
   //
-  // Round-1 finding F1: the charge-specific "boost" branch using
-  // `overlaps('charge_types', ...)` is effectively dead because
-  // `charge_types` is empty on 99.99 % of rows. Removed until a real
-  // charge->authority index lands (tracked: `charge_type_top_authorities`
-  // join, post-round-2 backlog). General top-cited fallback remains as
-  // the primary source.
+  // Two-path strategy:
+  //   (a) charge-specific: overlaps(charge_types, parsed.charges) —
+  //       up to 100 rows, ordered by citation_count DESC.
+  //   (b) general top-cited: citation_count DESC — up to 100 rows,
+  //       appended to fill the prompt window without duplicates.
   //
-  // Round-1 finding L4: every charge currently returns the same ~200
-  // federal top-cited cases because the charge-specific index does not
-  // exist. Surface this to the model via a prominent NOTE in the prompt
-  // so it does not bluff generic federal classics as charge-specific
-  // authority.
+  // Ordering columns: citation_count is populated + indexed.
+  // date_filed is 100 % populated. Safe ordering chain.
   //
-  // Ordering columns: citation_count is populated + has an index (323 ms
-  // for the 200-row limit query on 7.78M rows). date_filed is 100 %
-  // populated. Safe ordering chain.
+  // Previously: soft NOTE "charge-specific authority index pending"
+  // surfaced to the model because overlaps returned zero rows. Now
+  // removed — the model gets real charge-specific cases first, so the
+  // disclaimer is no longer accurate and would mislead.
   try {
     const CASE_COLS = "canonical_id, case_name, primary_citation, citation_count";
+    const CHARGE_SPECIFIC_LIMIT = 100;
+    const GENERAL_LIMIT = 100;
 
+    const seenIds = new Set<string>();
+    const orderedRows: Array<{
+      canonical_id: string;
+      case_name: string;
+      primary_citation: string | null;
+    }> = [];
+
+    // (a) Charge-specific — only run when the caller supplied charges.
+    if (parsed.charges && parsed.charges.length > 0) {
+      const { data: chargeRows } = await supabase
+        .from("entities_cases")
+        .select(CASE_COLS)
+        .overlaps("charge_types", parsed.charges)
+        .gt("citation_count", 0)
+        .order("citation_count", { ascending: false, nullsFirst: false })
+        .order("date_filed", { ascending: false, nullsFirst: false })
+        .limit(CHARGE_SPECIFIC_LIMIT);
+      for (const r of chargeRows ?? []) {
+        if (!r.canonical_id || !r.case_name) continue;
+        if (seenIds.has(r.canonical_id)) continue;
+        seenIds.add(r.canonical_id);
+        orderedRows.push({
+          canonical_id: r.canonical_id,
+          case_name: r.case_name,
+          primary_citation: r.primary_citation ?? null,
+        });
+      }
+    }
+
+    // (b) General top-cited — always runs as fallback/fill. Deduped against
+    // (a) so a charge-specific case isn't listed twice under two headers.
     const { data: topCited } = await supabase
       .from("entities_cases")
       .select(CASE_COLS)
       .gt("citation_count", 0)
       .order("citation_count", { ascending: false, nullsFirst: false })
       .order("date_filed", { ascending: false, nullsFirst: false })
-      .limit(200);
+      .limit(GENERAL_LIMIT + seenIds.size);
+    for (const r of topCited ?? []) {
+      if (!r.canonical_id || !r.case_name) continue;
+      if (seenIds.has(r.canonical_id)) continue;
+      seenIds.add(r.canonical_id);
+      orderedRows.push({
+        canonical_id: r.canonical_id,
+        case_name: r.case_name,
+        primary_citation: r.primary_citation ?? null,
+      });
+      if (orderedRows.length >= CHARGE_SPECIFIC_LIMIT + GENERAL_LIMIT) break;
+    }
 
     lines.push("## Cases (type=case)");
-    // L4: prominent charge-specific authority gap disclosure.
-    if (parsed.charges && parsed.charges.length > 0) {
-      lines.push(
-        `  # NOTE: Charge-specific authority index pending for [${parsed.charges.join(
-          ", "
-        )}]. The cases below are top-cited federal authorities (charge-agnostic); cite only cases clearly relevant to the facts of the intake. Do not present generic federal classics as charge-specific precedent.`
-      );
-    }
-    for (const r of topCited ?? []) {
-      if (!r.canonical_id) continue;
-      // E5: skip rows without a case_name — "(unknown case name)" leaking
-      // into customer-facing prompts is unprofessional and unhelpful.
-      if (!r.case_name) continue;
+    for (const r of orderedRows) {
       validIds.add(r.canonical_id);
       lines.push(
         `  ${r.canonical_id} — ${r.case_name}${r.primary_citation ? ` (${r.primary_citation})` : ""}`

--- a/supabase/functions/generate-report/index.ts
+++ b/supabase/functions/generate-report/index.ts
@@ -469,41 +469,76 @@ async function buildEntityWhitelist(
 
   // Cases — ordered by citation_count DESC, date_filed DESC.
   //
-  // History: the original query filtered `authority_score IS NOT NULL` and
-  // `charge_types && $charges`. DB audit 2026-04-22 (plan 2026-04-22-worry-
-  // phase2-residual-concerns.md, T1) showed `authority_score` is 0 %
-  // populated across all 7.78M rows and `charge_types` is empty ({}) on all
-  // but ~677 rows. The old query returned 0 cases for every report and the
-  // Phase 2 badge feature silently shipped with an empty whitelist. This
-  // block mirrors the Node implementation at src/lib/report/entity-whitelist.ts
-  // (belt-and-suspenders merge: charge boost + general top-cited fallback).
+  // 2026-04-22 (T101 — PR #56): charge-specific authority now wired.
+  // `entities_cases.charge_types` is populated on 122,553 rows (1.57 % of
+  // 7.78M); 604 of those have citation_count > 0. Two-path strategy:
+  //   (a) charge-specific: overlaps(charge_types, parsed.charges) via
+  //       PostgREST `charge_types=ov.{...}` — GIN index makes this ~500ms.
+  //   (b) general top-cited: citation_count DESC — fallback and fill.
+  // Rows are de-duped across paths; charge-specific cases are listed FIRST
+  // so the model sees them at the top of the prompt. Mirrors the Node
+  // implementation at src/lib/report/entity-whitelist.ts.
   const charges = params.charges ?? [];
   const caseColsQs = "select=canonical_id,case_name,primary_citation,citation_count";
-  // Round-1 finding F1: the charge-specific boost branch (overlaps on
-  // `charge_types`) is effectively dead — that column is empty on 99.99%
-  // of rows. Removed until a real charge->authority index lands. See
-  // src/lib/report/entity-whitelist.ts for the companion fix. Finding C3
-  // (PostgREST array-literal encoding) is moot once this branch is gone
-  // but the fix is kept above in history for when the branch returns.
-  //
-  // Round-1 finding L4: prominent NOTE surfacing that charge-specific
-  // authority is pending, so the model does not bluff generic federal
-  // classics as charge-specific precedent.
-  const topCitedRows: any[] = await pgFetch(
-    `entities_cases?${caseColsQs}&citation_count=gt.0&order=citation_count.desc.nullslast,date_filed.desc.nullslast&limit=200`
-  );
-  lines.push("## Cases (type=case)");
+  const CHARGE_SPECIFIC_LIMIT = 100;
+  const GENERAL_LIMIT = 100;
+
+  const seenCaseIds = new Set<string>();
+  const orderedCaseRows: Array<{
+    canonical_id: string;
+    case_name: string;
+    primary_citation: string | null;
+  }> = [];
+
+  // (a) Charge-specific rows — only when caller supplied charges.
+  // PostgREST array-literal encoding: {"drug-possession-cocaine","dui-dwi"}
+  // Elements with commas/quotes would need escaping, but our charge slugs
+  // are [a-z0-9-] only (enforced by MAX_CHARGE_LEN validation above and
+  // the intake form's controlled vocabulary). Belt-and-suspenders: wrap
+  // each slug in double-quotes so that invariant can't be broken by a
+  // future slug extension.
   if (charges.length > 0) {
-    lines.push(
-      `  # NOTE: Charge-specific authority index pending for [${charges.join(
-        ", "
-      )}]. The cases below are top-cited federal authorities (charge-agnostic); cite only cases clearly relevant to the facts of the intake. Do not present generic federal classics as charge-specific precedent.`
+    const arrayLit = `{${charges
+      .map((c) => `"${c.replace(/"/g, '\\"')}"`)
+      .join(",")}}`;
+    const chargeRows: any[] = await pgFetch(
+      `entities_cases?${caseColsQs}&charge_types=ov.${encodeURIComponent(
+        arrayLit
+      )}&citation_count=gt.0&order=citation_count.desc.nullslast,date_filed.desc.nullslast&limit=${CHARGE_SPECIFIC_LIMIT}`
     );
+    for (const r of chargeRows) {
+      if (!r?.canonical_id || !r.case_name) continue;
+      if (seenCaseIds.has(r.canonical_id)) continue;
+      seenCaseIds.add(r.canonical_id);
+      orderedCaseRows.push({
+        canonical_id: r.canonical_id,
+        case_name: r.case_name,
+        primary_citation: r.primary_citation ?? null,
+      });
+    }
   }
+
+  // (b) General top-cited — always runs as fill. Request slightly more than
+  // GENERAL_LIMIT to absorb dedupe against (a).
+  const topCitedRows: any[] = await pgFetch(
+    `entities_cases?${caseColsQs}&citation_count=gt.0&order=citation_count.desc.nullslast,date_filed.desc.nullslast&limit=${
+      GENERAL_LIMIT + seenCaseIds.size
+    }`
+  );
   for (const r of topCitedRows) {
-    if (!r?.canonical_id) continue;
-    // E5: skip rows without a case_name.
-    if (!r.case_name) continue;
+    if (!r?.canonical_id || !r.case_name) continue;
+    if (seenCaseIds.has(r.canonical_id)) continue;
+    seenCaseIds.add(r.canonical_id);
+    orderedCaseRows.push({
+      canonical_id: r.canonical_id,
+      case_name: r.case_name,
+      primary_citation: r.primary_citation ?? null,
+    });
+    if (orderedCaseRows.length >= CHARGE_SPECIFIC_LIMIT + GENERAL_LIMIT) break;
+  }
+
+  lines.push("## Cases (type=case)");
+  for (const r of orderedCaseRows) {
     validIds.add(r.canonical_id);
     lines.push(
       `  ${r.canonical_id} — ${r.case_name}${r.primary_citation ? ` (${r.primary_citation})` : ""}`


### PR DESCRIPTION
## Summary
- Whitelist now returns real charge-specific top-cited authority via `overlaps(charge_types, …)` instead of surfacing a "NOTE: charge-specific authority index pending" disclaimer.
- Two-path strategy: (a) charge-specific first, (b) general top-cited fallback, cross-deduped, charge-specific rendered first.
- Node + Deno mirrors updated in lockstep; parity test asserts absence of the deprecated NOTE and asserts charge-specific cases precede general fallback.

## Why
DB state as of 2026-04-22: `entities_cases.charge_types` is populated on 122,553 rows (1.57% of 7.78M), with 604 having citation_count > 0. The overlaps path returns real signal (~500ms measured). The soft NOTE would now mislead.

## Test plan
- [x] `npm test src/lib/report` — 24/24 pass.
- [x] `npx tsc --noEmit` — clean.
- [x] Parity test updated to assert: charge-specific precedes general, dedupe works, old NOTE is absent.
- [ ] Deploy edge function after merge: `npx supabase functions deploy generate-report --project-ref jxjbjmgdukwkoclydqdr`.

## Cascade
- us: whitelist carries real signal instead of bluffing.
- customers: reports cite charge-relevant cases.
- future-us: classifier can expand coverage without touching this code path.

Follow-up to PR #35 (Phase 2 citation badges).

Co-Authored-By: Claude Opus 4.7 (1M context)