### PR TITLE
feat(per-tier-mode): rebuild orphaned per-tier generation-mode dispatcher

### DIFF
--- a/scripts/generate-session-handoff.mjs
+++ b/scripts/generate-session-handoff.mjs
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+/**
+ * generate-session-handoff.mjs
+ *
+ * Given a caseId, emits a Claude Code session prompt to stdout
+ * containing the case's intake + tier context. Operator pastes the
+ * prompt into a fresh Claude Code session, runs it by hand, then POSTs
+ * the final HTML to /api/admin/session-report/<caseId>.
+ *
+ * Referenced by /api/cron/notify-session-handoff as the manual handoff
+ * CLI. Zero side effects — read-only DB query + stdout.
+ *
+ * Usage:
+ *   node scripts/generate-session-handoff.mjs <caseId>
+ */
+import { createClient } from "@supabase/supabase-js";
+import fs from "node:fs";
+import path from "node:path";
+
+function loadEnvLocal() {
+  const p = path.resolve(process.cwd(), ".env.local");
+  if (!fs.existsSync(p)) return;
+  const raw = fs.readFileSync(p, "utf8");
+  for (const line of raw.split(/\r?\n/)) {
+    const m = /^([A-Z0-9_]+)=(.*)$/.exec(line);
+    if (!m) continue;
+    const [, k, v] = m;
+    if (!(k in process.env)) process.env[k] = v;
+  }
+}
+
+function die(msg, code = 1) {
+  process.stderr.write(`[generate-session-handoff] ${msg}\n`);
+  process.exit(code);
+}
+
+async function main() {
+  const caseId = process.argv[2];
+  if (!caseId) die("usage: node scripts/generate-session-handoff.mjs <caseId>");
+
+  loadEnvLocal();
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) die("NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY missing");
+
+  const sb = createClient(url, key, { auth: { persistSession: false } });
+
+  const { data: caseRow, error: caseErr } = await sb
+    .from("cases")
+    .select("id, tier, intake_id, status")
+    .eq("id", caseId)
+    .maybeSingle();
+  if (caseErr) die(`case fetch error: ${caseErr.message}`);
+  if (!caseRow) die(`case not found: ${caseId}`);
+
+  const { data: intake, error: intakeErr } = await sb
+    .from("intakes")
+    .select("*")
+    .eq("id", caseRow.intake_id)
+    .maybeSingle();
+  if (intakeErr) die(`intake fetch error: ${intakeErr.message}`);
+  if (!intake) die(`intake not found for case ${caseId}`);
+
+  const prompt = `You are generating a ${caseRow.tier} report for ImNotAnAttorney.
+
+CONTEXT:
+- Case ID: ${caseRow.id}
+- Tier: ${caseRow.tier}
+- Intake ID: ${caseRow.intake_id}
+
+INTAKE (as provided by the defendant):
+\`\`\`json
+${JSON.stringify(intake, null, 2)}
+\`\`\`
+
+INSTRUCTIONS:
+1. Read ImNotAnAttorney/system/templates/ for the current report template for tier "${caseRow.tier}".
+2. Read ImNotAnAttorney/.claude/rules/atti-persona.md + content-rules.md for voice + UPL constraints.
+3. Generate the full report as HTML (no markdown). Use existing Phase 2 <cite data-entity-id="..."> tags for legal references — the sanitizer strips any unverified cites.
+4. UPL hard rules: never "you should" / "we recommend" / "your best option". Use "consider" / "one option is" / "questions to explore".
+5. Never mention AI, Claude, LLM, algorithms, automated analysis.
+6. When the HTML is ready, POST it to the prod admin endpoint:
+
+\`\`\`
+curl -X POST https://imnotanattorney.com/api/admin/session-report/${caseRow.id} \\
+  -H "X-Admin-Password: $ADMIN_PASSWORD" \\
+  -H "Content-Type: application/json" \\
+  --data-raw '{"report_html":"<!-- paste final HTML here -->"}'
+\`\`\`
+
+Success criterion: 200 OK with {"delivered":true,"caseId":"${caseRow.id}","mode":"session"}.`;
+
+  process.stdout.write(prompt);
+  process.stdout.write("\n");
+}
+
+main().catch((err) => {
+  process.stderr.write(`[generate-session-handoff] unhandled: ${err instanceof Error ? err.message : String(err)}\n`);
+  process.exit(1);
+});

--- a/src/app/admin/tier-generation/TierModeForm.tsx
+++ b/src/app/admin/tier-generation/TierModeForm.tsx
@@ -1,0 +1,89 @@
+"use client";
+/**
+ * Client component: mode dropdown + notes field + Save button.
+ *
+ * POSTs to /api/admin/tier-generation-config with X-Admin-Password.
+ * Password pulled from localStorage (set by login flow elsewhere in
+ * /admin/*) — same pattern as existing admin forms.
+ */
+import { useState } from "react";
+
+type Props = {
+  tierSlug: string;
+  currentMode: string;
+  currentNotes: string;
+};
+
+const MODES = ["api", "mechanical", "hybrid", "session"] as const;
+
+export default function TierModeForm({ tierSlug, currentMode, currentNotes }: Props) {
+  const [mode, setMode] = useState(currentMode);
+  const [notes, setNotes] = useState(currentNotes);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [saved, setSaved] = useState(false);
+
+  async function save() {
+    setSaving(true);
+    setError(null);
+    setSaved(false);
+    try {
+      const pw =
+        typeof window !== "undefined"
+          ? window.localStorage.getItem("admin_password") ?? ""
+          : "";
+      const r = await fetch("/api/admin/tier-generation-config", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Admin-Password": pw,
+        },
+        body: JSON.stringify({ tier_slug: tierSlug, mode, notes }),
+      });
+      if (!r.ok) {
+        const j = await r.json().catch(() => ({ error: `http-${r.status}` }));
+        throw new Error(typeof j.error === "string" ? j.error : `http-${r.status}`);
+      }
+      setSaved(true);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const dirty = mode !== currentMode || notes !== currentNotes;
+
+  return (
+    <div className="flex items-start gap-2">
+      <select
+        value={mode}
+        onChange={(e) => setMode(e.target.value)}
+        className="bg-neutral-800 border border-neutral-700 rounded px-2 py-1"
+        disabled={saving}
+      >
+        {MODES.map((m) => (
+          <option key={m} value={m}>
+            {m}
+          </option>
+        ))}
+      </select>
+      <input
+        value={notes}
+        onChange={(e) => setNotes(e.target.value)}
+        placeholder="notes"
+        className="bg-neutral-800 border border-neutral-700 rounded px-2 py-1 text-xs w-48"
+        disabled={saving}
+      />
+      <button
+        onClick={save}
+        disabled={!dirty || saving}
+        className="px-3 py-1 bg-blue-600 hover:bg-blue-500 disabled:bg-neutral-700 disabled:text-neutral-500 rounded text-sm"
+      >
+        {saving ? "Saving..." : "Save"}
+      </button>
+      {saved && <span className="text-green-400 text-xs self-center">saved</span>}
+      {error && <span className="text-red-400 text-xs self-center">{error}</span>}
+    </div>
+  );
+}

--- a/src/app/admin/tier-generation/page.tsx
+++ b/src/app/admin/tier-generation/page.tsx
@@ -1,0 +1,81 @@
+/**
+ * Admin UI: /admin/tier-generation
+ *
+ * Server Component. Fetches rows server-side (via admin client) and
+ * renders a table with a client-side dropdown form per row. Flipping
+ * a mode re-hits the POST endpoint below.
+ *
+ * Protected by the standard admin middleware (X-Admin-Password header
+ * on the API endpoint). This page itself is rendered behind the admin
+ * auth layer per existing /admin/* conventions.
+ */
+import { createAdminClient } from "@/lib/supabase/admin";
+import TierModeForm from "./TierModeForm";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+type Row = {
+  tier_slug: string;
+  mode: string;
+  updated_at: string;
+  updated_by: string | null;
+  notes: string | null;
+};
+
+export default async function TierGenerationPage() {
+  const sb = createAdminClient();
+  const { data, error } = await sb
+    .from("tier_generation_config")
+    .select("tier_slug, mode, updated_at, updated_by, notes")
+    .order("tier_slug");
+
+  if (error) {
+    return (
+      <main className="p-8">
+        <h1 className="text-xl font-bold mb-4">Tier Generation Config</h1>
+        <p className="text-red-400">DB error: {error.message}</p>
+      </main>
+    );
+  }
+
+  const rows = (data ?? []) as Row[];
+
+  return (
+    <main className="p-8 max-w-5xl mx-auto">
+      <h1 className="text-xl font-bold mb-2">Tier Generation Config</h1>
+      <p className="text-sm text-neutral-400 mb-6">
+        Per-tier generation-mode switch. Default <code>api</code> = existing Edge
+        Function path. <code>mechanical</code> = HTML skeleton only.{" "}
+        <code>hybrid</code> = skeleton + Haiku per slot. <code>session</code> =
+        operator generates by hand via pasted prompt.
+      </p>
+      <table className="w-full border border-neutral-800 text-sm">
+        <thead className="bg-neutral-900">
+          <tr>
+            <th className="text-left p-2 border-b border-neutral-800">Tier</th>
+            <th className="text-left p-2 border-b border-neutral-800">Mode</th>
+            <th className="text-left p-2 border-b border-neutral-800">Updated</th>
+            <th className="text-left p-2 border-b border-neutral-800">By</th>
+            <th className="text-left p-2 border-b border-neutral-800">Notes</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((r) => (
+            <tr key={r.tier_slug} className="border-b border-neutral-900">
+              <td className="p-2 font-mono">{r.tier_slug}</td>
+              <td className="p-2">
+                <TierModeForm tierSlug={r.tier_slug} currentMode={r.mode} currentNotes={r.notes ?? ""} />
+              </td>
+              <td className="p-2 text-neutral-400">
+                {new Date(r.updated_at).toISOString().replace("T", " ").slice(0, 16)}
+              </td>
+              <td className="p-2 text-neutral-400">{r.updated_by ?? "—"}</td>
+              <td className="p-2 text-neutral-300 truncate max-w-xs">{r.notes ?? ""}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </main>
+  );
+}

--- a/src/app/api/admin/session-report/[caseId]/route.ts
+++ b/src/app/api/admin/session-report/[caseId]/route.ts
@@ -1,0 +1,84 @@
+/**
+ * Session-mode report paste endpoint.
+ *
+ * Rahim runs generate-session-handoff.mjs to get the Claude Code session
+ * prompt, runs it, POSTs the final HTML here. Flips status to delivered,
+ * sends delivery email.
+ *
+ * Plan: docs/plans/2026-04-24-per-tier-generation-mode-rebuild.md
+ */
+import { NextResponse, NextRequest } from "next/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { requireAdmin } from "@/lib/auth/guards";
+import { sendEmail } from "@/lib/email";
+import { caseThreadId } from "@/lib/site";
+
+export const runtime = "nodejs";
+
+export async function POST(
+  req: NextRequest,
+  ctx: { params: Promise<{ caseId: string }> },
+) {
+  const auth = requireAdmin(req);
+  if (!auth.authorized) return auth.error;
+  const { caseId } = await ctx.params;
+  const body = await req.json().catch(() => null);
+  if (!body?.report_html || typeof body.report_html !== "string") {
+    return NextResponse.json(
+      { error: "missing-report-html" },
+      { status: 400 },
+    );
+  }
+  const sb = createAdminClient();
+  const { data: caseRow } = await sb
+    .from("cases")
+    .select("id, tier, status, email")
+    .eq("id", caseId)
+    .maybeSingle();
+  if (!caseRow)
+    return NextResponse.json({ error: "case-not-found" }, { status: 404 });
+  if (caseRow.status !== "awaiting-session-generation") {
+    return NextResponse.json(
+      { error: "wrong-status", actual: caseRow.status },
+      { status: 409 },
+    );
+  }
+  const { error: updateError } = await sb
+    .from("cases")
+    .update({
+      report_html: body.report_html,
+      report_format_version: 2,
+      generator_prompt_version: "2.1.0-session",
+      generator_mode: "session",
+      generator_cost_usd: 0,
+      generator_deployed_at: new Date().toISOString(),
+      status: "delivered",
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", caseId);
+  if (updateError)
+    return NextResponse.json({ error: "db-update-failed" }, { status: 500 });
+  if (caseRow.email) {
+    await sendEmail(
+      {
+        to: caseRow.email,
+        subject: "Your report is ready",
+        unsubscribeEmail: caseRow.email,
+        threadingHeaders: {
+          inReplyTo: caseThreadId(caseId),
+          references: caseThreadId(caseId),
+        },
+        html: `<p>Your ${caseRow.tier} report has been completed by a researcher and is ready to view.</p>`,
+      },
+      {
+        category: "transactional",
+        case_id: caseId,
+        metadata: { tier: caseRow.tier, event: "session-delivered" },
+      },
+    );
+  }
+  return NextResponse.json(
+    { delivered: true, caseId, mode: "session" },
+    { status: 200 },
+  );
+}

--- a/src/app/api/admin/tier-generation-config/route.ts
+++ b/src/app/api/admin/tier-generation-config/route.ts
@@ -1,0 +1,57 @@
+/**
+ * Admin endpoint to flip tier_generation_config.mode per tier.
+ *
+ * GET: list all rows (for admin UI render)
+ * POST: { tier_slug, mode, notes? } — update one row
+ *
+ * Gated by X-Admin-Password (requireAdmin).
+ */
+import { NextResponse, NextRequest } from "next/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { requireAdmin } from "@/lib/auth/guards";
+
+export const runtime = "nodejs";
+
+const VALID_MODES = new Set(["api", "mechanical", "hybrid", "session"]);
+
+export async function GET(req: NextRequest) {
+  const auth = requireAdmin(req);
+  if (!auth.authorized) return auth.error;
+  const sb = createAdminClient();
+  const { data, error } = await sb
+    .from("tier_generation_config")
+    .select("tier_slug, mode, updated_at, updated_by, notes")
+    .order("tier_slug");
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({ rows: data ?? [] });
+}
+
+export async function POST(req: NextRequest) {
+  const auth = requireAdmin(req);
+  if (!auth.authorized) return auth.error;
+  const body = await req.json().catch(() => null);
+  const tier_slug = body?.tier_slug;
+  const mode = body?.mode;
+  const notes = body?.notes;
+  if (typeof tier_slug !== "string" || tier_slug.length === 0) {
+    return NextResponse.json({ error: "missing-tier_slug" }, { status: 400 });
+  }
+  if (typeof mode !== "string" || !VALID_MODES.has(mode)) {
+    return NextResponse.json(
+      { error: "invalid-mode", allowed: [...VALID_MODES] },
+      { status: 400 },
+    );
+  }
+  const sb = createAdminClient();
+  const { error } = await sb
+    .from("tier_generation_config")
+    .update({
+      mode,
+      notes: typeof notes === "string" ? notes : null,
+      updated_by: "admin-ui",
+      updated_at: new Date().toISOString(),
+    })
+    .eq("tier_slug", tier_slug);
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({ ok: true, tier_slug, mode });
+}

--- a/src/app/api/cron/notify-session-handoff/route.ts
+++ b/src/app/api/cron/notify-session-handoff/route.ts
@@ -1,0 +1,71 @@
+/**
+ * Telegram notification for session-mode handoff.
+ *
+ * Called by the CD dispatcher after flipping a case to
+ * status='awaiting-session-generation'. Fires a Telegram message with
+ * the exact CLI command + paste-destination URL so Rahim can take over
+ * the generation by hand. Persists notify state on the case row.
+ *
+ * Plan: docs/plans/2026-04-24-per-tier-generation-mode-rebuild.md
+ */
+import { NextResponse, NextRequest } from "next/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { requireCron } from "@/lib/auth/guards";
+
+export const runtime = "nodejs";
+
+export async function POST(req: NextRequest) {
+  const auth = requireCron(req);
+  if (!auth.authorized) return auth.error;
+  const url = new URL(req.url);
+  const caseId = url.searchParams.get("caseId");
+  if (!caseId)
+    return NextResponse.json({ error: "missing-caseId" }, { status: 400 });
+
+  const sb = createAdminClient();
+  const { data } = await sb
+    .from("cases")
+    .select("id, tier, status, session_generation_payload")
+    .eq("id", caseId)
+    .maybeSingle();
+  if (!data)
+    return NextResponse.json({ error: "case-not-found" }, { status: 404 });
+
+  const msg = `Session-gen pending: ${data.tier} order ${data.id}. Run:\n  node C:\\Users\\email\\projects\\ImNotAnAttorney-web\\scripts\\generate-session-handoff.mjs ${data.id}\nPaste output into Claude Code. POST final HTML to /api/admin/session-report/${data.id} with X-Admin-Password header.`;
+  const token = process.env.TELEGRAM_ATLAS_BOT_TOKEN;
+  const chat = process.env.TELEGRAM_CHAT_ID;
+  let notified = false;
+  let failureReason: string | null = null;
+  if (token && chat) {
+    try {
+      const r = await fetch(
+        `https://api.telegram.org/bot${token}/sendMessage`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ chat_id: chat, text: msg }),
+        },
+      );
+      if (r.ok) notified = true;
+      else failureReason = `telegram-${r.status}`;
+    } catch (err) {
+      failureReason = `telegram-exception: ${err instanceof Error ? err.message : String(err)}`;
+    }
+  } else {
+    failureReason = "telegram-env-missing";
+  }
+  const existing =
+    (data.session_generation_payload as Record<string, unknown>) ?? {};
+  const patch = {
+    session_generation_payload: {
+      ...existing,
+      notified_at: notified ? new Date().toISOString() : null,
+      notify_failure_reason: failureReason,
+    },
+  };
+  const { error: patchError } = await sb.from("cases").update(patch).eq("id", caseId);
+  if (patchError)
+    // eslint-disable-next-line no-console
+    console.error("[notify-handoff] failed to persist notify state:", patchError.message);
+  return NextResponse.json({ notified, caseId, failureReason });
+}

--- a/src/app/api/generate/case-decoder/route.ts
+++ b/src/app/api/generate/case-decoder/route.ts
@@ -33,6 +33,7 @@ import { createAdminClient } from "@/lib/supabase/admin";
 import { sendEmail } from "@/lib/email";
 import { caseThreadId } from "@/lib/site";
 import { requireOperatorSecret } from "@/lib/auth/guards";
+import { getTierGenerationMode } from "@/lib/report/mode-config";
 
 /**
  * Thin dispatcher, validates auth + idempotency, then fires off
@@ -130,6 +131,89 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({
       skipped: true,
       message: "Already processing or completed",
+    });
+  }
+
+  // ──────────────────────────────────────────────────────────────
+  // PER-TIER MODE DISPATCH (pre-Edge-Function branch)
+  // ──────────────────────────────────────────────────────────────
+  // Reads tier_generation_config.mode for 'case-decoder'. All tiers
+  // default to 'api' at time of ship, so this falls through to the
+  // existing Edge Function path unchanged. Admin UI (TierModeForm)
+  // flips a tier to mechanical/hybrid/session once dogfooded.
+  //
+  // Failure policy: any non-'api' path failure falls through to the
+  // Edge Function so we never strand a paid case on a flipped mode.
+  // 'session' mode INTENTIONALLY does not fall through — setting
+  // status='awaiting-session-generation' is the desired terminal
+  // state until the operator pastes the final HTML.
+  const mode = await getTierGenerationMode("case-decoder");
+  const fwdBase = new URL(req.url).origin;
+  const fwdHeaders = {
+    Authorization: req.headers.get("authorization") ?? "",
+    "Content-Type": "application/json",
+  };
+
+  if (mode === "mechanical" || mode === "hybrid") {
+    const target = `${fwdBase}/api/reports/${mode}/${caseId}`;
+    try {
+      const r = await fetch(target, { method: "POST", headers: fwdHeaders });
+      if (r.ok) {
+        return NextResponse.json({
+          success: true,
+          caseId,
+          status: "generating",
+          mode,
+          message: `${mode} generation accepted`,
+        });
+      }
+      // eslint-disable-next-line no-console
+      console.error(
+        `[CD-dispatcher] ${mode} path returned ${r.status}; falling through to api`,
+      );
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error(
+        `[CD-dispatcher] ${mode} fetch failed; falling through to api:`,
+        err,
+      );
+    }
+  } else if (mode === "session") {
+    const { error: statusErr } = await supabase
+      .from("cases")
+      .update({
+        status: "awaiting-session-generation",
+        generator_mode: "session",
+        updated_at: new Date().toISOString(),
+      })
+      .eq("id", caseId);
+    if (statusErr) {
+      // eslint-disable-next-line no-console
+      console.error(
+        `[CD-dispatcher] session status flip failed:`,
+        statusErr.message,
+      );
+      return NextResponse.json(
+        { error: "session-flip-failed" },
+        { status: 500 },
+      );
+    }
+    const cronSecret = process.env.CRON_AUTH_TOKEN;
+    if (cronSecret) {
+      fetch(`${fwdBase}/api/cron/notify-session-handoff?caseId=${caseId}`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${cronSecret}` },
+      }).catch((err) =>
+        // eslint-disable-next-line no-console
+        console.error(`[CD-dispatcher] notify-session-handoff failed:`, err),
+      );
+    }
+    return NextResponse.json({
+      success: true,
+      caseId,
+      status: "awaiting-session-generation",
+      mode: "session",
+      message: "Operator will complete by hand.",
     });
   }
 

--- a/src/app/api/reports/hybrid/[caseId]/route.ts
+++ b/src/app/api/reports/hybrid/[caseId]/route.ts
@@ -1,0 +1,120 @@
+/**
+ * Hybrid report generation route.
+ *
+ * Called by the Vercel CD dispatcher (src/app/api/generate/case-decoder/route.ts)
+ * when tier_generation_config.case-decoder.mode = 'hybrid'. Runs the mechanical
+ * skeleton + parallel Haiku calls, writes report_html + generator_mode + cost +
+ * status=review via after(). Alerts Telegram on hard failure.
+ *
+ * Plan: docs/plans/2026-04-24-per-tier-generation-mode-rebuild.md
+ */
+import { NextResponse, NextRequest, after } from "next/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { requireOperatorSecret } from "@/lib/auth/guards";
+import { renderCaseDecoderHybrid } from "@/lib/report/hybrid/render-case-decoder";
+
+export const runtime = "nodejs";
+export const maxDuration = 300;
+
+export async function POST(
+  req: NextRequest,
+  ctx: { params: Promise<{ caseId: string }> },
+) {
+  const auth = requireOperatorSecret(req);
+  if (!auth.authorized) return auth.error;
+  const { caseId } = await ctx.params;
+
+  const sb = createAdminClient();
+  const { data: caseRow } = await sb
+    .from("cases")
+    .select("id, tier, intake_id, status")
+    .eq("id", caseId)
+    .maybeSingle();
+  if (!caseRow)
+    return NextResponse.json({ error: "case-not-found" }, { status: 404 });
+  const { data: intake } = await sb
+    .from("intakes")
+    .select("*")
+    .eq("id", caseRow.intake_id)
+    .maybeSingle();
+  if (!intake)
+    return NextResponse.json({ error: "intake-not-found" }, { status: 404 });
+  if (caseRow.tier !== "case-decoder")
+    return NextResponse.json(
+      { error: "unsupported-tier", tier: caseRow.tier },
+      { status: 400 },
+    );
+
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey)
+    return NextResponse.json(
+      { error: "missing-anthropic-key" },
+      { status: 500 },
+    );
+
+  after(async () => {
+    try {
+      const r = await renderCaseDecoderHybrid(
+        {
+          first_name: intake.first_name,
+          charge_type: intake.charge_type,
+          state: intake.state,
+          jurisdiction_level: intake.jurisdiction_level,
+          arrest_date: intake.arrest_date,
+          court_date: intake.court_date,
+          plea_offered: intake.plea_offered,
+          co_defendants: intake.co_defendants,
+          filled_out_by: intake.filled_out_by,
+          situation: intake.situation,
+          specific_question: intake.specific_question,
+        },
+        apiKey,
+      );
+      const { error: writeError } = await sb
+        .from("cases")
+        .update({
+          report_html: r.html,
+          report_format_version: 2,
+          generator_prompt_version: "2.1.0-hybrid",
+          generator_mode: "hybrid",
+          generator_cost_usd: r.costUsd,
+          generator_deployed_at: new Date().toISOString(),
+          status: "review",
+          updated_at: new Date().toISOString(),
+        })
+        .eq("id", caseId);
+      if (writeError) throw writeError;
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error("[hybrid] failed", err);
+      await sb
+        .from("cases")
+        .update({
+          status: "generation-failed",
+          updated_at: new Date().toISOString(),
+        })
+        .eq("id", caseId);
+      try {
+        const token = process.env.TELEGRAM_ATLAS_BOT_TOKEN;
+        const chat = process.env.TELEGRAM_CHAT_ID;
+        if (token && chat) {
+          await fetch(`https://api.telegram.org/bot${token}/sendMessage`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              chat_id: chat,
+              text: `Hybrid CD generation FAILED: case=${caseId}. Flip admin UI back to api if this recurs.`,
+            }),
+          });
+        }
+      } catch {
+        /* fire-and-forget */
+      }
+    }
+  });
+
+  return NextResponse.json(
+    { accepted: true, caseId, mode: "hybrid" },
+    { status: 202 },
+  );
+}

--- a/src/app/api/reports/mechanical/[caseId]/route.ts
+++ b/src/app/api/reports/mechanical/[caseId]/route.ts
@@ -1,0 +1,103 @@
+/**
+ * Mechanical report generation route.
+ *
+ * Called by the Vercel CD dispatcher when tier_generation_config.<tier>.mode
+ * = 'mechanical'. Runs the mechanical skeleton ONLY (no LLM calls) and
+ * writes report_html + generator_mode + status=review via after().
+ *
+ * Note: for case-decoder specifically, mechanical mode is rarely the right
+ * choice (~60-65% of CD content is generative, above the 15% pure-mechanical
+ * cap). This route exists so smaller tiers (playbook add-ons, Tier 9 instant
+ * SKUs) can opt in without the dispatcher forking further.
+ */
+import { NextResponse, NextRequest, after } from "next/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { requireOperatorSecret } from "@/lib/auth/guards";
+import { renderCaseDecoderMechanical } from "@/lib/report/mechanical/render-case-decoder";
+
+export const runtime = "nodejs";
+export const maxDuration = 60;
+
+export async function POST(
+  req: NextRequest,
+  ctx: { params: Promise<{ caseId: string }> },
+) {
+  const auth = requireOperatorSecret(req);
+  if (!auth.authorized) return auth.error;
+  const { caseId } = await ctx.params;
+
+  const sb = createAdminClient();
+  const { data: caseRow } = await sb
+    .from("cases")
+    .select("id, tier, intake_id, status")
+    .eq("id", caseId)
+    .maybeSingle();
+  if (!caseRow)
+    return NextResponse.json({ error: "case-not-found" }, { status: 404 });
+  const { data: intake } = await sb
+    .from("intakes")
+    .select("*")
+    .eq("id", caseRow.intake_id)
+    .maybeSingle();
+  if (!intake)
+    return NextResponse.json({ error: "intake-not-found" }, { status: 404 });
+  if (caseRow.tier !== "case-decoder")
+    return NextResponse.json(
+      { error: "unsupported-tier", tier: caseRow.tier },
+      { status: 400 },
+    );
+
+  after(async () => {
+    try {
+      const r = renderCaseDecoderMechanical({
+        first_name: intake.first_name,
+        charge_type: intake.charge_type,
+        state: intake.state,
+        jurisdiction_level: intake.jurisdiction_level,
+        arrest_date: intake.arrest_date,
+        court_date: intake.court_date,
+        plea_offered: intake.plea_offered,
+        co_defendants: intake.co_defendants,
+        filled_out_by: intake.filled_out_by,
+        situation: intake.situation,
+        specific_question: intake.specific_question,
+      });
+      // Mechanical output still contains {{SLOT:...}} markers intended for
+      // hybrid fill-in. For pure-mechanical delivery, replace each marker
+      // with a neutral placeholder so the HTML is self-contained.
+      const filledHtml = r.slotsEmitted.reduce(
+        (h, slot) => h.split(`{{SLOT:${slot}}}`).join("<!-- mechanical: slot omitted -->"),
+        r.html,
+      );
+      const { error: writeError } = await sb
+        .from("cases")
+        .update({
+          report_html: filledHtml,
+          report_format_version: 2,
+          generator_prompt_version: "2.1.0-mechanical",
+          generator_mode: "mechanical",
+          generator_cost_usd: 0,
+          generator_deployed_at: new Date().toISOString(),
+          status: "review",
+          updated_at: new Date().toISOString(),
+        })
+        .eq("id", caseId);
+      if (writeError) throw writeError;
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error("[mechanical] failed", err);
+      await sb
+        .from("cases")
+        .update({
+          status: "generation-failed",
+          updated_at: new Date().toISOString(),
+        })
+        .eq("id", caseId);
+    }
+  });
+
+  return NextResponse.json(
+    { accepted: true, caseId, mode: "mechanical" },
+    { status: 202 },
+  );
+}

--- a/src/lib/report/__tests__/mode-config.test.ts
+++ b/src/lib/report/__tests__/mode-config.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Unit tests for mode-config.ts.
+ *
+ * vi.mock replaces createAdminClient with a deterministic fake whose
+ * .from().select().eq().maybeSingle() returns configurable fixtures.
+ * Tests cover: each valid mode, fallback on unknown mode, fallback on
+ * DB error, cache hit behavior, cache expiry.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+let fixtureRow: { mode: string } | null = null;
+let fixtureError: { message: string } | null = null;
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: () => ({
+    from: () => ({
+      select: () => ({
+        eq: () => ({
+          maybeSingle: async () => ({
+            data: fixtureRow,
+            error: fixtureError,
+          }),
+        }),
+      }),
+    }),
+  }),
+}));
+
+import {
+  getTierGenerationMode,
+  __resetModeConfigCacheForTests,
+} from "../mode-config";
+
+describe("mode-config", () => {
+  beforeEach(() => {
+    fixtureRow = null;
+    fixtureError = null;
+    __resetModeConfigCacheForTests();
+  });
+
+  it("returns 'api' when row has mode='api'", async () => {
+    fixtureRow = { mode: "api" };
+    expect(await getTierGenerationMode("case-decoder")).toBe("api");
+  });
+
+  it("returns 'mechanical' when row has mode='mechanical'", async () => {
+    fixtureRow = { mode: "mechanical" };
+    expect(await getTierGenerationMode("case-decoder")).toBe("mechanical");
+  });
+
+  it("returns 'hybrid' when row has mode='hybrid'", async () => {
+    fixtureRow = { mode: "hybrid" };
+    expect(await getTierGenerationMode("case-decoder")).toBe("hybrid");
+  });
+
+  it("returns 'session' when row has mode='session'", async () => {
+    fixtureRow = { mode: "session" };
+    expect(await getTierGenerationMode("case-decoder")).toBe("session");
+  });
+
+  it("falls back to 'api' on unknown mode value", async () => {
+    fixtureRow = { mode: "garbage-not-a-mode" };
+    expect(await getTierGenerationMode("case-decoder")).toBe("api");
+  });
+
+  it("falls back to 'api' on missing row", async () => {
+    fixtureRow = null;
+    expect(await getTierGenerationMode("missing-tier")).toBe("api");
+  });
+
+  it("falls back to 'api' on DB read error", async () => {
+    fixtureError = { message: "connection refused" };
+    expect(await getTierGenerationMode("case-decoder")).toBe("api");
+  });
+
+  it("caches within the TTL window (second call does not re-query)", async () => {
+    fixtureRow = { mode: "hybrid" };
+    const a = await getTierGenerationMode("case-decoder");
+    // Change fixture — cache should shield us from the new value
+    fixtureRow = { mode: "session" };
+    const b = await getTierGenerationMode("case-decoder");
+    expect(a).toBe("hybrid");
+    expect(b).toBe("hybrid");
+  });
+});

--- a/src/lib/report/hybrid/__tests__/render-case-decoder.test.ts
+++ b/src/lib/report/hybrid/__tests__/render-case-decoder.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Unit tests for the hybrid CD orchestrator.
+ *
+ * vi.mock stubs callHaiku so the orchestrator spins without hitting
+ * the Anthropic API. Tests cover: fulfilled path (all slots filled +
+ * non-zero cost), rejected path (all slots fall back + cost zero),
+ * mixed path (partial fulfillment), invariant check (no leftover
+ * slot markers in final HTML).
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+type HaikuBehavior =
+  | { kind: "ok"; text: string; costUsd: number }
+  | { kind: "empty" }
+  | { kind: "error"; message: string };
+
+let nextBehaviors: HaikuBehavior[] = [];
+
+vi.mock("../haiku-client", () => ({
+  callHaiku: vi.fn(async () => {
+    const b = nextBehaviors.shift() ?? { kind: "ok", text: "default", costUsd: 0.001 };
+    if (b.kind === "ok") return { text: b.text, inputTokens: 100, outputTokens: 50, costUsd: b.costUsd };
+    if (b.kind === "empty") return { text: "", inputTokens: 0, outputTokens: 0, costUsd: 0 };
+    throw new Error(b.message);
+  }),
+}));
+
+import { renderCaseDecoderHybrid } from "../render-case-decoder";
+import { listSlotMarkers } from "../../mechanical/common";
+import { CASE_DECODER_SLOTS } from "../case-decoder-sections";
+
+const baseIntake = {
+  first_name: "Alex",
+  charge_type: "DUI",
+  state: "FL",
+  jurisdiction_level: "County",
+  arrest_date: "2026-03-01",
+  court_date: "2026-05-15",
+  plea_offered: null,
+  co_defendants: null,
+  filled_out_by: null,
+  situation: null,
+  specific_question: null,
+};
+
+describe("renderCaseDecoderHybrid", () => {
+  beforeEach(() => {
+    nextBehaviors = [];
+  });
+
+  it("fills every slot when all Haiku calls succeed", async () => {
+    for (let i = 0; i < CASE_DECODER_SLOTS.length; i++) {
+      nextBehaviors.push({ kind: "ok", text: `<p>slot ${i} ok</p>`, costUsd: 0.002 });
+    }
+    const r = await renderCaseDecoderHybrid(baseIntake, "fake-key");
+    expect(listSlotMarkers(r.html)).toEqual([]);
+    expect(r.slotsFulfilled).toHaveLength(CASE_DECODER_SLOTS.length);
+    expect(r.slotsFallback).toHaveLength(0);
+    expect(r.costUsd).toBeCloseTo(0.002 * CASE_DECODER_SLOTS.length, 5);
+  });
+
+  it("falls back when all Haiku calls fail", async () => {
+    for (let i = 0; i < CASE_DECODER_SLOTS.length; i++) {
+      nextBehaviors.push({ kind: "error", message: "boom" });
+    }
+    const r = await renderCaseDecoderHybrid(baseIntake, "fake-key");
+    expect(listSlotMarkers(r.html)).toEqual([]);
+    expect(r.slotsFulfilled).toHaveLength(0);
+    expect(r.slotsFallback).toHaveLength(CASE_DECODER_SLOTS.length);
+    expect(r.costUsd).toBe(0);
+  });
+
+  it("falls back when Haiku returns empty text", async () => {
+    for (let i = 0; i < CASE_DECODER_SLOTS.length; i++) {
+      nextBehaviors.push({ kind: "empty" });
+    }
+    const r = await renderCaseDecoderHybrid(baseIntake, "fake-key");
+    expect(listSlotMarkers(r.html)).toEqual([]);
+    expect(r.slotsFallback).toHaveLength(CASE_DECODER_SLOTS.length);
+  });
+
+  it("partial fulfillment: invariant still holds", async () => {
+    for (let i = 0; i < CASE_DECODER_SLOTS.length; i++) {
+      nextBehaviors.push(
+        i % 2 === 0
+          ? { kind: "ok", text: `<p>ok ${i}</p>`, costUsd: 0.001 }
+          : { kind: "error", message: "boom" },
+      );
+    }
+    const r = await renderCaseDecoderHybrid(baseIntake, "fake-key");
+    expect(listSlotMarkers(r.html)).toEqual([]);
+    expect(r.slotsFulfilled.length + r.slotsFallback.length).toBe(
+      CASE_DECODER_SLOTS.length,
+    );
+  });
+});

--- a/src/lib/report/hybrid/case-decoder-sections.ts
+++ b/src/lib/report/hybrid/case-decoder-sections.ts
@@ -1,0 +1,111 @@
+/**
+ * Per-slot Haiku prompts for the Case Decoder hybrid renderer.
+ *
+ * Each entry defines a slot name (matches the mechanical skeleton's
+ * `{{SLOT:name}}` token), a system prompt, and a user-prompt builder
+ * that receives the intake. The orchestrator calls all slots in
+ * parallel via Promise.allSettled and fills the skeleton.
+ *
+ * UPL guardrails: prompts never ask the model to give legal ADVICE.
+ * All prompts frame output as INFORMATION + questions. The sanitizer +
+ * Phase 2 whitelist strip any un-verified <cite> tags before render.
+ */
+import type { CaseDecoderIntake } from "../mechanical/common";
+
+export type SlotDef = {
+  slot: string;
+  maxTokens: number;
+  fallback: string;
+  system: string;
+  userPrompt: (intake: CaseDecoderIntake) => string;
+};
+
+const COMMON_SYSTEM = `You are the voice layer of ImNotAnAttorney's Case Decoder report.
+You write legal INFORMATION — not advice — for a defendant who is often 2am-scared.
+Rules:
+- Never use "you should", "we recommend", "we advise", "your best option".
+- Use "consider", "one option is", "questions to explore".
+- No specific case citations unless already-verified (Phase 2 <cite> tags are added by the pipeline, not by you).
+- Do not mention AI, Claude, LLM, algorithms, or automated analysis.
+- Pro-defendant, never anti-attorney. The enemy is the information gap.
+- Keep paragraphs short (<=3 sentences). No markdown; emit HTML that fits inside the given slot's parent element (usually <p> or nested block-level).
+- Default to 2nd-person ("you"), warm, direct, no filler, no pleasantries.`;
+
+function intakeSummary(i: CaseDecoderIntake): string {
+  return [
+    `Charge: ${i.charge_type ?? "(unknown)"}`,
+    `Jurisdiction: ${i.state ?? "(unknown)"} / ${i.jurisdiction_level ?? "(unknown)"}`,
+    `Arrest: ${i.arrest_date ?? "(unspecified)"}`,
+    `Court date: ${i.court_date ?? "(not yet set)"}`,
+    `Plea offered: ${i.plea_offered ?? "(none on the table)"}`,
+    `Co-defendants: ${i.co_defendants ?? "(none)"}`,
+    `Situation in their words: ${i.situation ?? "(not provided)"}`,
+    `Specific question: ${i.specific_question ?? "(not provided)"}`,
+  ].join("\n");
+}
+
+export const CASE_DECODER_SLOTS: readonly SlotDef[] = [
+  {
+    slot: "plain_english_charge_explanation",
+    maxTokens: 600,
+    fallback:
+      "<p>Your charge, translated out of legalese: the prosecution has to prove specific facts beyond a reasonable doubt. The calibrated questions further down help you surface which facts they are weakest on.</p>",
+    system: COMMON_SYSTEM,
+    userPrompt: (i) =>
+      `Given this intake:\n\n${intakeSummary(i)}\n\nWrite 1-2 short paragraphs (HTML <p>s) translating the charge into plain English. Explain what specific facts the prosecution must prove. No citations. 120-180 words total.`,
+  },
+  {
+    slot: "what_this_means_for_you",
+    maxTokens: 500,
+    fallback:
+      "<p>What comes next: a sequence of court dates, decisions about representation, and choices about plea vs trial. The questions below are designed to make those decisions less scary by surfacing what your attorney actually thinks.</p>",
+    system: COMMON_SYSTEM,
+    userPrompt: (i) =>
+      `Given this intake:\n\n${intakeSummary(i)}\n\nWrite 1-2 short paragraphs (HTML <p>s) describing what this situation typically looks like over the next 30-60 days from the defendant's point of view. Information only — no advice. 90-140 words total.`,
+  },
+  {
+    slot: "top_three_defense_angles",
+    maxTokens: 700,
+    fallback:
+      "<ol><li>Challenge the stop / search / statement: was the evidence lawfully obtained?</li><li>Scrutinize the witnesses: what do they actually know firsthand vs hearsay?</li><li>Probe the prosecution's narrative: what facts don't fit their theory?</li></ol>",
+    system: COMMON_SYSTEM,
+    userPrompt: (i) =>
+      `Given this intake:\n\n${intakeSummary(i)}\n\nList three defense angles worth exploring. Each as a short HTML <li>. Wrap the list in <ol>. Angles should be charge-specific where possible (e.g. for DUI, consider breathalyzer calibration; for drug possession, consider constructive possession). Information + questions only, no advice. Total 100-160 words.`,
+  },
+  {
+    slot: "prosecution_burden_summary",
+    maxTokens: 450,
+    fallback:
+      "<p>The prosecution has the burden. They must prove every element of the charge beyond a reasonable doubt. If even one element falls, the case falls with it.</p>",
+    system: COMMON_SYSTEM,
+    userPrompt: (i) =>
+      `Given this intake:\n\n${intakeSummary(i)}\n\nWrite 1 short paragraph (HTML <p>) restating the prosecution's burden of proof for this specific charge. 60-100 words. No citations.`,
+  },
+  {
+    slot: "question_framework_preamble",
+    maxTokens: 250,
+    fallback:
+      "These 15 questions are ordered from \"orient\" to \"act\" — the first five map the terrain, the next five probe the evidence, and the last five force a decision. Bring them printed. Write down the answers.",
+    system: COMMON_SYSTEM,
+    userPrompt: (i) =>
+      `Given this intake:\n\n${intakeSummary(i)}\n\nWrite 2 sentences (plain text, no HTML) introducing why the 15 questions below are ordered this way, specific to the defendant's situation. 40-70 words.`,
+  },
+  {
+    slot: "attorney_email_body",
+    maxTokens: 600,
+    fallback:
+      "Subject: Questions about our case\n\nHi [attorney],\n\nI've been thinking about our case and I want to make our next meeting as productive as possible. Could you help me understand the following — even a short reply to each would be useful:\n\n1. What is your theory of defense?\n2. What evidence do you think the prosecution is weakest on?\n3. What motions are you planning to file, and on what grounds?\n4. What is a realistic best- and worst-case outcome?\n\nI'm not trying to second-guess — I just want to understand what you're seeing so I can support the work.\n\nThanks,\n[your name]",
+    system: COMMON_SYSTEM,
+    userPrompt: (i) =>
+      `Given this intake:\n\n${intakeSummary(i)}\n\nWrite an email the defendant could paste-and-send to their attorney, referencing the charge type and asking 4 specific questions. Plain text (no HTML — the skeleton wraps it in <pre>). Respectful, professional, not accusatory. 130-200 words.`,
+  },
+  {
+    slot: "seven_day_plan_voice",
+    maxTokens: 700,
+    fallback:
+      "<p>Day 1: Read your discovery front-to-back. Day 2: Print the 15 questions and write your current best guesses at the answers. Day 3: Email your attorney the list. Day 4: Start a dated log of every interaction with the system. Day 5-6: Line up a second opinion consultation. Day 7: Reassess — what have you learned, what's still unclear, what comes next?</p>",
+    system: COMMON_SYSTEM,
+    userPrompt: (i) =>
+      `Given this intake:\n\n${intakeSummary(i)}\n\nWrite a 7-day plan as HTML. Use <ol> with one <li> per day. Each day has one concrete action. Information only. 120-180 words total.`,
+  },
+];

--- a/src/lib/report/hybrid/haiku-client.ts
+++ b/src/lib/report/hybrid/haiku-client.ts
@@ -1,0 +1,80 @@
+/**
+ * Minimal Anthropic SDK wrapper for per-slot Haiku 4.5 calls.
+ *
+ * Handles retry with jittered exponential backoff on transient API
+ * errors (500/502/503/504/529 overloaded). Returns plain string text
+ * + per-call token/cost accounting for the orchestrator to aggregate.
+ *
+ * Prompt-caching is NOT set here because each slot prompt is one-shot
+ * per report (no shared prefix worth caching across slots in the same
+ * generation). If CD volume rises, consider caching a shared preamble.
+ */
+import Anthropic from "@anthropic-ai/sdk";
+
+export type HaikuResult = {
+  text: string;
+  inputTokens: number;
+  outputTokens: number;
+  costUsd: number;
+};
+
+// Haiku 4.5 pricing as of 2026-04. Update if Anthropic pricing changes.
+// https://docs.anthropic.com/en/docs/about-claude/pricing
+const PRICE_PER_MTOK_INPUT_USD = 1.0;
+const PRICE_PER_MTOK_OUTPUT_USD = 5.0;
+
+const RETRY_STATUSES = new Set([500, 502, 503, 504, 529]);
+const MAX_ATTEMPTS = 3;
+
+function jitteredBackoffMs(attempt: number): number {
+  // attempt=1 → ~250-500ms, attempt=2 → ~500-1000ms
+  const base = 250 * Math.pow(2, attempt - 1);
+  return base + Math.floor(Math.random() * base);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+export async function callHaiku(
+  apiKey: string,
+  system: string,
+  user: string,
+  opts?: { maxTokens?: number },
+): Promise<HaikuResult> {
+  const client = new Anthropic({ apiKey });
+  const maxTokens = opts?.maxTokens ?? 1024;
+
+  let lastErr: unknown = null;
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    try {
+      const resp = await client.messages.create({
+        model: "claude-haiku-4-5-20251001",
+        max_tokens: maxTokens,
+        system,
+        messages: [{ role: "user", content: user }],
+      });
+      const block = resp.content.find((b) => b.type === "text");
+      const text = block && block.type === "text" ? block.text : "";
+      const inputTokens = resp.usage?.input_tokens ?? 0;
+      const outputTokens = resp.usage?.output_tokens ?? 0;
+      const costUsd =
+        (inputTokens / 1_000_000) * PRICE_PER_MTOK_INPUT_USD +
+        (outputTokens / 1_000_000) * PRICE_PER_MTOK_OUTPUT_USD;
+      return { text, inputTokens, outputTokens, costUsd };
+    } catch (err) {
+      lastErr = err;
+      const status =
+        err && typeof err === "object" && "status" in err
+          ? Number((err as { status?: number }).status)
+          : 0;
+      if (!RETRY_STATUSES.has(status) || attempt >= MAX_ATTEMPTS) {
+        throw err;
+      }
+      await sleep(jitteredBackoffMs(attempt));
+    }
+  }
+  throw lastErr instanceof Error
+    ? lastErr
+    : new Error("[haiku-client] unknown failure after retries");
+}

--- a/src/lib/report/hybrid/render-case-decoder.ts
+++ b/src/lib/report/hybrid/render-case-decoder.ts
@@ -1,0 +1,76 @@
+/**
+ * Hybrid Case Decoder renderer — mechanical skeleton + parallel Haiku.
+ *
+ * Orchestration:
+ *   1. Render the mechanical skeleton (emits {{SLOT:...}} tokens)
+ *   2. Fire all slot Haiku calls in parallel via Promise.allSettled
+ *   3. Replace each slot in the skeleton with either the Haiku text
+ *      (on fulfilled) or the slot's fallback string (on rejected)
+ *   4. Assert zero unreplaced markers remain (invariant)
+ *   5. Return { html, costUsd } (sum of all fulfilled call costs)
+ *
+ * Callers: /api/reports/hybrid/[caseId]/route.ts (operator/dispatcher
+ * POST), and indirectly the CD dispatcher when mode='hybrid'.
+ */
+import {
+  CaseDecoderIntake,
+  assertNoSlotsRemain,
+  replaceSlot,
+} from "../mechanical/common";
+import { renderCaseDecoderMechanical } from "../mechanical/render-case-decoder";
+import { callHaiku } from "./haiku-client";
+import { CASE_DECODER_SLOTS } from "./case-decoder-sections";
+
+export type HybridResult = {
+  html: string;
+  costUsd: number;
+  slotsFulfilled: string[];
+  slotsFallback: string[];
+};
+
+export async function renderCaseDecoderHybrid(
+  intake: CaseDecoderIntake,
+  apiKey: string,
+): Promise<HybridResult> {
+  const mech = renderCaseDecoderMechanical(intake);
+  let html = mech.html;
+
+  const results = await Promise.allSettled(
+    CASE_DECODER_SLOTS.map((def) =>
+      callHaiku(apiKey, def.system, def.userPrompt(intake), {
+        maxTokens: def.maxTokens,
+      }).then((r) => ({ def, r })),
+    ),
+  );
+
+  let costUsd = 0;
+  const fulfilled: string[] = [];
+  const fallback: string[] = [];
+
+  for (let i = 0; i < results.length; i++) {
+    const def = CASE_DECODER_SLOTS[i];
+    const res = results[i];
+    if (res.status === "fulfilled") {
+      const text = res.value.r.text.trim();
+      if (text.length > 0) {
+        html = replaceSlot(html, def.slot, text);
+        costUsd += res.value.r.costUsd;
+        fulfilled.push(def.slot);
+        continue;
+      }
+    }
+    // rejected OR empty text → fall back
+    html = replaceSlot(html, def.slot, def.fallback);
+    fallback.push(def.slot);
+    if (res.status === "rejected") {
+      // eslint-disable-next-line no-console
+      console.error(
+        `[hybrid-cd] slot=${def.slot} failed: ${res.reason instanceof Error ? res.reason.message : String(res.reason)}`,
+      );
+    }
+  }
+
+  assertNoSlotsRemain(html);
+
+  return { html, costUsd, slotsFulfilled: fulfilled, slotsFallback: fallback };
+}

--- a/src/lib/report/mechanical/__tests__/render-case-decoder.test.ts
+++ b/src/lib/report/mechanical/__tests__/render-case-decoder.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Unit tests for the mechanical CD renderer.
+ *
+ * Asserts the skeleton emits the expected slot tokens, that intake
+ * strings are escaped, and that the surviving HTML is valid enough
+ * for sanitize-html to consume.
+ */
+import { describe, it, expect } from "vitest";
+import { renderCaseDecoderMechanical } from "../render-case-decoder";
+import { listSlotMarkers } from "../common";
+
+const baseIntake = {
+  first_name: "Alex",
+  charge_type: "DUI",
+  state: "FL",
+  jurisdiction_level: "County",
+  arrest_date: "2026-03-01",
+  court_date: "2026-05-15",
+  plea_offered: "90 days + fine",
+  co_defendants: "none",
+  filled_out_by: "self",
+  situation: "I was pulled over leaving dinner.",
+  specific_question: "Can they use the breathalyzer result?",
+};
+
+describe("renderCaseDecoderMechanical", () => {
+  it("emits all expected slot tokens", () => {
+    const { html, slotsEmitted } = renderCaseDecoderMechanical(baseIntake);
+    const found = new Set(listSlotMarkers(html));
+    for (const s of slotsEmitted) {
+      expect(found.has(s)).toBe(true);
+    }
+  });
+
+  it("interpolates intake strings into the intake summary", () => {
+    const { html } = renderCaseDecoderMechanical(baseIntake);
+    expect(html).toContain("Alex");
+    expect(html).toContain("DUI");
+    expect(html).toContain("FL");
+  });
+
+  it("escapes HTML-special characters from intake", () => {
+    const { html } = renderCaseDecoderMechanical({
+      ...baseIntake,
+      first_name: "<img src=x>",
+    });
+    expect(html).not.toContain("<img src=x>");
+    expect(html).toContain("&lt;img src=x&gt;");
+  });
+
+  it("handles null intake fields gracefully", () => {
+    const { html } = renderCaseDecoderMechanical({
+      first_name: null,
+      charge_type: null,
+      state: null,
+      jurisdiction_level: null,
+      arrest_date: null,
+      court_date: null,
+      plea_offered: null,
+      co_defendants: null,
+      filled_out_by: null,
+      situation: null,
+      specific_question: null,
+    });
+    expect(html).toContain("friend");
+    expect(html).toContain("your charge");
+  });
+});

--- a/src/lib/report/mechanical/common.ts
+++ b/src/lib/report/mechanical/common.ts
@@ -1,0 +1,77 @@
+/**
+ * Shared helpers for mechanical + hybrid renderers.
+ *
+ * Slot markers use the form `{{SLOT:name}}` as a PLAIN-TEXT token that
+ * HTML escapers leave untouched. The orchestrator replaces each marker
+ * via string-replace after Haiku responses arrive. A post-fill invariant
+ * check asserts zero unreplaced markers survive into final HTML — any
+ * slot that wasn't filled falls back to a placeholder by contract.
+ */
+
+export type CaseDecoderIntake = {
+  first_name: string | null;
+  charge_type: string | null;
+  state: string | null;
+  jurisdiction_level: string | null;
+  arrest_date: string | null;
+  court_date: string | null;
+  plea_offered: string | null;
+  co_defendants: string | null;
+  filled_out_by: string | null;
+  situation: string | null;
+  specific_question: string | null;
+};
+
+const SLOT_RX = /\{\{SLOT:([a-z0-9_-]+)\}\}/gi;
+
+export function slotMarker(name: string): string {
+  if (!/^[a-z0-9_-]+$/i.test(name)) {
+    throw new Error(`[mechanical/common] invalid slot name: ${name}`);
+  }
+  return `{{SLOT:${name}}}`;
+}
+
+export function listSlotMarkers(html: string): string[] {
+  const names: string[] = [];
+  for (const m of html.matchAll(SLOT_RX)) names.push(m[1]);
+  return names;
+}
+
+export function replaceSlot(html: string, name: string, value: string): string {
+  const marker = slotMarker(name);
+  // Split/join avoids regex escaping concerns in `name`.
+  return html.split(marker).join(value);
+}
+
+export function assertNoSlotsRemain(html: string): void {
+  const leftover = listSlotMarkers(html);
+  if (leftover.length > 0) {
+    throw new Error(
+      `[mechanical/common] unreplaced slot markers in final HTML: ${leftover.join(", ")}`,
+    );
+  }
+}
+
+/**
+ * Lightweight HTML escape for plain-text body content (NOT attributes).
+ * Used when intake strings are inlined into the mechanical skeleton.
+ */
+export function escapeHtml(s: string | null | undefined): string {
+  if (s === null || s === undefined) return "";
+  return String(s)
+    .split("&").join("&amp;")
+    .split("<").join("&lt;")
+    .split(">").join("&gt;")
+    .split('"').join("&quot;")
+    .split("'").join("&#39;");
+}
+
+/**
+ * Wrap inline legal-reference text in the Phase 2 <cite> shell so the
+ * existing entity-whitelist transformer can upgrade it to a badge OR
+ * strip it at sanitize time if unverified.
+ */
+export function wrapCite(entityId: string, text: string): string {
+  const eid = entityId.replace(/["<>&]/g, "");
+  return `<cite data-entity-id="${eid}">${escapeHtml(text)}</cite>`;
+}

--- a/src/lib/report/mechanical/render-case-decoder.ts
+++ b/src/lib/report/mechanical/render-case-decoder.ts
@@ -1,0 +1,118 @@
+/**
+ * Mechanical skeleton for Case Decoder reports.
+ *
+ * Renders the fixed structural scaffolding of a CD report: intake
+ * summary, charge breakdown stubs, 15-question framework header,
+ * attorney-email-template shell, 7-day action plan skeleton.
+ * Voice-critical sections (e.g. "what this means for you", the
+ * calibrated question prose) are emitted as `{{SLOT:name}}` tokens
+ * that the hybrid orchestrator fills via Haiku calls.
+ *
+ * The mechanical path itself (flipped via tier_generation_config) is
+ * rarely the right choice for CD (~60-65% of CD content is generative,
+ * above the 15% pure-mechanical cap) — kept here because it backs the
+ * hybrid renderer and can still be flipped per-tier for tiers where
+ * mechanical alone suffices (e.g. playbooks, Tier 9 instant SKUs).
+ */
+import {
+  CaseDecoderIntake,
+  escapeHtml,
+  slotMarker,
+} from "./common";
+
+export type MechanicalResult = {
+  html: string;
+  slotsEmitted: string[];
+};
+
+const SLOTS = [
+  "plain_english_charge_explanation",
+  "what_this_means_for_you",
+  "top_three_defense_angles",
+  "prosecution_burden_summary",
+  "question_framework_preamble",
+  "attorney_email_body",
+  "seven_day_plan_voice",
+] as const;
+
+export function renderCaseDecoderMechanical(
+  intake: CaseDecoderIntake,
+): MechanicalResult {
+  const firstName = escapeHtml(intake.first_name) || "friend";
+  const charge = escapeHtml(intake.charge_type) || "your charge";
+  const state = escapeHtml(intake.state) || "your state";
+  const jurisdiction = escapeHtml(intake.jurisdiction_level) || "your court";
+  const arrestDate = escapeHtml(intake.arrest_date) || "unspecified";
+  const courtDate = escapeHtml(intake.court_date) || "not yet set";
+  const plea = escapeHtml(intake.plea_offered) || "none on the table";
+  const coDefendants = escapeHtml(intake.co_defendants) || "none";
+  const situation = escapeHtml(intake.situation) || "";
+  const specificQuestion = escapeHtml(intake.specific_question) || "";
+
+  const html = `<article class="report cd-report">
+  <header>
+    <h1>Case Decoder — ${firstName}</h1>
+    <p class="intake-summary">${charge} in ${state} (${jurisdiction}). Arrest: ${arrestDate}. Court: ${courtDate}. Plea: ${plea}. Co-defendants: ${coDefendants}.</p>
+  </header>
+
+  <section id="plain-english-explanation">
+    <h2>What the prosecution must prove</h2>
+    ${slotMarker("plain_english_charge_explanation")}
+  </section>
+
+  <section id="what-this-means">
+    <h2>What this means for you</h2>
+    ${slotMarker("what_this_means_for_you")}
+  </section>
+
+  <section id="defense-angles">
+    <h2>Three angles worth exploring</h2>
+    ${slotMarker("top_three_defense_angles")}
+  </section>
+
+  <section id="prosecution-burden">
+    <h2>The prosecution's burden, in plain English</h2>
+    ${slotMarker("prosecution_burden_summary")}
+  </section>
+
+  <section id="questions">
+    <h2>15 calibrated questions to bring to your attorney</h2>
+    <p class="question-preamble">${slotMarker("question_framework_preamble")}</p>
+    <ol class="question-list">
+      <li>What is your theory of defense?</li>
+      <li>Which elements of the charge do you think the prosecution will struggle with?</li>
+      <li>What is the single strongest piece of evidence against me?</li>
+      <li>What is the single weakest piece of evidence against me?</li>
+      <li>What motions are you planning to file?</li>
+      <li>On what grounds would you move to suppress the stop/search/statement?</li>
+      <li>Have you reviewed my co-defendants' statements and what they say about my role?</li>
+      <li>What is a realistic best-case outcome at trial?</li>
+      <li>What is a realistic worst-case outcome at trial?</li>
+      <li>If we take a plea, what collateral consequences should I expect (immigration, licensing, firearms, housing)?</li>
+      <li>Who is the prosecutor assigned, and what patterns have you seen from them?</li>
+      <li>Who is the judge, and what patterns have you seen from them?</li>
+      <li>What is the deadline for the plea currently offered?</li>
+      <li>If we reject the plea, what are the prosecution's next most likely moves?</li>
+      <li>What can I do this week that would strengthen our position?</li>
+    </ol>
+  </section>
+
+  <section id="attorney-email">
+    <h2>Email template for your attorney</h2>
+    <pre class="attorney-email">${slotMarker("attorney_email_body")}</pre>
+  </section>
+
+  <section id="seven-day-plan">
+    <h2>Your 7-day plan</h2>
+    ${slotMarker("seven_day_plan_voice")}
+  </section>
+
+  ${specificQuestion ? `<aside class="your-question"><h3>Your specific question</h3><p>${specificQuestion}</p></aside>` : ""}
+  ${situation ? `<aside class="your-situation"><h3>Context you shared</h3><p>${situation}</p></aside>` : ""}
+</article>`;
+
+  return {
+    html,
+    slotsEmitted: [...SLOTS],
+  };
+}

--- a/src/lib/report/mode-config.ts
+++ b/src/lib/report/mode-config.ts
@@ -1,0 +1,79 @@
+/**
+ * Per-tier generation-mode accessor.
+ *
+ * Reads the `tier_generation_config` table to determine which generation
+ * path the dispatcher should take for a given tier (slug). A 60-second
+ * in-memory TTL cache keeps hot lookups cheap; the dispatcher runs on
+ * every inbound CD request, so one DB round-trip per cold entry is fine
+ * but per-request would be wasteful.
+ *
+ * The table's PK column is `tier_slug` (NOT `tier` — an earlier orphan-
+ * recovery doc had this wrong). Valid modes: 'api' | 'mechanical' |
+ * 'hybrid' | 'session'. Fallback to 'api' on any read error so a DB
+ * hiccup never silently flips behavior away from the Edge Function path.
+ */
+import { createAdminClient } from "@/lib/supabase/admin";
+
+export type TierGenerationMode = "api" | "mechanical" | "hybrid" | "session";
+
+const VALID_MODES: ReadonlySet<TierGenerationMode> = new Set([
+  "api",
+  "mechanical",
+  "hybrid",
+  "session",
+]);
+
+const CACHE_TTL_MS = 60_000;
+
+interface CacheEntry {
+  mode: TierGenerationMode;
+  expiresAt: number;
+}
+
+const cache = new Map<string, CacheEntry>();
+
+/**
+ * Test-only. Clears the in-memory cache so unit tests don't leak state.
+ */
+export function __resetModeConfigCacheForTests(): void {
+  cache.clear();
+}
+
+function isValidMode(v: unknown): v is TierGenerationMode {
+  return typeof v === "string" && VALID_MODES.has(v as TierGenerationMode);
+}
+
+export async function getTierGenerationMode(
+  tierSlug: string,
+): Promise<TierGenerationMode> {
+  const now = Date.now();
+  const hit = cache.get(tierSlug);
+  if (hit && hit.expiresAt > now) return hit.mode;
+
+  try {
+    const sb = createAdminClient();
+    const { data, error } = await sb
+      .from("tier_generation_config")
+      .select("mode")
+      .eq("tier_slug", tierSlug)
+      .maybeSingle();
+    if (error) {
+      // eslint-disable-next-line no-console
+      console.error(
+        `[mode-config] read error for tier=${tierSlug}: ${error.message}; falling back to 'api'`,
+      );
+      cache.set(tierSlug, { mode: "api", expiresAt: now + CACHE_TTL_MS });
+      return "api";
+    }
+    const mode = isValidMode(data?.mode) ? data!.mode : "api";
+    cache.set(tierSlug, { mode, expiresAt: now + CACHE_TTL_MS });
+    return mode;
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error(
+      `[mode-config] exception for tier=${tierSlug}: ${err instanceof Error ? err.message : String(err)}; falling back to 'api'`,
+    );
+    cache.set(tierSlug, { mode: "api", expiresAt: now + CACHE_TTL_MS });
+    return "api";
+  }
+}


### PR DESCRIPTION
## Summary

Rebuilds the orphaned per-tier generation-mode dispatcher system per the plan in `docs/plans/2026-04-23-per-tier-generation-mode-orphan-resume.md` (PR #69). Zero-behavior-change scaffolding: all 20 tiers stay `mode='api'` in `tier_generation_config` so the existing Edge Function path is unchanged. Flipping a tier via admin UI activates the new paths.

## Schema audit (verified against prod 2026-04-24)

- `tier_generation_config` table EXISTS with PK `tier_slug` (not `tier` as earlier orphan-resume doc claimed). 20 rows seeded `mode='api'`.
- `cases.{generator_mode, generator_cost_usd, session_generation_payload, report_format_version}` columns EXIST.
- `cases.status` has **no** CHECK constraint — `'awaiting-session-generation'` accepted without schema change.
- **No migration in this PR.**

## Four modes

| Mode | Path | LLM cost | Latency | Use |
|---|---|---|---|---|
| `api` | existing Supabase Edge Function | full Opus | 60-120s | **default today** |
| `mechanical` | skeleton only, no LLM | $0 | <1s | small tiers that fit 15% gen cap |
| `hybrid` | skeleton + parallel Haiku 4.5 per slot | ~$0.06/case | ~10s | CD once dogfooded (88% cost drop vs Opus) |
| `session` | flip status to `awaiting-session-generation` + Telegram operator | $0 | manual | high-value cases Rahim writes by hand |

## What's in this PR

**18 files changed, 1,579 insertions.**

Core libs:
- `src/lib/report/mode-config.ts` — typed accessor + 60s TTL cache, falls back to `'api'` on any error
- `src/lib/report/mechanical/common.ts` — slot-marker helpers, HTML escape, cite wrapper
- `src/lib/report/mechanical/render-case-decoder.ts` — CD skeleton with 7 voice-critical `{{SLOT:*}}` tokens
- `src/lib/report/hybrid/haiku-client.ts` — Anthropic SDK wrapper + jittered retry on 5xx/529
- `src/lib/report/hybrid/case-decoder-sections.ts` — per-slot prompts + fallbacks
- `src/lib/report/hybrid/render-case-decoder.ts` — orchestrator (`Promise.allSettled` + invariant check)

API routes:
- `src/app/api/reports/hybrid/[caseId]/route.ts` — hybrid path endpoint
- `src/app/api/reports/mechanical/[caseId]/route.ts` — mechanical path endpoint
- `src/app/api/admin/session-report/[caseId]/route.ts` — operator HTML paste endpoint (session mode)
- `src/app/api/cron/notify-session-handoff/route.ts` — Telegram handoff
- `src/app/api/admin/tier-generation-config/route.ts` — GET/POST mode flipping

Admin UI:
- `src/app/admin/tier-generation/page.tsx` — list with 20 tiers
- `src/app/admin/tier-generation/TierModeForm.tsx` — per-row dropdown + notes + Save

CLI:
- `scripts/generate-session-handoff.mjs` — session-mode Claude Code paste-prompt generator

Tests (3 files, 16 cases):
- `src/lib/report/__tests__/mode-config.test.ts` — all modes + fallback + cache
- `src/lib/report/mechanical/__tests__/render-case-decoder.test.ts` — skeleton shape + escape
- `src/lib/report/hybrid/__tests__/render-case-decoder.test.ts` — orchestrator fulfilled/rejected/empty/partial

Modified:
- `src/app/api/generate/case-decoder/route.ts` — dispatcher block between idempotency guard and Edge Function fire-and-forget. Branches on `getTierGenerationMode('case-decoder')`. `api` falls through unchanged. `mechanical`/`hybrid` POST to new routes (fall through to `api` on any non-2xx or network error). `session` flips status + fires notify cron.

## Verification

- [x] `./node_modules/.bin/tsc --noEmit --skipLibCheck` — exit 0
- [x] `./node_modules/.bin/vitest run` (3 new files) — 16/16 PASS
- [x] All 20 `tier_generation_config` rows still `mode='api'` at time of ship (zero behavior change)
- [x] Pre-push webpack build
- [ ] Preview deploy smoke: GET `/admin/tier-generation` (with ADMIN_PASSWORD) shows 20 tier rows + dropdowns

## UPL rules enforced in hybrid prompts

- No "you should" / "we recommend" / "your best option"
- Never mention AI/Claude/LLM/algorithms/automated analysis
- Phase 2 `<cite data-entity-id="...">` tags only; unverified strips by existing sanitizer
- Pro-defendant, never anti-attorney

## Rollout gate (NOT this PR)

Before flipping any tier off `'api'`:
- Haiku voice eval (Dunford red-flag gate per orphan-resume doc)
- Session-mode UX copy for `awaiting-session-generation` state page
- 3 QA checkouts with hybrid flipped; verify cost < \$0.10/case, wall-clock < 60s p50

🤖 Generated with [Claude Code](https://claude.com/claude-code)