### PR TITLE
fix(partner-deep-link): CTA grammar — "Start My The X-Ray" broken

### DIFF
--- a/src/app/r/[code]/[product]/page.tsx
+++ b/src/app/r/[code]/[product]/page.tsx
@@ -265,6 +265,13 @@ export default async function DeepLinkProductPage({ params, searchParams }: Page
   const noAttorneyYet = NO_ATTORNEY_YET[tierSlug] ?? null;
   const proofItems = TIER_PROOF_ITEMS[tierSlug] ?? DEFAULT_PROOF_ITEMS;
   const stakesParagraph = TIER_STAKES[tierSlug] ?? null;
+  // CTA label: "Start My X" breaks grammatically on tier names that start
+  // with "The " — "Start My The X-Ray" flagged as a close-tab line by the
+  // AWT sweep R1 skeptical-buyer on situation-room. Drop "My" prefix for
+  // "The *" tiers; keep the warmer "My" on other tiers.
+  const ctaLabel = tier.name.startsWith("The ")
+    ? `Start ${tier.name}`
+    : `Start My ${tier.name}`;
   // Stay in cents until the final display to avoid float drift for larger
   // tiers (e.g. War Room 499700 cents). Display rule: >=$100 renders whole
   // dollars (cents on a $897 crisis product read as haggling per
@@ -452,7 +459,7 @@ export default async function DeepLinkProductPage({ params, searchParams }: Page
             href={checkoutHref}
             className="block w-full text-center px-6 py-4 bg-amber-500 text-black font-bold rounded-xl text-lg hover:bg-amber-400 transition-colors"
           >
-            Start My {tier.name}
+            {ctaLabel}
           </Link>
 
           <p className="text-center text-zinc-500 text-xs mt-4">


### PR DESCRIPTION
## Summary
Adversarial-walkthrough R1 on `/r/E2EREFE/situation-room` close-the-tab line = `"Start My The Situation Room"` (primary CTA). Same bug on X-Ray + War Room. Root: `TIER_CORE.name` for top-3 tiers begins with "The ".

Fix: tier-name-aware CTA label. `"The *"` tiers drop "My" → `Start The X-Ray`. Other tiers keep `Start My Case Decoder`.

## Why critical
At $2,247 / $4,497 / $8,997 AOV a malformed primary CTA reads as "template nobody proofed" — ceiling-tier buyers tab out on micro-signals. This is the single highest-severity finding from the Tier-1 sibling-surface R1 sweep.

## Test plan
- [x] tsc clean
- [ ] Post-deploy: curl `/r/E2EREFE/x-ray` → `Start The X-Ray` visible
- [ ] curl `/r/E2EREFE/case-decoder` → `Start My Case Decoder` preserved

Part of `docs/plans/2026-04-22-worry-conversion-surfaces-sweep.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)