### PR TITLE
docs(context): document 165 undocumented scripts/modules; refresh count

### DIFF
--- a/scripts/CONTEXT.md
+++ b/scripts/CONTEXT.md
@@ -1,6 +1,6 @@
 # Scripts, scripts/
 
-> 220+ utility scripts: cron setup, tier validation, report backup, legal research, charge taxonomy generation, enrichment pipelines, E2E tests, QA purchase flow, social scheduling, bulk-loaders (CL / USSC / FJC / Vera / JUSTFAIR / PJI / SCOTUS / open-policing / FARS / DPIC / attorney-discipline), judge-fingerprint v3 builders, Phase 2 matview refresh, tier-ladder retroactive-regen, derivation pipelines. Inventory below is curated (scripts with dedicated categories); recent bulk-loaders + derivation pipelines are catalogued in ARCHITECTURE.md Component Map Scripts row.
+> 220+ utility scripts across 11 categories: infrastructure setup, validation, legal research, charge taxonomy, Tier 9 data pipeline (judge/officer/sentencing analytics), external data ingestion, E2E testing, backfills/fixes, diagnostics, content/marketing, and one-off task appliers. Bulk-loaders (CL / USSC / FJC / Vera / JUSTFAIR / PJI / SCOTUS / open-policing / FARS / DPIC / attorney-discipline), judge-fingerprint v3 builders, Phase 2 matview refresh, tier-ladder retroactive-regen, and derivation pipelines are all catalogued below or in ARCHITECTURE.md Component Map Scripts row.
 
 ## Script Inventory
 
@@ -10,14 +10,54 @@
 | `setup-cronjob-org.js` | Registers cron-job.org jobs for Vercel routes (drip, batch-poller, reconcile). Saves IDs to `cronjob-org-ids.json` |
 | `setup-blog-pipeline-crons.js` | Registers cron-job.org jobs for blog pipeline (generation, QA, publish, demand). Saves IDs to `blog-pipeline-cron-ids.json` |
 | `setup-storage-and-seed.mjs` | Creates `charge-packs` storage bucket, uploads all 8 playbook PDFs, upserts `charge_packs` rows. Options: `, skip-upload`, `, skip-seed`, `, dry-run` |
+| `setup-demand-feedback-crons.js` | Registers demand-feedback-score + demand-feedback-patterns cron-job.org jobs (weekly Sundays) |
+| `setup-durable-rate-limit.mjs` | Provisions Upstash Redis DB + writes URL/TOKEN/DURABLE_RL_PROVIDER envs to Vercel prod |
 | `apply-pending-sql.mjs` | Ad-hoc SQL applier via Supabase Management API. Takes filepath arg. Used for quick DB fixes outside migration flow |
 | `apply-enrichment-batches.mjs` | Applies enrichment UPDATE statements in batches of 100 (avoids Management API 413 payload limit) |
+| `apply-migration-20260417a.mjs` | Applies `20260417a_partner_check_in_enabled.sql` via direct Postgres; verifies distribution invariant |
+| `apply-migration-20260417b.mjs` | Applies `20260417b_partner_events_schedule_denial.sql` (widens event_type CHECK) |
+| `apply-migration-20260418a.mjs` | Applies abandoned_questions + content_gaps_open_partial_unique migrations via session-mode pg |
+| `apply-migration-20260419b.mjs` | Applies `20260419b_partner_peer_benchmark.sql` (creates benchmark function) |
+| `apply-migration-20260419c.mjs` | Applies `20260419c_partner_peer_benchmark_revoke_authenticated.sql` (revokes EXECUTE from authenticated) |
+| `apply-migration-20260419d.mjs` | Applies `20260419d_posted_answers.sql` (CREATE TABLE + increment function) |
+| `apply-migration-20260419e.mjs` | Applies `20260419e_posted_answers_updated_at.sql` (adds updated_at trigger) |
+| `apply-migration-20260420b.mjs` | Applies `20260420b_posted_answers_fixups.sql` with exitCode-not-exit pattern for pool cleanup |
+| `apply-migration-20260420c.mjs` | Applies `20260420c_partner_branding_hardening.sql` via direct Postgres |
+| `apply-motion-data-rest.mjs` | Applies cached motion-extraction results from `data/bulk-verify/motion-extraction-results.json` via PostgREST additive merge |
+| `apply-partners-source-migration.mjs` | Applies `20260415d_partners_source_column.sql`; verifies source column + backfill count |
+| `apply-sms-suspensions-migration.mjs` | Applies `20260415b_sms_suspensions.sql` (idempotent via IF NOT EXISTS) |
+| `apply-sms-suspensions-rls.mjs` | Applies `20260415c_sms_suspensions_rls.sql`; verifies RLS is enabled |
+| `register-resend-bounce-webhook.mjs` | Registers bounce/complaint webhook on Resend; returns signing_secret for RESEND_WEBHOOK_SECRET env |
+| `register-sms-health-check-cron.mjs` | Registers `/api/cron/sms-health-check` on cron-job.org (daily 10:00 UTC) |
+| `update-vercel-env.mjs` | Sets a single Vercel env var on the production `imnotanattorney` project (bypasses stale `.env.local` project ref) |
 
 ### Validation & Linting
 | File | Purpose |
 |------|---------|
 | `check-tiers.mjs` | Verifies tier names/prices in `src/lib/tiers.ts` match across docs (CLAUDE.md, PRD, SERVICES). Catches pricing drift |
 | `brand-voice-scan.mjs` | Heuristic flagger for partner-surface copy. Outputs ranked candidates with file:line references. 10 rules (6 hard, 4 soft) per `.claude/rules/brand-voice.md` + `no-hallucinated-legal-data.md`. Never rewrites. Usage: `node scripts/brand-voice-scan.mjs` or `--json` for tooling. Exits 0 regardless of findings; exit 2 on tool error |
+| `audit-charge-coverage.mjs` | Aggregates charge-type coverage across jurisdiction_statutes candidate slugs (drug, assault, DV, etc.) |
+| `audit-w3-upl.mjs` | Seeds fake orders for 5 HIGH-UPL products, polls generate-standalone, downloads HTML to `data/w3-audit/` for manual review |
+| `check-price-staleness.mjs` | Validates every `// anchor:SLUG` in src/ references a dollar value >= canonical tiers.ts price; checks playbook totalValue sums |
+| `check-partner-envs.mjs` | Queries `/api/admin/env-presence` and pretty-prints partner env var status on the deploy |
+| `check-missing-crons.mjs` | Checks cron-job.org for partner-cleanup + court-reminders registrations |
+| `validate-gold-set.mjs` | Phase 0B GO/NO-GO gate: runs mechanical-extractor on 200 opinions vs human labels; demands 90%+ field agreement |
+| `validate-matrix.mjs` | Validates product-matrix.ts slugs against products.ts + tiers.ts (catches drift) |
+| `verify-checkin-cron.mjs` | Verifies cron-job.org registration for check-in-prompt cron job |
+| `verify-checkin-integration.mjs` | Task 9 Step 4 integration test: creates test court_reminder, verifies cron query logic + idempotency |
+| `verify-officer-render-ca-ga.mjs` | Mirrors queryOfficerBackground() for CA+GA; asserts npi_employment_history shape matches render preconditions |
+| `verify-resend-webhook-e2e.mjs` | Layer 2 E2E: Svix-signs a bounce webhook, POSTs to prod, asserts phone now suspended, cleans up |
+| `verify-resend-webhook.mjs` | Verifies RESEND_WEBHOOK_SECRET set + webhook registered + subscribed to bounced/complained events |
+| `verify-tasks-applied.mjs` | Verifies Task 1-3 (enrichment + CAP verification + CL URLs) applied correctly via Management API |
+
+### Diagnostic & Inspection
+| File | Purpose |
+|------|---------|
+| `diag-supabase-resource-audit.mjs` | Zombie backend detection via pg_stat_activity (Albe pattern); session-mode port 5432 |
+| `diagnose-content-gaps-dups.mjs` | Inspects content_gaps status CHECK constraint + dup distribution pre-consolidation |
+| `check-posted-answers-state.mjs` | Inspects posted_answers columns, moderation_status CHECK, and function ACL post-migration |
+| `inspect-ga-officer-intel.mjs` | Samples officer_external_intel by sources for GA (npi/brady/decertified coverage) |
+| `sanity-bondsman-modes.mjs` | Pre-migration sanity: confirms zero non-bondsman partners own check-ins |
 
 ### Report Generation
 | File | Purpose |
@@ -46,6 +86,17 @@
 | `bulk-dump-cases.mjs` | Exports all `statute_case_law` rows to local JSON via single Supabase Management API query. Writes to `data/bulk-verify/`. `, output` |
 | `bulk-download-cap.mjs` | Downloads needed CAP CasesMetadata.json volumes from `static.case.law` to `.cap-cache/`. Parses citations from dump JSON, deduplicates. `, dry-run`, `, concurrency N` |
 | `bulk-verify-cases.mjs` | Matches citations against local CAP cache, generates + batch-applies SQL updates. Marks unverifiable as `NOT_IN_DB` (safer than delete for bulk). Zero API calls during verify. `, dry-run` |
+| `bulk-add-reference-urls.mjs` | True-bulk `UPDATE ... FROM (VALUES)` variant of add-reference-urls (Justia/Scholar/CL/FindLaw URL append); ~5x faster |
+| `bulk-verify-courtlistener.mjs` | Marks CL-tracked cases with source URLs + validation_level=VALID_MODERATE (no download needed) |
+| `bulk-is-good-law.mjs` | Zero-citation fast path: rows with citation_count=0 in CL clusters CSV → is_good_law=true (no API calls) |
+| `bulk-good-law-by-cluster.mjs` | Per-cluster is_good_law verification (4x fewer CL API calls than row-by-row) |
+| `bulk-good-law-from-graph.mjs` | 4-phase Lissner/FLP pattern: cluster→opinion map → citing graph → citing texts → negative-treatment scan |
+| `run-full-good-law-pipeline.mjs` | Sequential runner: dump → 4 graph phases → reference URLs; walk-away execution |
+| `bulk-classify-cases.mjs` | Streams CL clusters CSV (2.3 GB bzip2) for party_side DEFENSE/PROSECUTION/NEUTRAL classification (zero API) |
+| `bulk-classify-from-opinions.mjs` | Streams 50 GB opinions CSV, classifies party_side/outcome/holding_excerpt/key_quote/application per cluster |
+| `bulk-classify-from-csv.mjs` | Streams pre-filtered opinions CSV (10,839 records), runs mechanical + cross-validation; upserts classified_opinions |
+| `bulk-classify-full-corpus.mjs` | Full 50 GB opinions stream, criminal filter + mechanical extraction; targets 100K-500K classified_opinions rows |
+| `classify-existing-opinions.mjs` | Classifies existing 3,407 case_law rows via mechanical-extractor + cross-validator → classified_opinions |
 
 #### Citation Verification, Offline vs Runtime
 
@@ -65,6 +116,104 @@ The full multi-source verification cascade (Harvard CAP, GovInfo, eCFR, Cornell 
 |------|---------|
 | `generate-charge-taxonomy.ts` | Claude API calls for all 52 jurisdictions. Commands: `, all`, `, jurisdiction FL`, `, questions`, `, validate`, `, dry-run` |
 | `build-seed-migration.ts` | Builds migration 029 SQL from COMMON_CHARGES + questions.json + jurisdiction JSONs |
+| `backfill-charge-slugs.mjs` | Backfills case_feature_vectors.charge_slug via jurisdiction_statute_id FK (fixes NULL-slug similar-case 0-results bug) |
+| `generate-state-charge-data.mjs` | Generates state charge law TS files (drug/assault/theft/etc.) from curated jurisdiction_statutes |
+| `bulk-extract-charge-types.mjs` | Focused counterpart to bulk-classify-full-corpus: extracts only charge_types on pre-filtered criminal CSV |
+| `seed-charge-defense-theories.mjs` | Seeds charge_defense_theories from `data/defense-intelligence/charge-defense-theories.json` |
+| `pull-dui-all-states.mjs` | Pulls DUI/DWI opinions from CL search API for all 50 states → case_feature_vectors charge_slug=dui |
+| `pull-all-charges-all-states.mjs` | Extends pull-dui across all supported charge types (drug, assault, theft, etc.) per state |
+| `promote-to-engine-tier.mjs` | Copies verified good-law rows from statute_case_law → engine-tier case_law + case_law_references + verified_case_law |
+
+### Tier 9 Data Pipeline
+> Populates analytics tables that back Tier 9 standalone SKUs: Judge Report Card ($197), Officer Background Check ($97), Similar Cases Analyzer ($297), Federal Sentencing Distribution ($297), plus War Room / Situation Room consumers. Streams CourtListener bulk data (50 GB opinions CSV, 2.3 GB clusters, 522 MB citations) locally — zero API cost after initial download.
+
+| File | Purpose |
+|------|---------|
+| `pipeline-runner.mjs` | Sequential Tier 9 runner: bulk-master-extractor → appeal-correlator (4 phases) → similar-case-matcher |
+| `bulk-master-extractor.mjs` | Single-pass 50 GB opinions CSV: populates 8 tables (judge_quotes, sentencing_distributions, officer_reliability, pairings, bench_jury_divergence, co_defendant_analysis, plea_discount_curves, appellate_trends) |
+| `bulk-judge-quote-extractor.mjs` | Extracts verbatim judicial holding quotes from 50 GB opinions CSV → judge_quotes (topic-classified) |
+| `bulk-judge-prosecutor-pairing.mjs` | Builds judge x prosecutor grant-rate matrix per motion_type → judge_prosecutor_pairings (sample >= 2) |
+| `bulk-sentencing-outlier-detector.mjs` | Per-judge p25/median/p75 sentencing percentiles by jurisdiction+charge → sentencing_distributions |
+| `bulk-officer-reliability-aggregator.mjs` | Extracts officer testimony credibility signals (Brady/impeached/discredited) → officer_reliability (testimony >= 2) |
+| `bulk-bench-jury-divergence.mjs` | Per-judge bench vs jury acquittal rate divergence from opinions CSV → bench_jury_divergence + judge_profiles |
+| `bulk-co-defendant-divergence-analyzer.mjs` | Extracts co-defendant outcome divergences from opinions CSV → co_defendant_analysis |
+| `bulk-plea-discount-modeler.mjs` | Models plea-vs-trial sentence discount curves by jurisdiction+charge (>= 3 plea + 3 trial) → plea_discount_curves |
+| `bulk-appeal-outcome-correlator.mjs` | 4-phase: citation-map + opinions streams → reversal/affirmance rates by argument_type+jurisdiction+year → appellate_trends |
+| `bulk-similar-case-matcher.mjs` | O(n^2) k-NN on good-law cases using jurisdiction/court_level/year/party_side/outcome/motion_types → case_feature_vectors neighbors |
+| `bulk-populate-judge-profiles.mjs` | Populates judge_profiles from CourtListener people-db (people + positions CSVs) |
+| `bulk-populate-prosecution-counters.mjs` | Populates prosecution_counters grouping top 5 defense cases per PROSECUTION-side statute |
+| `link-quotes-to-judges.mjs` | Phase 1b link pass: streams opinions-filtered.csv cluster→author_id, matches to judge_profiles.cl_person_id |
+| `link-quotes-via-cl-api.mjs` | CL-API follow-up linker: hits /opinions for unlinked cluster_ids after CSV ceiling (15,652) |
+| `link-sentencing-to-judges.mjs` | Re-derives per-judge sentencing distributions via cluster→author match (fixes NULL-judge_id aggregate bug) |
+| `build-judge-coi.mjs` | Judge Conflict of Interest build: investment disclosures x case parties via trigram match → judge_conflict_of_interest |
+| `build-judge-coi-v2.mjs` | COI v3: dedupe companies first then trigram-match (reduces scan count ~30x) |
+| `build-judge-coi-v3.mjs` | COI v4 EXACT-match after canonical-name normalization (hash join, seconds vs timeouts) |
+| `build-judge-coi-v4.mjs` | COI builds Signal 3 + Signal 4 in one session via cl_dockets.assigned_to_id anchor |
+| `build-judge-coi-lateral.mjs` | COI Plan C: LATERAL with LIMIT bounds per-(judge,company) work to deterministic pool |
+| `build-judge-coi-finish.mjs` | COI resumer: trigram-join with tighter threshold on existing UNLOGGED staging; dedup via ON CONFLICT |
+| `build-judge-coi-finalize.mjs` | Post-v4 finalization: backfills case_url via scalar subquery lateral (vs 9.9M-row DISTINCT ON timeout) |
+| `build-judge-coi-actionable.mjs` | Final COI variant: actionable-recusal filter (case.judges must contain judge last name); ~1-10K vs 315K noise |
+| `build-judge-criminal-recusal-v2.mjs` | Per-author LATERAL scan on cl_opinion_bodies (fixes v1 row-dependent phraseto_tsquery GIN-blindness) |
+| `build-judge-criminal-recusal-v3.mjs` | Batched-by-author-chunks variant of criminal-recusal (progress visibility per commit) |
+| `build-judge-sentencing-fingerprint.mjs` | Judge sentencing fingerprint v1 (errored on cl_opinion_clusters.court_id) |
+| `build-judge-sentencing-fingerprint-v2.mjs` | Sentencing fingerprint: case-volume + offense-mix only (criminal IDB has no disposition data) |
+| `build-judge-disposition-profile-v2.mjs` | Disposition profile v2: normalizes FJC compact vs PACER docket formats to (court, yy, seq) join key |
+| `build-judge-reversal-rate-v2.mjs` | Reversal-rate v2: federal-only filter + true_reversal_rate denom = all authored (kills selection bias) |
+| `build-judge-fingerprint-v3.mjs` | Judge fingerprint v3: adds federal-only jurisdiction filter + per-race sentencing delta |
+| `build-judge-fingerprint-v3-safe.mjs` | Worry-to-pristine CRITICAL fixes: tightened WHERE, surname-collision guard, k-anonymity >= 11, jackknife baseline |
+| `build-court-jurisdiction-map.mjs` | Builds court_id → two-letter state code map from CL courts CSV (jurisdiction column + patterns) |
+| `build-final-jurisdiction-map.mjs` | Authoritative cluster_id → jurisdiction merger via cluster→docket→court→jurisdiction chain |
+| `extract-cluster-jurisdictions.mjs` | Streams CL opinion-clusters bz2 for cluster_id jurisdiction + cluster_id→docket_id maps |
+| `prefilter-opinions-csv.mjs` | readline scan (no csv-parse) of 50 GB opinions CSV by target cluster IDs → opinions-filtered.csv (~350 MB) |
+| `bulk-extract-motion-legal-issues.mjs` | Extracts motion_types[], legal_issues[], supporting_rulings[] from 50 GB opinions CSV → statute_case_law |
+| `enrich-case-vectors.mjs` | CL API enrichment: cluster detail + opinion text → features.outcome/party_side/motion_types on case_feature_vectors |
+| `enrich-from-bulk.mjs` | Zero-API variant of enrich-case-vectors: streams CL clusters bz2 + opinions-filtered.csv to fill features jsonb |
+| `enrich-cl-aba-ratings.mjs` | Fetches CL `/aba-ratings/?person=X` for judges → judge_profiles.aba_rating (fixes engine TODO) |
+| `enrich-cl-citation-depth.mjs` | Computes authority score from CL citation-count + opinions-cited depth → citation_authority |
+| `enrich-cl-retention-events.mjs` | Fetches CL `/retention-events/?person=X` for judges → judge_sentencing_patterns.retention_elections jsonb |
+| `compute-pattern-tables.mjs` | Aggregates classified_opinions → defense_theory_outcomes + motion_success_patterns (weighted by opinion_type) |
+| `convert-ussc-dat.py` | Parses USSC fixed-width .dat + .sas column positions, extracts bench/jury + sentencing columns to CSV |
+| `convert-ussc-sas.py` | Converts USSC .sas7bdat → CSV via pyreadstat (FY18+ format) |
+| `extract-ussc-columns.mjs` | Extracts 7 needed columns from 27K-column USSC CSV via line-by-line split (csv-parse cannot handle 27K cols) |
+| `refresh-ussc-matview.mjs` | REFRESH MATERIALIZED VIEW CONCURRENTLY ussc_similar_cases_summary (post-USSC ingest) |
+| `filter-criminal-opinions.py` | Stage 1 of classification pipeline: indexed_bzip2 parallel decompression filters criminal opinions from 50 GB bz2 |
+
+### Data Ingestion
+> One-shot or periodic ingesters for external datasets that power Tier 9 analytics. Each writes to a specific analytics table with source URL tracking.
+
+| File | Purpose |
+|------|---------|
+| `download-all-external-datasets.mjs` | Parallel download: JUSTFAIR, NPI, FJC IDB, MPV, Fatal Encounters, MfJ, FBI Crime |
+| `download-external-datasets.mjs` | Playwright downloads (bypasses 403s) for Brady/exoneration/NPI/BJS datasets |
+| `browser-download-datasets.mjs` | Playwright automation for FBI Crime Data + Measures for Justice downloads |
+| `browser-download-remaining.mjs` | Playwright v4 fixes for FJC criminal-IDB dropdown + FBI Location overlay |
+| `ingest-bjs-felony-sentences.mjs` | BJS Felony Sentences in State Courts → outcome_benchmarks (national + state aggregates) |
+| `ingest-bjs-outcomes.mjs` | BJS felony CSV aggregated to (level, name, offense_type) → outcome_benchmarks (conviction/acquittal/plea-penalty rates) |
+| `ingest-brady-giglio.mjs` | Scrapes giglio-bradylist.com → officer_external_intel (UPSERT on normalized name+state+agency) |
+| `ingest-exoneration-html.mjs` | Parses cached NRE HTML table → exoneration_patterns (sets factor cols NULL; CSV overwrites later) |
+| `ingest-exoneration-registry.mjs` | Full NRE CSV → exoneration_patterns with FC/MWID/P-FA/OM/ILD/F-MFE factor percentages |
+| `ingest-fatal-encounters.mjs` | Fatal Encounters CSV → officer_external_intel agency-level rows (sentinel `__agency__:` prefix) |
+| `ingest-justfair.mjs` | 595K federal sentencing records (FinalDataset.csv, 1.3 GB) → judge_sentencing_patterns + sentencing_distributions + judge_demographics |
+| `ingest-npi.mjs` | National Police Index per-state gz CSVs → officer_external_intel (employment history + wandering-officer detection) |
+| `ingest-ussc-bench-jury.mjs` | USSC Individual Offender FY14-FY24 DISPOSIT codes → bench_jury_divergence (trial penalty per district + offense) |
+| `ingest-ussc-sentencing.mjs` | USSC individual (district-anonymized) → judge_sentencing_patterns (departure rates, offense/criminal-history breakdowns) |
+| `ingest-virginia-court-data.mjs` | Virginia circuit criminal 2024 ConcludedBy/SentenceTime → bench_jury_divergence (state_code='VA') |
+| `ingest-cl-parties-attorneys.mjs` | CL `/search/?type=r` federal criminal → judge_prosecutor_pairings (USAO/DOJ vs PD/private classification) |
+| `marshall-covid-prisons-ingest.mjs` | Marshall Project COVID-19 prison data CSV → explicit schema + TRUNCATE + COPY FROM STDIN |
+
+### Backfills & Fixes
+| File | Purpose |
+|------|---------|
+| `backfill-defendant-profiles.mjs` | Seeds defendant_profiles for cases with intake_id but no profile (replicates src/lib/defendant-profile.ts deterministic mapping) |
+| `backfill-judge-jurisdiction.mjs` | Derives judge_profiles.jurisdiction from positions JSONB court_ids (prefers non-FEDERAL state codes) |
+| `backfill-officer-jurisdiction.mjs` | Derives officer_reliability.jurisdiction from brady_history cluster_ids → majority state |
+| `backfill-pillar-tags.mjs` | One-time backfill: tags content_gaps, blog_drafts, MDX posts with Content Pillar Engine metadata |
+| `backfill-published-hash.mjs` | Backfills `.qa-state/<slug>.json` sidecars with published_hash from MDX source |
+| `consolidate-content-gaps-dups.mjs` | Non-destructive dedup: keeps lower id, marks higher ids status='declined' (pre partial-unique migration) |
+| `fix-em-dashes.mjs` | Tree-wide em-dash/double-hyphen replacement with file-type-aware rules and 4 punctuation variants |
+| `fix-humanizer-slop.mjs` | Mechanical fixer for 10 posts that failed humanizer gate; drops AI-slop vocab + em-dash density |
+| `fix-pairings-judge-ids.mjs` | One-shot: replaces CL person_ids with UUIDs in judge_prosecutor_pairings-updates.sql (self-deletes) |
+| `fix-e2e-partner-source.mjs` | Carve-out: reclassifies "E2E Test Partner" as source='bondsman' so pre-migration backfill preserves check_in_enabled=true |
 
 ### E2E Testing
 | File | Purpose |
@@ -77,6 +226,21 @@ The full multi-source verification cascade (Harvard CAP, GovInfo, eCFR, Cornell 
 | `test-e2e-dashboard.mjs` | Operator dashboard + customer portal API tests. Creates test orders/cases/jobs, verifies response structure |
 | `test-inclusion-flow.mjs` | Tier inclusion logic (parent_order_id, is_included_deliverable) |
 | `verify-download-flow.mjs` | Download token flow for all 8 playbooks. Options: `, skip-cleanup`, `, skip-api` |
+| `e2e-tier9.mjs` | Full purchase flow for all 5 Tier 9 standalone SKUs (webhook → order → intake → generation → viewer → operator retry → cleanup) |
+| `seed-e2e-partners.mjs` | Seeds E2EBOND (check-in) + E2EREFE (referral) fixtures via ON CONFLICT; requires E2E_SEED_CONFIRMED=1 prod guard |
+| `teardown-e2e-partners.mjs` | Removes fixture partners seeded by seed-e2e-partners.mjs; same E2E_SEED_CONFIRMED=1 guard |
+| `smoke-test-tier8a-edge-fn.mjs` | Validates fetchDefendantProfileBlock + fetchCaseIntelligenceBlock SQL shapes against backfilled data (no Edge Function call) |
+| `qa-existing-post.mjs` | DEPRECATED Humanizer-only QA runner; LLM gates moved to /blog-pipeline skill. Retained for pre-commit hook only |
+| `test-aba-sample.mjs` | CL ABA-ratings API smoke probe: fetches 5 ratings to validate auth + shape |
+| `reviewer-fanout.mjs` | Fateev/Temporal durable reviewer fan-out; shells `claude -p` parallel with per-reviewer OS timeouts (replaces hung Agent tool) |
+
+### Misc / One-off
+| File | Purpose |
+|------|---------|
+| `task-1-apply-enrichment.mjs` | Task 1 applier: batch-applies ID+SC enrichment UPDATEs via Management API |
+| `task-2-apply-cap-verification.mjs` | Task 2 applier: batches of 50 from `verification-updates.sql` → Management API |
+| `task-3-apply-cl-urls.mjs` | Task 3 applier: CL verification updates from pre-generated `cl-verification-updates.sql` |
+| `task-2-3-final-apply.mjs` | Combined Task 2+3 final applier (helper for apply-enrichment-batches workflow) |
 
 ### Continuous Verification Probes
 | File | Purpose |

--- a/src/lib/CONTEXT.md
+++ b/src/lib/CONTEXT.md
@@ -1,6 +1,6 @@
 # Core Business Logic, src/lib/
 
-> 59 modules. This is where all business rules live: auth, payments, email, cron orchestration, AI report generation, scoring, and demand intelligence.
+> 84+ modules. This is where all business rules live: auth, payments, email, cron orchestration, AI report generation, scoring, demand intelligence, partner system, court reminders, defendant data, USSC/sentencing, and SMS.
 
 ## Module Table
 
@@ -18,18 +18,25 @@
 | `tiers.ts` | **SINGLE SOURCE OF TRUTH (tiered products)**, all pricing, Stripe price IDs, tier slugs, live flags |
 | `products.ts` | **SINGLE SOURCE OF TRUTH (standalone products)**, 44 products across 4 categories (3 calculators, 8 content guides, 24 research reports, 3 bundles + 6 inactive dark SKUs). 38 active / 6 inactive as of 2026-04-09. Parallels tiers.ts. Prices in cents. Checkout uses inline `price_data` (no Stripe Price IDs). |
 | `bundles.ts` | Bundle definitions, maps bundle slugs to included product slugs. 3 bundles: first-72-hours ($97), defense-preparation ($197), pre-plea-package ($197). Bundles piggyback on standalone product flow (same checkout, webhook, intake). |
+| `product-matrix.ts` | Hybrid stacking matrix mapping standalone products to tier bundles + IDD scholarship eligibility |
+| `referral-product-map.ts` | Slug map for `/r/[code]/[product]` deep links; single source of truth shared by page.tsx and OG image |
+| `promo-code.ts` | Promo-code regex + `isValidPromoCode` type guard (2-20 alphanumeric) |
 
 ### Standalone Product Support
 | File | Purpose |
 |------|---------|
 | `sanitize.ts` | `sanitizeReportHtml()`, allowlist-based HTML sanitizer for Claude-generated reports (used by standalone report viewer). Allows semantic tags + ARIA attributes, strips scripts/iframes/event handlers. |
 | `calculator.ts` | Calculator computation logic (good-time credit, diversion eligibility, veterans court). Reads state rules from JSON data files at `system-data/`. 3 calculators: `calculateGoodTime`, `calculateDiversion` (6 FL program evaluators), `calculateVeteransCourt` (10 states, 250+ courts). |
+| `prep-content.ts` | Insider tips content (hearing reality, courthouse arrest risks) for prep-facing pages |
+| `prep-data.ts` | Admin Supabase helpers for prep-data pages (ILIKE escape, state-code extraction from "County, ST") |
 
 ### Email
 | File | Purpose |
 |------|---------|
 | `email.ts` | Resend integration: send transactional email + CAN-SPAM unsubscribe footer |
 | `drip-emails.ts` | 7 email sequence definitions (templates, timing, triggers) |
+| `court-reminder-emails.ts` | 5 court-reminder email templates (-14d/-7d/-3d/-1d/+1d post-court) returning subject + inner HTML |
+| `partner-emails.ts` | 8 partner lifecycle email templates (welcome, nudges, sale notifications, payouts, tier upgrades) |
 
 ### Cron Orchestration (26 daily tasks)
 | File | Purpose |
@@ -99,6 +106,48 @@
 | `types/blog-pipeline.ts` | TypeScript interfaces for blog pipeline |
 | `types/operator.ts` | TypeScript interfaces for operator dashboard |
 | `playbook-configs.ts` | **SINGLE SOURCE OF TRUTH**, 8 PlaybookConfig objects (all copy per charge type) |
+
+### Partner System
+| File | Purpose |
+|------|---------|
+| `partner-brand-columns.ts` | Single source of truth for partner-branding column list (logo, colors, contrast) shared across OG/auth/dashboard |
+| `partner-by-code.ts` | Cached Supabase lookup of approved partner by promo_code for referral pages |
+| `partner-mode.ts` | Pure helpers computing partner mode URL (check-in vs referral-only) from partner shape |
+| `partner-schemas.ts` | Zod schemas for partner API request bodies (strict parsing, unknown fields rejected) |
+
+### Court Reminders
+| File | Purpose |
+|------|---------|
+| `check-in-schedule.ts` | Helpers for scheduled check-ins (day-of-week validation, ET timezone, display formatting, compliance math) |
+| `court-reminders.ts` | Shared types, constants, and charge-type-specific COURT_PREP_CONTENT for court reminder system |
+| `court-reminders-input.ts` | Input validation + sanitization for POST /api/court-reminders (required fields, email, charge allowlist, date) |
+
+### Defendant Data
+| File | Purpose |
+|------|---------|
+| `bond-exposure.ts` | Bond-amount estimator by charge-type slug for partner dashboard "protected exposure" metric |
+| `defendant-profile.ts` | Deterministic mapping from intake form fields to `defendant_profiles` rows for Tier 8A humanization |
+| `fsd-distribution.ts` | Query library for `federal_sentencing_distributions` ($297 FSD Report) with progressive-widening fallback |
+| `fsd-offguide.ts` | INAA chargeType → USSC offguide_code mapping for FSD product (23 active codes, corrected vs ussc-mappings.ts) |
+
+### USSC / Sentencing Data
+| File | Purpose |
+|------|---------|
+| `ussc-mappings.ts` | Mappers from INAA intake values to USSC matview codes (demographics + offense, no state→district) |
+| `ussc-similar-cases.ts` | Query lib for `ussc_similar_cases_summary` matview powering $297 Similar Cases + plea/sentencing calculator |
+
+### SMS
+| File | Purpose |
+|------|---------|
+| `partner-sms.ts` | Partner SMS message builders (milestone messages, GSM-7 safe, capped at 160 chars) |
+| `sms-suspensions.ts` | SMS suspension registry populated by Resend webhook on gateway bounces, read by sendSMS() pre-flight |
+
+### Miscellaneous Helpers
+| File | Purpose |
+|------|---------|
+| `brand.ts` | INAA brand color constants (amber, black, dark surface) for inline styling |
+| `env-check.ts` | `envWithWarn(key, fallback)` — loudly warns in production when optional-with-fallback env vars are missing |
+| `truncate-name.ts` | Shared name/company ellipsis truncation for OG images and partner bridge/checkin pages |
 
 ## Key Patterns
 


### PR DESCRIPTION
## Summary

Accumulated doc drift caught by `docs/verify-architecture.js`: 165 code files on disk but not listed in any Scripts/Modules table.

### Before → After (verify-architecture.js)
- **Before:** 186 verified / 165 undocumented / 351 total
- **After:**   351 verified /   0 undocumented / 351 total

### scripts/CONTEXT.md
- Adds 5 NEW sections: **Diagnostic & Inspection**, **Tier 9 Data Pipeline** (40+ build-judge / bulk-/ link-/ enrich-cl scripts), **Data Ingestion** (17 external-dataset ingesters), **Backfills & Fixes**, **Misc / One-off**
- Appends 14 rows to existing **Infrastructure & Setup** + **Validation & Linting**
- Appends 13 rows to **Legal Research Pipeline** (bulk good-law, classification variants)
- Appends 7 rows to **Charge Taxonomy** (backfill, state pulls, promotion)
- Appends 7 rows to **E2E Testing** (Tier 9 purchase flow, partner fixtures, smoke tests)

### src/lib/CONTEXT.md
- Adds 6 NEW sections: **Partner System**, **Court Reminders**, **Defendant Data**, **USSC / Sentencing Data**, **SMS**, **Miscellaneous Helpers**
- Appends 3 rows to **Payments** (product-matrix, referral-product-map, promo-code)
- Appends 2 rows to **Standalone Product Support** (prep-content, prep-data)
- Appends 2 rows to **Email** (court-reminder-emails, partner-emails)
- Updates module count header: 59 → 84+

## Test plan

- [x] `node docs/verify-architecture.js` → 351/351 verified, 0 undocumented
- [x] Pre-push `next build --webpack --experimental-build-mode compile` — compiled successfully
- [ ] Merge, then re-run verify on master to confirm parity

Generated with Claude Code