### PR TITLE
docs(playbook): fix stale live-status claim — all 8 configs live

### DIFF
--- a/PLAYBOOK-ARCHITECTURE.md
+++ b/PLAYBOOK-ARCHITECTURE.md
@@ -1,12 +1,12 @@
 # Playbook Landing Page Architecture
 
-**Last Updated:** 2026-03-26
+**Last Updated:** 2026-04-24 (live-status refresh)
 
 ## Overview
 
 The INAA-web playbook system is a modular, data-driven architecture for creating charge-specific defense playbook sales pages. All pages share the same layout component (`PlaybookSalesPage.tsx`), configured via data objects in `playbook-configs.ts`.
 
-**Current Status:** 8 playbook configs defined. DUI First Offense is `live: true`; others in test mode.
+**Current Status:** All 8 playbook configs `live: true` — first-offense DUI flipped live 2026-03-24, remaining 7 flipped 2026-03-25 per `src/lib/tiers.ts` `// LIVE` annotations on each tier entry.
 
 ---
 


### PR DESCRIPTION
## Summary

PLAYBOOK-ARCHITECTURE.md opening status said:

> 8 playbook configs defined. DUI First Offense is `live: true`; others in test mode.

Stale since 2026-03-25 when the other 7 tiers flipped live. All 8 playbooks are now live in Stripe.

## Verification

Grep `live:` in `src/lib/tiers.ts` → 20 live, 1 test (non-playbook). The 8 playbook tier entries (lines 46/63/80/97/114/131/148/165) each carry a `// LIVE, YYYY-MM-DD` annotation:

- First-Offense DUI: LIVE 2026-03-24
- Other 7 playbooks: LIVE 2026-03-25

## Fix

- **Current Status** line rewritten: `All 8 playbook configs live: true` with explicit dates
- **Last Updated** bumped to 2026-04-24

## Diff

2 lines changed, docs-only.

## Test plan

- [x] tiers.ts live annotations verified for all 8 playbook slugs
- [x] No src/ changes → pre-push hook skipped build gate
- [ ] CI: Docs Freshness (runs on push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)