### PR TITLE
docs(architecture): refresh stale counts — Component Map + System Overview

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -6,7 +6,7 @@
 
 ## System Overview
 
-Legal empowerment platform for criminal defendants. "We Research. You Ask." Combines a content funnel (60 MDX blog posts, free ungated resources, Plea Analyzer acquisition wedge) with e-commerce (8 playbooks at $127/$147, 5 service tiers at $197–$9,997, 44 standalone products, 32 paid $97–$497, 12 free, across 4 categories) and automated case processing (Claude AI report generation). Live at imnotanattorney.com.
+Legal empowerment platform for criminal defendants. "We Research. You Ask." Combines a content funnel (60 MDX blog posts, free ungated resources, Plea Analyzer acquisition wedge) with e-commerce (8 playbooks at $127/$147, 5 service tiers at $197–$9,997, 49 standalone products, 35 paid $97–$497, 14 free, across 4 categories) and automated case processing (Claude AI report generation). Live at imnotanattorney.com.
 
 One of three repos in the INAA ecosystem: `ImNotAnAttorney` (business docs/templates), `ImNotAnAttorney-web` (this, customer-facing), `ImNotAnAttorney-engine` (background job workers). All three share the same Supabase database.
 
@@ -46,13 +46,13 @@ Properties that MUST hold system-wide. Violating any of these is a critical defe
 
 | Subsystem | What It Does | Details |
 |---------, |-------------|---------|
-| **Pages & Routes** | 90+ pages + 130+ API routes (App Router) — added /pji, /pji/[circuit], /pji/[circuit]/[instruction], /assault-defense[/state], /drug-possession-defense[/state], /domestic-violence-defense[/state], /admin/tier-generation, /tools/scotus-case-search, /research/defense-score-data, /district-court-intelligence | [`src/app/CONTEXT.md`](src/app/CONTEXT.md) |
+| **Pages & Routes** | 80+ pages + 120+ API routes (App Router) — added /pji, /pji/[circuit], /pji/[circuit]/[instruction], /assault-defense[/state], /drug-possession-defense[/state], /domestic-violence-defense[/state], /admin/tier-generation, /tools/scotus-case-search, /research/defense-score-data, /district-court-intelligence | [`src/app/CONTEXT.md`](src/app/CONTEXT.md) |
 | **Core Business Logic** | Auth, payments, email, cron, reports, scoring, sanitization, **Phase 2 cite-tag transform + entity whitelist + badge renderer** | [`src/lib/CONTEXT.md`](src/lib/CONTEXT.md) |
-| **Standalone Products** | 44 active: calculators (incl. Federal Sentencing Distribution $297 + SCOTUS Case Search), content guides, research reports, bundles | `src/lib/products.ts` + `src/lib/bundles.ts` |
-| **UI Components** | 45+ components + `ReportVerificationFooter` (live confidence-tier head count from `v_entity_confidence`) + `RelatedStateCharges` (pSEO cross-state linking) | [`src/components/CONTEXT.md`](src/components/CONTEXT.md) |
-| **Database** | 90+ tables (post-USSC + PJI + JUSTFAIR + Vera + Marshall + SCOTUS + FARS + DPIC + police_stops + attorney_discipline + 9 tier-ladder derivation tables + 5 judge-fingerprint tables + v_entity_confidence matview), 80+ migrations, `generate-report` Edge Function, storage buckets | [`supabase/CONTEXT.md`](supabase/CONTEXT.md) |
+| **Standalone Products** | 49 active (59 total, 10 inactive): calculators (incl. Federal Sentencing Distribution $297 + SCOTUS Case Search), content guides, research reports, bundles | `src/lib/products.ts` + `src/lib/bundles.ts` |
+| **UI Components** | 80+ components + `ReportVerificationFooter` (live confidence-tier head count from `v_entity_confidence`) + `RelatedStateCharges` (pSEO cross-state linking) | [`src/components/CONTEXT.md`](src/components/CONTEXT.md) |
+| **Database** | 90+ tables (post-USSC + PJI + JUSTFAIR + Vera + Marshall + SCOTUS + FARS + DPIC + police_stops + attorney_discipline + 9 tier-ladder derivation tables + 5 judge-fingerprint tables + v_entity_confidence matview), 140+ migrations, `generate-report` Edge Function, storage buckets | [`supabase/CONTEXT.md`](supabase/CONTEXT.md) |
 | **Content** | 60+ MDX blog posts + social content queue + 50-state pSEO pages (dui / drug-possession / assault / domestic-violence) | [`content/CONTEXT.md`](content/CONTEXT.md) |
-| **Scripts** | 80+ utilities: cron setup, legal research, Playwright E2E, bulk-loaders (CL / USSC / FJC / Vera / JUSTFAIR / PJI / SCOTUS / open-policing / FARS / DPIC / attorney-discipline), judge-fingerprint v3 builders, Phase 2 matview refresh, tier-ladder retroactive-regen, derivation pipelines | [`scripts/CONTEXT.md`](scripts/CONTEXT.md) |
+| **Scripts** | 220+ utilities: cron setup, legal research, Playwright E2E, bulk-loaders (CL / USSC / FJC / Vera / JUSTFAIR / PJI / SCOTUS / open-policing / FARS / DPIC / attorney-discipline), judge-fingerprint v3 builders, Phase 2 matview refresh, tier-ladder retroactive-regen, derivation pipelines | [`scripts/CONTEXT.md`](scripts/CONTEXT.md) |
 | **Playbook System** | 8 configurable sales pages (1 component, 8 configs) | [`PLAYBOOK-ARCHITECTURE.md`](PLAYBOOK-ARCHITECTURE.md) |
 | **Design System** | Brand tokens: Amber + Navy on black, Playfair + Lato. Phase 2 adds 6 confidence-tier CSS classes (platinum / gold / verified / cross-verified / high / medium + top-tier alias) | [`design-system/brand.md`](design-system/brand.md) |
 | **Per-Tier Generation Mode** | `tier_generation_config` table (mechanical/hybrid/session/api) + `cases.generator_mode` + `cases.generator_cost_usd` + `cases.session_generation_payload` + admin UI at `/admin/tier-generation` + paste-back `/api/admin/session-report/:case_id` | `src/lib/report/mode-config.ts`, `src/lib/report/mechanical/`, `src/lib/report/hybrid/`, `src/app/api/reports/{mechanical,hybrid}/` |


### PR DESCRIPTION
## Summary

Audited counts claimed in ARCHITECTURE.md against actual repo state. Found 2 literally false claims + 6 stale lower-bound claims. Refreshed all.

## Drift table

| Subsystem | Old claim | Actual | Status |
|-----------|-----------|--------|--------|
| Pages | `90+` | **82** | FALSE (overcount) |
| API routes | `130+` | **120** | FALSE (overcount) |
| Components | `45+` | **80** | stale lower-bound |
| DB migration files | `80+` | **140** | stale lower-bound |
| Scripts | `80+` | **225** | stale lower-bound |
| Standalone active | `44` | **49** | stale |
| Standalone paid | `32` | **35** | stale |
| Standalone free | `12` | **14** | stale |

## Why this matters

Stale counts in ARCHITECTURE.md waste reader time and erode trust. "90+ pages" is specifically harmful because it implies growth since last refresh when actual count dropped to 82 (probably from the Session B stale-branch cleanup that deleted duplicate page trees). "Scripts: 80+" being actual 225 means the doc was last sized ~4 months ago.

## Verification

All counts derived via PowerShell `Get-ChildItem ... | Measure-Object`:
- Pages: `src/app` recursive `page.tsx` → 82
- API routes: `src/app/api` recursive `route.ts` → 120
- Components: `src/components` recursive `*.tsx` → 80
- DB migration files: `supabase/migrations/*.sql` → 140
- Scripts: `scripts` recursive `{mjs,js,ts,py}` → 225
- Standalone products: Grep `isActive: true` in `src/lib/products.ts` → 49; Grep `price: 0,` → 14 free, therefore 35 paid

## Scope

- Blog count (`60 MDX blog posts`) left untouched — blog-scope is owned by other sessions; blog-count refresh belongs in a PR from that scope.

## Diff

6 line changes in ARCHITECTURE.md, docs-only, zero code impact.

## Test plan

- [x] Each count verified via Get-ChildItem + Measure-Object against live repo
- [x] No src/ changes → pre-push hook skipped build gate
- [ ] CI: Docs Freshness (runs on push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)