### PR TITLE
fix(sample-pages): speed-sell + anti-attorney + unverified-citation cleanup — AWT R1

### DIFF
--- a/src/app/sample-xray/page.tsx
+++ b/src/app/sample-xray/page.tsx
@@ -758,11 +758,17 @@ export default function SampleXRayPage() {
                 <p className="font-semibold text-white">
                   &ldquo;{TIER_CORE["x-ray"].priceDisplay} is a lot of money.&rdquo;
                 </p>
+                {/* AWT R1 (2026-04-22): dropped "single pretrial motion
+                    from a private attorney costs $2,500-$5,000" — unverified
+                    legal-services cost claim (UPL-adjacent + no-hallucinated-
+                    legal-data HARD RULE). Also drop "for less than one motion"
+                    — positions product as substitute for attorney motion work,
+                    UPL risk. Kept credit-toward-War-Room anchor. */}
                 <p className="mt-2 text-sm text-zinc-400">
-                  A single pretrial motion from a private attorney costs
-                  $2,500-$5,000. This analysis covers your entire discovery, every
-                  document, every contradiction, every question, for less than one
-                  motion. And your {TIER_CORE["x-ray"].priceDisplay} is fully credited if you
+                  Every discovery document your attorney will argue against —
+                  cross-referenced, contradictions logged, questions calibrated.
+                  This is the research layer private defense teams build from
+                  scratch on every case. And your {TIER_CORE["x-ray"].priceDisplay} is fully credited if you
                   upgrade to {TIER_CORE["war-room"].name}.
                 </p>
               </div>
@@ -847,10 +853,16 @@ export default function SampleXRayPage() {
                 <p className="text-sm font-semibold text-white">
                   The Delivery Commitment
                 </p>
+                {/* AWT sibling-surfaces-sweep R1 (2026-04-22): "Your case
+                    moves on a schedule. So do we." was a speed-as-value-prop
+                    line — brand-voice HARD RULE bans speed-selling. SLA
+                    remains (transactional commitment, buyer has already
+                    committed if they're reading checkout-adjacent copy) but
+                    the tagline is pulled. */}
                 <p className="mt-1 text-xs text-zinc-400">
-                  Delivered within 10 business days of document receipt or 20%
-                  automatic refund. Past 15 business days: full refund. Your case
-                  moves on a schedule. So do we.
+                  Delivered within 10 business days of document receipt, or
+                  20% automatic refund. Past 15 business days: full refund.
+                  The commitment is a floor on rigor, not a speed promise.
                 </p>
               </div>
             </div>

--- a/src/app/sample/page.tsx
+++ b/src/app/sample/page.tsx
@@ -83,9 +83,16 @@ function InlineCTA({ variant }: { variant: "mid" | "end" }) {
       >
         Get Your Case Analysis, {TIER_CORE["case-decoder"].priceDisplay} →
       </Link>
+      {/* AWT sibling-surfaces-sweep R1 (2026-04-22): removed "Delivered
+          within 48 hours" front-of-funnel per brand-voice HARD RULE — never
+          sell on speed. SLA copy lives in transactional (post-checkout)
+          flows where the buyer has already committed. Also reframed refund
+          trigger away from "something your attorney hasn't raised" (UPL-
+          adjacent — implies we benchmark attorney work) to a neutral
+          information-surface promise. */}
       <p className="mt-2 text-xs text-zinc-400">
-        Delivered within 48 hours. Find It or It&apos;s Free &mdash; full refund
-        if we don&apos;t find something your attorney hasn&apos;t raised.
+        If the report doesn&apos;t surface questions you hadn&apos;t yet
+        considered, one email and we refund. No argument, no retention call.
       </p>
     </div>
   );
@@ -118,8 +125,9 @@ export default function SamplePage() {
           </h1>
           <p className="mt-4 text-zinc-400">
             This is from a real DWI case. Names, case numbers, and dates have
-            been changed. The questions, communication tools, and action plan are
-            real. The attorney hadn&apos;t addressed most of what we found.
+            been changed. The questions, communication tools, and action plan
+            are real. Most of what we documented hadn&apos;t yet surfaced in
+            the defendant&apos;s attorney conversations.
           </p>
         </div>
 
@@ -156,13 +164,18 @@ export default function SamplePage() {
             <p className="text-xs font-bold uppercase tracking-wider text-amber-400">
               Methodology Note
             </p>
+            {/* AWT R1: dropped unverified "most cited in published legal
+                scholarship" superlative — per no-hallucinated-legal-data.md
+                HARD RULE, any published-authority claim needs verified
+                source URLs or it comes off the page. Attribution itself
+                stays (the published treatises are real) but the ranking
+                claim is pulled. */}
             <p className="mt-3 text-sm leading-relaxed text-zinc-300">
               Every question and framework in this report traces to documented
               winning methods from elite criminal defense attorneys. Calibrated
-              for DWI defense using documented methodology from Lawrence Taylor
+              for DWI defense using published methodology from Lawrence Taylor
               (DWI suppression), Robert Remar (field sobriety analysis), and
-              Robert Ramsey (BAC forensics), three of the most cited DUI defense
-              attorneys in published legal scholarship.
+              Robert Ramsey (BAC forensics).
             </p>
           </div>
 

--- a/src/components/sample/SampleCrossPromo.tsx
+++ b/src/components/sample/SampleCrossPromo.tsx
@@ -34,7 +34,7 @@ export function SampleCrossPromo() {
           id="sample-cross-promo-heading"
           className="mt-3 text-xl font-bold text-white md:text-2xl"
         >
-          Two more tools, both under $100, both instant
+          Two more tools, both under $100, delivered on purchase
         </h2>
         <p className="mt-3 text-sm text-zinc-400">
           These work alongside whatever tier you choose. No overlap, no upsell
@@ -53,7 +53,7 @@ export function SampleCrossPromo() {
             <p className="mt-2 text-2xl font-bold text-white">
               {ask.priceDisplay}
               <span className="ml-2 text-xs font-normal text-zinc-400">
-                · Instant
+                · On purchase
               </span>
             </p>
           </header>
@@ -103,7 +103,7 @@ export function SampleCrossPromo() {
             <p className="mt-2 text-2xl font-bold text-white">
               {dci.priceDisplay}
               <span className="ml-2 text-xs font-normal text-zinc-400">
-                · Instant
+                · On purchase
               </span>
             </p>
           </header>


### PR DESCRIPTION
## Summary

- AWT sibling-surfaces-sweep R1 applied to /sample + /sample-xray standalone preview pages + shared SampleCrossPromo component.
- Closes 6 findings across 3 files: brand-voice HARD RULE violations (speed-selling), anti-attorney framing, unverified "most cited" legal-scholarship claim, UPL-adjacent refund trigger, and unverified legal-services cost figure.
- Follows the same tier-differentiation sweep as #60 (partner deep-link XR/WR/SR). Same lens panel, same repeatable pipeline.

## Findings closed

| ID | Severity | File | Fix |
|----|----------|------|-----|
| F-SMP-1 | CRITICAL | /sample | Removed "Delivered within 48 hours" from hero refund promise |
| F-SMP-2 | CRITICAL | /sample | "The attorney hadn't addressed most of what we found" → pro-defendant reframe |
| F-SMP-3 | CRITICAL | /sample | Dropped unverified "most cited DUI defense attorneys in published legal scholarship" superlative |
| F-SXR-1 | CRITICAL | /sample-xray | Removed "Your case moves on a schedule. So do we." speed-as-value-prop tagline |
| F-SXR-2 | CRITICAL | /sample + /sample-xray | SampleCrossPromo "both instant" / "· Instant" → "delivered on purchase" / "· On purchase" |
| F-SXR-3 | CRITICAL | /sample-xray | Removed unverified "$2,500-$5,000 pretrial motion" cost claim + "less than one motion" attorney-work-substitution framing |

## Deferred to R2

- F-SXR-framework-citations (Chapman II / Scheck / MacCarthy methodology names) — need verification pass
- F-PRICE hardcoding audit — main displays already pull from TIER_CORE; ancillary strings to audit separately

## Test plan

- [x] `npx tsc --noEmit --skipLibCheck` clean
- [x] `npm run build:local` passes (pre-push hook)
- [ ] Production render: GET /sample — no "48 hours" / no "hadn't addressed" / no "most cited" superlative
- [ ] Production render: GET /sample-xray — no "So do we" / no "$2,500-$5,000 motion" cost claim
- [ ] SampleCrossPromo renders on both pages with "On purchase" badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
