### PR TITLE
fix(pji): bypass PostgREST 1000-row cap in drift-check stored-SHA lookup

### DIFF
--- a/src/app/api/cron/refresh-pji/route.ts
+++ b/src/app/api/cron/refresh-pji/route.ts
@@ -100,15 +100,22 @@ export async function GET(req: NextRequest) {
   if (!authed.authorized) return authed.error;
 
   const supabase = createAdminClient();
-  const { data: storedRows, error: storedErr } = await supabase
-    .from("pattern_jury_instructions")
-    .select("circuit, source_pdf_sha256")
-    .not("source_pdf_sha256", "is", null);
-  if (storedErr) return NextResponse.json({ error: storedErr.message }, { status: 500 });
-
+  // Fetch stored SHA per monitored circuit via one-row-per-circuit lookups.
+  // A single bulk query hits the PostgREST 1000-row cap (pattern_jury_instructions
+  // is >1,800 rows); circuits past the cutoff (e.g. 11, added last) silently miss
+  // their stored_sha and drift detection degrades to dead-link-only. One query
+  // per circuit (N=8) is O(N) but sidesteps the cap cleanly.
   const storedMap = new Map<number, string>();
-  for (const r of storedRows ?? []) {
-    if (r.source_pdf_sha256 && !storedMap.has(r.circuit)) storedMap.set(r.circuit, r.source_pdf_sha256);
+  for (const cir of CIRCUIT_URLS) {
+    const { data: row, error } = await supabase
+      .from("pattern_jury_instructions")
+      .select("source_pdf_sha256")
+      .eq("circuit", cir.circuit)
+      .not("source_pdf_sha256", "is", null)
+      .limit(1)
+      .maybeSingle();
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    if (row?.source_pdf_sha256) storedMap.set(cir.circuit, row.source_pdf_sha256);
   }
 
   const results: {


### PR DESCRIPTION
## Summary

Follow-up to #80. The prod smoke-test after #80 exposed a latent bug in `/api/cron/refresh-pji`: circuit 11 (273 rows, last ingested) returned `stored_sha: null` in the response despite all 273 rows carrying a populated `source_pdf_sha256`. Drift detection for circuit 11 had silently degraded to dead-link-only.

## Root cause

`SELECT circuit, source_pdf_sha256 FROM pattern_jury_instructions WHERE source_pdf_sha256 IS NOT NULL` hits the Supabase/PostgREST hard 1000-row cap (`cl-bulk-data-defensive.md` gotcha #5 / `MEMORY.md` index entry). `pattern_jury_instructions` has 1,806 populated rows. The server returns the first 1000 by PK order, dropping rows after that — including all 273 rows for circuit 11.

Empirically verified in a standalone client against prod:

```
rows returned: 1000 (count: 1806)
by circuit: { 1: 69, 3: 36, 5: 17, 6: 136, 7: 65, 8: 134, 9: 396, 10: 147 }
```

Circuit 11 entirely absent. Circuit 5 undercounted (17/251 populated). Adding `.range(0, 4999)` did not help — the cap is server-enforced.

## Fix

Replace the single bulk `.select().not()` with N=8 per-circuit lookups: `.eq("circuit", c).limit(1).maybeSingle()`, one per entry in `CIRCUIT_URLS`. Each query returns at most 1 row, nowhere near the 1000-row cap. Runtime impact: 8 sequential queries add ~1-2s on a cron that runs quarterly.

## Verification

- [x] Typecheck clean.
- [x] Pre-push webpack build passed.
- [ ] Preview deploy: hit `/api/cron/refresh-pji` with `Authorization: Bearer $CRON_AUTH_TOKEN`. Expect 8 circuits with `stored_sha` non-null for every circuit. Specifically: circuit 11 `stored_sha` should equal `d59474e1304917a20ca86af1fc952a194c053868555de7508629a07f84e068b4`.
- [ ] Expect `drifted_count: 0` and `dead_link_count: 0`.

## Context

PR #80 shipped ~30 min ago (extended `CIRCUIT_URLS` from 6 to 8 circuits). Without this follow-up, the expanded coverage from #80 is only half-effective: the new circuits get fetched + SHA-computed but can't be compared against a stored value, so drift would never be flagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)