### PR TITLE
feat(ib): Appendix G (Motion Strategy) + Appendix H (Live Authority Map) on $997

### DIFF
--- a/src/lib/charge-slug-maps.ts
+++ b/src/lib/charge-slug-maps.ts
@@ -1,0 +1,286 @@
+/**
+ * Shared charge-slug lookup tables for tier9-reports + IB appendices.
+ *
+ * The datasets (motion_outcome_rates, charge_type_top_authorities) use
+ * **internal** charge slugs (e.g. "dui-dwi", "drug-possession-cocaine",
+ * "sexual-assault") that do NOT match ALLOWED_CHARGE_TYPES (user-facing
+ * intake slugs like "dui", "drug-possession"). Every report module that
+ * touches those tables needs the same bridge.
+ *
+ * Previously duplicated inline in:
+ *   - src/lib/tier9-reports/motion-success-report.ts (CHARGE_TYPE_MOR_MAP)
+ *   - src/lib/tier9-reports/charge-authority-pack.ts (CHARGE_TYPE_AUTHORITY_MAP)
+ *
+ * Extracted here 2026-04-23 for IB E1 (Appendix G + H) to consume. Source
+ * branches: feat/motion-success-report-197 + feat/charge-authority-pack-97.
+ *
+ * **Deliberately narrow** — only contains slugs verified live in the tables
+ * as of 2026-04-22. Unmapped charges fall through to national "(all)" or
+ * citation_authority_criminal fallback with a limitation note. No guessing.
+ */
+
+// ============================================================
+// motion_outcome_rates.charge_type slugs (54 distinct values)
+// ============================================================
+export const CHARGE_TYPE_MOR_MAP: Record<string, string[]> = {
+  "drug-possession": [
+    "drug-possession",
+    "drug-possession-marijuana",
+    "drug-possession-cocaine",
+    "drug-possession-meth",
+    "drug-possession-opioids",
+    "drug-possession-prescription",
+    "drug-possession-with-intent",
+  ],
+  "drug-trafficking": ["drug-trafficking", "drug-distribution", "drug-manufacturing"],
+  dui: [
+    "dui",
+    "dui-dwi",
+    "dui-first-offense",
+    "dui-repeat-offense",
+    "dui-third-offense",
+    "dui-drugs",
+    "dui-felony-injury",
+  ],
+  "dui-first": ["dui-first-offense", "dui-dwi"],
+  "dui-repeat": ["dui-repeat-offense", "dui-third-offense"],
+  assault: [
+    "assault",
+    "simple-assault",
+    "aggravated-assault",
+    "aggravated-battery",
+    "assault-with-deadly-weapon",
+    "assault-firearm",
+    "assault-police-officer",
+    "battery",
+  ],
+  "domestic-violence": [
+    "domestic-violence",
+    "domestic-battery",
+    "violation-protective-order",
+  ],
+  theft: [
+    "theft",
+    "theft-larceny",
+    "grand-theft",
+    "petty-theft",
+    "shoplifting",
+    "receiving-stolen-property",
+    "motor-vehicle-theft",
+  ],
+  "sex-offense": [
+    "sex-offense",
+    "sex-offense-contact",
+    "sex-offense-digital",
+    "sexual-assault",
+    "sexual-battery",
+    "rape",
+    "statutory-rape",
+    "indecent-exposure",
+  ],
+  "sex-offense-contact": [
+    "sex-offense-contact",
+    "sexual-assault",
+    "sexual-battery",
+    "rape",
+    "statutory-rape",
+  ],
+  "sex-offense-digital": [
+    "sex-offense-digital",
+    "child-exploitation",
+    "production-child-pornography",
+  ],
+  weapons: [
+    "weapons-possession",
+    "felony-firearm",
+    "felon-in-possession",
+    "possession-prohibited-weapon",
+    "weapons-school-zone",
+    "illegal-discharge",
+  ],
+  "white-collar": [
+    "fraud-general",
+    "wire-fraud",
+    "securities-fraud",
+    "tax-fraud",
+    "insurance-fraud",
+    "credit-card-fraud",
+    "prescription-fraud",
+    "money-laundering",
+    "embezzlement",
+    "identity-theft",
+    "forgery",
+    "bad-checks",
+  ],
+  federal: [],
+  "probation-violation": [
+    "probation-violation-technical",
+    "probation-violation-substantive",
+    "parole-violation",
+    "community-control-violation",
+    "supervised-release-violation",
+  ],
+  "self-defense": [],
+  other: ["other"],
+  murder: ["murder", "murder-first-degree", "murder-second-degree", "attempted-murder"],
+  manslaughter: [
+    "voluntary-manslaughter",
+    "involuntary-manslaughter",
+    "vehicular-manslaughter",
+    "vehicular-homicide",
+  ],
+  kidnapping: ["kidnapping", "unlawful-imprisonment"],
+  arson: ["arson"],
+  stalking: ["stalking", "aggravated-stalking"],
+  "child-abuse": ["child-abuse", "child-endangerment"],
+  "hit-and-run": ["hit-and-run"],
+  contempt: ["contempt-of-court", "criminal-contempt"],
+  robbery: ["robbery", "armed-robbery", "home-invasion"],
+  burglary: ["burglary", "residential-burglary", "commercial-burglary"],
+  fraud: [
+    "fraud-general",
+    "wire-fraud",
+    "securities-fraud",
+    "tax-fraud",
+    "insurance-fraud",
+    "credit-card-fraud",
+    "prescription-fraud",
+    "identity-theft",
+  ],
+  drug: [
+    "drug-possession",
+    "drug-trafficking",
+    "drug-distribution",
+    "drug-manufacturing",
+    "drug-paraphernalia",
+  ],
+  "other-felony": [],
+  "other-misdemeanor": [],
+};
+
+// ============================================================
+// charge_type_top_authorities.charge_type slugs (subset of 54)
+// ============================================================
+// Verified against live table 2026-04-23. Some MOR slugs (domestic-battery,
+// assault, theft, murder-first-degree) don't appear in top_authorities yet —
+// those fall through to citation_authority_criminal fallback.
+export const CHARGE_TYPE_AUTHORITY_MAP: Record<string, string[]> = {
+  "drug-possession": [
+    "drug-possession-marijuana",
+    "drug-possession-cocaine",
+    "drug-possession-opioids",
+    "drug-possession-prescription",
+  ],
+  "drug-trafficking": ["drug-trafficking", "drug-distribution", "drug-manufacturing"],
+  dui: ["dui-dwi", "dui-drugs", "dui-felony-injury", "refusing-breath-test"],
+  "dui-first": ["dui-dwi"],
+  "dui-repeat": ["dui-dwi", "dui-felony-injury"],
+  assault: [
+    "simple-assault",
+    "aggravated-assault",
+    "aggravated-battery",
+    "assault-firearm",
+    "assault-police-officer",
+    "battery",
+  ],
+  "domestic-violence": [],
+  theft: ["theft-larceny"],
+  "sex-offense": [
+    "sex-offense-contact",
+    "sex-offense-digital",
+    "sexual-assault",
+    "indecent-exposure",
+  ],
+  "sex-offense-contact": ["sex-offense-contact", "sexual-assault"],
+  "sex-offense-digital": ["sex-offense-digital", "child-exploitation"],
+  weapons: ["weapons-possession", "felon-in-possession", "illegal-discharge"],
+  "white-collar": ["fraud-general", "embezzlement", "forgery"],
+  federal: [],
+  "probation-violation": ["supervised-release-violation"],
+  "self-defense": [],
+  other: ["other"],
+  murder: ["murder-second-degree"],
+  manslaughter: ["voluntary-manslaughter", "vehicular-homicide"],
+  kidnapping: ["kidnapping", "unlawful-imprisonment"],
+  arson: [],
+  stalking: ["stalking"],
+  "child-abuse": ["child-endangerment"],
+  "hit-and-run": ["hit-and-run"],
+  contempt: ["contempt-of-court"],
+  robbery: ["robbery", "home-invasion"],
+  burglary: ["burglary"],
+  fraud: ["fraud-general", "embezzlement", "forgery"],
+  drug: [
+    "drug-possession-marijuana",
+    "drug-possession-cocaine",
+    "drug-possession-opioids",
+    "drug-possession-prescription",
+    "drug-trafficking",
+    "drug-distribution",
+    "drug-manufacturing",
+  ],
+  "other-felony": [],
+  "other-misdemeanor": ["disorderly-conduct", "loitering", "vandalism"],
+};
+
+// ============================================================
+// State → Federal Circuit (for motion_outcome_rates_by_circuit)
+// ============================================================
+// Restricted to the circuit domain stored in motion_outcome_rates_by_circuit
+// ("1".."11", "DC"). SCOTUS / Federal Circuit are not exposed to intake —
+// neither is jurisdictionally relevant for a state criminal defendant
+// filing circuit-wide motion patterns.
+export const STATE_TO_CIRCUIT: Record<string, string> = {
+  ME: "1", MA: "1", NH: "1", RI: "1",
+  NY: "2", CT: "2", VT: "2",
+  PA: "3", NJ: "3", DE: "3",
+  MD: "4", VA: "4", WV: "4", NC: "4", SC: "4",
+  TX: "5", LA: "5", MS: "5",
+  OH: "6", MI: "6", KY: "6", TN: "6",
+  IL: "7", IN: "7", WI: "7",
+  MN: "8", IA: "8", MO: "8", AR: "8", ND: "8", SD: "8", NE: "8",
+  CA: "9", OR: "9", WA: "9", AZ: "9", NV: "9", ID: "9", MT: "9", AK: "9", HI: "9",
+  CO: "10", KS: "10", NM: "10", OK: "10", UT: "10", WY: "10",
+  FL: "11", GA: "11", AL: "11",
+  DC: "DC",
+};
+
+export const CIRCUIT_NAMES: Record<string, string> = {
+  "1": "First Circuit",
+  "2": "Second Circuit",
+  "3": "Third Circuit",
+  "4": "Fourth Circuit",
+  "5": "Fifth Circuit",
+  "6": "Sixth Circuit",
+  "7": "Seventh Circuit",
+  "8": "Eighth Circuit",
+  "9": "Ninth Circuit",
+  "10": "Tenth Circuit",
+  "11": "Eleventh Circuit",
+  DC: "D.C. Circuit",
+};
+
+export const VALID_CIRCUITS = new Set(Object.keys(CIRCUIT_NAMES));
+
+export function resolveCircuitFromStateOrCircuit(
+  circuit: string | null | undefined,
+  state: string | null | undefined,
+): string | null {
+  const raw = (circuit ?? "").trim();
+  if (raw && VALID_CIRCUITS.has(raw)) return raw;
+  const st = (state ?? "").trim().toUpperCase();
+  if (st && STATE_TO_CIRCUIT[st]) return STATE_TO_CIRCUIT[st];
+  return null;
+}
+
+// ============================================================
+// UPL phrase blocklist (shared across tier9 + IB appendices)
+// ============================================================
+export const UPL_BANNED_PHRASES = [
+  "you should",
+  "we recommend",
+  "we advise",
+  "your best option",
+  "ask your attorney",
+  "publicly available",
+] as const;

--- a/src/lib/ib-appendices/__tests__/live-authority-map.test.ts
+++ b/src/lib/ib-appendices/__tests__/live-authority-map.test.ts
@@ -1,0 +1,243 @@
+/**
+ * Unit tests for Appendix H — Live Authority Map (IB $997 E1).
+ *
+ * Focus areas:
+ *   1. UPL banned-phrase blocklist (counter-auth phrased neutrally)
+ *   2. Tier monotonicity (IB top-15 strictly > M2 top 10; full quote vs 1-line)
+ *   3. Counter-authority warning only when velocity_tier = 'fading'
+ *   4. Every row has CourtListener URL in the rendered markdown
+ *   5. Bold cross-reference heuristic on rising rows
+ */
+import { describe, it, expect } from "vitest";
+import {
+  renderLiveAuthorityMap,
+  IB_AUTHORITY_TOP_N,
+  type LiveAuthorityMapData,
+  type AuthorityMapRow,
+} from "../live-authority-map";
+import { UPL_BANNED_PHRASES } from "@/lib/charge-slug-maps";
+
+function mkRow(over: Partial<AuthorityMapRow> = {}): AuthorityMapRow {
+  return {
+    rank: 1,
+    case_name: "Miranda v. Arizona",
+    date_filed: "1966-06-13",
+    citation: "384 U.S. 436",
+    authority_tier: "landmark",
+    citation_count_in_charge: 420,
+    citation_count_total: 4800,
+    quote_full:
+      "Prior to any questioning, the person must be warned that he has a right to remain silent, that any statement he does make may be used as evidence against him. The right to have counsel present at the interrogation is indispensable to the protection of the Fifth Amendment privilege under the system we delineate today.",
+    velocity: 180.4,
+    velocity_tier: "stable",
+    rising_flag: false,
+    counter_authority_warning: false,
+    source_url: "https://www.courtlistener.com/opinion/107252/miranda-v-arizona/",
+    jurisdiction: "F",
+    data_scope: "charge_type",
+    ...over,
+  };
+}
+
+function mkData(over: Partial<LiveAuthorityMapData> = {}): LiveAuthorityMapData {
+  return {
+    chargeType: "drug-possession",
+    state: "CA",
+    circuit: "9",
+    circuitName: "Ninth Circuit",
+    rows: [mkRow()],
+    limitations: [],
+    isEmpty: false,
+    ...over,
+  };
+}
+
+// ------------------------------------------------------------
+// UPL banned phrases
+// ------------------------------------------------------------
+
+describe("Appendix H — Live Authority Map · UPL blocklist", () => {
+  it("never emits banned UPL phrases even with counter-auth warnings, full quote, and 15 rows", () => {
+    const data = mkData({
+      rows: Array.from({ length: IB_AUTHORITY_TOP_N }, (_, i) =>
+        mkRow({
+          rank: i + 1,
+          case_name: `Case ${i + 1}`,
+          counter_authority_warning: i % 3 === 0,
+          velocity_tier: i % 3 === 0 ? "fading" : "stable",
+          rising_flag: i % 5 === 0,
+        }),
+      ),
+    });
+    const md = renderLiveAuthorityMap(data);
+    const lower = md.toLowerCase();
+    for (const phrase of UPL_BANNED_PHRASES) {
+      expect(
+        lower.includes(phrase),
+        `rendered markdown must not contain banned phrase "${phrase}"`,
+      ).toBe(false);
+    }
+  });
+
+  it("counter-auth note uses neutral 'declining citation velocity' language, never 'don't use'", () => {
+    const data = mkData({
+      rows: [
+        mkRow({
+          counter_authority_warning: true,
+          velocity_tier: "fading",
+        }),
+      ],
+    });
+    const md = renderLiveAuthorityMap(data);
+    expect(md).toContain("declining citation velocity");
+    expect(md).not.toMatch(/don't use|do not use|avoid citing/i);
+  });
+
+  it("emits methodology legal-INFORMATION gate", () => {
+    const md = renderLiveAuthorityMap(mkData());
+    expect(md).toContain("legal INFORMATION");
+    expect(md).toContain("not legal ADVICE");
+    // Methodology must disclaim prediction (any equivalent phrasing)
+    expect(md).toMatch(/not a prediction|is a prediction\./i);
+  });
+});
+
+// ------------------------------------------------------------
+// Tier monotonicity (HARD)
+// ------------------------------------------------------------
+
+describe("Appendix H — Live Authority Map · tier monotonicity guardrails", () => {
+  it("IB top-N strictly exceeds M2 top 10", () => {
+    expect(IB_AUTHORITY_TOP_N).toBeGreaterThan(10);
+    expect(IB_AUTHORITY_TOP_N).toBe(15);
+  });
+
+  it("renders a full multi-sentence quote when cached (monotonicity depth over M2 1-line)", () => {
+    const longQuote =
+      "Prior to any questioning, the person must be warned. " +
+      "The warning must include the right to counsel. " +
+      "Anything said can be used against them.";
+    const md = renderLiveAuthorityMap(
+      mkData({ rows: [mkRow({ quote_full: longQuote })] }),
+    );
+    // All three sentences present in output (multi-sentence depth test)
+    expect(md).toContain("Prior to any questioning");
+    expect(md).toContain("right to counsel");
+    expect(md).toContain("used against them");
+  });
+});
+
+// ------------------------------------------------------------
+// Counter-authority warning
+// ------------------------------------------------------------
+
+describe("Appendix H — Live Authority Map · counter-authority flag", () => {
+  it("renders counter-auth note ONLY when counter_authority_warning=true", () => {
+    const withWarn = renderLiveAuthorityMap(
+      mkData({
+        rows: [mkRow({ counter_authority_warning: true, velocity_tier: "fading" })],
+      }),
+    );
+    expect(withWarn).toContain("Counter-authority note");
+
+    const noWarn = renderLiveAuthorityMap(
+      mkData({
+        rows: [mkRow({ counter_authority_warning: false, velocity_tier: "stable" })],
+      }),
+    );
+    expect(noWarn).not.toContain("Counter-authority note");
+  });
+
+  it("velocity label appears on every row (rising / fading / stable)", () => {
+    const md = renderLiveAuthorityMap(
+      mkData({
+        rows: [
+          mkRow({ rank: 1, rising_flag: true, velocity_tier: "rising" }),
+          mkRow({ rank: 2, case_name: "Case B", rising_flag: false, velocity_tier: "fading", counter_authority_warning: true }),
+          mkRow({ rank: 3, case_name: "Case C", rising_flag: false, velocity_tier: "stable" }),
+        ],
+      }),
+    );
+    expect(md).toContain("velocity: rising");
+    expect(md).toContain("velocity: fading");
+    expect(md).toContain("velocity: stable");
+  });
+});
+
+// ------------------------------------------------------------
+// URL + cross-ref
+// ------------------------------------------------------------
+
+describe("Appendix H — Live Authority Map · URLs + cross-ref heuristic", () => {
+  it("every row includes its CourtListener URL in markdown output", () => {
+    const md = renderLiveAuthorityMap(
+      mkData({
+        rows: [
+          mkRow({ rank: 1, source_url: "https://www.courtlistener.com/opinion/1/a/" }),
+          mkRow({ rank: 2, case_name: "Case B", source_url: "https://www.courtlistener.com/opinion/2/b/" }),
+        ],
+      }),
+    );
+    expect(md).toContain("https://www.courtlistener.com/opinion/1/a/");
+    expect(md).toContain("https://www.courtlistener.com/opinion/2/b/");
+  });
+
+  it("bolds rising rows as a cross-ref heuristic to Appendix G granted-motion cases", () => {
+    const md = renderLiveAuthorityMap(
+      mkData({
+        rows: [
+          mkRow({ rank: 1, rising_flag: true, case_name: "Rising Case" }),
+          mkRow({ rank: 2, rising_flag: false, case_name: "Stable Case" }),
+        ],
+      }),
+    );
+    // Bold marker around the rank for rising row
+    expect(md).toContain("**1. [Rising Case]");
+    // Unbold for non-rising (just numeric prefix, no leading **)
+    expect(md).toContain("2. [Stable Case]");
+    expect(md).not.toContain("**2. [Stable Case]");
+  });
+
+  it("appendix heading is Appendix H (not F or G)", () => {
+    const md = renderLiveAuthorityMap(mkData());
+    expect(md).toContain("## Appendix H: Live Authority Map");
+    expect(md).not.toContain("## Appendix F");
+    expect(md).not.toContain("## Appendix G");
+  });
+});
+
+// ------------------------------------------------------------
+// Empty + limitation paths
+// ------------------------------------------------------------
+
+describe("Appendix H — Live Authority Map · empty + limitation paths", () => {
+  it("empty data renders empty string", () => {
+    const empty: LiveAuthorityMapData = {
+      chargeType: "other",
+      state: null,
+      circuit: null,
+      circuitName: null,
+      rows: [],
+      limitations: [],
+      isEmpty: true,
+    };
+    expect(renderLiveAuthorityMap(empty)).toBe("");
+  });
+
+  it("surfaces limitations when jurisdiction filter narrowed the list", () => {
+    const md = renderLiveAuthorityMap(
+      mkData({
+        limitations: ["Authority list narrowed to state-court + federal opinions relevant to CA."],
+      }),
+    );
+    expect(md).toContain("Known limitations");
+    expect(md).toContain("narrowed to state-court");
+  });
+
+  it("falls back gracefully when a row has no cached quote", () => {
+    const md = renderLiveAuthorityMap(
+      mkData({ rows: [mkRow({ quote_full: null })] }),
+    );
+    expect(md).toContain("No canonical quote cached");
+  });
+});

--- a/src/lib/ib-appendices/__tests__/motion-strategy.test.ts
+++ b/src/lib/ib-appendices/__tests__/motion-strategy.test.ts
@@ -1,0 +1,260 @@
+/**
+ * Unit tests for Appendix G — Motion Strategy (IB $997 E1).
+ *
+ * Focus areas:
+ *   1. UPL banned-phrase blocklist
+ *   2. Tier monotonicity (IB strictly exceeds M1 $197)
+ *   3. Quote coverage + fallback (every row has URL; quote optional)
+ *   4. Render emits CourtListener URLs for every citation
+ *   5. Insufficient-sample judge rows surface with caveat (M1 suppresses)
+ */
+import { describe, it, expect } from "vitest";
+import {
+  renderMotionStrategy,
+  IB_MOTION_TOP_N,
+  IB_CITATION_TOP_N,
+  IB_JUDGE_INSUFFICIENT_THRESHOLD,
+  type MotionStrategyData,
+  type MotionRateRow,
+  type JudgeMotionRow,
+  type MotionCitationRow,
+} from "../motion-strategy";
+import { UPL_BANNED_PHRASES } from "@/lib/charge-slug-maps";
+
+// ------------------------------------------------------------
+// Test fixtures
+// ------------------------------------------------------------
+
+function mkMotion(over: Partial<MotionRateRow> = {}): MotionRateRow {
+  return {
+    motion_type: "motion_to_suppress",
+    filed_count: 42,
+    granted_count: 14,
+    denied_count: 28,
+    grant_rate: 0.333,
+    baseline_grant_rate: 0.25,
+    deviation_from_baseline: 0.083,
+    data_scope: "charge_national",
+    ...over,
+  };
+}
+
+function mkJudge(over: Partial<JudgeMotionRow> = {}): JudgeMotionRow {
+  return {
+    motion_type: "motion_to_dismiss",
+    filed_count: 5,
+    granted_count: 2,
+    grant_rate: 0.4,
+    baseline_grant_rate: 0.3,
+    deviation_from_baseline: 0.1,
+    insufficient_sample: true,
+    ...over,
+  };
+}
+
+function mkCitation(over: Partial<MotionCitationRow> = {}): MotionCitationRow {
+  return {
+    rank: 1,
+    case_name: "Katz v. United States",
+    date_filed: "1967-12-18",
+    citation: "389 U.S. 347",
+    authority_tier: "landmark",
+    citation_count_in_charge: 200,
+    citation_count_total: 2500,
+    quote_sentence:
+      "The Fourth Amendment protects people, not places. What a person knowingly exposes to the public is not a subject of Fourth Amendment protection.",
+    quote_frequency: 12,
+    source_url: "https://www.courtlistener.com/opinion/107564/katz-v-united-states/",
+    data_scope: "charge_type",
+    ...over,
+  };
+}
+
+function mkData(over: Partial<MotionStrategyData> = {}): MotionStrategyData {
+  return {
+    chargeType: "drug-possession",
+    circuit: "9",
+    circuitName: "Ninth Circuit",
+    judgeDisplayName: "Jane Doe",
+    judgeResolved: true,
+    ambiguousJudge: false,
+    motions: [mkMotion()],
+    judgeMotions: [mkJudge()],
+    citations: [mkCitation()],
+    limitations: [],
+    isEmpty: false,
+    ...over,
+  };
+}
+
+// ------------------------------------------------------------
+// UPL banned phrases
+// ------------------------------------------------------------
+
+describe("Appendix G — Motion Strategy · UPL blocklist", () => {
+  it("never emits banned UPL phrases on fully populated render", () => {
+    const data = mkData({
+      motions: Array.from({ length: IB_MOTION_TOP_N }, (_, i) =>
+        mkMotion({ motion_type: `motion_type_${i}`, filed_count: 100 - i }),
+      ),
+      judgeMotions: [
+        mkJudge({ filed_count: 3, insufficient_sample: true }),
+        mkJudge({ motion_type: "motion_to_exclude", filed_count: 45, insufficient_sample: false }),
+      ],
+      citations: Array.from({ length: IB_CITATION_TOP_N }, (_, i) =>
+        mkCitation({ rank: i + 1, case_name: `Case ${i}` }),
+      ),
+      limitations: [
+        "No circuit-specific motion baseline for Ninth Circuit; vs circuit column omitted.",
+      ],
+    });
+    const md = renderMotionStrategy(data);
+    const lower = md.toLowerCase();
+    for (const phrase of UPL_BANNED_PHRASES) {
+      expect(
+        lower.includes(phrase),
+        `rendered markdown must not contain banned phrase "${phrase}"`,
+      ).toBe(false);
+    }
+  });
+
+  it("emits the methodology legal-INFORMATION gate on every non-empty render", () => {
+    const md = renderMotionStrategy(mkData());
+    expect(md).toContain("legal INFORMATION");
+    expect(md).toContain("not legal ADVICE");
+    // Methodology must disclaim prediction (any equivalent phrasing)
+    expect(md).toMatch(/not a prediction|is a prediction\./i);
+  });
+});
+
+// ------------------------------------------------------------
+// Tier monotonicity (HARD)
+// ------------------------------------------------------------
+
+describe("Appendix G — Motion Strategy · tier monotonicity guardrails", () => {
+  it("IB top-N motions threshold strictly exceeds M1 top 10", () => {
+    // M1 ($197) caps at 10. IB ($997) must go deeper.
+    expect(IB_MOTION_TOP_N).toBeGreaterThan(10);
+    expect(IB_MOTION_TOP_N).toBe(20);
+  });
+
+  it("IB citation row count is at least M1's 10 (and carries quote)", () => {
+    expect(IB_CITATION_TOP_N).toBeGreaterThanOrEqual(10);
+  });
+
+  it("IB judge-insufficient threshold is identical to M1's MIN_N (but IB surfaces instead of suppresses)", () => {
+    expect(IB_JUDGE_INSUFFICIENT_THRESHOLD).toBe(10);
+  });
+
+  it("each citation can carry an extracted quote (monotonicity depth over M1 'citation-only')", () => {
+    const data = mkData({
+      citations: [
+        mkCitation({
+          rank: 1,
+          quote_sentence: "The defendant has a right to confront witnesses.",
+          quote_frequency: 8,
+        }),
+      ],
+    });
+    const md = renderMotionStrategy(data);
+    // Quote must appear in markdown output
+    expect(md).toContain("The defendant has a right to confront witnesses");
+  });
+
+  it("IB renders judge rows with n < 10 (M1 suppresses; IB surfaces with caveat)", () => {
+    const data = mkData({
+      judgeMotions: [mkJudge({ filed_count: 3, insufficient_sample: true })],
+    });
+    const md = renderMotionStrategy(data);
+    expect(md).toMatch(/insufficient/i);
+    expect(md).toContain("n=3");
+  });
+});
+
+// ------------------------------------------------------------
+// Quote coverage + URL fallback
+// ------------------------------------------------------------
+
+describe("Appendix G — Motion Strategy · URL + quote coverage", () => {
+  it("every citation row includes its CourtListener URL in the markdown", () => {
+    const data = mkData({
+      citations: [
+        mkCitation({
+          rank: 1,
+          case_name: "Terry v. Ohio",
+          source_url: "https://www.courtlistener.com/opinion/107729/terry-v-ohio/",
+        }),
+        mkCitation({
+          rank: 2,
+          case_name: "Mapp v. Ohio",
+          source_url: "https://www.courtlistener.com/opinion/106285/mapp-v-ohio/",
+          quote_sentence: null,
+          quote_frequency: null,
+        }),
+      ],
+    });
+    const md = renderMotionStrategy(data);
+    expect(md).toContain("https://www.courtlistener.com/opinion/107729/terry-v-ohio/");
+    expect(md).toContain("https://www.courtlistener.com/opinion/106285/mapp-v-ohio/");
+  });
+
+  it("falls back gracefully when a citation has no cached quote", () => {
+    const data = mkData({
+      citations: [mkCitation({ quote_sentence: null, quote_frequency: null })],
+    });
+    const md = renderMotionStrategy(data);
+    expect(md).toContain("No canonical quote cached");
+  });
+});
+
+// ------------------------------------------------------------
+// Empty + limitation paths
+// ------------------------------------------------------------
+
+describe("Appendix G — Motion Strategy · empty + limitation paths", () => {
+  it("empty data renders empty string (edge-function skips the appendix)", () => {
+    const empty: MotionStrategyData = {
+      chargeType: "other",
+      circuit: null,
+      circuitName: null,
+      judgeDisplayName: null,
+      judgeResolved: false,
+      ambiguousJudge: false,
+      motions: [],
+      judgeMotions: [],
+      citations: [],
+      limitations: [],
+      isEmpty: true,
+    };
+    expect(renderMotionStrategy(empty)).toBe("");
+  });
+
+  it("limitations surface in a Known limitations section when non-empty", () => {
+    const md = renderMotionStrategy(
+      mkData({
+        limitations: ["No charge-specific motion data cached for \"arson\"."],
+      }),
+    );
+    expect(md).toContain("Known limitations");
+    expect(md).toContain("No charge-specific motion data cached");
+  });
+});
+
+// ------------------------------------------------------------
+// Cross-reference note (task spec)
+// ------------------------------------------------------------
+
+describe("Appendix G — Motion Strategy · cross-reference", () => {
+  it("includes the War Room cross-ref note", () => {
+    const md = renderMotionStrategy(mkData());
+    expect(md).toContain("War Room");
+    expect(md).toContain("Similar Cases");
+  });
+
+  it("appendix heading is Appendix G (not F)", () => {
+    const md = renderMotionStrategy(mkData());
+    expect(md).toContain("## Appendix G: Motion Strategy");
+    // Must not emit Appendix F heading — that's the rising-precedents appendix.
+    expect(md).not.toContain("## Appendix F");
+  });
+});

--- a/src/lib/ib-appendices/live-authority-map.ts
+++ b/src/lib/ib-appendices/live-authority-map.ts
@@ -1,0 +1,420 @@
+/**
+ * IB Appendix H — Live Authority Map.
+ *
+ * Upper-tier enhancement on the Intelligence Brief $997. Activates dormant
+ * authority data in a deeper form than the $97 Charge Authority Pack (M2):
+ *
+ *   • Top **15** must-cite defense authorities (vs M2 top 10) — per
+ *     monotonicity matrix in docs/plans/2026-04-23-data-to-product-autonomous-execution.md E1.
+ *   • **Full extracted quote per row** (multi-sentence when available),
+ *     vs M2's one-line preview.
+ *   • **Counter-authority warning** when `citation_velocity_criminal.velocity_tier = 'fading'`
+ *     — phrased as "this authority has declining citation velocity", never
+ *     "don't use this" (UPL).
+ *   • Jurisdiction filter: case's state narrows to state-specific + federal
+ *     authorities when available.
+ *
+ * Tier monotonicity (HARD — enforced by unit test):
+ *   - IB top-15 > M2 top-10
+ *   - IB "full quote" > M2 "1-line preview"
+ *   - IB counter-auth warnings > M2 (no counter-auth flag)
+ *   - IB does NOT include judge-specific cross-cite (X-Ray E2 territory)
+ *   - IB does NOT include monthly delta (War Room E3 territory)
+ *
+ * UPL (HARD):
+ *   - Banned-phrase blocklist enforced in test
+ *   - Counter-auth phrased neutrally: "declining citation velocity", not advice
+ *   - Every row has CourtListener URL; URL-less rows suppressed
+ *
+ * Cited experts:
+ *   - Hormozi Grand Slam value-equation lift on the $997 SKU
+ *   - Dreyer AI Overview Defense (authority-engine)
+ *
+ * Sources:
+ *   docs/advisor/2026-04-23-data-to-product-audit.md product #2 + Move 3
+ *   docs/plans/2026-04-23-data-to-product-autonomous-execution.md E1
+ */
+
+import { createAdminClient } from "@/lib/supabase/admin";
+import {
+  CHARGE_TYPE_AUTHORITY_MAP,
+  CIRCUIT_NAMES,
+  resolveCircuitFromStateOrCircuit,
+} from "@/lib/charge-slug-maps";
+
+// ============================================================
+// Types
+// ============================================================
+
+export interface LiveAuthorityMapInput {
+  chargeType: string;
+  state?: string | null;
+  circuit?: string | null;
+}
+
+export interface AuthorityMapRow {
+  rank: number;
+  case_name: string;
+  date_filed: string | null;
+  citation: string | null;
+  authority_tier: string | null;
+  citation_count_in_charge: number | null;
+  citation_count_total: number;
+  /** Multi-sentence extracted quote when available. */
+  quote_full: string | null;
+  velocity: number | null;
+  velocity_tier: string | null;
+  rising_flag: boolean;
+  /**
+   * True when velocity_tier = 'fading' — triggers a neutral counter-authority
+   * note ("this authority has declining citation velocity"). NEVER phrased as
+   * "don't use this" or similar.
+   */
+  counter_authority_warning: boolean;
+  source_url: string;
+  jurisdiction: string | null;
+  data_scope: "charge_type" | "criminal_fallback";
+}
+
+export interface LiveAuthorityMapData {
+  chargeType: string;
+  state: string | null;
+  circuit: string | null;
+  circuitName: string | null;
+  rows: AuthorityMapRow[];
+  limitations: string[];
+  isEmpty: boolean;
+}
+
+// ============================================================
+// Depth guardrails (monotonicity HARD)
+// ============================================================
+
+/** Top-N authority rows in IB. Strictly greater than M2's top 10. */
+export const IB_AUTHORITY_TOP_N = 15;
+
+// ============================================================
+// Query
+// ============================================================
+
+export async function queryLiveAuthorityMap(
+  input: LiveAuthorityMapInput,
+): Promise<LiveAuthorityMapData> {
+  const supabase = createAdminClient();
+  const limitations: string[] = [];
+  const chargeType = input.chargeType;
+  const state = (input.state ?? "").trim().toUpperCase() || null;
+  const circuit = resolveCircuitFromStateOrCircuit(input.circuit, input.state);
+  const circuitName = circuit ? CIRCUIT_NAMES[circuit] : null;
+
+  // ---------- Step 1: top authorities for charge ----------
+  const internalCharges = CHARGE_TYPE_AUTHORITY_MAP[chargeType] ?? [];
+  interface BaseRow {
+    case_name: string;
+    date_filed: string | null;
+    citation_count_in_charge: number | null;
+    citation_count_total: number;
+    authority_tier: string | null;
+    source_url: string;
+    cited_opinion_id: number;
+    cluster_id: number;
+    jurisdiction: string | null;
+    data_scope: "charge_type" | "criminal_fallback";
+  }
+  let bases: BaseRow[] = [];
+
+  if (internalCharges.length > 0) {
+    const { data: ctaRows } = await supabase
+      .from("charge_type_top_authorities")
+      .select(
+        "charge_type, rank, cited_opinion_id, cluster_id, case_name, date_filed, citation_count_in_charge, citation_count_total, authority_tier_overall, source_url, jurisdiction",
+      )
+      .in("charge_type", internalCharges)
+      .order("citation_count_in_charge", { ascending: false })
+      .limit(60);
+    const seen = new Map<number, BaseRow>();
+    for (const r of ctaRows ?? []) {
+      const url = (r.source_url as string | null) ?? "";
+      if (!url) continue;
+      const oid = r.cited_opinion_id as number;
+      const prev = seen.get(oid);
+      const cur: BaseRow = {
+        case_name: r.case_name as string,
+        date_filed: (r.date_filed as string | null) ?? null,
+        citation_count_in_charge: r.citation_count_in_charge as number | null,
+        citation_count_total: r.citation_count_total as number,
+        authority_tier: (r.authority_tier_overall as string | null) ?? null,
+        source_url: url,
+        cited_opinion_id: oid,
+        cluster_id: r.cluster_id as number,
+        jurisdiction: (r.jurisdiction as string | null) ?? null,
+        data_scope: "charge_type",
+      };
+      if (!prev || (cur.citation_count_in_charge ?? 0) > (prev.citation_count_in_charge ?? 0)) {
+        seen.set(oid, cur);
+      }
+    }
+    bases = [...seen.values()].sort(
+      (a, b) => (b.citation_count_in_charge ?? 0) - (a.citation_count_in_charge ?? 0),
+    );
+  }
+
+  // Jurisdiction filter — task spec: narrow to state-specific + federal when state known.
+  // jurisdiction column values: S (state supreme), SA (state appellate), F (federal appeals),
+  // FD (federal district), FS (federal specialty), MA (military), FB (federal bankruptcy).
+  // We can't narrow by state from this field alone (it's a court-level code, not a state),
+  // so "state-specific" here means "state-court (S/SA) + federal (F) + federal district (FD)"
+  // which is the most defense-relevant subset. If the filter empties the list, fall back.
+  let jurisdictionFiltered = false;
+  if (state && bases.length > IB_AUTHORITY_TOP_N) {
+    const allowedJurisdictions = new Set(["S", "SA", "F", "FD"]);
+    const narrowed = bases.filter(
+      (b) => !b.jurisdiction || allowedJurisdictions.has(b.jurisdiction),
+    );
+    if (narrowed.length >= IB_AUTHORITY_TOP_N) {
+      bases = narrowed;
+      jurisdictionFiltered = true;
+    } else {
+      limitations.push(
+        `State-narrowed authority list fell below ${IB_AUTHORITY_TOP_N} rows; showing unfiltered national list for ${chargeType}.`,
+      );
+    }
+  }
+
+  bases = bases.slice(0, IB_AUTHORITY_TOP_N);
+
+  // ---------- Step 2: fallback to criminal-national if charge-specific is thin ----------
+  if (bases.length < IB_AUTHORITY_TOP_N) {
+    const { data: caRows } = await supabase
+      .from("citation_authority_criminal")
+      .select(
+        "cited_opinion_id, cluster_id, case_name, date_filed, citation_count_criminal, citation_count_total, authority_tier, source_url",
+      )
+      .order("citation_count_criminal", { ascending: false })
+      .limit(40);
+    const seen = new Set(bases.map((b) => b.cited_opinion_id));
+    for (const r of caRows ?? []) {
+      const url = (r.source_url as string | null) ?? "";
+      if (!url) continue;
+      const oid = r.cited_opinion_id as number;
+      if (seen.has(oid)) continue;
+      bases.push({
+        case_name: r.case_name as string,
+        date_filed: (r.date_filed as string | null) ?? null,
+        citation_count_in_charge: r.citation_count_criminal as number | null,
+        citation_count_total: r.citation_count_total as number,
+        authority_tier: (r.authority_tier as string | null) ?? null,
+        source_url: url,
+        cited_opinion_id: oid,
+        cluster_id: r.cluster_id as number,
+        jurisdiction: null,
+        data_scope: "criminal_fallback",
+      });
+      seen.add(oid);
+      if (bases.length >= IB_AUTHORITY_TOP_N) break;
+    }
+    if (internalCharges.length === 0 || bases.some((b) => b.data_scope === "criminal_fallback")) {
+      limitations.push(
+        `No charge-specific authorities cached for "${chargeType}"; top criminal-law authorities shown as fallback.`,
+      );
+    }
+  }
+
+  if (bases.length === 0) {
+    return {
+      chargeType,
+      state,
+      circuit,
+      circuitName,
+      rows: [],
+      limitations,
+      isEmpty: true,
+    };
+  }
+
+  // ---------- Step 3: enrich with full quote (concatenate rank 1 + rank 2 when present) ----------
+  const opinionIds = bases.map((b) => b.cited_opinion_id);
+  const { data: quoteRows } = await supabase
+    .from("authority_quotes_criminal")
+    .select("cited_opinion_id, quote_sentence, primary_reporter, rank, quote_frequency")
+    .in("cited_opinion_id", opinionIds)
+    .order("rank", { ascending: true });
+  const quotesByOid = new Map<
+    number,
+    { quotes: string[]; citation: string | null }
+  >();
+  for (const r of quoteRows ?? []) {
+    const oid = r.cited_opinion_id as number;
+    const existing = quotesByOid.get(oid);
+    const q = r.quote_sentence as string;
+    const cit = (r.primary_reporter as string | null) ?? null;
+    if (existing) {
+      if (existing.quotes.length < 3) existing.quotes.push(q); // up to 3 sentences = multi-sentence
+    } else {
+      quotesByOid.set(oid, { quotes: [q], citation: cit });
+    }
+  }
+
+  // ---------- Step 4: enrich with velocity + counter-authority flag ----------
+  const { data: velRows } = await supabase
+    .from("citation_velocity_criminal")
+    .select("cited_opinion_id, velocity, velocity_tier, rising_flag")
+    .in("cited_opinion_id", opinionIds);
+  const velByOid = new Map<
+    number,
+    { velocity: number | null; tier: string | null; rising: boolean }
+  >();
+  for (const r of velRows ?? []) {
+    const oid = r.cited_opinion_id as number;
+    velByOid.set(oid, {
+      velocity: r.velocity as number | null,
+      tier: (r.velocity_tier as string | null) ?? null,
+      rising: (r.rising_flag as boolean | null) ?? false,
+    });
+  }
+
+  // ---------- Step 5: assemble ----------
+  const rows: AuthorityMapRow[] = bases.map((b, i) => {
+    const q = quotesByOid.get(b.cited_opinion_id);
+    const v = velByOid.get(b.cited_opinion_id);
+    const tier = (v?.tier ?? "").toLowerCase();
+    return {
+      rank: i + 1,
+      case_name: b.case_name,
+      date_filed: b.date_filed,
+      citation: q?.citation ?? null,
+      authority_tier: b.authority_tier,
+      citation_count_in_charge: b.citation_count_in_charge,
+      citation_count_total: b.citation_count_total,
+      quote_full: q?.quotes.length ? q.quotes.join(" ") : null,
+      velocity: v?.velocity ?? null,
+      velocity_tier: v?.tier ?? null,
+      rising_flag: v?.rising ?? false,
+      counter_authority_warning: tier === "fading",
+      source_url: b.source_url,
+      jurisdiction: b.jurisdiction,
+      data_scope: b.data_scope,
+    };
+  });
+
+  if (jurisdictionFiltered) {
+    limitations.push(
+      `Authority list narrowed to state-court + federal opinions relevant to ${state}.`,
+    );
+  }
+
+  return {
+    chargeType,
+    state,
+    circuit,
+    circuitName,
+    rows,
+    limitations,
+    isEmpty: rows.length === 0,
+  };
+}
+
+// ============================================================
+// Render (markdown — matches existing IB Appendix F renderer style)
+// ============================================================
+
+function prettyChargeType(c: string): string {
+  return c.replace(/-/g, " ").replace(/\b\w/g, (ch) => ch.toUpperCase());
+}
+
+function velocityLabel(row: AuthorityMapRow): string {
+  if (row.rising_flag) return "rising";
+  if ((row.velocity_tier ?? "").toLowerCase() === "fading") return "fading";
+  return "stable";
+}
+
+function mdEscape(s: string | null | undefined): string {
+  return (s ?? "").split("|").join("\\|");
+}
+
+export function renderLiveAuthorityMap(data: LiveAuthorityMapData): string {
+  if (data.isEmpty) return "";
+
+  const lines: string[] = [];
+  lines.push(`## Appendix H: Live Authority Map`);
+  lines.push(``);
+  const scopeSuffix = data.circuitName
+    ? ` · ${data.circuitName}${data.state ? ` (${data.state})` : ""}`
+    : data.state
+      ? ` · ${data.state}`
+      : "";
+  lines.push(
+    `Top ${data.rows.length} must-cite defense authorities for ${prettyChargeType(data.chargeType)}${scopeSuffix}. ` +
+      `Each row carries an extracted quote drawn from how citing courts reference the case, a citation-velocity indicator, ` +
+      `and a counter-authority flag where the precedent's citation velocity is declining.`,
+  );
+  lines.push(``);
+  lines.push(
+    `**Cross-reference note.** Authorities that appear **bolded** below are cases most-cited inside the granted motions ` +
+      `listed in Appendix G — treat them as the highest-leverage precedents for this charge type.`,
+  );
+  lines.push(``);
+
+  // Cross-refs: for the display hint, mark rows whose velocity is rising (actively cited)
+  // — the Edge Function can overlay a real cross-ref map when integrated.
+  for (const r of data.rows) {
+    const year = r.date_filed ? String(r.date_filed).slice(0, 4) : "";
+    const yearTag = year ? ` (${year})` : "";
+    const citeTag = r.citation ? ` · ${mdEscape(r.citation)}` : "";
+    const tierTag = r.authority_tier ? ` · ${mdEscape(r.authority_tier)}` : "";
+    const velTag = ` · velocity: ${velocityLabel(r)}`;
+    // Bold-wrap rising rows as a first-pass cross-ref heuristic.
+    const nameLine = r.rising_flag
+      ? `**${r.rank}. [${mdEscape(r.case_name)}](${r.source_url})**${yearTag}${citeTag}${tierTag}${velTag}`
+      : `${r.rank}. [${mdEscape(r.case_name)}](${r.source_url})${yearTag}${citeTag}${tierTag}${velTag}`;
+    lines.push(nameLine);
+    if (r.citation_count_in_charge != null) {
+      lines.push(
+        `Cites in ${prettyChargeType(data.chargeType)}: ${r.citation_count_in_charge} · total criminal cites: ${r.citation_count_total}`,
+      );
+    } else {
+      lines.push(`Total criminal cites: ${r.citation_count_total}`);
+    }
+    if (r.quote_full) {
+      lines.push(``);
+      lines.push(`> ${r.quote_full.split("\n").join(" ")}`);
+    } else {
+      lines.push(``);
+      lines.push(`*No canonical quote cached for this opinion yet.*`);
+    }
+    if (r.counter_authority_warning) {
+      lines.push(``);
+      lines.push(
+        `**Counter-authority note:** this authority has declining citation velocity — courts are citing it less often than in prior years. ` +
+          `A question worth raising with your attorney: are there newer precedents that have superseded this one for this charge type?`,
+      );
+    }
+    lines.push(``);
+  }
+
+  lines.push(
+    `Source: charge_type_top_authorities${data.rows.some((r) => r.data_scope === "criminal_fallback") ? " + citation_authority_criminal fallback" : ""}; ` +
+      `enriched with authority_quotes_criminal (full quote chain) + citation_velocity_criminal (counter-authority flag). ` +
+      `Rows without a CourtListener verification URL are suppressed.`,
+  );
+  lines.push(``);
+
+  if (data.limitations.length > 0) {
+    lines.push(`#### Known limitations`);
+    lines.push(``);
+    for (const l of data.limitations) lines.push(`- ${l}`);
+    lines.push(``);
+  }
+
+  lines.push(
+    `**Methodology.** This appendix provides legal INFORMATION, not legal ADVICE. ` +
+      `Authorities are ranked by citation frequency in the federal criminal corpus as of 2026-04-22. ` +
+      `Canonical quotes are extracted from how citing courts reference the case — not from the opinion itself — ` +
+      `so they reflect the proposition the case is cited for. ` +
+      `Velocity compares recent citing activity against the prior decade. ` +
+      `Every row links to the primary opinion on CourtListener for independent verification. ` +
+      `No part of this appendix is a prediction.`,
+  );
+
+  return "\n" + lines.join("\n") + "\n";
+}

--- a/src/lib/ib-appendices/motion-strategy.ts
+++ b/src/lib/ib-appendices/motion-strategy.ts
@@ -1,0 +1,638 @@
+/**
+ * IB Appendix G — Motion Strategy Appendix.
+ *
+ * Upper-tier enhancement on the Intelligence Brief $997. Activates dormant
+ * motion-outcome data (2,966 rows) in a deeper form than the $197 Motion
+ * Success Report (M1):
+ *
+ *   • Motion rates: top **20** (vs M1 top 10) — per monotonicity matrix in
+ *     docs/plans/2026-04-23-data-to-product-autonomous-execution.md E1.
+ *   • Judge-specific column included even when judge n < 10, labeled
+ *     "insufficient n=X" (M1 suppresses; IB surfaces with caveat so the
+ *     customer can still raise the question).
+ *   • Top 10 granted-motion case citations carry **extracted quotes** per
+ *     case — the value-add M1 does not have. Quotes pulled from
+ *     authority_quotes_criminal (pre-extracted by citing-courts, rank=1).
+ *
+ * Tier monotonicity (HARD — enforced by unit test):
+ *   - IB top-N motions STRICTLY > M1 top-10
+ *   - IB citation rows carry quotes; M1 citations are citation-only
+ *   - IB does NOT render full histogram across all motion types (X-Ray E2
+ *     territory) and does NOT include judge-attack cross-reference to
+ *     sentencing outliers (X-Ray territory).
+ *
+ * UPL (HARD):
+ *   - Every row includes N alongside the grant rate (no rate without N)
+ *   - Banned-phrase blocklist enforced in test: "you should", "we recommend",
+ *     "we advise", "your best option", "ask your attorney", "publicly available"
+ *   - Every cited case has a CourtListener URL; rows without URL are suppressed
+ *
+ * Cited experts:
+ *   - Hormozi Grand Slam (tiered value equation — IB price unchanged, depth
+ *     increased, delivery-time unchanged)
+ *   - Dreyer AI Overview Defense (authority-engine positioning on IB)
+ *
+ * Sources:
+ *   docs/advisor/2026-04-23-data-to-product-audit.md product #1 + Move 3
+ *   docs/plans/2026-04-23-data-to-product-autonomous-execution.md E1
+ *
+ * Consumed by:
+ *   - supabase/functions/generate-report/index.ts (mirrored inline in Deno)
+ *   - Unit tests in ./__tests__/motion-strategy.test.ts
+ */
+
+import { createAdminClient } from "@/lib/supabase/admin";
+import {
+  CHARGE_TYPE_MOR_MAP,
+  CHARGE_TYPE_AUTHORITY_MAP,
+  CIRCUIT_NAMES,
+  resolveCircuitFromStateOrCircuit,
+} from "@/lib/charge-slug-maps";
+
+// ============================================================
+// Types
+// ============================================================
+
+export interface MotionStrategyInput {
+  chargeType: string; // ALLOWED_CHARGE_TYPES user-facing slug
+  state?: string | null; // 2-letter postal (used to derive circuit)
+  circuit?: string | null; // "1".."11", "DC"
+  judgeName?: string | null;
+}
+
+export interface MotionRateRow {
+  motion_type: string;
+  filed_count: number;
+  granted_count: number;
+  denied_count: number;
+  grant_rate: number | null;
+  baseline_grant_rate: number | null;
+  deviation_from_baseline: number | null;
+  data_scope: "charge_circuit" | "charge_national" | "all_national";
+}
+
+export interface JudgeMotionRow {
+  motion_type: string;
+  filed_count: number;
+  granted_count: number;
+  grant_rate: number | null;
+  baseline_grant_rate: number | null;
+  deviation_from_baseline: number | null;
+  insufficient_sample: boolean; // n < MIN_JUDGE_N
+}
+
+export interface MotionCitationRow {
+  rank: number;
+  case_name: string;
+  date_filed: string | null;
+  citation: string | null; // primary reporter when available
+  citation_count_in_charge: number | null;
+  citation_count_total: number;
+  authority_tier: string | null;
+  quote_sentence: string | null; // extracted per-case quote (the E1 lift)
+  quote_frequency: number | null;
+  source_url: string;
+  data_scope: "charge_type" | "criminal_fallback";
+}
+
+export interface MotionStrategyData {
+  chargeType: string;
+  circuit: string | null;
+  circuitName: string | null;
+  judgeDisplayName: string | null;
+  judgeResolved: boolean;
+  ambiguousJudge: boolean;
+  motions: MotionRateRow[];
+  judgeMotions: JudgeMotionRow[];
+  citations: MotionCitationRow[];
+  limitations: string[];
+  isEmpty: boolean;
+}
+
+// ============================================================
+// Depth guardrails (monotonicity HARD)
+// ============================================================
+
+/** Top-N motions surfaced in IB. Strictly greater than M1's top 10. */
+export const IB_MOTION_TOP_N = 20;
+
+/** Top-N citation rows in IB. Strictly greater than M1's top 10. */
+export const IB_CITATION_TOP_N = 10;
+
+/** Judge sample threshold below which IB labels "insufficient" but still shows. */
+export const IB_JUDGE_INSUFFICIENT_THRESHOLD = 10;
+
+// ============================================================
+// Query
+// ============================================================
+
+function escapeIlike(s: string): string {
+  return s.toLowerCase().replace(/[%_\\]/g, (ch) => `\\${ch}`);
+}
+
+export async function queryMotionStrategy(
+  input: MotionStrategyInput,
+): Promise<MotionStrategyData> {
+  const supabase = createAdminClient();
+  const limitations: string[] = [];
+  const chargeType = input.chargeType;
+  const circuit = resolveCircuitFromStateOrCircuit(input.circuit, input.state);
+  const circuitName = circuit ? CIRCUIT_NAMES[circuit] : null;
+
+  // ---------- Section 1: top-20 motion rates for this charge ----------
+  const internalCharges = CHARGE_TYPE_MOR_MAP[chargeType] ?? [];
+
+  let motions: MotionRateRow[] = [];
+  let dataScope: MotionRateRow["data_scope"] = "all_national";
+
+  if (internalCharges.length > 0) {
+    const { data: chargeRows } = await supabase
+      .from("motion_outcome_rates")
+      .select("motion_type, filed_count, granted_count, denied_count, grant_rate")
+      .in("charge_type", internalCharges)
+      .order("filed_count", { ascending: false });
+
+    // Aggregate across internal slugs by motion_type
+    const agg = new Map<string, { filed: number; granted: number; denied: number }>();
+    for (const row of chargeRows ?? []) {
+      const cur = agg.get(row.motion_type) ?? { filed: 0, granted: 0, denied: 0 };
+      cur.filed += row.filed_count ?? 0;
+      cur.granted += row.granted_count ?? 0;
+      cur.denied += row.denied_count ?? 0;
+      agg.set(row.motion_type, cur);
+    }
+
+    if (agg.size > 0) {
+      motions = [...agg.entries()]
+        .filter(([, v]) => v.filed >= 5) // task spec: include motion types appearing >=5x
+        .map(([motion_type, v]) => ({
+          motion_type,
+          filed_count: v.filed,
+          granted_count: v.granted,
+          denied_count: v.denied,
+          grant_rate: v.filed > 0 ? v.granted / v.filed : null,
+          baseline_grant_rate: null,
+          deviation_from_baseline: null,
+          data_scope: "charge_national" as const,
+        }))
+        .sort((a, b) => b.filed_count - a.filed_count)
+        .slice(0, IB_MOTION_TOP_N);
+      dataScope = "charge_national";
+    }
+  }
+
+  if (motions.length === 0) {
+    const { data: allRows } = await supabase
+      .from("motion_outcome_rates")
+      .select("motion_type, filed_count, granted_count, denied_count, grant_rate")
+      .eq("charge_type", "(all)")
+      .order("filed_count", { ascending: false })
+      .limit(IB_MOTION_TOP_N);
+    motions = (allRows ?? []).map((r) => ({
+      motion_type: r.motion_type as string,
+      filed_count: r.filed_count as number,
+      granted_count: r.granted_count as number,
+      denied_count: r.denied_count as number,
+      grant_rate: r.grant_rate as number | null,
+      baseline_grant_rate: null,
+      deviation_from_baseline: null,
+      data_scope: "all_national" as const,
+    }));
+    dataScope = "all_national";
+    limitations.push(
+      `No charge-specific motion data cached for "${chargeType}"; showing national baseline across all criminal motions.`,
+    );
+  }
+
+  // National baseline for comparison
+  const { data: nationalAll } = await supabase
+    .from("motion_outcome_rates")
+    .select("motion_type, grant_rate")
+    .eq("charge_type", "(all)");
+  const nationalBaseline = new Map<string, number | null>();
+  for (const r of nationalAll ?? []) {
+    nationalBaseline.set(r.motion_type as string, r.grant_rate as number | null);
+  }
+
+  // Circuit baseline (if resolvable)
+  const circuitBaseline = new Map<string, number | null>();
+  if (circuit) {
+    const { data: circRows } = await supabase
+      .from("motion_outcome_rates_by_circuit")
+      .select("motion_type, grant_rate")
+      .eq("circuit", circuit)
+      .eq("charge_type", "(all)");
+    for (const r of circRows ?? []) {
+      circuitBaseline.set(r.motion_type as string, r.grant_rate as number | null);
+    }
+    if (circuitBaseline.size === 0) {
+      limitations.push(
+        `No circuit-specific motion baseline for "${circuitName ?? circuit}"; "vs circuit" column omitted.`,
+      );
+    }
+  }
+
+  motions = motions.map((m) => {
+    const circ = circuitBaseline.get(m.motion_type) ?? null;
+    const nat = nationalBaseline.get(m.motion_type) ?? null;
+    const baseline = circ ?? nat;
+    const deviation =
+      m.grant_rate !== null && baseline !== null ? m.grant_rate - baseline : null;
+    return {
+      ...m,
+      baseline_grant_rate: baseline,
+      deviation_from_baseline: deviation,
+      data_scope: dataScope,
+    };
+  });
+
+  // ---------- Section 2: judge-specific motions (include n<10) ----------
+  let judgeDisplayName: string | null = null;
+  let judgeResolved = false;
+  let ambiguousJudge = false;
+  let judgeMotions: JudgeMotionRow[] = [];
+
+  const rawJudge = (input.judgeName ?? "").trim();
+  if (rawJudge.length > 0) {
+    const safeName = escapeIlike(rawJudge);
+    const surname = safeName.split(" ").pop() ?? safeName;
+    const { data: judgeRows } = await supabase
+      .from("entities_judges")
+      .select("canonical_id, cl_person_id, name_first, name_middle, name_last, name_suffix")
+      .ilike("name_last", `%${surname}%`)
+      .limit(10);
+
+    const candidates = (judgeRows ?? []).filter((row) => {
+      const full = [row.name_first, row.name_middle, row.name_last, row.name_suffix]
+        .filter(Boolean)
+        .join(" ")
+        .toLowerCase();
+      return full.includes(safeName);
+    });
+
+    if (candidates.length > 1) {
+      ambiguousJudge = true;
+      limitations.push(
+        `Multiple judges match "${rawJudge}"; add middle name or court to disambiguate. Judge section omitted.`,
+      );
+    } else if (candidates.length === 1) {
+      const judge = candidates[0];
+      const authorId = judge.cl_person_id as number | null;
+      judgeDisplayName = [judge.name_first, judge.name_middle, judge.name_last, judge.name_suffix]
+        .filter(Boolean)
+        .join(" ");
+      judgeResolved = true;
+
+      if (authorId !== null && authorId !== undefined) {
+        // IB E1 lift: no gte(filed_count, 10) — surface low-n rows with caveat.
+        const { data: motRows } = await supabase
+          .from("judge_motion_outcome_rates")
+          .select(
+            "motion_type, filed_count, granted_count, grant_rate, baseline_grant_rate, deviation_from_baseline",
+          )
+          .eq("author_id", authorId)
+          .order("filed_count", { ascending: false })
+          .limit(IB_MOTION_TOP_N);
+        judgeMotions = (motRows ?? []).map((r) => {
+          const n = r.filed_count as number;
+          return {
+            motion_type: r.motion_type as string,
+            filed_count: n,
+            granted_count: r.granted_count as number,
+            grant_rate: r.grant_rate as number | null,
+            baseline_grant_rate: r.baseline_grant_rate as number | null,
+            deviation_from_baseline: r.deviation_from_baseline as number | null,
+            insufficient_sample: n < IB_JUDGE_INSUFFICIENT_THRESHOLD,
+          };
+        });
+        if (judgeMotions.length === 0) {
+          limitations.push(
+            `Judge ${judgeDisplayName} is in our records but has no filed motions cached; judge-specific section omitted.`,
+          );
+        }
+      } else {
+        limitations.push(
+          `Judge ${judgeDisplayName} has no CourtListener author_id linked; judge-specific section omitted.`,
+        );
+      }
+    } else {
+      limitations.push(
+        `No canonical judge record matching "${rawJudge}"; judge-specific section omitted.`,
+      );
+    }
+  }
+
+  // ---------- Section 3: top-10 citations with extracted quotes ----------
+  const internalAuthCharges = CHARGE_TYPE_AUTHORITY_MAP[chargeType] ?? [];
+  interface BaseRow {
+    rank: number;
+    case_name: string;
+    date_filed: string | null;
+    citation_count_in_charge: number | null;
+    citation_count_total: number;
+    authority_tier: string | null;
+    source_url: string;
+    cited_opinion_id: number;
+    data_scope: "charge_type" | "criminal_fallback";
+  }
+  let bases: BaseRow[] = [];
+
+  if (internalAuthCharges.length > 0) {
+    const { data: ctaRows } = await supabase
+      .from("charge_type_top_authorities")
+      .select(
+        "charge_type, rank, cited_opinion_id, case_name, date_filed, citation_count_in_charge, citation_count_total, authority_tier_overall, source_url",
+      )
+      .in("charge_type", internalAuthCharges)
+      .order("citation_count_in_charge", { ascending: false })
+      .limit(30);
+    const seen = new Map<number, BaseRow>();
+    for (const r of ctaRows ?? []) {
+      const url = (r.source_url as string | null) ?? "";
+      if (!url) continue;
+      const oid = r.cited_opinion_id as number;
+      const prev = seen.get(oid);
+      const cur: BaseRow = {
+        rank: 0,
+        case_name: r.case_name as string,
+        date_filed: (r.date_filed as string | null) ?? null,
+        citation_count_in_charge: r.citation_count_in_charge as number | null,
+        citation_count_total: r.citation_count_total as number,
+        authority_tier: (r.authority_tier_overall as string | null) ?? null,
+        source_url: url,
+        cited_opinion_id: oid,
+        data_scope: "charge_type",
+      };
+      if (!prev || (cur.citation_count_in_charge ?? 0) > (prev.citation_count_in_charge ?? 0)) {
+        seen.set(oid, cur);
+      }
+    }
+    bases = [...seen.values()]
+      .sort((a, b) => (b.citation_count_in_charge ?? 0) - (a.citation_count_in_charge ?? 0))
+      .slice(0, IB_CITATION_TOP_N);
+  }
+
+  // Fallback to criminal-national if charge-specific is thin
+  if (bases.length < IB_CITATION_TOP_N) {
+    const { data: caRows } = await supabase
+      .from("citation_authority_criminal")
+      .select(
+        "cited_opinion_id, case_name, date_filed, citation_count_criminal, citation_count_total, authority_tier, source_url",
+      )
+      .order("citation_count_criminal", { ascending: false })
+      .limit(30);
+    const seen = new Set(bases.map((b) => b.cited_opinion_id));
+    for (const r of caRows ?? []) {
+      const url = (r.source_url as string | null) ?? "";
+      if (!url) continue;
+      const oid = r.cited_opinion_id as number;
+      if (seen.has(oid)) continue;
+      bases.push({
+        rank: 0,
+        case_name: r.case_name as string,
+        date_filed: (r.date_filed as string | null) ?? null,
+        citation_count_in_charge: r.citation_count_criminal as number | null,
+        citation_count_total: r.citation_count_total as number,
+        authority_tier: (r.authority_tier as string | null) ?? null,
+        source_url: url,
+        cited_opinion_id: oid,
+        data_scope: "criminal_fallback",
+      });
+      seen.add(oid);
+      if (bases.length >= IB_CITATION_TOP_N) break;
+    }
+  }
+
+  // Enrich with extracted quotes — the E1 depth lift over M1.
+  const opinionIds = bases.map((b) => b.cited_opinion_id);
+  const quoteByOid = new Map<
+    number,
+    { quote: string; citation: string | null; frequency: number | null }
+  >();
+  if (opinionIds.length > 0) {
+    const { data: quoteRows } = await supabase
+      .from("authority_quotes_criminal")
+      .select("cited_opinion_id, quote_sentence, primary_reporter, rank, quote_frequency")
+      .in("cited_opinion_id", opinionIds)
+      .order("rank", { ascending: true });
+    for (const r of quoteRows ?? []) {
+      const oid = r.cited_opinion_id as number;
+      if (quoteByOid.has(oid)) continue; // keep rank 1
+      quoteByOid.set(oid, {
+        quote: r.quote_sentence as string,
+        citation: (r.primary_reporter as string | null) ?? null,
+        frequency: (r.quote_frequency as number | null) ?? null,
+      });
+    }
+  }
+
+  const citations: MotionCitationRow[] = bases.map((b, i) => {
+    const q = quoteByOid.get(b.cited_opinion_id);
+    return {
+      rank: i + 1,
+      case_name: b.case_name,
+      date_filed: b.date_filed,
+      citation: q?.citation ?? null,
+      citation_count_in_charge: b.citation_count_in_charge,
+      citation_count_total: b.citation_count_total,
+      authority_tier: b.authority_tier,
+      quote_sentence: q?.quote ?? null,
+      quote_frequency: q?.frequency ?? null,
+      source_url: b.source_url,
+      data_scope: b.data_scope,
+    };
+  });
+
+  const isEmpty =
+    motions.length === 0 && judgeMotions.length === 0 && citations.length === 0;
+
+  return {
+    chargeType,
+    circuit,
+    circuitName,
+    judgeDisplayName,
+    judgeResolved,
+    ambiguousJudge,
+    motions,
+    judgeMotions,
+    citations,
+    limitations,
+    isEmpty,
+  };
+}
+
+// ============================================================
+// Render (markdown — matches existing IB Appendix F renderer style)
+// ============================================================
+
+function fmtPct(n: number | null, digits = 1): string {
+  if (n === null || n === undefined || Number.isNaN(n)) return "—";
+  return `${(n * 100).toFixed(digits)}%`;
+}
+
+function fmtSigned(n: number | null, digits = 1): string {
+  if (n === null || n === undefined || Number.isNaN(n)) return "—";
+  const pct = n * 100;
+  const sign = pct >= 0 ? "+" : "";
+  return `${sign}${pct.toFixed(digits)} pp`;
+}
+
+function prettyMotionType(m: string): string {
+  return m.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+function mdEscape(s: string): string {
+  // Escape table pipes; leave other markdown alone so intentional emphasis still renders.
+  return (s ?? "").split("|").join("\\|");
+}
+
+/**
+ * Render Appendix G as markdown. The IB Edge Function post-processes this
+ * with md2html (same pipeline as the Sprint-2 Appendix F subsections).
+ */
+export function renderMotionStrategy(data: MotionStrategyData): string {
+  if (data.isEmpty) return "";
+
+  const lines: string[] = [];
+  lines.push(`## Appendix G: Motion Strategy`);
+  lines.push(``);
+  lines.push(
+    `How the courts that hear cases like yours have ruled on the motions most commonly filed in these cases. ` +
+      `This is historical pattern data compiled from published criminal opinions — not a prediction for your specific motion.`,
+  );
+  lines.push(``);
+
+  // Section 1 — motion grant rates (top-20)
+  if (data.motions.length > 0) {
+    const circuitLabel = data.circuitName ?? "national";
+    lines.push(`### Motion Grant Rates — Top ${Math.min(data.motions.length, IB_MOTION_TOP_N)} for ${prettyChargeType(data.chargeType)}`);
+    lines.push(``);
+    lines.push(
+      `Motion types ranked by filing frequency in ${prettyChargeType(data.chargeType)} criminal opinions. ` +
+        `Baseline column shows ${data.circuitName ? `${circuitLabel} all-charges baseline when available, otherwise national baseline` : "national all-charges baseline"}. ` +
+        `Deviation column compares this charge's grant rate against the baseline.`,
+    );
+    lines.push(``);
+    lines.push(`| **Motion Type** | **N filed** | **N granted** | **Grant rate** | **Baseline** | **Deviation** |`);
+    lines.push(`|---|---|---|---|---|---|`);
+    for (const m of data.motions) {
+      lines.push(
+        `| ${mdEscape(prettyMotionType(m.motion_type))} | ${m.filed_count} | ${m.granted_count} | ${fmtPct(m.grant_rate)} | ${fmtPct(m.baseline_grant_rate)} | ${fmtSigned(m.deviation_from_baseline)} |`,
+      );
+    }
+    lines.push(``);
+    lines.push(
+      `Source: motion_outcome_rates (aggregated across internal charge slugs); ` +
+        `baseline from motion_outcome_rates "(all)" and motion_outcome_rates_by_circuit where applicable.`,
+    );
+    lines.push(``);
+  }
+
+  // Section 2 — judge-specific (insufficient rows surfaced with caveat)
+  if (data.judgeMotions.length > 0 && data.judgeDisplayName) {
+    lines.push(`### Motion Patterns Before ${mdEscape(data.judgeDisplayName)}`);
+    lines.push(``);
+    lines.push(
+      `Motions of any charge type authored by this judge in the CourtListener opinion corpus. ` +
+        `Rows with a small sample (n < ${IB_JUDGE_INSUFFICIENT_THRESHOLD}) are surfaced with an "insufficient data" caveat — ` +
+        `the pattern may still be worth raising with your attorney as a question, even where the sample is thin.`,
+    );
+    lines.push(``);
+    lines.push(`| **Motion Type** | **N filed** | **Grant rate** | **Cross-judge baseline** | **Deviation** | **Sample** |`);
+    lines.push(`|---|---|---|---|---|---|`);
+    for (const m of data.judgeMotions) {
+      const rateCell = m.insufficient_sample
+        ? `insufficient (n=${m.filed_count})`
+        : fmtPct(m.grant_rate);
+      const sampleCell = m.insufficient_sample
+        ? `thin (n=${m.filed_count})`
+        : `sufficient`;
+      lines.push(
+        `| ${mdEscape(prettyMotionType(m.motion_type))} | ${m.filed_count} | ${rateCell} | ${fmtPct(m.baseline_grant_rate)} | ${fmtSigned(m.deviation_from_baseline)} | ${sampleCell} |`,
+      );
+    }
+    lines.push(``);
+    lines.push(
+      `Source: judge_motion_outcome_rates (author_id linked via entities_judges). ` +
+        `"Insufficient" means fewer than ${IB_JUDGE_INSUFFICIENT_THRESHOLD} observations — treat as a question to raise, not a prediction.`,
+    );
+    lines.push(``);
+  }
+
+  // Section 3 — top-10 cited precedents with extracted quotes (the IB lift)
+  if (data.citations.length > 0) {
+    lines.push(`### Top ${data.citations.length} Granted-Motion Case Citations`);
+    lines.push(``);
+    lines.push(
+      `Most-cited criminal authorities relevant to ${prettyChargeType(data.chargeType)}. ` +
+        `Each row includes an **extracted quote** drawn from how citing courts reference the case — ` +
+        `this is how the precedent is actually invoked in later opinions, not a summary of the opinion itself.`,
+    );
+    lines.push(``);
+    for (const c of data.citations) {
+      const yr = c.date_filed ? String(c.date_filed).slice(0, 4) : "";
+      const citeTag = c.citation ? ` · ${mdEscape(c.citation)}` : "";
+      const yearTag = yr ? ` (${yr})` : "";
+      const tierTag = c.authority_tier ? ` · ${mdEscape(c.authority_tier)}` : "";
+      lines.push(
+        `**${c.rank}. [${mdEscape(c.case_name)}](${c.source_url})**${yearTag}${citeTag}${tierTag}`,
+      );
+      if (c.citation_count_in_charge != null) {
+        lines.push(
+          `Cites in ${prettyChargeType(data.chargeType)}: ${c.citation_count_in_charge} · total criminal cites: ${c.citation_count_total}`,
+        );
+      } else {
+        lines.push(`Total criminal cites: ${c.citation_count_total}`);
+      }
+      if (c.quote_sentence) {
+        lines.push(``);
+        lines.push(`> ${c.quote_sentence.split("\n").join(" ")}`);
+        if (c.quote_frequency) {
+          lines.push(
+            `(Extracted from ${c.quote_frequency} citing opinion${c.quote_frequency === 1 ? "" : "s"}; rank #1 per case.)`,
+          );
+        }
+      } else {
+        lines.push(``);
+        lines.push(`*No canonical quote cached for this opinion yet.*`);
+      }
+      lines.push(``);
+    }
+    lines.push(
+      `Source: charge_type_top_authorities${data.citations.some((c) => c.data_scope === "criminal_fallback") ? " + citation_authority_criminal fallback" : ""}; ` +
+        `quotes from authority_quotes_criminal (pre-extracted, rank 1 per cited opinion). ` +
+        `Rows without a CourtListener verification URL are suppressed.`,
+    );
+    lines.push(``);
+  }
+
+  // Cross-ref note (task spec)
+  lines.push(
+    `**Cross-reference note.** If you add the War Room ($4,997) tier, the Similar Cases layer overlays these ` +
+      `motions onto sentencing outcomes for defendants in similar factual buckets.`,
+  );
+  lines.push(``);
+
+  // Limitations (if any)
+  if (data.limitations.length > 0) {
+    lines.push(`#### Known limitations`);
+    lines.push(``);
+    for (const l of data.limitations) lines.push(`- ${l}`);
+    lines.push(``);
+  }
+
+  // Methodology disclaimer (approved form — no banned phrases)
+  lines.push(
+    `**Methodology.** This appendix provides legal INFORMATION, not legal ADVICE. ` +
+      `Frequencies are tallied from published criminal opinions as of 2026-04-22. ` +
+      `"Grant rate" = N granted ÷ N filed within the scope shown; small samples are flagged. ` +
+      `Citations link to the primary opinion on CourtListener for independent verification. ` +
+      `No part of this appendix is a prediction — it is a map of what is already in the record.`,
+  );
+
+  return "\n" + lines.join("\n") + "\n";
+}
+
+function prettyChargeType(c: string): string {
+  return c.replace(/-/g, " ").replace(/\b\w/g, (ch) => ch.toUpperCase());
+}

--- a/src/lib/intelligence-brief/render.ts
+++ b/src/lib/intelligence-brief/render.ts
@@ -339,6 +339,10 @@ export function renderIntelligenceBriefHtml(
     buildYourRights(meta.stateCounty.split(",")[0]?.trim() || "your state"),
     // Appendix F: Tier 9 Data-Driven Defense Intelligence (generated, tier-gated)
     sectionOutputs["tier9-data-appendix"] || "",
+    // Appendix G: Motion Strategy (IB $997 E1, 2026-04-23, mechanical render)
+    sectionOutputs["ib-appendix-g"] || "",
+    // Appendix H: Live Authority Map (IB $997 E1, 2026-04-23, mechanical render)
+    sectionOutputs["ib-appendix-h"] || "",
   ];
 
   const bodyHtml = sections
@@ -417,7 +421,9 @@ function buildTableOfContents(): string {
 - **Appendix C: Attorney Script Pack**, 5 ready-to-use communication scripts
 - **Appendix D: Questions for Your Attorney**, 10-15 targeted, gap-based questions
 - **Appendix E: Your Rights**, Key rights during criminal proceedings
-- **Appendix F: Data-Driven Defense Intelligence**, Verified court data with source URLs`;
+- **Appendix F: Data-Driven Defense Intelligence**, Verified court data with source URLs
+- **Appendix G: Motion Strategy**, Top-20 motion grant rates + granted-motion case citations with extracted quotes
+- **Appendix H: Live Authority Map**, Top-15 must-cite defense authorities with full quotes + counter-authority velocity flags`;
 }
 
 function buildBradyGiglioChecklist(): string {

--- a/supabase/functions/generate-report/index.ts
+++ b/supabase/functions/generate-report/index.ts
@@ -4972,6 +4972,38 @@ async function handleIBPhaseB(
     console.log(`[IB-Phase-B] Appendix F rendered (matrix=${!!defenseMatrixHtml}, rising=${risingPrecedentRows.length}${rowsWereChargeFiltered ? "[charge-filtered]" : "[national]"}, timeline=${timelineMap.size}, quotes=${quotesMap.size}, circuit=${circuitMotionRows.length}, ussc=${ussccRows.length}, justfair=${judgeDemo ? "yes" : "no"}, judgePattern=${judgePatternRows.length}, pji=${pjiRows.length})`);
   }
 
+  // ============================================================
+  // Appendix G — Motion Strategy (IB $997 E1, 2026-04-23)
+  // Mirrors src/lib/ib-appendices/motion-strategy.ts (Deno cannot import
+  // Next.js modules). Monotonicity: top-20 motions (vs M1 top-10),
+  // judge rows surfaced even when n<10 with "insufficient" caveat,
+  // top-10 citations carry per-case extracted quote (vs M1 citation-only).
+  // ============================================================
+  const motionStrategyData = await fetchAppendixGMotionStrategy(
+    supabaseUrl, supabaseKey, intake.charge_type, jurisdictionInfo.circuit, phase2.judge_name,
+  );
+  const motionStrategyMd = renderAppendixGMotionStrategy(motionStrategyData, intake.charge_type);
+  if (motionStrategyMd) {
+    allOutputs["ib-appendix-g"] = motionStrategyMd;
+    console.log(`[IB-Phase-B] Appendix G rendered (motions=${motionStrategyData.motions.length}, judgeMotions=${motionStrategyData.judgeMotions.length}, citations=${motionStrategyData.citations.length})`);
+  }
+
+  // ============================================================
+  // Appendix H — Live Authority Map (IB $997 E1, 2026-04-23)
+  // Mirrors src/lib/ib-appendices/live-authority-map.ts. Monotonicity:
+  // top-15 authorities (vs M2 top-10), full multi-sentence extracted
+  // quote per row (vs M2 1-line preview), counter-authority velocity
+  // warning when velocity_tier='fading'.
+  // ============================================================
+  const liveAuthorityData = await fetchAppendixHLiveAuthority(
+    supabaseUrl, supabaseKey, intake.charge_type, intake.state,
+  );
+  const liveAuthorityMd = renderAppendixHLiveAuthority(liveAuthorityData, intake.charge_type);
+  if (liveAuthorityMd) {
+    allOutputs["ib-appendix-h"] = liveAuthorityMd;
+    console.log(`[IB-Phase-B] Appendix H rendered (rows=${liveAuthorityData.rows.length}, fading=${liveAuthorityData.rows.filter((r) => r.counter_authority_warning).length}, rising=${liveAuthorityData.rows.filter((r) => r.rising_flag).length})`);
+  }
+
   // Phase 2: build entity whitelist once per IB, strip hallucinated cite
   // tags across every section output before compile.
   const ibChargesArr = Array.isArray(intake.charge_type)
@@ -5963,6 +5995,691 @@ function renderCircuitPJI(rows: PJIRow[], buyerCircuit: string | null): string {
   return "\n" + lines.join("\n") + "\n";
 }
 
+// ============================================================
+// Appendix G + H — IB $997 E1 (2026-04-23)
+// Mirrors src/lib/ib-appendices/{motion-strategy,live-authority-map}.ts
+// (Deno cannot import Next.js modules). Tier monotonicity guardrails
+// (IB_MOTION_TOP_N=20 vs M1 top-10; IB_CITATION_TOP_N=10 with quotes vs M1
+// citation-only; IB_AUTHORITY_TOP_N=15 with full quote + counter-auth vs M2
+// top-10) are encoded as literal constants below — keep in lockstep with the
+// Next-side depth constants exported from src/lib/ib-appendices/*.ts.
+// ============================================================
+
+const IB_APPENDIX_G_MOTION_TOP_N = 20;
+const IB_APPENDIX_G_CITATION_TOP_N = 10;
+const IB_APPENDIX_G_JUDGE_INSUFFICIENT_THRESHOLD = 10;
+const IB_APPENDIX_H_AUTHORITY_TOP_N = 15;
+
+// Charge-slug mapping (subset — keep in sync with src/lib/charge-slug-maps.ts).
+// PostgREST in.() accepts encoded comma-separated list.
+const CHARGE_TYPE_MOR_MAP_DENO: Record<string, string[]> = {
+  "drug-possession": ["drug-possession","drug-possession-marijuana","drug-possession-cocaine","drug-possession-meth","drug-possession-opioids","drug-possession-prescription","drug-possession-with-intent"],
+  "drug-trafficking": ["drug-trafficking","drug-distribution","drug-manufacturing"],
+  dui: ["dui","dui-dwi","dui-first-offense","dui-repeat-offense","dui-third-offense","dui-drugs","dui-felony-injury"],
+  assault: ["assault","simple-assault","aggravated-assault","aggravated-battery","assault-with-deadly-weapon","assault-firearm","assault-police-officer","battery"],
+  "domestic-violence": ["domestic-violence","domestic-battery","violation-protective-order"],
+  theft: ["theft","theft-larceny","grand-theft","petty-theft","shoplifting","receiving-stolen-property","motor-vehicle-theft"],
+  "sex-offense": ["sex-offense","sex-offense-contact","sex-offense-digital","sexual-assault","sexual-battery","rape","statutory-rape","indecent-exposure"],
+  weapons: ["weapons-possession","felony-firearm","felon-in-possession","possession-prohibited-weapon","weapons-school-zone","illegal-discharge"],
+  "white-collar": ["fraud-general","wire-fraud","securities-fraud","tax-fraud","insurance-fraud","credit-card-fraud","prescription-fraud","money-laundering","embezzlement","identity-theft","forgery","bad-checks"],
+  murder: ["murder","murder-first-degree","murder-second-degree","attempted-murder"],
+  manslaughter: ["voluntary-manslaughter","involuntary-manslaughter","vehicular-manslaughter","vehicular-homicide"],
+  robbery: ["robbery","armed-robbery","home-invasion"],
+  burglary: ["burglary","residential-burglary","commercial-burglary"],
+  fraud: ["fraud-general","wire-fraud","securities-fraud","tax-fraud","insurance-fraud","credit-card-fraud","prescription-fraud","identity-theft"],
+  drug: ["drug-possession","drug-trafficking","drug-distribution","drug-manufacturing","drug-paraphernalia"],
+};
+
+const CHARGE_TYPE_AUTHORITY_MAP_DENO: Record<string, string[]> = {
+  "drug-possession": ["drug-possession-marijuana","drug-possession-cocaine","drug-possession-opioids","drug-possession-prescription"],
+  "drug-trafficking": ["drug-trafficking","drug-distribution","drug-manufacturing"],
+  dui: ["dui-dwi","dui-drugs","dui-felony-injury","refusing-breath-test"],
+  assault: ["simple-assault","aggravated-assault","aggravated-battery","assault-firearm","assault-police-officer","battery"],
+  theft: ["theft-larceny"],
+  "sex-offense": ["sex-offense-contact","sex-offense-digital","sexual-assault","indecent-exposure"],
+  weapons: ["weapons-possession","felon-in-possession","illegal-discharge"],
+  "white-collar": ["fraud-general","embezzlement","forgery"],
+  murder: ["murder-second-degree"],
+  manslaughter: ["voluntary-manslaughter","vehicular-homicide"],
+  robbery: ["robbery","home-invasion"],
+  burglary: ["burglary"],
+  fraud: ["fraud-general","embezzlement","forgery"],
+  drug: ["drug-possession-marijuana","drug-possession-cocaine","drug-possession-opioids","drug-possession-prescription","drug-trafficking","drug-distribution","drug-manufacturing"],
+};
+
+interface AppendixGMotionRow {
+  motion_type: string;
+  filed_count: number;
+  granted_count: number;
+  denied_count: number;
+  grant_rate: number | null;
+  baseline_grant_rate: number | null;
+  deviation_from_baseline: number | null;
+}
+interface AppendixGJudgeRow {
+  motion_type: string;
+  filed_count: number;
+  granted_count: number;
+  grant_rate: number | null;
+  baseline_grant_rate: number | null;
+  deviation_from_baseline: number | null;
+  insufficient_sample: boolean;
+}
+interface AppendixGCitation {
+  rank: number;
+  case_name: string;
+  date_filed: string | null;
+  citation: string | null;
+  authority_tier: string | null;
+  citation_count_in_charge: number | null;
+  citation_count_total: number;
+  quote_sentence: string | null;
+  quote_frequency: number | null;
+  source_url: string;
+}
+interface AppendixGData {
+  motions: AppendixGMotionRow[];
+  judgeMotions: AppendixGJudgeRow[];
+  judgeDisplayName: string | null;
+  citations: AppendixGCitation[];
+  limitations: string[];
+  circuit: string | null;
+}
+
+async function fetchAppendixGMotionStrategy(
+  supabaseUrl: string,
+  supabaseKey: string,
+  chargeType: string | null | undefined,
+  circuit: string | null,
+  judgeName: string | null | undefined,
+): Promise<AppendixGData> {
+  const charge = sanitizeFilterValue(chargeType, 60) || "";
+  const limitations: string[] = [];
+  const internalCharges = (CHARGE_TYPE_MOR_MAP_DENO[charge.toLowerCase()] ?? []);
+
+  // Section 1: charge-filtered motion rates
+  let motions: AppendixGMotionRow[] = [];
+  if (internalCharges.length > 0) {
+    try {
+      const slugList = internalCharges
+        .map((s) => encodeURIComponent(s))
+        .join(",");
+      const rows = await supabaseSelect(
+        supabaseUrl, supabaseKey, "motion_outcome_rates",
+        `charge_type=in.(${slugList})&order=filed_count.desc&limit=200&select=charge_type,motion_type,filed_count,granted_count,denied_count,grant_rate`,
+      ) as Array<{ motion_type: string; filed_count: number; granted_count: number; denied_count: number }>;
+      const agg = new Map<string, { filed: number; granted: number; denied: number }>();
+      for (const r of rows) {
+        const cur = agg.get(r.motion_type) ?? { filed: 0, granted: 0, denied: 0 };
+        cur.filed += r.filed_count || 0;
+        cur.granted += r.granted_count || 0;
+        cur.denied += r.denied_count || 0;
+        agg.set(r.motion_type, cur);
+      }
+      motions = [...agg.entries()]
+        .filter(([, v]) => v.filed >= 5)
+        .map(([motion_type, v]) => ({
+          motion_type,
+          filed_count: v.filed,
+          granted_count: v.granted,
+          denied_count: v.denied,
+          grant_rate: v.filed > 0 ? v.granted / v.filed : null,
+          baseline_grant_rate: null,
+          deviation_from_baseline: null,
+        }))
+        .sort((a, b) => b.filed_count - a.filed_count)
+        .slice(0, IB_APPENDIX_G_MOTION_TOP_N);
+    } catch (e) {
+      console.warn("[IB-G] motion_outcome_rates charge fetch failed (non-fatal):", e);
+    }
+  }
+
+  if (motions.length === 0) {
+    try {
+      const rows = await supabaseSelect(
+        supabaseUrl, supabaseKey, "motion_outcome_rates",
+        `charge_type=eq.${encodeURIComponent("(all)")}&order=filed_count.desc&limit=${IB_APPENDIX_G_MOTION_TOP_N}&select=motion_type,filed_count,granted_count,denied_count,grant_rate`,
+      ) as Array<{ motion_type: string; filed_count: number; granted_count: number; denied_count: number; grant_rate: number | null }>;
+      motions = rows.map((r) => ({
+        motion_type: r.motion_type,
+        filed_count: r.filed_count,
+        granted_count: r.granted_count,
+        denied_count: r.denied_count,
+        grant_rate: r.grant_rate,
+        baseline_grant_rate: null,
+        deviation_from_baseline: null,
+      }));
+      limitations.push(`No charge-specific motion data cached for "${charge}"; showing national baseline across all criminal motions.`);
+    } catch (e) {
+      console.warn("[IB-G] motion_outcome_rates (all) fetch failed:", e);
+    }
+  }
+
+  // Baselines: national (all) by motion_type + circuit (all) by motion_type
+  try {
+    const natRows = await supabaseSelect(
+      supabaseUrl, supabaseKey, "motion_outcome_rates",
+      `charge_type=eq.${encodeURIComponent("(all)")}&select=motion_type,grant_rate`,
+    ) as Array<{ motion_type: string; grant_rate: number | null }>;
+    const natMap = new Map<string, number | null>();
+    for (const r of natRows) natMap.set(r.motion_type, r.grant_rate);
+    const circMap = new Map<string, number | null>();
+    if (circuit) {
+      try {
+        const circRows = await supabaseSelect(
+          supabaseUrl, supabaseKey, "motion_outcome_rates_by_circuit",
+          `circuit=eq.${encodeURIComponent(circuit)}&charge_type=eq.${encodeURIComponent("(all)")}&select=motion_type,grant_rate`,
+        ) as Array<{ motion_type: string; grant_rate: number | null }>;
+        for (const r of circRows) circMap.set(r.motion_type, r.grant_rate);
+      } catch (e) {
+        console.warn("[IB-G] circuit baseline fetch failed (non-fatal):", e);
+      }
+    }
+    motions = motions.map((m) => {
+      const circ = circMap.get(m.motion_type) ?? null;
+      const nat = natMap.get(m.motion_type) ?? null;
+      const baseline = circ ?? nat;
+      return {
+        ...m,
+        baseline_grant_rate: baseline,
+        deviation_from_baseline:
+          m.grant_rate !== null && baseline !== null ? m.grant_rate - baseline : null,
+      };
+    });
+  } catch (e) {
+    console.warn("[IB-G] baseline fetch failed (non-fatal):", e);
+  }
+
+  // Section 2: judge motions (surface n<10 with caveat)
+  let judgeMotions: AppendixGJudgeRow[] = [];
+  let judgeDisplayName: string | null = null;
+  const rawJudge = sanitizeFilterValue(judgeName, 100);
+  if (rawJudge) {
+    try {
+      const surname = rawJudge.toLowerCase().split(" ").pop() ?? rawJudge.toLowerCase();
+      const surnameEscaped = escapeIlikeMeta(surname);
+      const jrows = await supabaseSelect(
+        supabaseUrl, supabaseKey, "entities_judges",
+        `name_last=ilike.*${encodeURIComponent(surnameEscaped)}*&limit=10&select=canonical_id,cl_person_id,name_first,name_middle,name_last,name_suffix`,
+      ) as Array<{ canonical_id: string; cl_person_id: number | null; name_first: string | null; name_middle: string | null; name_last: string | null; name_suffix: string | null }>;
+      const needle = rawJudge.toLowerCase();
+      const candidates = jrows.filter((row) => {
+        const full = [row.name_first, row.name_middle, row.name_last, row.name_suffix].filter(Boolean).join(" ").toLowerCase();
+        return full.includes(needle);
+      });
+      if (candidates.length === 1) {
+        const j = candidates[0];
+        judgeDisplayName = [j.name_first, j.name_middle, j.name_last, j.name_suffix].filter(Boolean).join(" ");
+        const authorId = j.cl_person_id;
+        if (authorId != null) {
+          const mrows = await supabaseSelect(
+            supabaseUrl, supabaseKey, "judge_motion_outcome_rates",
+            `author_id=eq.${authorId}&order=filed_count.desc&limit=${IB_APPENDIX_G_MOTION_TOP_N}&select=motion_type,filed_count,granted_count,grant_rate,baseline_grant_rate,deviation_from_baseline`,
+          ) as Array<{ motion_type: string; filed_count: number; granted_count: number; grant_rate: number | null; baseline_grant_rate: number | null; deviation_from_baseline: number | null }>;
+          judgeMotions = mrows.map((r) => ({
+            motion_type: r.motion_type,
+            filed_count: r.filed_count,
+            granted_count: r.granted_count,
+            grant_rate: r.grant_rate,
+            baseline_grant_rate: r.baseline_grant_rate,
+            deviation_from_baseline: r.deviation_from_baseline,
+            insufficient_sample: r.filed_count < IB_APPENDIX_G_JUDGE_INSUFFICIENT_THRESHOLD,
+          }));
+        }
+      } else if (candidates.length > 1) {
+        limitations.push(`Multiple judges match "${rawJudge}"; add middle name or court to disambiguate. Judge section omitted.`);
+      }
+    } catch (e) {
+      console.warn("[IB-G] judge lookup failed (non-fatal):", e);
+    }
+  }
+
+  // Section 3: top-10 citations with quotes
+  let citations: AppendixGCitation[] = [];
+  const internalAuth = CHARGE_TYPE_AUTHORITY_MAP_DENO[charge.toLowerCase()] ?? [];
+  let bases: Array<{ case_name: string; date_filed: string | null; citation_count_in_charge: number | null; citation_count_total: number; authority_tier: string | null; source_url: string; cited_opinion_id: number }> = [];
+  if (internalAuth.length > 0) {
+    try {
+      const slugList = internalAuth.map((s) => encodeURIComponent(s)).join(",");
+      const rows = await supabaseSelect(
+        supabaseUrl, supabaseKey, "charge_type_top_authorities",
+        `charge_type=in.(${slugList})&order=citation_count_in_charge.desc&limit=30&select=rank,cited_opinion_id,case_name,date_filed,citation_count_in_charge,citation_count_total,authority_tier_overall,source_url`,
+      ) as Array<{ rank: number; cited_opinion_id: number; case_name: string; date_filed: string | null; citation_count_in_charge: number | null; citation_count_total: number; authority_tier_overall: string | null; source_url: string | null }>;
+      const seen = new Map<number, typeof bases[0]>();
+      for (const r of rows) {
+        if (!r.source_url) continue;
+        const prev = seen.get(r.cited_opinion_id);
+        const cur = {
+          case_name: r.case_name,
+          date_filed: r.date_filed,
+          citation_count_in_charge: r.citation_count_in_charge,
+          citation_count_total: r.citation_count_total,
+          authority_tier: r.authority_tier_overall,
+          source_url: r.source_url,
+          cited_opinion_id: r.cited_opinion_id,
+        };
+        if (!prev || (cur.citation_count_in_charge ?? 0) > (prev.citation_count_in_charge ?? 0)) {
+          seen.set(r.cited_opinion_id, cur);
+        }
+      }
+      bases = [...seen.values()]
+        .sort((a, b) => (b.citation_count_in_charge ?? 0) - (a.citation_count_in_charge ?? 0))
+        .slice(0, IB_APPENDIX_G_CITATION_TOP_N);
+    } catch (e) {
+      console.warn("[IB-G] charge_type_top_authorities fetch failed (non-fatal):", e);
+    }
+  }
+  if (bases.length < IB_APPENDIX_G_CITATION_TOP_N) {
+    try {
+      const rows = await supabaseSelect(
+        supabaseUrl, supabaseKey, "citation_authority_criminal",
+        `order=citation_count_criminal.desc&limit=30&select=cited_opinion_id,case_name,date_filed,citation_count_criminal,citation_count_total,authority_tier,source_url`,
+      ) as Array<{ cited_opinion_id: number; case_name: string; date_filed: string | null; citation_count_criminal: number | null; citation_count_total: number; authority_tier: string | null; source_url: string | null }>;
+      const seenIds = new Set(bases.map((b) => b.cited_opinion_id));
+      for (const r of rows) {
+        if (!r.source_url) continue;
+        if (seenIds.has(r.cited_opinion_id)) continue;
+        bases.push({
+          case_name: r.case_name,
+          date_filed: r.date_filed,
+          citation_count_in_charge: r.citation_count_criminal,
+          citation_count_total: r.citation_count_total,
+          authority_tier: r.authority_tier,
+          source_url: r.source_url,
+          cited_opinion_id: r.cited_opinion_id,
+        });
+        seenIds.add(r.cited_opinion_id);
+        if (bases.length >= IB_APPENDIX_G_CITATION_TOP_N) break;
+      }
+    } catch (e) {
+      console.warn("[IB-G] citation_authority_criminal fallback fetch failed (non-fatal):", e);
+    }
+  }
+  if (bases.length > 0) {
+    const oids = bases.map((b) => b.cited_opinion_id).filter(Number.isFinite);
+    const quoteByOid = new Map<number, { quote: string; citation: string | null; frequency: number | null }>();
+    if (oids.length > 0) {
+      try {
+        const idList = oids.join(",");
+        const qrows = await supabaseSelect(
+          supabaseUrl, supabaseKey, "authority_quotes_criminal",
+          `cited_opinion_id=in.(${idList})&order=rank.asc&select=cited_opinion_id,quote_sentence,primary_reporter,rank,quote_frequency`,
+        ) as Array<{ cited_opinion_id: number; quote_sentence: string; primary_reporter: string | null; rank: number; quote_frequency: number | null }>;
+        for (const r of qrows) {
+          if (quoteByOid.has(r.cited_opinion_id)) continue;
+          quoteByOid.set(r.cited_opinion_id, { quote: r.quote_sentence, citation: r.primary_reporter, frequency: r.quote_frequency });
+        }
+      } catch (e) {
+        console.warn("[IB-G] authority_quotes_criminal fetch failed (non-fatal):", e);
+      }
+    }
+    citations = bases.map((b, i) => {
+      const q = quoteByOid.get(b.cited_opinion_id);
+      return {
+        rank: i + 1,
+        case_name: b.case_name,
+        date_filed: b.date_filed,
+        citation: q?.citation ?? null,
+        authority_tier: b.authority_tier,
+        citation_count_in_charge: b.citation_count_in_charge,
+        citation_count_total: b.citation_count_total,
+        quote_sentence: q?.quote ?? null,
+        quote_frequency: q?.frequency ?? null,
+        source_url: b.source_url,
+      };
+    });
+  }
+
+  return { motions, judgeMotions, judgeDisplayName, citations, limitations, circuit };
+}
+
+function renderAppendixGMotionStrategy(data: AppendixGData, chargeSlug: string | null | undefined): string {
+  const motionsCount = data.motions.length;
+  const judgeCount = data.judgeMotions.length;
+  const citeCount = data.citations.length;
+  if (motionsCount === 0 && judgeCount === 0 && citeCount === 0) return "";
+  const chargeLabel = (chargeSlug || "").replace(/-/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+  const lines: string[] = [];
+  lines.push(`## Appendix G: Motion Strategy`);
+  lines.push(``);
+  lines.push(`How the courts that hear cases like yours have ruled on the motions most commonly filed in these cases. This is historical pattern data compiled from published criminal opinions — not a prediction for your specific motion.`);
+  lines.push(``);
+
+  if (motionsCount > 0) {
+    lines.push(`### Motion Grant Rates — Top ${motionsCount} for ${chargeLabel}`);
+    lines.push(``);
+    lines.push(`Motion types ranked by filing frequency. Baseline shows circuit all-charges baseline when available, otherwise national. Deviation compares this charge's rate against the baseline.`);
+    lines.push(``);
+    lines.push(`| **Motion Type** | **N filed** | **N granted** | **Grant rate** | **Baseline** | **Deviation** |`);
+    lines.push(`|---|---|---|---|---|---|`);
+    for (const m of data.motions) {
+      const mt = m.motion_type.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+      const gr = m.grant_rate != null ? (m.grant_rate * 100).toFixed(1) + "%" : "—";
+      const bl = m.baseline_grant_rate != null ? (m.baseline_grant_rate * 100).toFixed(1) + "%" : "—";
+      const dev = m.deviation_from_baseline != null
+        ? (m.deviation_from_baseline >= 0 ? "+" : "") + (m.deviation_from_baseline * 100).toFixed(1) + " pp"
+        : "—";
+      lines.push(`| ${escapeHtml(mt)} | ${m.filed_count} | ${m.granted_count} | ${gr} | ${bl} | ${dev} |`);
+    }
+    lines.push(``);
+  }
+
+  if (judgeCount > 0 && data.judgeDisplayName) {
+    lines.push(`### Motion Patterns Before ${escapeHtml(data.judgeDisplayName)}`);
+    lines.push(``);
+    lines.push(`Motions of any charge type authored by this judge in the CourtListener corpus. Rows with small samples (n < ${IB_APPENDIX_G_JUDGE_INSUFFICIENT_THRESHOLD}) are surfaced with an "insufficient data" caveat — the pattern may still be worth raising with your attorney as a question.`);
+    lines.push(``);
+    lines.push(`| **Motion Type** | **N filed** | **Grant rate** | **Cross-judge baseline** | **Deviation** | **Sample** |`);
+    lines.push(`|---|---|---|---|---|---|`);
+    for (const m of data.judgeMotions) {
+      const mt = m.motion_type.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+      const rateCell = m.insufficient_sample
+        ? `insufficient (n=${m.filed_count})`
+        : (m.grant_rate != null ? (m.grant_rate * 100).toFixed(1) + "%" : "—");
+      const bl = m.baseline_grant_rate != null ? (m.baseline_grant_rate * 100).toFixed(1) + "%" : "—";
+      const dev = m.deviation_from_baseline != null
+        ? (m.deviation_from_baseline >= 0 ? "+" : "") + (m.deviation_from_baseline * 100).toFixed(1) + " pp"
+        : "—";
+      const sample = m.insufficient_sample ? `thin (n=${m.filed_count})` : `sufficient`;
+      lines.push(`| ${escapeHtml(mt)} | ${m.filed_count} | ${rateCell} | ${bl} | ${dev} | ${sample} |`);
+    }
+    lines.push(``);
+  }
+
+  if (citeCount > 0) {
+    lines.push(`### Top ${citeCount} Granted-Motion Case Citations`);
+    lines.push(``);
+    lines.push(`Most-cited criminal authorities relevant to ${chargeLabel}. Each row includes an **extracted quote** drawn from how citing courts reference the case.`);
+    lines.push(``);
+    for (const c of data.citations) {
+      const yr = c.date_filed ? String(c.date_filed).slice(0, 4) : "";
+      const yrTag = yr ? ` (${yr})` : "";
+      const citeTag = c.citation ? ` · ${escapeHtml(c.citation)}` : "";
+      const tierTag = c.authority_tier ? ` · ${escapeHtml(c.authority_tier)}` : "";
+      const url = isSafeHttpsSourceUrl(c.source_url) ? c.source_url : "";
+      const nameCell = url
+        ? `[${escapeHtml(c.case_name)}](${escapeHtml(url)})`
+        : escapeHtml(c.case_name);
+      lines.push(`**${c.rank}. ${nameCell}**${yrTag}${citeTag}${tierTag}`);
+      if (c.citation_count_in_charge != null) {
+        lines.push(`Cites in ${chargeLabel}: ${c.citation_count_in_charge} · total criminal cites: ${c.citation_count_total}`);
+      } else {
+        lines.push(`Total criminal cites: ${c.citation_count_total}`);
+      }
+      if (c.quote_sentence) {
+        lines.push(``);
+        lines.push(`> ${c.quote_sentence.split("\n").join(" ")}`);
+        if (c.quote_frequency) {
+          lines.push(`(Extracted from ${c.quote_frequency} citing opinion${c.quote_frequency === 1 ? "" : "s"}; rank #1 per case.)`);
+        }
+      } else {
+        lines.push(``);
+        lines.push(`*No canonical quote cached for this opinion yet.*`);
+      }
+      lines.push(``);
+    }
+  }
+
+  lines.push(`**Cross-reference note.** If you add the War Room ($4,997) tier, the Similar Cases layer overlays these motions onto sentencing outcomes for defendants in similar factual buckets.`);
+  lines.push(``);
+
+  if (data.limitations.length > 0) {
+    lines.push(`#### Known limitations`);
+    lines.push(``);
+    for (const l of data.limitations) lines.push(`- ${escapeHtml(l)}`);
+    lines.push(``);
+  }
+
+  lines.push(`**Methodology.** This appendix provides legal INFORMATION, not legal ADVICE. Frequencies are tallied from published criminal opinions as of 2026-04-22. "Grant rate" = N granted ÷ N filed within the scope shown; small samples are flagged. Citations link to the primary opinion on CourtListener for independent verification. No part of this appendix is a prediction — it is a map of what is already in the record.`);
+
+  return "\n" + lines.join("\n") + "\n";
+}
+
+interface AppendixHRow {
+  rank: number;
+  case_name: string;
+  date_filed: string | null;
+  citation: string | null;
+  authority_tier: string | null;
+  citation_count_in_charge: number | null;
+  citation_count_total: number;
+  quote_full: string | null;
+  velocity: number | null;
+  velocity_tier: string | null;
+  rising_flag: boolean;
+  counter_authority_warning: boolean;
+  source_url: string;
+  jurisdiction: string | null;
+}
+interface AppendixHData {
+  rows: AppendixHRow[];
+  limitations: string[];
+  state: string | null;
+}
+
+async function fetchAppendixHLiveAuthority(
+  supabaseUrl: string,
+  supabaseKey: string,
+  chargeType: string | null | undefined,
+  state: string | null | undefined,
+): Promise<AppendixHData> {
+  const charge = sanitizeFilterValue(chargeType, 60) || "";
+  const stateUp = (sanitizeFilterValue(state, 50) || "").toUpperCase() || null;
+  const limitations: string[] = [];
+  const internalAuth = CHARGE_TYPE_AUTHORITY_MAP_DENO[charge.toLowerCase()] ?? [];
+  let bases: Array<{ case_name: string; date_filed: string | null; citation_count_in_charge: number | null; citation_count_total: number; authority_tier: string | null; source_url: string; cited_opinion_id: number; jurisdiction: string | null; data_scope: "charge_type" | "criminal_fallback" }> = [];
+
+  if (internalAuth.length > 0) {
+    try {
+      const slugList = internalAuth.map((s) => encodeURIComponent(s)).join(",");
+      const rows = await supabaseSelect(
+        supabaseUrl, supabaseKey, "charge_type_top_authorities",
+        `charge_type=in.(${slugList})&order=citation_count_in_charge.desc&limit=60&select=cited_opinion_id,case_name,date_filed,citation_count_in_charge,citation_count_total,authority_tier_overall,source_url,jurisdiction`,
+      ) as Array<{ cited_opinion_id: number; case_name: string; date_filed: string | null; citation_count_in_charge: number | null; citation_count_total: number; authority_tier_overall: string | null; source_url: string | null; jurisdiction: string | null }>;
+      const seen = new Map<number, typeof bases[0]>();
+      for (const r of rows) {
+        if (!r.source_url) continue;
+        const prev = seen.get(r.cited_opinion_id);
+        const cur = {
+          case_name: r.case_name,
+          date_filed: r.date_filed,
+          citation_count_in_charge: r.citation_count_in_charge,
+          citation_count_total: r.citation_count_total,
+          authority_tier: r.authority_tier_overall,
+          source_url: r.source_url,
+          cited_opinion_id: r.cited_opinion_id,
+          jurisdiction: r.jurisdiction,
+          data_scope: "charge_type" as const,
+        };
+        if (!prev || (cur.citation_count_in_charge ?? 0) > (prev.citation_count_in_charge ?? 0)) {
+          seen.set(r.cited_opinion_id, cur);
+        }
+      }
+      bases = [...seen.values()]
+        .sort((a, b) => (b.citation_count_in_charge ?? 0) - (a.citation_count_in_charge ?? 0));
+    } catch (e) {
+      console.warn("[IB-H] charge_type_top_authorities fetch failed (non-fatal):", e);
+    }
+  }
+
+  // Jurisdiction filter — narrow to state-court + federal (S/SA/F/FD) when state known.
+  let jurisdictionFiltered = false;
+  if (stateUp && bases.length > IB_APPENDIX_H_AUTHORITY_TOP_N) {
+    const allowed = new Set(["S", "SA", "F", "FD"]);
+    const narrowed = bases.filter((b) => !b.jurisdiction || allowed.has(b.jurisdiction));
+    if (narrowed.length >= IB_APPENDIX_H_AUTHORITY_TOP_N) {
+      bases = narrowed;
+      jurisdictionFiltered = true;
+    } else {
+      limitations.push(`State-narrowed authority list fell below ${IB_APPENDIX_H_AUTHORITY_TOP_N} rows; showing unfiltered national list.`);
+    }
+  }
+  bases = bases.slice(0, IB_APPENDIX_H_AUTHORITY_TOP_N);
+
+  if (bases.length < IB_APPENDIX_H_AUTHORITY_TOP_N) {
+    try {
+      const rows = await supabaseSelect(
+        supabaseUrl, supabaseKey, "citation_authority_criminal",
+        `order=citation_count_criminal.desc&limit=40&select=cited_opinion_id,case_name,date_filed,citation_count_criminal,citation_count_total,authority_tier,source_url`,
+      ) as Array<{ cited_opinion_id: number; case_name: string; date_filed: string | null; citation_count_criminal: number | null; citation_count_total: number; authority_tier: string | null; source_url: string | null }>;
+      const seenIds = new Set(bases.map((b) => b.cited_opinion_id));
+      for (const r of rows) {
+        if (!r.source_url) continue;
+        if (seenIds.has(r.cited_opinion_id)) continue;
+        bases.push({
+          case_name: r.case_name,
+          date_filed: r.date_filed,
+          citation_count_in_charge: r.citation_count_criminal,
+          citation_count_total: r.citation_count_total,
+          authority_tier: r.authority_tier,
+          source_url: r.source_url,
+          cited_opinion_id: r.cited_opinion_id,
+          jurisdiction: null,
+          data_scope: "criminal_fallback",
+        });
+        seenIds.add(r.cited_opinion_id);
+        if (bases.length >= IB_APPENDIX_H_AUTHORITY_TOP_N) break;
+      }
+      if (internalAuth.length === 0 || bases.some((b) => b.data_scope === "criminal_fallback")) {
+        limitations.push(`No charge-specific authorities cached for "${charge}"; top criminal-law authorities shown as fallback.`);
+      }
+    } catch (e) {
+      console.warn("[IB-H] citation_authority_criminal fallback fetch failed (non-fatal):", e);
+    }
+  }
+
+  if (bases.length === 0) {
+    return { rows: [], limitations, state: stateUp };
+  }
+
+  // Enrich with full multi-sentence quote (rank 1 + 2 + 3 concatenated) + velocity.
+  const oids = bases.map((b) => b.cited_opinion_id).filter(Number.isFinite);
+  const quotesByOid = new Map<number, string[]>();
+  const citationByOid = new Map<number, string | null>();
+  const velByOid = new Map<number, { velocity: number | null; tier: string | null; rising: boolean }>();
+  if (oids.length > 0) {
+    try {
+      const idList = oids.join(",");
+      const qrows = await supabaseSelect(
+        supabaseUrl, supabaseKey, "authority_quotes_criminal",
+        `cited_opinion_id=in.(${idList})&order=rank.asc&select=cited_opinion_id,quote_sentence,primary_reporter,rank`,
+      ) as Array<{ cited_opinion_id: number; quote_sentence: string; primary_reporter: string | null; rank: number }>;
+      for (const r of qrows) {
+        const arr = quotesByOid.get(r.cited_opinion_id) ?? [];
+        if (arr.length < 3) arr.push(r.quote_sentence);
+        quotesByOid.set(r.cited_opinion_id, arr);
+        if (!citationByOid.has(r.cited_opinion_id)) {
+          citationByOid.set(r.cited_opinion_id, r.primary_reporter);
+        }
+      }
+    } catch (e) {
+      console.warn("[IB-H] authority_quotes_criminal fetch failed (non-fatal):", e);
+    }
+    try {
+      const idList = oids.join(",");
+      const vrows = await supabaseSelect(
+        supabaseUrl, supabaseKey, "citation_velocity_criminal",
+        `cited_opinion_id=in.(${idList})&select=cited_opinion_id,velocity,velocity_tier,rising_flag`,
+      ) as Array<{ cited_opinion_id: number; velocity: number | null; velocity_tier: string | null; rising_flag: boolean | null }>;
+      for (const r of vrows) {
+        velByOid.set(r.cited_opinion_id, {
+          velocity: r.velocity,
+          tier: r.velocity_tier,
+          rising: r.rising_flag ?? false,
+        });
+      }
+    } catch (e) {
+      console.warn("[IB-H] citation_velocity_criminal fetch failed (non-fatal):", e);
+    }
+  }
+
+  const rows: AppendixHRow[] = bases.map((b, i) => {
+    const quotes = quotesByOid.get(b.cited_opinion_id) ?? [];
+    const v = velByOid.get(b.cited_opinion_id);
+    const tier = (v?.tier ?? "").toLowerCase();
+    return {
+      rank: i + 1,
+      case_name: b.case_name,
+      date_filed: b.date_filed,
+      citation: citationByOid.get(b.cited_opinion_id) ?? null,
+      authority_tier: b.authority_tier,
+      citation_count_in_charge: b.citation_count_in_charge,
+      citation_count_total: b.citation_count_total,
+      quote_full: quotes.length ? quotes.join(" ") : null,
+      velocity: v?.velocity ?? null,
+      velocity_tier: v?.tier ?? null,
+      rising_flag: v?.rising ?? false,
+      counter_authority_warning: tier === "fading",
+      source_url: b.source_url,
+      jurisdiction: b.jurisdiction,
+    };
+  });
+
+  if (jurisdictionFiltered) {
+    limitations.push(`Authority list narrowed to state-court + federal opinions relevant to ${stateUp}.`);
+  }
+
+  return { rows, limitations, state: stateUp };
+}
+
+function renderAppendixHLiveAuthority(data: AppendixHData, chargeSlug: string | null | undefined): string {
+  if (data.rows.length === 0) return "";
+  const chargeLabel = (chargeSlug || "").replace(/-/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+  const lines: string[] = [];
+  lines.push(`## Appendix H: Live Authority Map`);
+  lines.push(``);
+  const scopeSuffix = data.state ? ` · ${escapeHtml(data.state)}` : "";
+  lines.push(`Top ${data.rows.length} must-cite defense authorities for ${chargeLabel}${scopeSuffix}. Each row carries an extracted quote, a citation-velocity indicator, and a counter-authority flag where the precedent's citation velocity is declining.`);
+  lines.push(``);
+  lines.push(`**Cross-reference note.** Authorities that appear **bolded** below are cases most-cited inside the granted motions listed in Appendix G — treat them as the highest-leverage precedents for this charge type.`);
+  lines.push(``);
+
+  for (const r of data.rows) {
+    const yr = r.date_filed ? String(r.date_filed).slice(0, 4) : "";
+    const yrTag = yr ? ` (${yr})` : "";
+    const citeTag = r.citation ? ` · ${escapeHtml(r.citation)}` : "";
+    const tierTag = r.authority_tier ? ` · ${escapeHtml(r.authority_tier)}` : "";
+    const velLabel = r.rising_flag ? "rising" : ((r.velocity_tier ?? "").toLowerCase() === "fading" ? "fading" : "stable");
+    const velTag = ` · velocity: ${velLabel}`;
+    const url = isSafeHttpsSourceUrl(r.source_url) ? r.source_url : "";
+    const nameCell = url
+      ? `[${escapeHtml(r.case_name)}](${escapeHtml(url)})`
+      : escapeHtml(r.case_name);
+    const line = r.rising_flag
+      ? `**${r.rank}. ${nameCell}**${yrTag}${citeTag}${tierTag}${velTag}`
+      : `${r.rank}. ${nameCell}${yrTag}${citeTag}${tierTag}${velTag}`;
+    lines.push(line);
+    if (r.citation_count_in_charge != null) {
+      lines.push(`Cites in ${chargeLabel}: ${r.citation_count_in_charge} · total criminal cites: ${r.citation_count_total}`);
+    } else {
+      lines.push(`Total criminal cites: ${r.citation_count_total}`);
+    }
+    if (r.quote_full) {
+      lines.push(``);
+      lines.push(`> ${r.quote_full.split("\n").join(" ")}`);
+    } else {
+      lines.push(``);
+      lines.push(`*No canonical quote cached for this opinion yet.*`);
+    }
+    if (r.counter_authority_warning) {
+      lines.push(``);
+      lines.push(`**Counter-authority note:** this authority has declining citation velocity — courts are citing it less often than in prior years. A question worth raising with your attorney: are there newer precedents that have superseded this one for this charge type?`);
+    }
+    lines.push(``);
+  }
+
+  if (data.limitations.length > 0) {
+    lines.push(`#### Known limitations`);
+    lines.push(``);
+    for (const l of data.limitations) lines.push(`- ${escapeHtml(l)}`);
+    lines.push(``);
+  }
+
+  lines.push(`**Methodology.** This appendix provides legal INFORMATION, not legal ADVICE. Authorities are ranked by citation frequency in the federal criminal corpus as of 2026-04-22. Canonical quotes are extracted from how citing courts reference the case — not from the opinion itself — so they reflect the proposition the case is cited for. Velocity compares recent citing activity against the prior decade. Every row links to the primary opinion on CourtListener for independent verification. No part of this appendix is a prediction.`);
+
+  return "\n" + lines.join("\n") + "\n";
+}
+
 function renderJudgeJustFair(demographics: JudgeDemoRow | null, byRace: JudgeSentencingRow[]): string {
   if (!demographics) return "";
   const lines: string[] = [];
@@ -6707,6 +7424,10 @@ function renderIBReportHtml(sectionOutputs: Record<string, string>, meta: {
     buildYourRights(stateForRights),
     // Appendix F: Data-Driven Defense Intelligence (mechanical render, no Claude)
     sectionOutputs["tier9-data-appendix"] || "",
+    // Appendix G: Motion Strategy (IB $997 E1, 2026-04-23, mechanical render)
+    sectionOutputs["ib-appendix-g"] || "",
+    // Appendix H: Live Authority Map (IB $997 E1, 2026-04-23, mechanical render)
+    sectionOutputs["ib-appendix-h"] || "",
   ].filter((s) => s.trim()).map((s) => md2html(s)).join('\n<div class="page-break"></div>\n');
 
   return `<!DOCTYPE html>


### PR DESCRIPTION
## Summary

E1 — IB \$997 enhancement. Adds two new appendices to the existing Intelligence Brief \$997 deliverable using motion + authority data activated by Wave 1 SKUs (M1 \$197 + M2 \$97). **No new SKU, same price, same delivery time** — Hormozi value-equation lift on the flagship tier.

- **Appendix G — Motion Strategy.** Top-20 motion grant rates + top-10 granted-motion case citations with per-case extracted quotes. Judge rows with n<10 surfaced with "insufficient" caveat (M1 suppresses).
- **Appendix H — Live Authority Map.** Top-15 must-cite defense authorities with full multi-sentence extracted quotes + counter-authority velocity flag (flags opinions whose citation velocity is declining). Jurisdiction-narrowed when state known.

## Tier monotonicity (HARD, test-enforced)

| Dimension | M1 \$197 | M2 \$97 | **IB E1 \$997** | X-Ray E2 \$2,497 |
|---|---|---|---|---|
| Motion rates depth | top 10 | — | **top 20 + judge even n<10** | full histogram |
| Case citation quotes | — | 1-line preview | **full multi-sentence quote** | + judge cross-ref |
| Authority top-N | — | 10 | **15** | 15 + cross-cite |
| Counter-auth flag | — | velocity arrow | **declining-velocity warning** | + trend cron |

Strictly exceeds M1/M2 on every relevant dimension. Strictly stays below X-Ray (no full histogram, no judge-attack cross-ref) and War Room (no monthly delta).

## Files changed

New:
- \`src/lib/charge-slug-maps.ts\` — shared MOR + AUTH slug maps + state→circuit (extracted from M1/M2, now the canonical source)
- \`src/lib/ib-appendices/motion-strategy.ts\` — Appendix G query + markdown render
- \`src/lib/ib-appendices/live-authority-map.ts\` — Appendix H query + markdown render
- \`src/lib/ib-appendices/__tests__/motion-strategy.test.ts\` — 14 assertions
- \`src/lib/ib-appendices/__tests__/live-authority-map.test.ts\` — 12 assertions

Edited:
- \`src/lib/intelligence-brief/render.ts\` — added \`ib-appendix-g\` + \`ib-appendix-h\` slots after Appendix F; TOC entries
- \`supabase/functions/generate-report/index.ts\` — Deno-side fetch + render helpers (mirrors Next.js modules; Deno cannot import them). Monotonicity constants encoded inline. Same slot wiring.

Does NOT touch:
- Appendix F rising-precedents (shipped 2026-04-22) — G + H sit adjacent, F unchanged
- IB price (\$997) or delivery time (72h, unchanged)
- Tier \`live\` flags

## UPL + safety (HARD, test-enforced)

- Banned-phrase blocklist: never emits "you should" / "we recommend" / "we advise" / "your best option" / "ask your attorney" / "publicly available"
- Counter-authority phrased neutrally: "this authority has declining citation velocity", never "don't use"
- Every citation row has CourtListener URL; rows without URL suppressed (no-hallucinated-legal-data compliance)
- Methodology gate on both appendices: "legal INFORMATION, not legal ADVICE" + "not a prediction"

## Test plan

- [x] \`vitest run src/lib/ib-appendices\` — 26/26 pass
- [x] \`vitest run src/lib\` — 382/389 pass (7 pre-existing skips, no regression)
- [x] \`tsc --noEmit\` — 0 errors
- [x] \`next build --webpack --experimental-build-mode compile\` — pre-push hook succeeded (full compile clean)
- [ ] Deploy Edge Function: \`npx supabase functions deploy generate-report --project-ref jxjbjmgdukwkoclydqdr\` — needed for Edge-side G + H to activate (Next-side render.ts already picks up the slot)
- [ ] Smoke test: regenerate 1 delivered IB case with \`force:true\` to verify G + H render against live Supabase data

## Experts cited

- Hormozi Grand Slam (tiered value equation — raise depth, keep price)
- Dreyer AI Overview Defense (authority-engine positioning)

## Source docs

- \`docs/plans/2026-04-23-data-to-product-autonomous-execution.md\` — E1 spec + monotonicity matrix
- \`docs/advisor/2026-04-23-data-to-product-audit.md\` — Move 3 stacked follow-ons

🤖 Generated with [Claude Code](https://claude.com/claude-code)