### PR TITLE
docs(context): refresh stale counts across 3 subsystem CONTEXT.md files

### DIFF
--- a/src/app/CONTEXT.md
+++ b/src/app/CONTEXT.md
@@ -1,6 +1,6 @@
 # Pages & Routes, src/app/
 
-> Next.js App Router: 58 pages and 80 API routes. All routes are server components by default; client components marked `"use client"`.
+> Next.js App Router: 82 pages and 120 API routes. All routes are server components by default; client components marked `"use client"`.
 
 ## Page Map
 

--- a/src/components/CONTEXT.md
+++ b/src/components/CONTEXT.md
@@ -1,6 +1,6 @@
 # UI Components, src/components/
 
-> 45 React components. Server Components by default; client components marked `"use client"` for interactivity.
+> 80 React components. Server Components by default; client components marked `"use client"` for interactivity.
 
 ## Component Groups
 

--- a/supabase/CONTEXT.md
+++ b/supabase/CONTEXT.md
@@ -1,6 +1,6 @@
 # Database Layer, supabase/
 
-> Supabase PostgreSQL: 50+ tables, 41 sequential migrations, RLS policies, 3 Edge Functions, and 3 storage buckets. Shared by all three INAA repos (web, engine, business-docs).
+> Supabase PostgreSQL: 90+ tables, 140+ migrations, RLS policies, 3 Edge Functions, and 3 storage buckets. Shared by all three INAA repos (web, engine, business-docs).
 
 ## Schema Overview
 


### PR DESCRIPTION
## Summary

Same drift pattern as PR #76 (ARCHITECTURE.md counts) and PR #78 (`scripts/CONTEXT.md` 40+ → 220+). Three additional subsystem CONTEXT.md files had stale opening-paragraph counts:

| File | Old claim | Actual | Delta |
|------|-----------|--------|-------|
| `src/app/CONTEXT.md` | 58 pages + 80 API routes | 82 + 120 | +24 / +40 |
| `src/components/CONTEXT.md` | 45 React components | 80 | +35 |
| `supabase/CONTEXT.md` | 50+ tables + 41 migrations | 90+ tables + 140+ migrations | +40 / +99 |

## Verification

PowerShell `Get-ChildItem | Measure-Object` on repo:

| Subsystem | Path + filter | Count |
|-----------|---------------|-------|
| Pages | `src/app` recursive `page.tsx` | 82 |
| API routes | `src/app/api` recursive `route.ts` | 120 |
| Components | `src/components` recursive `*.tsx` | 80 |
| DB migration files | `supabase/migrations/*.sql` | 140 |

Table count (`90+`) is trusted from ARCHITECTURE.md (already asserted there); not independently verified via DB query in this PR.

## Note on SKIP_BUILD

Pre-push hook triggered `next build` because CONTEXT.md files live under `src/`. The worktree has no `node_modules`, build can't run. Change is 3 lines of markdown, zero code touched — hook is false-positive on docs-only `src/` changes. Used `SKIP_BUILD=1` escape as documented by the hook itself. Vercel preview will do the actual build on PR.

Follow-up: consider tightening the pre-push hook to distinguish code changes from markdown changes under `src/`. Out of scope for this PR.

## Diff

3 lines changed across 3 files, docs-only.

## Test plan

- [x] Each count verified against live repo via Get-ChildItem + Measure-Object
- [x] SKIP_BUILD=1 justified (docs-only change, worktree lacks node_modules)
- [ ] CI: Vercel preview runs actual build

🤖 Generated with [Claude Code](https://claude.com/claude-code)