### PR TITLE
docs(architecture): fix invariant #14 drift — cite live cron enforcement

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -40,7 +40,7 @@ Properties that MUST hold system-wide. Violating any of these is a critical defe
 
 13. **Verification-URL HARD rule for legal data.** Every case-law citation, statute section, or "good-law" claim stored by the system carries a verification URL in `source_urls[]`. Any claim without a URL is treated as fabricated and cannot pass the Phase 2 whitelist. `formatOrdinal` duplicated Deno/Node by necessity — locked by `format-ordinal-parity.test.ts`.
 
-14. **Cold-email isolation.** Primary brand domains (`imnotanattorney.com`, `inaa.com`, `tastedrop.com`, `cloudculture.com`, `myculture.cloud`) may NEVER be the FROM address of bounce-verification probes, cold outreach, or any batch send with >5% bounce risk. Enforced in `scraping/bounce-verify*.mjs` via `FORBIDDEN_DOMAINS` blocklist + env-var requirement; cron `/api/cron/rising-precedent-alerts` reads `RESEND_FROM_EMAIL` and fatal-exits if it matches any primary domain.
+14. **Cold-email isolation.** Primary brand domains (`imnotanattorney.com`, `inaa.com`, `tastedrop.com`, `cloudculture.com`, `myculture.cloud`) may NEVER be the FROM address of bounce-verification probes, cold outreach, or any batch send with >5% bounce risk. Enforced live via `FORBIDDEN_FROM_DOMAINS` constant in `src/app/api/cron/rising-precedent-alerts/route.ts` (lines 78-89) + `isForbiddenFromAddress()` guard on every send. Source rule: `~/.claude/rules/never-cold-email-from-primary-domain.md`.
 
 ## Component Map
 


### PR DESCRIPTION
## Summary

ARCHITECTURE.md invariant #14 (Cold-email isolation) cited `scraping/bounce-verify*.mjs` + `FORBIDDEN_DOMAINS` — but those files and that literal don't exist in any ecosystem repo. The scripts were removed or never landed in-repo; docs never got updated.

Fix: replace stale reference with the actual live enforcement path (`src/app/api/cron/rising-precedent-alerts/route.ts` lines 78-89 + `isForbiddenFromAddress()` helper).

## Verification

- `Glob scraping/bounce-verify*.mjs` across web + parent + engine repos → **0 matches**
- `Grep FORBIDDEN_DOMAINS|bounce-verify` across web + parent + engine → **1 match** (ARCHITECTURE.md itself, same line being fixed)
- `Read src/app/api/cron/rising-precedent-alerts/route.ts:78-89` → confirms `FORBIDDEN_FROM_DOMAINS` constant + `isForbiddenFromAddress()` guard exist under those names
- Source rule `~/.claude/rules/never-cold-email-from-primary-domain.md` also cited `scraping/bounce-verify*.mjs`; that rule file lives globally outside these repos and could be updated separately if desired (not in this PR's scope)

## Why this matters

Invariants are load-bearing for every future session's mental model. A stale invariant wastes reader time (they grep for files that don't exist) and erodes trust in the rest of the doc. Surgical one-line fix keeps invariant #14 accurate to the current code.

## Diff

```
-14. ... Enforced in `scraping/bounce-verify*.mjs` via `FORBIDDEN_DOMAINS` blocklist + env-var requirement; cron `/api/cron/rising-precedent-alerts` reads `RESEND_FROM_EMAIL` and fatal-exits if it matches any primary domain.
+14. ... Enforced live via `FORBIDDEN_FROM_DOMAINS` constant in `src/app/api/cron/rising-precedent-alerts/route.ts` (lines 78-89) + `isForbiddenFromAddress()` guard on every send. Source rule: `~/.claude/rules/never-cold-email-from-primary-domain.md`.
```

1 line changed, docs-only, zero code impact.

## Test plan

- [x] `/scripts/` and `/scraping/` confirmed absent before editing
- [x] Actual enforcement file + line numbers verified against live code
- [x] No src/ changes → pre-push hook correctly skipped build gate
- [ ] CI: Docs Freshness check (runs on push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)