### PR TITLE
chore: align eslint-config-next to ^16.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@types/sanitize-html": "^2.16.0",
     "csv-parse": "^6.2.1",
     "eslint": "^9",
-    "eslint-config-next": "16.1.6",
+    "eslint-config-next": "^16.2.2",
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "pg": "^8.20.0",
     "playwright": "^1.59.1",


### PR DESCRIPTION
## Summary

Single-line `package.json` bump: `eslint-config-next` aligned to `^16.2.2` to match the `next` version range. Prevents lint config drift from runtime.

## Origin

Orphan commit `d9fb9984` (authored 2026-04-16) salvaged from local branch `atlas/improve-2026-04-16` during 2026-04-23 crash-recovery triage. Backed up at `rescue/atlas-improve-2026-04-16` on origin.

## Test plan

- [x] Pre-commit tsc — no TS to check (devDep version bump)
- [x] `npm install` re-resolves cleanly (already in lock cache)
- [ ] CI passes lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)