### PR TITLE
docs: fix 5 broken relative-path .md links

### DIFF
--- a/docs/handoff/2026-04-07-arch-doc-audit.md
+++ b/docs/handoff/2026-04-07-arch-doc-audit.md
@@ -510,7 +510,7 @@ Checkout Success OTO: 24-hour countdown timer (localStorage + server session), p
 
 ### Backup Worker GitHub Actions (stale doc lines 2049-2070)
 
-**Why stale:** Describes `.github/workflows/generate-report.yml` running a cron every 5 minutes to catch Edge Function timeouts. This directly contradicts the global rule "NEVER use GitHub Actions schedule/cron triggers. Use cron-job.org hitting API routes instead" (from `~/.claude/CLAUDE.md`) AND the INAA memory entry "[No GitHub Actions cron](feedback_no_github_cron.md)".
+**Why stale:** Describes `.github/workflows/generate-report.yml` running a cron every 5 minutes to catch Edge Function timeouts. This directly contradicts the global rule "NEVER use GitHub Actions schedule/cron triggers. Use cron-job.org hitting API routes instead" (from `~/.claude/CLAUDE.md`). Captured in project memory under the `feedback_no_github_cron` entry (auto-memory, `~/.claude/projects/…/memory/` — not an in-repo path).
 
 Either:
 (a) The workflow file still exists in violation of the rule (worth fixing),

--- a/docs/plans/2026-04-17-bondsman-modes-implementation-v2-diffs.md
+++ b/docs/plans/2026-04-17-bondsman-modes-implementation-v2-diffs.md
@@ -1,10 +1,8 @@
 # Bondsman Modes — v2 Diffs (supersedes v1 tasks)
 
-> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Read v1 plan + this diff together. This doc OVERRIDES v1 on every task where it appears. Findings traceability: [2026-04-17-bondsman-modes-findings-and-fixes.md](2026-04-17-bondsman-modes-findings-and-fixes.md).
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. This doc OVERRIDES any v1 task where it appears.
 
-**Supersedes:** [2026-04-17-bondsman-modes-implementation.md](2026-04-17-bondsman-modes-implementation.md) (v1 — task structure intact, code contents overridden per below).
-**Design:** [2026-04-17-modes-design.md](2026-04-17-modes-design.md) (still authoritative for intent).
-**Findings:** [2026-04-17-bondsman-modes-findings-and-fixes.md](2026-04-17-bondsman-modes-findings-and-fixes.md) (110 review findings).
+**Sibling docs note:** the original v1 plan + separate design doc + review-findings doc that this header previously cited were drafted in a working-tree session that never committed (verified via `git log --all -- <filename>`). Only this v2-diffs file landed. Treat this file as self-contained; prior referenced artifacts are unrecoverable from git history.
 
 **Added tasks:** 3.5 (CourtReminderForm props), 5.5 (partner-by-code helper), 19.5 (ToolkitSection demotion), 25.5 (card content), 26.5 (checklist content), 27 (ComplianceReportClient enumerated), 32.0 (E2E seed partners).
 


### PR DESCRIPTION
## Summary

Explore-agent audit of all `.md` files (388 files scanned, 101 inline links) found 5 broken relative-path links across 2 files. All 5 targets verified via `git log --all -- <filename>` as never having existed in git history — these are dead drafts, not renames.

## Fixes

### `docs/plans/2026-04-17-bondsman-modes-implementation-v2-diffs.md` (4 broken)

Header previously referenced 3 sibling plan files that never landed:
- `2026-04-17-bondsman-modes-findings-and-fixes.md` (cited twice: lines 3 + 7)
- `2026-04-17-bondsman-modes-implementation.md` (v1, line 5)
- `2026-04-17-modes-design.md` (line 6)

Rewrite header to note the siblings were drafted in a working-tree session that never committed. Readers should treat the v2-diffs file as self-contained.

### `docs/handoff/2026-04-07-arch-doc-audit.md` (1 broken)

Line 513 linked `feedback_no_github_cron.md` — that's an auto-memory filename that lives outside the repo (`~/.claude/projects/…/memory/`), not a repo-relative path. Rewrite the prose to note the entry lives in project auto-memory; link removed.

## Verification

Agent report:
- Scope: repo root `*.md`, `docs/**`, `design-system/`, `src/**/CONTEXT.md`, `supabase/CONTEXT.md`, `scripts/CONTEXT.md`, `PLAYBOOK-ARCHITECTURE.md`
- Excluded: `content/` (blog, off limits), `node_modules/`, `.claude/worktrees/`, `.next/`
- 388 markdown files scanned
- 101 inline links
- 14 ending in `.md`
- **5 broken** (below cap of 50)
- No systemic `OBSOLETE → archive` rename cascade
- No broken links in authoritative index files (ARCHITECTURE.md, CLAUDE.md, PLAYBOOK-ARCHITECTURE.md, all CONTEXT.md siblings)

Post-fix: 0 broken relative-path `.md` links.

## Diff

2 files, 5 insertions / 3 deletions. Docs-only.

## Test plan

- [x] Each broken target confirmed absent via `git log --all -- <filename>` (never committed)
- [x] Post-fix re-scan shows 0 broken links
- [x] Prose stays informative — readers get equivalent context without the dead link
- [ ] CI: Docs Freshness (runs on push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)