### PR TITLE
feat(similar-cases): add motion_context footer from motion_outcome_rates (E5)

### DIFF
--- a/src/app/api/tools/similar-cases/route.ts
+++ b/src/app/api/tools/similar-cases/route.ts
@@ -30,6 +30,7 @@ import {
   normalizeAgeBucket,
   type SimilarCasesRow,
 } from "@/lib/ussc-similar-cases";
+import { queryMotionContext } from "@/lib/ussc-similar-cases-motion-context";
 
 interface SimilarCasesInput {
   offguide: string;
@@ -120,7 +121,7 @@ export async function POST(req: NextRequest) {
         ? normalizeAgeBucket(input.age)
         : null;
 
-  const [response, districtDisplay] = await Promise.all([
+  const [response, districtDisplay, motionContext] = await Promise.all([
     queryBucket(supabase, {
       district: input.district ?? null,
       offguide: input.offguide,
@@ -129,6 +130,7 @@ export async function POST(req: NextRequest) {
       age_bucket,
     }),
     queryDistrictDisplay(supabase, input.district ?? null),
+    queryMotionContext(supabase, input.offguide),
   ]);
 
   const { plea, trial } = extractPleaTrialSplit(response.rows);
@@ -172,6 +174,7 @@ export async function POST(req: NextRequest) {
       },
       trial_tax_months,
       district_display: districtDisplay,
+      motion_context: motionContext,
       federalOnly: true,
       dataSource:
         "USSC Individual Offender Datafiles FY2014-FY2024 (690,491 federal sentences across 23,210 buckets)",

--- a/src/lib/__tests__/ussc-similar-cases-motion-context.test.ts
+++ b/src/lib/__tests__/ussc-similar-cases-motion-context.test.ts
@@ -1,0 +1,274 @@
+import { describe, it, expect } from "vitest";
+import {
+  getMotionChargesForOffguide,
+  USSC_OFFGUIDE_TO_CHARGE_MAP,
+  MOR_CHARGE_EXPANSION,
+} from "../ussc-offguide-charge-map";
+import {
+  aggregateTopMotions,
+  buildUnmappedContext,
+  queryMotionContext,
+  MOTION_CONTEXT_UPL_BANNED,
+  type MotionContext,
+} from "../ussc-similar-cases-motion-context";
+
+describe("USSC offguide -> MOR charge bridge", () => {
+  describe("USSC_OFFGUIDE_TO_CHARGE_MAP", () => {
+    it("covers all 29 distinct offguide values observed in matview", () => {
+      const observed = [
+        "1", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19",
+        "2", "21", "22", "23", "24", "25", "26", "27", "28", "29",
+        "3", "30", "4", "5", "6", "7", "9", "UNK",
+      ];
+      for (const code of observed) {
+        expect(code in USSC_OFFGUIDE_TO_CHARGE_MAP).toBe(true);
+      }
+    });
+
+    it("maps exactly 14 of 29 observed codes to MOR slugs (best-effort coverage)", () => {
+      // 29 distinct offguide values observed in ussc_similar_cases_summary
+      // (note: 20=Manslaughter is NOT in the observed set, so canonical "20"
+      // mapping exists in USSC_OFFGUIDE_TO_CHARGE_MAP but doesn't count here).
+      const observed = [
+        "1", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19",
+        "2", "21", "22", "23", "24", "25", "26", "27", "28", "29",
+        "3", "30", "4", "5", "6", "7", "9", "UNK",
+      ];
+      const mapped = observed.filter((c) => USSC_OFFGUIDE_TO_CHARGE_MAP[c] !== null);
+      // Mapped: 1, 4, 7, 9, 10, 13, 15, 16, 21, 25, 26, 27, 29, 30 = 14
+      expect(mapped.length).toBe(14);
+    });
+
+    it("every non-null canonical slug has an MOR_CHARGE_EXPANSION entry", () => {
+      for (const [code, canonical] of Object.entries(USSC_OFFGUIDE_TO_CHARGE_MAP)) {
+        if (canonical === null) continue;
+        expect(MOR_CHARGE_EXPANSION[canonical]).toBeDefined();
+        expect(MOR_CHARGE_EXPANSION[canonical].length).toBeGreaterThan(0);
+      }
+    });
+
+    it("maps drug-trafficking offguide 10 to drug-trafficking cluster", () => {
+      const result = getMotionChargesForOffguide("10");
+      expect(result).not.toBeNull();
+      expect(result!.canonical).toBe("drug-trafficking");
+      expect(result!.charges).toContain("drug-trafficking");
+      expect(result!.charges).toContain("drug-distribution");
+    });
+
+    it("maps fraud offguide 16 to fraud-general cluster (includes embezzlement)", () => {
+      const result = getMotionChargesForOffguide("16");
+      expect(result).not.toBeNull();
+      expect(result!.canonical).toBe("fraud-general");
+      expect(result!.charges).toContain("fraud-general");
+      expect(result!.charges).toContain("embezzlement");
+    });
+
+    it("maps firearms offguide 13 to weapons-possession cluster", () => {
+      const result = getMotionChargesForOffguide("13");
+      expect(result).not.toBeNull();
+      expect(result!.canonical).toBe("weapons-possession");
+      expect(result!.charges).toContain("felon-in-possession");
+    });
+  });
+
+  describe("null / unmapped handling", () => {
+    it("returns null for unmapped immigration (17)", () => {
+      expect(getMotionChargesForOffguide("17")).toBeNull();
+    });
+
+    it("returns null for UNK", () => {
+      expect(getMotionChargesForOffguide("UNK")).toBeNull();
+    });
+
+    it("returns null for null / undefined / empty", () => {
+      expect(getMotionChargesForOffguide(null)).toBeNull();
+      expect(getMotionChargesForOffguide(undefined)).toBeNull();
+      expect(getMotionChargesForOffguide("")).toBeNull();
+    });
+
+    it("returns null for non-numeric garbage", () => {
+      expect(getMotionChargesForOffguide("not-a-code")).toBeNull();
+    });
+  });
+});
+
+describe("aggregateTopMotions", () => {
+  it("aggregates filed/granted across cluster members, caps at top 3", () => {
+    const rows = [
+      { motion_type: "suppress", charge_type: "drug-trafficking", filed_count: 100, granted_count: 20, denied_count: 80, grant_rate: 0.2 },
+      { motion_type: "suppress", charge_type: "drug-distribution", filed_count: 50, granted_count: 15, denied_count: 35, grant_rate: 0.3 },
+      { motion_type: "dismiss", charge_type: "drug-trafficking", filed_count: 80, granted_count: 10, denied_count: 70, grant_rate: 0.125 },
+      { motion_type: "sever", charge_type: "drug-trafficking", filed_count: 40, granted_count: 5, denied_count: 35, grant_rate: 0.125 },
+      { motion_type: "franks", charge_type: "drug-trafficking", filed_count: 10, granted_count: 1, denied_count: 9, grant_rate: 0.1 },
+    ];
+    const top = aggregateTopMotions(rows);
+    expect(top.length).toBe(3);
+    expect(top[0].motion_type).toBe("suppress");
+    expect(top[0].n_filed).toBe(150);
+    expect(top[0].n_granted).toBe(35);
+    expect(top[0].grant_rate).toBe(Number((35 / 150).toFixed(4)));
+    expect(top[1].motion_type).toBe("dismiss");
+    expect(top[2].motion_type).toBe("sever");
+  });
+
+  it("breaks n_filed ties alphabetically on motion_type", () => {
+    const rows = [
+      { motion_type: "zebra", charge_type: "x", filed_count: 100, granted_count: 10, denied_count: 90, grant_rate: 0.1 },
+      { motion_type: "alpha", charge_type: "x", filed_count: 100, granted_count: 10, denied_count: 90, grant_rate: 0.1 },
+      { motion_type: "mango", charge_type: "x", filed_count: 100, granted_count: 10, denied_count: 90, grant_rate: 0.1 },
+    ];
+    const top = aggregateTopMotions(rows);
+    expect(top.map((m) => m.motion_type)).toEqual(["alpha", "mango", "zebra"]);
+  });
+
+  it("returns empty array when rows empty", () => {
+    expect(aggregateTopMotions([])).toEqual([]);
+  });
+
+  it("filters rows with filed_count=0 out of results", () => {
+    const rows = [
+      { motion_type: "zero", charge_type: "x", filed_count: 0, granted_count: 0, denied_count: 0, grant_rate: null },
+      { motion_type: "real", charge_type: "x", filed_count: 5, granted_count: 1, denied_count: 4, grant_rate: 0.2 },
+    ];
+    const top = aggregateTopMotions(rows);
+    expect(top.length).toBe(1);
+    expect(top[0].motion_type).toBe("real");
+  });
+
+  it("handles missing/NaN filed/granted counts safely", () => {
+    const rows = [
+      { motion_type: "ok", charge_type: "x", filed_count: 10, granted_count: 2, denied_count: 8, grant_rate: 0.2 },
+      // deliberately malformed - simulate DB returning null
+      { motion_type: "bad", charge_type: "x", filed_count: NaN, granted_count: NaN, denied_count: 0, grant_rate: null } as any,
+    ];
+    const top = aggregateTopMotions(rows as any);
+    expect(top.length).toBe(1);
+    expect(top[0].motion_type).toBe("ok");
+  });
+
+  it("grant_rate rounds to 4 decimal places", () => {
+    const rows = [
+      { motion_type: "m", charge_type: "x", filed_count: 3, granted_count: 1, denied_count: 2, grant_rate: 0.3333 },
+    ];
+    const top = aggregateTopMotions(rows);
+    expect(top[0].grant_rate).toBe(0.3333);
+  });
+});
+
+describe("buildUnmappedContext", () => {
+  it("has the required MotionContext shape with null mapping", () => {
+    const ctx: MotionContext = buildUnmappedContext();
+    expect(ctx.offguide_mapped_charge).toBeNull();
+    expect(ctx.top_motions).toEqual([]);
+    expect(typeof ctx.data_caveat).toBe("string");
+    expect(ctx.data_caveat.length).toBeGreaterThan(0);
+    expect(ctx.upgrade_cta_slug).toBe("motion-success-report");
+  });
+
+  it("caveat is UPL-clean", () => {
+    const ctx = buildUnmappedContext();
+    for (const banned of MOTION_CONTEXT_UPL_BANNED) {
+      expect(ctx.data_caveat.toLowerCase()).not.toContain(banned);
+    }
+  });
+});
+
+describe("queryMotionContext (mocked SupabaseClient)", () => {
+  function makeMockSb(rows: unknown[], error: Error | null = null) {
+    return {
+      from() {
+        return {
+          select() {
+            return {
+              in() {
+                return Promise.resolve({ data: rows, error });
+              },
+            };
+          },
+        };
+      },
+    } as any;
+  }
+
+  it("returns unmapped-shape for null offguide without hitting DB", async () => {
+    let called = false;
+    const sb = {
+      from() {
+        called = true;
+        return { select: () => ({ in: () => Promise.resolve({ data: [], error: null }) }) };
+      },
+    } as any;
+    const ctx = await queryMotionContext(sb, null);
+    expect(ctx.offguide_mapped_charge).toBeNull();
+    expect(ctx.top_motions).toEqual([]);
+    expect(called).toBe(false);
+  });
+
+  it("returns unmapped-shape for unmapped code 17 (immigration)", async () => {
+    const sb = makeMockSb([]);
+    const ctx = await queryMotionContext(sb, "17");
+    expect(ctx.offguide_mapped_charge).toBeNull();
+    expect(ctx.top_motions).toEqual([]);
+  });
+
+  it("returns top 3 sorted by filed desc for mapped offguide 10 (drug-trafficking)", async () => {
+    const sb = makeMockSb([
+      { motion_type: "suppress", charge_type: "drug-trafficking", filed_count: 500, granted_count: 100, denied_count: 400, grant_rate: 0.2 },
+      { motion_type: "dismiss", charge_type: "drug-trafficking", filed_count: 300, granted_count: 30, denied_count: 270, grant_rate: 0.1 },
+      { motion_type: "sever", charge_type: "drug-trafficking", filed_count: 100, granted_count: 10, denied_count: 90, grant_rate: 0.1 },
+      { motion_type: "franks", charge_type: "drug-trafficking", filed_count: 50, granted_count: 5, denied_count: 45, grant_rate: 0.1 },
+    ]);
+    const ctx = await queryMotionContext(sb, "10");
+    expect(ctx.offguide_mapped_charge).toBe("drug-trafficking");
+    expect(ctx.top_motions.length).toBe(3);
+    expect(ctx.top_motions[0].motion_type).toBe("suppress");
+    expect(ctx.top_motions[0].n_filed).toBe(500);
+    expect(ctx.upgrade_cta_slug).toBe("motion-success-report");
+  });
+
+  it("enforces top-3 cap even when DB returns 10 rows", async () => {
+    const rows = Array.from({ length: 10 }, (_, i) => ({
+      motion_type: `motion-${i}`,
+      charge_type: "drug-trafficking",
+      filed_count: 100 - i,
+      granted_count: 10,
+      denied_count: 90 - i,
+      grant_rate: 0.1,
+    }));
+    const sb = makeMockSb(rows);
+    const ctx = await queryMotionContext(sb, "10");
+    expect(ctx.top_motions.length).toBe(3);
+  });
+
+  it("returns unmapped-shape with canonical set when mapping OK but no rows", async () => {
+    const sb = makeMockSb([]);
+    const ctx = await queryMotionContext(sb, "10");
+    expect(ctx.offguide_mapped_charge).toBe("drug-trafficking");
+    expect(ctx.top_motions).toEqual([]);
+  });
+
+  it("degrades gracefully on DB error (no throw)", async () => {
+    const sb = makeMockSb([], new Error("connection reset"));
+    const ctx = await queryMotionContext(sb, "10");
+    expect(ctx.offguide_mapped_charge).toBeNull();
+    expect(ctx.top_motions).toEqual([]);
+  });
+
+  it("data_caveat for mapped responses is UPL-clean", async () => {
+    const sb = makeMockSb([
+      { motion_type: "suppress", charge_type: "drug-trafficking", filed_count: 5, granted_count: 1, denied_count: 4, grant_rate: 0.2 },
+    ]);
+    const ctx = await queryMotionContext(sb, "10");
+    for (const banned of MOTION_CONTEXT_UPL_BANNED) {
+      expect(ctx.data_caveat.toLowerCase()).not.toContain(banned);
+    }
+  });
+
+  it("data_caveat for unmapped responses is UPL-clean", async () => {
+    const sb = makeMockSb([]);
+    const ctx = await queryMotionContext(sb, "17");
+    for (const banned of MOTION_CONTEXT_UPL_BANNED) {
+      expect(ctx.data_caveat.toLowerCase()).not.toContain(banned);
+    }
+  });
+});

--- a/src/lib/ussc-offguide-charge-map.ts
+++ b/src/lib/ussc-offguide-charge-map.ts
@@ -1,0 +1,188 @@
+/**
+ * @fileoverview USSC numeric offguide code -> internal
+ * `motion_outcome_rates.charge_type` slug bridge.
+ *
+ * `ussc_similar_cases_summary.offguide` stores USSC Primary Sentencing
+ * Guideline codes as 1-2 character strings ("1","2","30","UNK", etc). They
+ * are FEDERAL primary-guideline numeric codes, NOT our internal
+ * motion_outcome_rates.charge_type slugs ("drug-trafficking", "fraud-general",
+ * "weapons-possession").
+ *
+ * Codebook source (anchored to `src/lib/fsd-offguide.ts` FSD_OFFGUIDE list,
+ * verified 2026-04-23 against federal_sentencing_distributions.offguide_label):
+ *   1=Admin of Justice, 2=Antitrust, 4=Assault, 5=Bribery/Corruption,
+ *   7=Child Pornography, 8=Commercialized Vice, 9=Drug Possession,
+ *  10=Drug Trafficking, 11=Environmental, 12=Extortion/Racketeering,
+ *  13=Firearms, 15=Forgery/Counter/Copyright, 16=Fraud/Theft/Embezzlement,
+ *  17=Immigration, 20=Manslaughter, 21=Money Laundering, 23=National Defense,
+ *  24=Obscenity/Other Sex Offenses, 25=Prison Offenses, 26=Robbery,
+ *  27=Sex Abuse, 29=Tax, 30=Other.
+ *
+ * Best-effort map to the internal slugs actually present in
+ * motion_outcome_rates.charge_type (127 distinct values verified live
+ * 2026-04-23). Unmapped codes (2, 5, 8, 11, 17, 23, 24, UNK) return
+ * null and callers suppress the motion_context block rather than fabricate
+ * a match. Partial correctness beats confident wrongness.
+ *
+ * Deliberately conservative:
+ *   - Immigration (17) -> null (no federal immigration-specific slug in MOR).
+ *   - National Defense (23), Antitrust (2), Environmental (11), Bribery (5),
+ *     Commercialized Vice (8) -> null (no confident MOR slug).
+ *   - Manslaughter (20) picks "voluntary-manslaughter" as canonical; callers
+ *     querying MOR IN-list union with adjacent slugs via MOR_CHARGE_EXPANSION
+ *     (see getMotionChargesForOffguide below).
+ *
+ * NOT duplicated into charge-slug-maps.ts because this is an offguide-to-slug
+ * bridge specific to Similar Cases ($297 Tier 9 SKU). The existing map is
+ * user-facing intake slug -> internal slug; this is a third leg.
+ */
+
+/**
+ * Primary mapping: USSC offguide numeric string -> motion_outcome_rates
+ * canonical charge_type slug (or null when no confident match exists).
+ *
+ * Coverage: 15 of 29 distinct offguide values observed in
+ * ussc_similar_cases_summary map to a MOR slug; 14 unmapped (returned as
+ * null).
+ */
+export const USSC_OFFGUIDE_TO_CHARGE_MAP: Record<string, string | null> = {
+  "1": "obstruction-justice",           // Admin of Justice
+  "2": null,                             // Antitrust (no MOR slug)
+  "3": null,                             // reserved/unused in FSD canon
+  "4": "assault",                        // Assault
+  "5": null,                             // Bribery/Corruption (no MOR slug)
+  "6": null,                             // reserved/unused
+  "7": "child-exploitation",            // Child Pornography
+  "8": null,                             // Commercialized Vice (no MOR slug)
+  "9": "drug-possession",               // Drug Possession
+  "10": "drug-trafficking",             // Drug Trafficking
+  "11": null,                            // Environmental (no MOR slug)
+  "12": null,                            // Extortion/Racketeering (no MOR slug)
+  "13": "weapons-possession",           // Firearms
+  "14": null,                            // reserved/unused
+  "15": "forgery",                       // Forgery/Counter/Copyright
+  "16": "fraud-general",                 // Fraud/Theft/Embezzlement
+  "17": null,                            // Immigration (no MOR slug)
+  "18": null,                            // reserved/unused
+  "19": null,                            // reserved/unused
+  "20": "voluntary-manslaughter",        // Manslaughter (canonical + expansion)
+  "21": "money-laundering",              // Money Laundering
+  "22": null,                            // reserved/unused
+  "23": null,                            // National Defense (no MOR slug)
+  "24": null,                            // Obscenity/Other Sex Offenses (ambiguous)
+  "25": "supervised-release-violation",  // Prison Offenses
+  "26": "robbery",                       // Robbery
+  "27": "sex-offense-contact",           // Sex Abuse
+  "28": null,                            // reserved/unused
+  "29": "tax-fraud",                     // Tax
+  "30": "other",                         // Other
+  UNK: null,                             // Unknown
+};
+
+/**
+ * Expansion: for offguide codes where our canonical slug is one member of a
+ * cluster in motion_outcome_rates, return the full cluster so downstream
+ * filtering via `.in('charge_type', [list])` captures the full signal.
+ *
+ * E.g. offguide 20 (Manslaughter) spans voluntary, involuntary, and vehicular
+ * variants in MOR - aggregating across all three yields more statistically
+ * meaningful filed/granted totals than the single canonical slug.
+ *
+ * Slugs listed here were verified live 2026-04-23 against
+ * motion_outcome_rates.charge_type. Only slugs that actually exist in that
+ * table are included - no guessing.
+ */
+export const MOR_CHARGE_EXPANSION: Record<string, string[]> = {
+  "drug-trafficking": [
+    "drug-trafficking",
+    "drug-distribution",
+    "drug-manufacturing",
+  ],
+  "drug-possession": [
+    "drug-possession",
+    "drug-possession-marijuana",
+    "drug-possession-cocaine",
+    "drug-possession-meth",
+    "drug-possession-opioids",
+    "drug-possession-prescription",
+    "drug-possession-with-intent",
+  ],
+  "weapons-possession": [
+    "weapons-possession",
+    "felony-firearm",
+    "felon-in-possession",
+    "possession-prohibited-weapon",
+    "illegal-discharge",
+  ],
+  "fraud-general": [
+    "fraud-general",
+    "wire-fraud",
+    "securities-fraud",
+    "insurance-fraud",
+    "credit-card-fraud",
+    "prescription-fraud",
+    "embezzlement",
+    "identity-theft",
+    "theft-larceny",
+    "grand-theft",
+  ],
+  assault: [
+    "assault",
+    "simple-assault",
+    "aggravated-assault",
+    "aggravated-battery",
+    "assault-with-deadly-weapon",
+    "assault-firearm",
+    "assault-police-officer",
+    "battery",
+  ],
+  "sex-offense-contact": [
+    "sex-offense-contact",
+    "sexual-assault",
+    "sexual-battery",
+    "rape",
+    "statutory-rape",
+  ],
+  "child-exploitation": [
+    "child-exploitation",
+    "production-child-pornography",
+  ],
+  robbery: ["robbery", "armed-robbery", "home-invasion"],
+  "voluntary-manslaughter": [
+    "voluntary-manslaughter",
+    "involuntary-manslaughter",
+    "vehicular-manslaughter",
+    "vehicular-homicide",
+  ],
+  forgery: ["forgery"],
+  "money-laundering": ["money-laundering"],
+  "tax-fraud": ["tax-fraud"],
+  "supervised-release-violation": [
+    "supervised-release-violation",
+    "parole-violation",
+    "community-control-violation",
+    "probation-violation-technical",
+    "probation-violation-substantive",
+  ],
+  "obstruction-justice": ["obstruction-justice"],
+  other: ["other"],
+};
+
+/**
+ * Public helper - return the motion_outcome_rates charge_type slug list for
+ * an offguide code, or null when the offguide has no confident mapping.
+ *
+ * Callers pass the returned list to `.in('charge_type', list)`.
+ *
+ * @param offguide Raw string value from ussc_similar_cases_summary.offguide.
+ * @returns Object with canonical slug plus expansion list, or null when unmapped.
+ */
+export function getMotionChargesForOffguide(
+  offguide: string | null | undefined,
+): { canonical: string; charges: string[] } | null {
+  if (typeof offguide !== "string" || offguide.length === 0) return null;
+  const canonical = USSC_OFFGUIDE_TO_CHARGE_MAP[offguide] ?? null;
+  if (canonical === null) return null;
+  const charges = MOR_CHARGE_EXPANSION[canonical] ?? [canonical];
+  return { canonical, charges };
+}

--- a/src/lib/ussc-similar-cases-motion-context.ts
+++ b/src/lib/ussc-similar-cases-motion-context.ts
@@ -1,0 +1,183 @@
+/**
+ * @fileoverview motion_context footer query module for the $297 Similar Cases
+ * Analyzer. Tier monotonicity (HARD):
+ *   - Top 3 motions only, charge-level aggregate across all districts/judges.
+ *   - Stays STRICTLY below Motion Success Report $197 (top 10 + per-judge +
+ *     per-circuit) and IB $997 Appendix G (top 20 + extracted quotes).
+ *   - No circuit filter, no judge filter, no quotes, no recommendations.
+ *
+ * Activates dormant `motion_outcome_rates` data (2,966 rows) on the existing
+ * Similar Cases SKU via USSC offguide -> internal charge slug bridge. When
+ * the offguide maps to nothing confident, the footer surfaces a null-state
+ * caveat rather than fabricating numbers.
+ *
+ * UPL-safe:
+ *   - Phrasing is "of N filed, M granted" - frequencies, not recommendations.
+ *   - No banned phrases ("you should", "we recommend", etc).
+ *   - Every motion returned has filed_count >= 1 (guaranteed by MOR rows).
+ *
+ * Sources:
+ *   docs/plans/2026-04-23-data-to-product-autonomous-execution.md M1 + E5.
+ *   src/lib/tier9-reports/motion-success-report.ts (upgrade target).
+ */
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { getMotionChargesForOffguide } from "./ussc-offguide-charge-map";
+
+/** A single motion row shown in the Similar Cases motion_context footer. */
+export interface MotionContextMotion {
+  motion_type: string;
+  n_filed: number;
+  n_granted: number;
+  /** granted / filed (nullable when filed=0 though MOR rows always have >=1). */
+  grant_rate: number | null;
+}
+
+/** The full motion_context block attached to the Similar Cases response. */
+export interface MotionContext {
+  /** Canonical MOR charge slug derived from offguide, or null when unmapped. */
+  offguide_mapped_charge: string | null;
+  /** Top 3 motions by filed_count for the mapped charge cluster. Empty when
+   *  offguide is unmapped or no MOR rows matched. */
+  top_motions: MotionContextMotion[];
+  /** User-facing caveat. Always non-empty. Branches on presence of data. */
+  data_caveat: string;
+  /** Upsell target slug - always "motion-success-report" for this footer. */
+  upgrade_cta_slug: string;
+}
+
+const DATA_CAVEAT_MAPPED =
+  "Motion filing rates are charge-level aggregates across all federal districts and judges (not case-specific). See Motion Success Report for your circuit plus judge-specific grant rates.";
+
+const DATA_CAVEAT_UNMAPPED =
+  "Charge-level motion data not available for this offense guideline. Motion Success Report covers 50-plus charge types with circuit plus judge-specific grant rates.";
+
+const UPGRADE_CTA_SLUG = "motion-success-report";
+
+const TOP_N = 3;
+
+/** Row shape returned by the motion_outcome_rates select below. */
+interface MotionOutcomeRow {
+  motion_type: string;
+  charge_type: string;
+  filed_count: number;
+  granted_count: number;
+  denied_count: number;
+  grant_rate: number | null;
+}
+
+/**
+ * Fetch the motion_context footer for a Similar Cases response.
+ *
+ * Flow:
+ *   1. Bridge offguide -> canonical MOR charge slug (plus expansion cluster).
+ *      If unmapped -> return unmapped-shape immediately (no DB call).
+ *   2. SELECT filed/granted/denied/grant_rate FROM motion_outcome_rates
+ *      WHERE charge_type IN (expansion_cluster).
+ *   3. Aggregate by motion_type (sum filed, sum granted across cluster members).
+ *   4. Sort by n_filed DESC, take TOP_N=3.
+ *
+ * Never throws - DB errors are logged and return the unmapped-shape so the
+ * Similar Cases response stays functional.
+ */
+export async function queryMotionContext(
+  sb: SupabaseClient,
+  offguide: string | null | undefined,
+): Promise<MotionContext> {
+  const mapping = getMotionChargesForOffguide(offguide);
+  if (mapping === null) {
+    return buildUnmappedContext();
+  }
+
+  const { data, error } = await sb
+    .from("motion_outcome_rates")
+    .select("motion_type, charge_type, filed_count, granted_count, denied_count, grant_rate")
+    .in("charge_type", mapping.charges);
+
+  if (error) {
+    console.error("[similar-cases-motion-context] query error:", error);
+    return buildUnmappedContext();
+  }
+
+  const rows = (data ?? []) as MotionOutcomeRow[];
+  const top = aggregateTopMotions(rows);
+
+  if (top.length === 0) {
+    // Mapping existed but no rows returned - treat as unmapped-shape but keep
+    // the canonical slug attached for telemetry.
+    return {
+      offguide_mapped_charge: mapping.canonical,
+      top_motions: [],
+      data_caveat: DATA_CAVEAT_UNMAPPED,
+      upgrade_cta_slug: UPGRADE_CTA_SLUG,
+    };
+  }
+
+  return {
+    offguide_mapped_charge: mapping.canonical,
+    top_motions: top,
+    data_caveat: DATA_CAVEAT_MAPPED,
+    upgrade_cta_slug: UPGRADE_CTA_SLUG,
+  };
+}
+
+/**
+ * Aggregate MOR rows by motion_type across the charge-slug cluster, keep only
+ * the top N=3 by n_filed. Deterministic ordering - ties break on motion_type
+ * ascending for stable test output.
+ *
+ * Exported for unit testing (pure function, no DB).
+ */
+export function aggregateTopMotions(rows: MotionOutcomeRow[]): MotionContextMotion[] {
+  const agg = new Map<string, { n_filed: number; n_granted: number }>();
+  for (const r of rows) {
+    if (!r || typeof r.motion_type !== "string" || r.motion_type.length === 0) continue;
+    const filed = Number.isFinite(r.filed_count) ? Number(r.filed_count) : 0;
+    const granted = Number.isFinite(r.granted_count) ? Number(r.granted_count) : 0;
+    const cur = agg.get(r.motion_type) ?? { n_filed: 0, n_granted: 0 };
+    cur.n_filed += filed;
+    cur.n_granted += granted;
+    agg.set(r.motion_type, cur);
+  }
+
+  return [...agg.entries()]
+    .map(([motion_type, v]) => ({
+      motion_type,
+      n_filed: v.n_filed,
+      n_granted: v.n_granted,
+      grant_rate:
+        v.n_filed > 0 ? Number((v.n_granted / v.n_filed).toFixed(4)) : null,
+    }))
+    .filter((m) => m.n_filed > 0)
+    .sort((a, b) => {
+      if (b.n_filed !== a.n_filed) return b.n_filed - a.n_filed;
+      return a.motion_type.localeCompare(b.motion_type);
+    })
+    .slice(0, TOP_N);
+}
+
+/**
+ * Shape returned when offguide is unmapped or when no MOR rows match.
+ * Exported for test-time parity checking.
+ */
+export function buildUnmappedContext(): MotionContext {
+  return {
+    offguide_mapped_charge: null,
+    top_motions: [],
+    data_caveat: DATA_CAVEAT_UNMAPPED,
+    upgrade_cta_slug: UPGRADE_CTA_SLUG,
+  };
+}
+
+/**
+ * Exported for test-time UPL verification. These phrases must NEVER appear in
+ * data_caveat or any other surfaced text in the motion_context block.
+ */
+export const MOTION_CONTEXT_UPL_BANNED = [
+  "you should",
+  "we recommend",
+  "we advise",
+  "your best option",
+  "ask your attorney",
+  "publicly available",
+] as const;


### PR DESCRIPTION
## Summary
- Activates dormant `motion_outcome_rates` data (2,966 rows) on the existing $297 Similar Cases SKU via a new USSC offguide-code → internal charge-slug bridge (`USSC_OFFGUIDE_TO_CHARGE_MAP`).
- Adds `motion_context` object to the API response: top-3 charge-level motions (n_filed, n_granted, grant_rate), data caveat, and upgrade CTA slug (`motion-success-report`).
- Tier-monotonic: top-3 charge-level aggregate, no circuit/judge filter. Stays strictly below Motion Success Report $197 (top 10 + per-judge + per-circuit) and IB $997 Appendix G (top 20 + extracted quotes).

## Offguide mapping coverage
- **14 of 29** distinct `ussc_similar_cases_summary.offguide` values mapped to `motion_outcome_rates.charge_type` slugs (verified live 2026-04-23).
- Mapped: 1 (Admin of Justice), 4 (Assault), 7 (Child Pornography), 9 (Drug Possession), 10 (Drug Trafficking), 13 (Firearms), 15 (Forgery), 16 (Fraud/Theft/Embezzlement), 21 (Money Laundering), 25 (Prison Offenses), 26 (Robbery), 27 (Sex Abuse), 29 (Tax), 30 (Other).
- Unmapped (return null, no fabrication): 2 (Antitrust), 5 (Bribery), 8 (Commercialized Vice), 11 (Environmental), 12 (Extortion/Racketeering), 17 (Immigration), 23 (National Defense), 24 (Obscenity/Other Sex), plus reserved/unused codes (3, 6, 14, 18, 19, 22, 28), and UNK.

## UPL posture
- All phrasing is frequencies ("of N filed, M were granted"), no recommendations.
- `MOTION_CONTEXT_UPL_BANNED` phrase list tested against `data_caveat` in both mapped and unmapped branches.

## Files
**Created:**
- `src/lib/ussc-offguide-charge-map.ts` — offguide → MOR charge slug bridge + expansion cluster
- `src/lib/ussc-similar-cases-motion-context.ts` — query module
- `src/lib/__tests__/ussc-similar-cases-motion-context.test.ts` — 26 tests

**Edited:**
- `src/app/api/tools/similar-cases/route.ts` — parallelized `queryMotionContext` in `Promise.all`; attached `motion_context` to response

## Verification
- `tsc --noEmit`: zero errors (run via `node node_modules/typescript/bin/tsc --noEmit`).
- `next build --webpack --experimental-build-mode compile`: clean compile (34.7s).
- Tests: 26/26 green via `node node_modules/vitest/vitest.mjs run src/lib/__tests__/ussc-similar-cases-motion-context.test.ts`.
- SKIP_TSC/SKIP_BUILD bypasses used only because worktree uses symlinked node_modules (no `npx tsc` / `npx next` resolution). Manual runs all clean.

## Experts cited
- Hormozi Grand Slam value equation (tiered $197/$997/$2497) — tier monotonicity.
- Dreyer Entity SEO / AI Overview Defense — charge-cluster aggregation surface.

Per plan: `docs/plans/2026-04-23-data-to-product-autonomous-execution.md` M1 + E5.

## Test plan
- [ ] POST `/api/tools/similar-cases` with `offguide=10` (Drug Trafficking) → `motion_context.offguide_mapped_charge === "drug-trafficking"`, `top_motions.length <= 3`.
- [ ] POST with `offguide=17` (Immigration, unmapped) → `offguide_mapped_charge: null`, `top_motions: []`, unmapped data_caveat.
- [ ] POST with `offguide=UNK` → unmapped shape.
- [ ] Verify no regression on district / plea / trial fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)