### PR TITLE
chore(docs): fix 3 drifted constant line refs in src/lib/CONTEXT.md

### DIFF
--- a/src/lib/CONTEXT.md
+++ b/src/lib/CONTEXT.md
@@ -149,9 +149,9 @@ No passwords. Flow: `POST /api/customer/magic-link` → token stored in `magic_l
 | Strategy weight | 10% | `score.ts:206` |
 | Time modifier weight | 30% | `score.ts:96` |
 | **Rate Limiting** | | |
-| Memory window | 60 seconds | `rate-limit.ts:27` |
-| Memory max requests | 3 per window | `rate-limit.ts:28` |
-| Memory max keys | 10,000 | `rate-limit.ts:29` |
+| Memory window | 60 seconds | `rate-limit.ts:28` |
+| Memory max requests | 3 per window | `rate-limit.ts:29` |
+| Memory max keys | 10,000 | `rate-limit.ts:30` |
 | **Site** | | |
 | SITE_URL | `https://imnotanattorney.com` | `site.ts:49` |
 | CONTACT_EMAIL | `help@imnotanattorney.com` | `site.ts:55` |
@@ -159,7 +159,7 @@ No passwords. Flow: `POST /api/customer/magic-link` → token stored in `magic_l
 | OPERATOR_TOKEN_TTL | 24 * 60 * 60 = 86,400s (24h) | `site.ts:148` |
 | PHASE2_TOKEN_TTL | 2,592,000s (30 days) | `site.ts:151` |
 | **Email** | | |
-| FROM_EMAIL | `noreply@imnotanattorney.com` | `email.ts:53-54` |
+| FROM_EMAIL | `noreply@imnotanattorney.com` | `email.ts:55-58` |
 | Nurture days | 1, 3, 5, 7, 10, 14 | `drip-emails.ts:7` |
 | DUI crisis days | 2, 4, 7 | `drip-emails.ts:11-14` |
 | Win-back days | 75, 78, 82, 89, 96 | `drip-emails.ts:39` |


### PR DESCRIPTION
## Summary
- Fixes the 3 drifted constant line references in src/lib/CONTEXT.md that were making the docs-freshness workflow exit 1 on every PR.
- `rate-limit.ts` lines bumped by 1 (memory window / max requests / max keys).
- `email.ts` FROM_EMAIL block shifted from 53-54 to 55-58 (now wrapped in envWithWarn).

## Why
Actual constant values are correct — only the documented line numbers had drifted. verify-architecture.js exits 1 when drifted > 0, so every PR was red at the doc-freshness gate.

## Result
- before: 183 verified / **3 drifted** / 158 undocumented (exit 1)
- after:  186 verified / **0 drifted** / 159 undocumented (exit 0)

Undocumented files (159 transient scripts + ~26 src/lib modules) do not fail the workflow — that's a documentation backlog, not a CI blocker. Tracked as follow-up.

## Test plan
- [x] `node docs/verify-architecture.js` exits 0.

## Cascade
- us: PR gate unblocks.
- future-us: line-number drift can recur; fix pattern is the same (grep + bump).

Co-Authored-By: Claude Opus 4.7 (1M context)