### PR TITLE
refactor: remove duplicate admin client in upload/finalize

### DIFF
--- a/src/app/api/upload/finalize/route.ts
+++ b/src/app/api/upload/finalize/route.ts
@@ -39,14 +39,14 @@ const OPERATOR_EMAIL =
  * Finalizes a discovery document upload by transitioning the case to "submitted"
  * status and sending notification emails to both the operator and the customer.
  *
- * @param req - JSON body with: caseId (required), email (optional, for ownership verification)
+ * @param req - JSON body with: caseId (required), email (required, for ownership verification)
  * @returns JSON with { success: true } on success, or { success: true, message: "Already submitted" } if idempotent
  */
 export async function POST(req: NextRequest) {
   try {
-    const supabaseRL = createAdminClient();
+    const supabase = createAdminClient();
     const ip = getClientIp(req);
-    const { limited } = await checkRateLimit(supabaseRL, `finalize:${ip}`, 10, 300);
+    const { limited } = await checkRateLimit(supabase, `finalize:${ip}`, 10, 300);
     if (limited) return NextResponse.json({ error: "Too many requests" }, { status: 429 });
 
     let body;
@@ -79,8 +79,6 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    const supabase = createAdminClient();
-
     // =========================================================================
     // 1. CASE VALIDATION
     // Verify the case exists and load its current state. We need file_urls to
@@ -101,10 +99,9 @@ export async function POST(req: NextRequest) {
 
     // =========================================================================
     // 2. OWNERSHIP CHECK
-    // If an email is provided, it must match the case's email. This prevents
-    // someone from finalizing another customer's case. The email param is
-    // optional here (unlike the upload endpoint) because the finalize button
-    // may be called from a context where email is already verified client-side.
+    // The email in the request must match the email on the case record. This
+    // prevents someone from finalizing another customer's case. Email is
+    // required (validated above) and verified case-insensitively.
     // =========================================================================
     if (caseRecord.email.toLowerCase() !== email.toLowerCase().trim()) {
       return NextResponse.json(


### PR DESCRIPTION
## Summary

Two related cleanups in `src/app/api/upload/finalize/route.ts`:

1. **Dedup admin client.** `supabaseRL` was created for rate limiting then immediately superseded by `supabase`. Merged into one `createAdminClient()` call.
2. **Fix stale email-optional comment.** JSDoc and section 2 comment said email is optional; in practice it is required. Comment now matches reality.

Net: -9 / +6 lines, single file, no behavior change.

## Origin

Orphan commit `88506509` (authored 2026-04-09) salvaged from local branch `atlas/improve-2026-04-09` during 2026-04-23 crash-recovery triage. Backed up at `rescue/atlas-improve-2026-04-09` on origin.

## Test plan

- [x] Pre-commit tsc — clean
- [ ] Upload finalize endpoint smoke test (via existing intake flow)

Generated with Claude Code