### PR TITLE
docs(scripts): refresh stale count — 40+ → 220+ utilities

### DIFF
--- a/scripts/CONTEXT.md
+++ b/scripts/CONTEXT.md
@@ -1,6 +1,6 @@
 # Scripts, scripts/
 
-> 40+ utility scripts: cron setup, tier validation, report backup, legal research, charge taxonomy generation, enrichment pipelines, E2E tests, QA purchase flow, social scheduling.
+> 220+ utility scripts: cron setup, tier validation, report backup, legal research, charge taxonomy generation, enrichment pipelines, E2E tests, QA purchase flow, social scheduling, bulk-loaders (CL / USSC / FJC / Vera / JUSTFAIR / PJI / SCOTUS / open-policing / FARS / DPIC / attorney-discipline), judge-fingerprint v3 builders, Phase 2 matview refresh, tier-ladder retroactive-regen, derivation pipelines. Inventory below is curated (scripts with dedicated categories); recent bulk-loaders + derivation pipelines are catalogued in ARCHITECTURE.md Component Map Scripts row.
 
 ## Script Inventory
 


### PR DESCRIPTION
## Summary

`scripts/CONTEXT.md` header said "40+ utility scripts" — actual count is 225. Pairs with PR #76 (ARCHITECTURE.md count refresh) — different file, same drift.

## Verification

```
Get-ChildItem scripts -Recurse -Include *.mjs,*.js,*.ts,*.py | Measure-Object
# → 225
```

## Fix

- Header: `40+` → `220+`
- Category list: expanded to match ARCHITECTURE.md Component Map Scripts row (bulk-loaders, judge-fingerprint v3 builders, Phase 2 matview refresh, tier-ladder retroactive-regen, derivation pipelines)
- Added cross-reference: "Inventory below is curated (scripts with dedicated categories); recent bulk-loaders + derivation pipelines are catalogued in ARCHITECTURE.md Component Map Scripts row."

The Script Inventory tables below the header are untouched — they list the original/well-known scripts and remain accurate for what they cover. The 180-odd bulk/derivation scripts are category-catalogued upstream in ARCHITECTURE.md rather than individually listed here (would balloon the file).

## Diff

1 line changed, docs-only.

## Test plan

- [x] Count verified via PowerShell Get-ChildItem
- [x] No src/ changes → pre-push hook skipped build gate
- [ ] CI: Docs Freshness (runs on push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)