### PR TITLE
fix(api): error logging — drip-progress + Stripe promo update failures

### DIFF
--- a/src/app/api/admin/partners/route.ts
+++ b/src/app/api/admin/partners/route.ts
@@ -171,13 +171,18 @@ export async function POST(req: NextRequest) {
     const stripePromo = await createPartnerPromoCode(partner.id, code, partner.name);
 
     // Update partner with Stripe promo code references
-    await supabase
+    const { error: updateErr } = await supabase
       .from("partners")
       .update({
         stripe_coupon_id: "bondsman-referral-10pct",
         stripe_promo_code_id: stripePromo.id,
       })
       .eq("id", partner.id);
+
+    if (updateErr) {
+      console.error("[Admin Partners] Failed to save Stripe promo refs for partner", partner.id, updateErr);
+      // Partner and Stripe promo exist — only the DB link failed. Log and continue.
+    }
   } catch (stripeErr) {
     console.error("[Admin Partners] Stripe promo code error:", stripeErr);
     // Partner created but promo code failed, don't roll back, operator can retry

--- a/src/app/api/cron/partner-drip/route.ts
+++ b/src/app/api/cron/partner-drip/route.ts
@@ -204,13 +204,21 @@ export async function GET(req: NextRequest) {
         }
 
         if (anySendSucceeded) {
-          await supabase
+          const { error: updateErr } = await supabase
             .from("partners")
             .update({
               last_activation_email_key: nextStep.key,
               activation_email_sent_at: new Date().toISOString(),
             })
             .eq("id", partner.id);
+
+          if (updateErr) {
+            console.error(
+              `[Partner Drip] Failed to record drip progress for partner ${partner.id}:`,
+              updateErr
+            );
+          }
+
           sent++;
         } else {
           console.error(`[Partner Drip] All channels failed for ${nextStep.key} to ${partner.email}`);


### PR DESCRIPTION
## Summary

Two related fixes that prevent silent failures on Supabase `.update()` calls — both small, both surface real bugs that were being swallowed.

### 1. Partner drip-progress (`/api/cron/partner-drip`)
The update that records `last_activation_email_key` had no error check. If it failed silently, the partner would receive the same drip step again on the next cron run = duplicate emails. Now logs the error with partner ID so it can be diagnosed.

### 2. Stripe promo ref (`/api/admin/partners` create)
The update that saves `stripe_coupon_id` / `stripe_promo_code_id` after creating a Stripe promo code had no error check. If it failed, the partner row would silently lack Stripe references with no log trace. Now logs the error with partner ID.

## Origin

Orphan commits `56d3e7df` + `5de144e3` (authored 2026-04-13) salvaged from local branch `atlas/improve-2026-04-13` during 2026-04-23 crash-recovery triage. Backed up at `rescue/atlas-improve-2026-04-13` on origin.

## Conflict resolution

`partner-drip/route.ts` had drifted on master (SMS sending block + `anySendSucceeded` flag added later). Resolved by merging both intents:
- Keep master's `anySendSucceeded` gate + SMS block
- Add the incoming `updateErr` capture + `console.error` inside the existing update path

Net effect on master: 1 line changed (no `await` → `const { error: updateErr } = await`) + 7 lines added (the error log block).

## Test plan

- [x] `npx tsc --noEmit --skipLibCheck` (pre-commit hook) — clean
- [x] `npm run build` — clean
- [ ] Trigger drip cron in dev, confirm error log fires when `partners` table is read-only
- [ ] Create test partner via admin, confirm error log fires when Stripe promo update fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)