### PR TITLE
feat(blog-pipeline): rewrite_attempts column + TS interface

### DIFF
--- a/src/lib/types/blog-pipeline.ts
+++ b/src/lib/types/blog-pipeline.ts
@@ -174,6 +174,14 @@ export interface BlogDraft {
   dna_result: QAResult | null;
   dna_details: DNADetails | null;
   qa_attempts: number;
+  /**
+   * Count of `blog_rewrite` worker invocations on this draft. Distinct from
+   * `qa_attempts` (which counts QA gate runs). Decline triggers when this
+   * reaches `MAX_REWRITE_ATTEMPTS` in the engine. Added 2026-04-22 to
+   * decouple the rewrite budget from the QA-runs counter so post-rewrite
+   * QA cycles aren't blocked by attempts spent before the rewriter existed.
+   */
+  rewrite_attempts: number;
   qa_passed_at: string | null;
   published_at: string | null;
   version: number;

--- a/supabase/migrations/20260422a_blog_drafts_rewrite_attempts.sql
+++ b/supabase/migrations/20260422a_blog_drafts_rewrite_attempts.sql
@@ -1,0 +1,19 @@
+-- Blog QA loop: separate rewrite-attempts counter from qa-attempts.
+--
+-- qa_attempts counts QA gate runs. After adding the blog_rewrite worker
+-- (engine commit e54ccd8), each QA fail can trigger a rewrite which
+-- updates the draft's MDX in place. Conflating QA-runs and rewrite-cycles
+-- in the same counter makes the decline budget arbitrary — a draft that
+-- got 2 QA runs before the rewriter existed has only 1 rewrite cycle
+-- left, which is too few to converge.
+--
+-- New column rewrite_attempts tracks ONLY the rewrite cycles. Decline
+-- triggers when rewrite_attempts >= MAX_REWRITE_ATTEMPTS (configured in
+-- engine). Default MAX_REWRITE_ATTEMPTS = 3, giving up to 4 QA runs total
+-- (1 initial + 3 post-rewrite).
+
+ALTER TABLE blog_drafts
+  ADD COLUMN IF NOT EXISTS rewrite_attempts INTEGER NOT NULL DEFAULT 0;
+
+COMMENT ON COLUMN blog_drafts.rewrite_attempts IS
+  'Count of blog_rewrite worker invocations on this draft. Distinct from qa_attempts (which counts QA gate runs). Decline triggers when this >= MAX_REWRITE_ATTEMPTS in the engine.';


### PR DESCRIPTION
## Summary

- Adds `blog_drafts.rewrite_attempts INTEGER NOT NULL DEFAULT 0` column via migration `20260422a_blog_drafts_rewrite_attempts.sql`
- Adds `rewrite_attempts: number` to the `BlogDraft` TS interface in `src/lib/types/blog-pipeline.ts`

## Why

Decouples the blog-pipeline rewrite budget from `qa_attempts`. Before: a draft that had 2 QA runs prior to the `blog_rewrite` worker existing only had 1 rewrite cycle left, below convergence threshold. After: `MAX_REWRITE_ATTEMPTS` (default 3) is tracked independently, giving drafts up to 4 QA runs (1 initial + 3 post-rewrite).

Companion to engine commit `b1928a0`. The engine is the sole writer of this column; no existing web-side consumer references it yet — this PR just lays the schema + type foundation.

## Origin

Orphan commit `86059d09` (authored 2026-04-22) was salvaged from local branch `fix/deep-link-coverage-check` during crash-recovery triage 2026-04-23. Migration was applied live via pg client on port 5432 at commit time; this PR tracks it in version control.

Rescue backup preserved at `rescue/blog-pipeline-rewrite-attempts` on origin (same SHA at older base).

## Test plan

- [x] `npx tsc --noEmit --skipLibCheck` → exit 0
- [x] `npm run build` → exit 0 (compile + TS pass + page-data collection all clean)
- [ ] Confirm prod schema has `rewrite_attempts` column (already applied per commit message, verify with `\d blog_drafts`)
- [ ] Engine-side writer already live in commit b1928a0 — no action needed here

🤖 Generated with [Claude Code](https://claude.com/claude-code)