### PR TITLE
fix(tier-3-skus): speed-sell + UPL-adjacent cleanup on 5 standalone SKUs — AWT R1

### DIFF
--- a/src/app/arrest-survival-kit/page.tsx
+++ b/src/app/arrest-survival-kit/page.tsx
@@ -84,9 +84,9 @@ const FAQ_ITEMS = [
       "No. This is legal INFORMATION \u2014 verified rights and procedures from official sources. Decisions about how to use this information stay with you.",
   },
   {
-    question: "How fast do I get it?",
+    question: "How is it delivered?",
     answer:
-      "Within 60 seconds of purchase. Generated on demand for your state.",
+      "On purchase. Generated on demand for your state and sent to your inbox.",
   },
   {
     question: "What if you don\u2019t have data for my agency?",
@@ -153,7 +153,8 @@ export default function ArrestSurvivalKitPage() {
 
           <p className="mt-4 text-lg text-zinc-400">
             Your state-specific rights checklist, first-48-hours action plan,
-            and bail hearing preparation &mdash; delivered in 60 seconds.
+            and bail hearing preparation &mdash; delivered to your inbox on
+            purchase.
           </p>
 
           <p className="mt-6 text-4xl font-extrabold text-amber-400">
@@ -346,7 +347,7 @@ export default function ArrestSurvivalKitPage() {
             >
               help@imnotanattorney.com
             </a>
-            {" "}&mdash; we respond within 2 hours.
+            {" "}&mdash; a defendant-side researcher replies, not a bot.
           </p>
 
           <p className="mt-4 text-sm text-zinc-400">

--- a/src/app/district-court-intelligence/page.tsx
+++ b/src/app/district-court-intelligence/page.tsx
@@ -83,9 +83,9 @@ const FAQ_ITEMS = [
       "No. This is legal INFORMATION \u2014 verified court data compiled into a structured report. Decisions about how to use this information stay with you.",
   },
   {
-    question: "How fast do I get it?",
+    question: "How is it delivered?",
     answer:
-      "Within 60 seconds of purchase. The report is generated on demand from our verified database.",
+      "On purchase. The report is generated on demand from our verified database and sent to your inbox.",
   },
   {
     question: "What if my district isn\u2019t covered?",
@@ -351,9 +351,9 @@ export default function DistrictCourtIntelligencePage() {
 
           <p className="mt-4 text-zinc-400">
             Most defendants walk into court with no idea how the district
-            operates. Defendants who prepare walk in knowing the conviction rates,
-            the sentencing patterns, and the motion outcomes. The prosecution
-            already has this data &mdash; level the playing field in 60 seconds.
+            operates. Defendants who prepare walk in knowing the conviction
+            rates, the sentencing patterns, and the motion outcomes. The
+            prosecution already has this data &mdash; now you can have it too.
           </p>
 
           <div className="mt-6">
@@ -378,7 +378,7 @@ export default function DistrictCourtIntelligencePage() {
             >
               help@imnotanattorney.com
             </a>
-            {" "}&mdash; we respond within 2 hours.
+            {" "}&mdash; a defendant-side researcher replies, not a bot.
           </p>
         </section>
       </FadeInUp>

--- a/src/app/judge-report-card/page.tsx
+++ b/src/app/judge-report-card/page.tsx
@@ -45,9 +45,9 @@ const FAQ_ITEMS = [
       "No. This is legal INFORMATION \u2014 verified court data compiled into a structured report. Decisions about how to use this information stay with you.",
   },
   {
-    question: "How fast do I get it?",
+    question: "How is it delivered?",
     answer:
-      "Within 60 seconds of purchase. The report is generated on demand from our verified database.",
+      "On purchase. The report is generated on demand from our verified database and sent to your inbox.",
   },
   {
     question: "What if my judge isn\u2019t in the database?",
@@ -132,7 +132,8 @@ export default function JudgeReportCardPage() {
             />
           </div>
           <p className="mt-2 text-xs text-zinc-400">
-            Generated on demand. Delivered within 60 seconds of purchase.
+            Generated on demand from verified court records. Delivered on
+            purchase.
           </p>
         </section>
       </FadeInUp>
@@ -319,7 +320,7 @@ export default function JudgeReportCardPage() {
             >
               help@imnotanattorney.com
             </a>
-            {" "}&mdash; we respond within 2 hours.
+            {" "}&mdash; a defendant-side researcher replies, not a bot.
           </p>
           <div className="mt-4">
             <TrustBadges variant="compact" />

--- a/src/app/officer-background-check/page.tsx
+++ b/src/app/officer-background-check/page.tsx
@@ -85,8 +85,9 @@ const FAQ_ITEMS = [
       "No. This is legal INFORMATION \u2014 verified court data. Decisions about how to use this information stay with you.",
   },
   {
-    question: "How fast do I get it?",
-    answer: "Within 60 seconds of purchase.",
+    question: "How is it delivered?",
+    answer:
+      "On purchase. The analysis is generated on demand from verified court records and sent to your inbox.",
   },
   {
     question: "What if the officer isn\u2019t in the database?",
@@ -192,7 +193,7 @@ export default function OfficerBackgroundCheckPage() {
           <p className="mt-6 text-4xl font-extrabold text-amber-400">{TIER_CORE["officer-background-check"].priceDisplay}</p>
 
           <p className="mt-2 text-sm text-zinc-400">
-            Less than a court filing fee &mdash; for data that could change your defense strategy.
+            Less than a court filing fee &mdash; for data that changes how your next attorney conversation goes.
           </p>
 
           <p className="mt-2 text-sm text-zinc-300">
@@ -334,7 +335,9 @@ export default function OfficerBackgroundCheckPage() {
           </h2>
 
           <p className="mt-4 text-zinc-400">
-            Most defendants never think to check the officer&rsquo;s record. Defendants who prepare check everything. The prosecution already has this data &mdash; level the playing field in 60 seconds.
+            Most defendants never think to check the officer&rsquo;s record.
+            Defendants who prepare check everything. The prosecution already
+            has this data &mdash; now you can have it too.
           </p>
 
           <div className="mt-6">
@@ -356,7 +359,7 @@ export default function OfficerBackgroundCheckPage() {
             <a href="mailto:help@imnotanattorney.com" className="text-amber-400 underline decoration-amber-400/50 hover:decoration-amber-400">
               help@imnotanattorney.com
             </a>
-            {" "}&mdash; we respond within 2 hours.
+            {" "}&mdash; a defendant-side researcher replies, not a bot.
           </p>
         </section>
       </FadeInUp>

--- a/src/app/similar-cases-analyzer/page.tsx
+++ b/src/app/similar-cases-analyzer/page.tsx
@@ -54,9 +54,9 @@ const faqItems = [
       "No. This is legal INFORMATION, verified court data compiled for your review. Decisions about how to use this information stay with you.",
   },
   {
-    question: "How fast do I get it?",
+    question: "How is it delivered?",
     answer:
-      "Within 60 seconds of purchase. The analysis runs on demand against our verified database.",
+      "On purchase. The analysis runs on demand against our verified database and is sent to your inbox.",
   },
   {
     question: "What if there aren\u2019t enough similar cases?",
@@ -197,7 +197,7 @@ export default function SimilarCasesAnalyzerPage() {
             </p>
             <p className="mt-6 text-3xl font-bold text-amber-400">{TIER_CORE["similar-cases-analyzer"].priceDisplay}</p>
             <p className="mt-2 text-sm text-zinc-400">
-              Your attorney charges more per hour than this costs &mdash; and this is data they&rsquo;d need weeks to compile.
+              Case-matching research priced as a flat file, not an hourly rate &mdash; compiled from records your attorney can verify.
             </p>
             <p className="mt-2 text-sm text-zinc-400">
               Factually similar case matching from verified court records
@@ -425,7 +425,7 @@ export default function SimilarCasesAnalyzerPage() {
               <a href="mailto:help@imnotanattorney.com" className="text-amber-400 underline decoration-amber-400/50 hover:decoration-amber-400">
                 help@imnotanattorney.com
               </a>
-              {" "}&mdash; we respond within 2 hours.
+              {" "}&mdash; a defendant-side researcher replies, not a bot.
             </p>
           </FadeInUp>
         </section>


### PR DESCRIPTION
## Summary

- AWT sibling-surfaces-sweep R1 for Tier 3 standalone SKU landing pages. Same adversarial lens panel as #60 (partner deep-link XR/WR/SR) and #62 (/sample + /sample-xray).
- Convergent finding across all 5 SKU pages: speed-selling in three places per page (FAQ, CTA tagline, support line) = 15 total brand-voice HARD RULE violations. Removed.
- Two UPL-adjacent price anchors softened (defense-strategy → attorney-conversation reframe; attorney-hours cost comparison → flat-file positioning).

## Surfaces audited + fixed

| URL | Violations before | Violations after |
|-----|-------------------|------------------|
| /judge-report-card | 3 speed-sell | 0 |
| /officer-background-check | 3 speed-sell + 1 UPL | 0 |
| /similar-cases-analyzer | 2 speed-sell + 1 UPL-adjacent cost claim | 0 |
| /arrest-survival-kit | 3 speed-sell | 0 |
| /district-court-intelligence | 3 speed-sell | 0 |

## Findings closed

| ID | Severity | Fix |
|----|----------|-----|
| F-T3-1 | CRITICAL (convergent × 5) | FAQ "How fast do I get it?" → "How is it delivered?" |
| F-T3-2 | CRITICAL (convergent × 5) | CTA block speed-sell anchors dropped |
| F-T3-3 | CRITICAL (convergent × 5) | "we respond within 2 hours" → "a defendant-side researcher replies, not a bot" |
| F-OBC-1 | WARNING (UPL) | "change your defense strategy" → "change how your next attorney conversation goes" |
| F-SCA-1 | WARNING (UPL + unverified) | "Your attorney charges more per hour... weeks to compile" → flat-file positioning with no attorney-work substitution or unverified claim |

## Deferred to R2

- checkout/page.tsx paid-SKU marketing lines "Downloaded by defendants within 60 seconds of purchase" (10 occurrences) — separate sweep scoped to /checkout product descriptions
- Free-tool "60 seconds" references (score/, plea-analyzer/, dui-checklist/) — time-commitment signals for FREE quizzes, not speed-selling paid deliverables; acceptable under brand-voice
- F-JRC-5 / F-SCA-2 "attorney-hours" price anchors remaining (softer ones) — reads as honest positioning, not work-substitution; keep

## Test plan

- [x] `npx tsc --noEmit --skipLibCheck` clean
- [x] `npm run build:local` passes (pre-push hook)
- [ ] Production render: GET /judge-report-card, /officer-background-check, /similar-cases-analyzer, /arrest-survival-kit, /district-court-intelligence — no "60 seconds" / no "2 hours" / no "defense strategy" anchor
- [ ] FAQ schema renders the updated Q/A pair

🤖 Generated with [Claude Code](https://claude.com/claude-code)
