### PR TITLE
fix(pji): extend drift-check cron to circuits 5 + 11

### DIFF
--- a/src/app/api/cron/refresh-pji/route.ts
+++ b/src/app/api/cron/refresh-pji/route.ts
@@ -22,13 +22,19 @@ export const maxDuration = 60;
 
 const ALLOWED_HOST_SUFFIX = ".uscourts.gov";
 
+// Source of truth: scripts/ingest/pji-ingest.mjs SOURCES array. Update here
+// when adding a circuit with a single canonical aggregate PDF.
+// 3rd Circuit is NOT included — it publishes 25+ chapter/offense PDFs with
+// different SHAs per row; drift-tracking by (circuit, source_url) is future work.
 const CIRCUIT_URLS: { circuit: number; url: string }[] = [
   { circuit: 1, url: "https://www.rid.uscourts.gov/sites/rid/files/documents/juryinstructions/PJI.pdf" },
+  { circuit: 5, url: "https://www.lb5.uscourts.gov/juryinstructions/Fifth/PJI-CRIMINAL_2024_EDITION_FINAL.pdf" },
   { circuit: 6, url: "https://www.ca6.uscourts.gov/sites/ca6/files/documents/pattern_jury/pdf/crmpattjur_full.pdf" },
   { circuit: 7, url: "https://juryinstruction.ca7.uscourts.gov/jury-instructions/instructions/criminal/Bauer_pattern_criminal_jury_instructions_2022updates.pdf" },
   { circuit: 8, url: "https://juryinstructions.ca8.uscourts.gov/instructions/criminal/Criminal-Jury-Instructions.pdf" },
   { circuit: 9, url: "https://www.ce9.uscourts.gov/jury-instructions/sites/default/files/WPD/Criminal_Instructions_2025_03.pdf" },
   { circuit: 10, url: "https://www.ca10.uscourts.gov/sites/ca10/files/documents/downloads/2025%20Criminal%20Pattern%20Jury%20Instructions.pdf" },
+  { circuit: 11, url: "https://www.ca11.uscourts.gov/sites/default/files/courtdocs/clk/FormCriminalPatternJuryInstructionsCurrentComplete.pdf" },
 ];
 
 function isAllowedHost(url: string): boolean {


### PR DESCRIPTION
## Summary

- Extend `/api/cron/refresh-pji` `CIRCUIT_URLS` from 6/9 circuits (1, 6, 7, 8, 9, 10) to 8/9 circuits (+ 5, + 11).
- Closes a gap introduced by PR #33: `pattern_jury_instructions` grew to 9 circuits (1,808 rows) but the drift-check cron was never updated, so 5th + 11th circuit PDFs were silently unmonitored for source-PDF drift.
- 3rd Circuit intentionally excluded: ca3 publishes 25+ per-chapter/per-offense PDFs with distinct SHAs per row; drift-tracking by `(circuit, source_url)` requires a data-model change and is out of scope for this fix.

## Verification

- [x] Both new URLs HEAD-verified 200 live before commit.
- [x] Both pass existing SSRF allowlist (`*.uscourts.gov`): `www.lb5.uscourts.gov`, `www.ca11.uscourts.gov`.
- [x] Typecheck clean (`./node_modules/.bin/tsc --noEmit --skipLibCheck` exit 0).
- [x] Pre-push hook build succeeded (webpack compile, 36.0s).
- [x] Live-tested the current 6-circuit version before change: all 6 return stored=current SHA, 0 drift, 0 dead links.

## Test plan

- [ ] Preview deploy: hit `/api/cron/refresh-pji` with `Authorization: Bearer $CRON_AUTH_TOKEN` and verify JSON returns 8 circuits in `results[]` with `drifted_count: 0`.
- [ ] Confirm SHAs for 5th + 11th match the values stored in `pattern_jury_instructions.source_pdf_sha256` for those circuits (zero drift on first run).
- [ ] Cron job 7508991 on cron-job.org is already enabled (re-enabled 2026-04-24); next scheduled run 2026-07-15 08:00 UTC picks up the new circuits automatically.

## Follow-up (not this PR)

- 3rd Circuit monitoring: needs `(circuit, source_url)` drift model. Tracked as next iteration after this lands.
- Consider source-of-truth unification: factor the URL list into a shared module importable by both `scripts/ingest/pji-ingest.mjs` and this route, so future circuit additions happen in one place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)