### PR TITLE
feat(xray): Federal PJI cross-ref + full judge motion histogram (E2)

### DIFF
--- a/src/app/api/generate/xray-sections/route.ts
+++ b/src/app/api/generate/xray-sections/route.ts
@@ -1,0 +1,113 @@
+/**
+ * X-Ray Section Assembly Endpoint — E2.
+ *
+ * POST /api/generate/xray-sections
+ *
+ * Called by the engine's report.mjs (ImNotAnAttorney-engine/src/workers/report.mjs)
+ * as the X-Ray is assembled. The engine posts the case's intake context and
+ * this route returns pre-rendered markdown for the two E2 sections:
+ *
+ *   - X1: Federal PJI Cross-Reference (federal charges only)
+ *   - X2: Full Judge Motion Histogram (when a judge is assigned)
+ *
+ * The engine appends the returned markdown to its Claude prompt as
+ * additional "== SECTION X1 ==" / "== SECTION X2 ==" stanzas, the same
+ * pattern used for phase-4 intelligence and phase-5 case law.
+ *
+ * Keeping this logic in the web repo (TypeScript, typechecked) ensures:
+ *   - Single source of truth for X-Ray section queries
+ *   - Monotonicity tests run against the same code the engine calls
+ *   - No duplication / drift between a TS implementation and an MJS port
+ *
+ * Auth: operator secret header. Engine runs server-side with the secret;
+ * no end-user traffic hits this route.
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { requireOperatorSecret } from "@/lib/auth/guards";
+import {
+  queryXrayFederalPjiCrossRef,
+  renderXrayFederalPjiCrossRef,
+} from "@/lib/xray-sections/federal-pji-cross-ref";
+import {
+  queryXrayJudgeHistogram,
+  renderXrayJudgeHistogram,
+} from "@/lib/xray-sections/judge-motion-histogram";
+
+export const runtime = "nodejs";
+export const maxDuration = 60;
+
+interface XraySectionsBody {
+  federalCharge?: string | null;
+  circuit?: string | null;
+  state?: string | null;
+  judgeName?: string | null;
+  judgeAuthorId?: number | null;
+  caseId?: string | null;
+}
+
+export async function POST(req: NextRequest) {
+  const auth = requireOperatorSecret(req);
+  if (!auth.authorized) return auth.error;
+
+  let body: XraySectionsBody;
+  try {
+    body = (await req.json()) as XraySectionsBody;
+  } catch {
+    return NextResponse.json({ error: "invalid-json" }, { status: 400 });
+  }
+
+  const {
+    federalCharge = null,
+    circuit = null,
+    state = null,
+    judgeName = null,
+    judgeAuthorId = null,
+    caseId = null,
+  } = body ?? {};
+
+  // X1 — federal PJI cross-reference (federal charges only; query returns
+  // isEmpty=true when the charge is not federal or the corpus is thin).
+  let x1Data = null;
+  let x1Markdown = "";
+  if (federalCharge && federalCharge.length > 0) {
+    x1Data = await queryXrayFederalPjiCrossRef({
+      federalCharge,
+      circuit,
+      state,
+      judgeName,
+      caseId,
+    });
+    x1Markdown = renderXrayFederalPjiCrossRef(x1Data);
+  }
+
+  // X2 — full judge motion histogram (requires judge). Query returns
+  // isEmpty=true when the judge has no cached rulings.
+  let x2Data = null;
+  let x2Markdown = "";
+  if ((judgeName && judgeName.length > 0) || (judgeAuthorId ?? 0) > 0) {
+    x2Data = await queryXrayJudgeHistogram({
+      judgeName,
+      judgeAuthorId,
+    });
+    x2Markdown = renderXrayJudgeHistogram(x2Data);
+  }
+
+  return NextResponse.json(
+    {
+      x1: {
+        enabled: Boolean(federalCharge),
+        isEmpty: x1Data?.isEmpty ?? true,
+        federalOnly: x1Data?.federalOnly ?? false,
+        markdown: x1Markdown,
+        data: x1Data,
+      },
+      x2: {
+        enabled: Boolean(judgeName || judgeAuthorId),
+        isEmpty: x2Data?.isEmpty ?? true,
+        markdown: x2Markdown,
+        data: x2Data,
+      },
+    },
+    { status: 200 },
+  );
+}

--- a/src/lib/xray-sections/__tests__/federal-pji-cross-ref.test.ts
+++ b/src/lib/xray-sections/__tests__/federal-pji-cross-ref.test.ts
@@ -1,0 +1,364 @@
+/**
+ * Unit tests for X-Ray Section X1 — Federal PJI Cross-Reference (X-Ray $2,497 E2).
+ *
+ * Focus areas:
+ *   1. Tier monotonicity (X-Ray strictly exceeds M4 $97 on PJI depth)
+ *   2. UPL banned-phrase blocklist
+ *   3. URL suppression — every cited case has a CourtListener URL in render
+ *   4. Quote coverage (extracted quote per case; graceful fallback)
+ *   5. Judge-attack cross-reference (X-Ray exclusive; missing from M4 + IB E1)
+ *   6. Empty / limitation / federal-only paths
+ */
+import { describe, it, expect } from "vitest";
+import {
+  renderXrayFederalPjiCrossRef,
+  XRAY_ATTACK_TOP_N,
+  XRAY_JUDGE_ATTACK_INSUFFICIENT_N,
+  INSTRUCTION_ATTACK_MOTION_TYPES,
+  type XrayFederalPjiData,
+  type XrayAttackAuthority,
+  type XrayCircuitVariant,
+  type XrayJudgeAttackRow,
+} from "../federal-pji-cross-ref";
+import { UPL_BANNED_PHRASES } from "@/lib/charge-slug-maps";
+import type { PjiMatch } from "@/lib/tier9-reports/federal-jury-instruction-brief";
+
+// ------------------------------------------------------------
+// Fixtures
+// ------------------------------------------------------------
+
+function mkPji(over: Partial<PjiMatch> = {}): PjiMatch {
+  return {
+    id: 42,
+    circuit: 9,
+    instruction_number: "8.124",
+    title: "Wire Fraud — Elements",
+    body:
+      "The government must prove each of the following elements beyond a reasonable doubt: First, that there was a scheme to defraud. Second, that the defendant used interstate wire communications. Third, that the defendant acted with intent to defraud.",
+    commentary: null,
+    statute_citations: ["18 U.S.C. § 1343"],
+    source_url: "https://www.ce9.uscourts.gov/jury-instructions/node/239",
+    effective_date: "2023-10-01",
+    ...over,
+  };
+}
+
+function mkAuth(over: Partial<XrayAttackAuthority> = {}): XrayAttackAuthority {
+  return {
+    rank: 1,
+    case_name: "Neder v. United States",
+    date_filed: "1999-06-10",
+    citation: "527 U.S. 1",
+    citation_count_in_charge: 420,
+    citation_count_total: 5400,
+    authority_tier: "landmark",
+    quote_sentence:
+      "Materiality of falsehood is an element of the federal mail fraud, wire fraud, and bank fraud statutes.",
+    quote_frequency: 38,
+    source_url: "https://www.courtlistener.com/opinion/118306/neder-v-united-states/",
+    framing:
+      "Cases where the defense cited challenging elements of instructions for Wire Fraud (18 U.S.C. § 1343).",
+    ...over,
+  };
+}
+
+function mkVariant(over: Partial<XrayCircuitVariant> = {}): XrayCircuitVariant {
+  return {
+    circuit: 1,
+    circuitName: "First Circuit",
+    instruction_number: "4.18.1343",
+    title: "Wire Fraud",
+    difference_summary:
+      "Length delta +3% vs primary; first divergent phrasing: \"knowingly devised or intended to devise…\"",
+    source_url: "https://www.ca1.uscourts.gov/sites/ca1/files/citations/4.18.1343.pdf",
+    is_primary: false,
+    ...over,
+  };
+}
+
+function mkJudgeAttack(over: Partial<XrayJudgeAttackRow> = {}): XrayJudgeAttackRow {
+  return {
+    motion_type: "motion_to_suppress",
+    filed_count: 34,
+    granted_count: 11,
+    grant_rate: 0.324,
+    baseline_grant_rate: 0.280,
+    deviation_from_baseline: 0.044,
+    insufficient_sample: false,
+    relevance_note:
+      "Suppression challenges often hinge on how the burden-of-proof instruction is phrased for the underlying element.",
+    ...over,
+  };
+}
+
+function mkData(over: Partial<XrayFederalPjiData> = {}): XrayFederalPjiData {
+  return {
+    federalCharge: "wire-fraud",
+    federalChargeLabel: "Wire Fraud (18 U.S.C. § 1343)",
+    circuit: "9",
+    circuitName: "Ninth Circuit",
+    state: "CA",
+    judgeDisplayName: "Jane Doe",
+    judgeResolved: true,
+    ambiguousJudge: false,
+    pji: mkPji(),
+    burdenSentences: [
+      { sentence: "The government must prove each of the following elements beyond a reasonable doubt." },
+    ],
+    attackAuthorities: [mkAuth()],
+    circuitVariants: [
+      {
+        circuit: 9,
+        circuitName: "Ninth Circuit",
+        instruction_number: "8.124",
+        title: "Wire Fraud — Elements",
+        difference_summary: "Primary instruction selected for this case.",
+        source_url: "https://www.ce9.uscourts.gov/jury-instructions/node/239",
+        is_primary: true,
+      },
+      mkVariant(),
+    ],
+    judgeAttackRows: [mkJudgeAttack()],
+    limitations: [],
+    federalOnly: false,
+    isEmpty: false,
+    ...over,
+  };
+}
+
+// ------------------------------------------------------------
+// Tier monotonicity (HARD)
+// ------------------------------------------------------------
+
+describe("Section X1 — Federal PJI Cross-Reference · tier monotonicity guardrails", () => {
+  it("X-Ray attack TOP_N (10) strictly exceeds M4 top 5", () => {
+    // M4 ($97) caps at 5. X-Ray ($2,497) must go deeper.
+    expect(XRAY_ATTACK_TOP_N).toBeGreaterThan(5);
+    expect(XRAY_ATTACK_TOP_N).toBe(10);
+  });
+
+  it("X-Ray carries extracted quote per case (M4 is citation-only)", () => {
+    const data = mkData({
+      attackAuthorities: [
+        mkAuth({
+          quote_sentence:
+            "The defendant has a right to have the jury find every element beyond a reasonable doubt.",
+        }),
+      ],
+    });
+    const md = renderXrayFederalPjiCrossRef(data);
+    expect(md).toContain(
+      "The defendant has a right to have the jury find every element beyond a reasonable doubt",
+    );
+  });
+
+  it("X-Ray circuit variants are not capped at M4's 3", () => {
+    // Render with 8 variants (every covered circuit) — monotonicity over M4's 3-cap.
+    const variants: XrayCircuitVariant[] = [
+      {
+        circuit: 9,
+        circuitName: "Ninth Circuit",
+        instruction_number: "8.124",
+        title: "Wire Fraud — Elements",
+        difference_summary: "Primary instruction selected for this case.",
+        source_url: "https://www.ce9.uscourts.gov/jury-instructions/node/239",
+        is_primary: true,
+      },
+      mkVariant({ circuit: 1, circuitName: "First Circuit" }),
+      mkVariant({ circuit: 3, circuitName: "Third Circuit" }),
+      mkVariant({ circuit: 5, circuitName: "Fifth Circuit" }),
+      mkVariant({ circuit: 6, circuitName: "Sixth Circuit" }),
+      mkVariant({ circuit: 7, circuitName: "Seventh Circuit" }),
+      mkVariant({ circuit: 8, circuitName: "Eighth Circuit" }),
+      mkVariant({ circuit: 10, circuitName: "Tenth Circuit" }),
+    ];
+    const md = renderXrayFederalPjiCrossRef(mkData({ circuitVariants: variants }));
+    expect(md).toContain("First Circuit");
+    expect(md).toContain("Third Circuit");
+    expect(md).toContain("Fifth Circuit");
+    expect(md).toContain("Sixth Circuit");
+    expect(md).toContain("Seventh Circuit");
+    expect(md).toContain("Eighth Circuit");
+    expect(md).toContain("Ninth Circuit");
+    expect(md).toContain("Tenth Circuit");
+    // Count distinct circuit headings rendered; must exceed M4 maximum of 3.
+    const renderedDistinctCircuits = variants.filter((v) =>
+      md.includes(v.circuitName),
+    );
+    expect(renderedDistinctCircuits.length).toBeGreaterThan(3);
+  });
+
+  it("X-Ray surfaces judge-attack cross-reference (absent from M4 and IB E1)", () => {
+    const md = renderXrayFederalPjiCrossRef(mkData());
+    expect(md).toContain("Judge-Attack Cross-Reference");
+  });
+
+  it("judge-attack cross-reference uses the exported motion-type filter set", () => {
+    // INSTRUCTION_ATTACK_MOTION_TYPES must contain the canonical instruction-
+    // attack motions; this is an invariant consumers (edge fn / engine) rely on.
+    expect(INSTRUCTION_ATTACK_MOTION_TYPES.has("motion_to_suppress")).toBe(true);
+    expect(INSTRUCTION_ATTACK_MOTION_TYPES.has("motion_to_dismiss")).toBe(true);
+    expect(INSTRUCTION_ATTACK_MOTION_TYPES.has("motion_for_judgment_of_acquittal")).toBe(
+      true,
+    );
+    expect(INSTRUCTION_ATTACK_MOTION_TYPES.has("motion_for_new_trial")).toBe(true);
+    expect(INSTRUCTION_ATTACK_MOTION_TYPES.has("motion_in_limine")).toBe(true);
+  });
+});
+
+// ------------------------------------------------------------
+// UPL banned phrases
+// ------------------------------------------------------------
+
+describe("Section X1 — Federal PJI Cross-Reference · UPL blocklist", () => {
+  it("never emits banned UPL phrases on fully populated render", () => {
+    const data = mkData({
+      attackAuthorities: Array.from({ length: XRAY_ATTACK_TOP_N }, (_, i) =>
+        mkAuth({ rank: i + 1, case_name: `Case ${i}` }),
+      ),
+      judgeAttackRows: [
+        mkJudgeAttack({ filed_count: 3, insufficient_sample: true }),
+        mkJudgeAttack({ motion_type: "motion_to_dismiss", filed_count: 50 }),
+      ],
+      limitations: [
+        "No pattern instruction cached for the Third Circuit; showing the Ninth Circuit instruction as the closest available reference.",
+      ],
+    });
+    const md = renderXrayFederalPjiCrossRef(data).toLowerCase();
+    for (const phrase of UPL_BANNED_PHRASES) {
+      expect(
+        md.includes(phrase),
+        `rendered markdown must not contain banned phrase "${phrase}"`,
+      ).toBe(false);
+    }
+  });
+
+  it("emits the legal-INFORMATION methodology gate on every non-empty render", () => {
+    const md = renderXrayFederalPjiCrossRef(mkData());
+    expect(md).toContain("legal INFORMATION");
+    expect(md).toContain("not legal ADVICE");
+    expect(md).toMatch(/not a prediction/i);
+  });
+
+  it("does not characterize judges as harsh/lenient/biased", () => {
+    const data = mkData({
+      judgeAttackRows: [
+        mkJudgeAttack({ grant_rate: 0.02, baseline_grant_rate: 0.30 }),
+      ],
+    });
+    const md = renderXrayFederalPjiCrossRef(data).toLowerCase();
+    for (const slur of ["harsh", "lenient", "biased", "hostile", "pro-defense", "pro-prosecution"]) {
+      expect(md.includes(slur), `judge rendered with banned characterization "${slur}"`).toBe(
+        false,
+      );
+    }
+  });
+});
+
+// ------------------------------------------------------------
+// URL + quote coverage
+// ------------------------------------------------------------
+
+describe("Section X1 — Federal PJI Cross-Reference · URL + quote coverage", () => {
+  it("every attack authority row includes its CourtListener URL in the markdown", () => {
+    const data = mkData({
+      attackAuthorities: [
+        mkAuth({
+          rank: 1,
+          case_name: "Apprendi v. New Jersey",
+          source_url:
+            "https://www.courtlistener.com/opinion/118398/apprendi-v-new-jersey/",
+        }),
+        mkAuth({
+          rank: 2,
+          case_name: "Alleyne v. United States",
+          source_url: "https://www.courtlistener.com/opinion/891125/alleyne-v-united-states/",
+          quote_sentence: null,
+          quote_frequency: null,
+        }),
+      ],
+    });
+    const md = renderXrayFederalPjiCrossRef(data);
+    expect(md).toContain(
+      "https://www.courtlistener.com/opinion/118398/apprendi-v-new-jersey/",
+    );
+    expect(md).toContain(
+      "https://www.courtlistener.com/opinion/891125/alleyne-v-united-states/",
+    );
+  });
+
+  it("falls back gracefully when an authority has no cached quote", () => {
+    const data = mkData({
+      attackAuthorities: [mkAuth({ quote_sentence: null, quote_frequency: null })],
+    });
+    const md = renderXrayFederalPjiCrossRef(data);
+    expect(md).toContain("No canonical citing-court quote cached");
+  });
+});
+
+// ------------------------------------------------------------
+// Judge-attack cross-reference (X-Ray exclusive)
+// ------------------------------------------------------------
+
+describe("Section X1 — Federal PJI Cross-Reference · judge-attack cross-reference", () => {
+  it("surfaces insufficient samples with n label rather than suppressing", () => {
+    const data = mkData({
+      judgeAttackRows: [mkJudgeAttack({ filed_count: 3, insufficient_sample: true })],
+    });
+    const md = renderXrayFederalPjiCrossRef(data);
+    expect(md).toMatch(/insufficient/i);
+    expect(md).toContain("n=3");
+  });
+
+  it("labels the threshold used for insufficient-sample classification", () => {
+    const md = renderXrayFederalPjiCrossRef(mkData());
+    // The section text references the threshold (10) so the reader knows
+    // where the caveat applies.
+    expect(md).toContain(String(XRAY_JUDGE_ATTACK_INSUFFICIENT_N));
+  });
+});
+
+// ------------------------------------------------------------
+// Empty + limitation + federal-only paths
+// ------------------------------------------------------------
+
+describe("Section X1 — Federal PJI Cross-Reference · empty + limitation paths", () => {
+  it("empty data renders empty string (X-Ray assembler skips the section)", () => {
+    const empty: XrayFederalPjiData = {
+      federalCharge: "not-federal",
+      federalChargeLabel: "not-federal",
+      circuit: null,
+      circuitName: null,
+      state: null,
+      judgeDisplayName: null,
+      judgeResolved: false,
+      ambiguousJudge: false,
+      pji: null,
+      burdenSentences: [],
+      attackAuthorities: [],
+      circuitVariants: [],
+      judgeAttackRows: [],
+      limitations: [],
+      federalOnly: true,
+      isEmpty: true,
+    };
+    expect(renderXrayFederalPjiCrossRef(empty)).toBe("");
+  });
+
+  it("limitations surface in a Known limitations section when non-empty", () => {
+    const md = renderXrayFederalPjiCrossRef(
+      mkData({
+        limitations: ["No charge-specific cache for Tax Evasion; used fallback."],
+      }),
+    );
+    expect(md).toContain("Known limitations");
+    expect(md).toContain("No charge-specific cache for Tax Evasion");
+  });
+
+  it("renders the section heading at the X1 canonical level", () => {
+    const md = renderXrayFederalPjiCrossRef(mkData());
+    expect(md).toContain("## Section X1: Federal Pattern Jury Instruction — Cross-Reference");
+    // Must not collide with IB's Appendix G heading (different product).
+    expect(md).not.toContain("## Appendix G");
+  });
+});

--- a/src/lib/xray-sections/__tests__/judge-motion-histogram.test.ts
+++ b/src/lib/xray-sections/__tests__/judge-motion-histogram.test.ts
@@ -1,0 +1,328 @@
+/**
+ * Unit tests for X-Ray Section X2 — Full Judge Motion Histogram (X-Ray $2,497 E2).
+ *
+ * Focus areas:
+ *   1. Tier monotonicity (X-Ray strictly exceeds IB E1's top 20 cap)
+ *   2. UPL banned-phrase blocklist
+ *   3. Baseline-deviation grouping correctness (above / at / below thresholds)
+ *   4. Insufficient-sample cohort (surfaced, not suppressed)
+ *   5. Empty / limitation paths
+ */
+import { describe, it, expect } from "vitest";
+import {
+  renderXrayJudgeHistogram,
+  XRAY_HISTOGRAM_DEVIATION_THRESHOLD,
+  XRAY_HISTOGRAM_INSUFFICIENT_N,
+  XRAY_HISTOGRAM_UNBOUNDED,
+  type XrayJudgeHistogramData,
+  type XrayJudgeHistogramRow,
+} from "../judge-motion-histogram";
+import { UPL_BANNED_PHRASES } from "@/lib/charge-slug-maps";
+import { IB_MOTION_TOP_N } from "@/lib/ib-appendices/motion-strategy";
+
+// ------------------------------------------------------------
+// Fixtures
+// ------------------------------------------------------------
+
+function mkRow(over: Partial<XrayJudgeHistogramRow> = {}): XrayJudgeHistogramRow {
+  return {
+    motion_type: "motion_to_suppress",
+    filed_count: 42,
+    granted_count: 14,
+    grant_rate: 0.333,
+    baseline_grant_rate: 0.28,
+    deviation_from_baseline: 0.053,
+    group: "at_baseline",
+    insufficient_sample: false,
+    ...over,
+  };
+}
+
+function mkData(over: Partial<XrayJudgeHistogramData> = {}): XrayJudgeHistogramData {
+  return {
+    judgeDisplayName: "Jane Doe",
+    judgeResolved: true,
+    ambiguousJudge: false,
+    totalMotionTypes: 5,
+    aboveBaselineRows: [
+      mkRow({
+        motion_type: "motion_to_exclude",
+        filed_count: 50,
+        granted_count: 35,
+        grant_rate: 0.7,
+        baseline_grant_rate: 0.4,
+        deviation_from_baseline: 0.3,
+        group: "above_baseline",
+      }),
+    ],
+    atBaselineRows: [
+      mkRow({
+        motion_type: "motion_to_dismiss",
+        filed_count: 40,
+        granted_count: 10,
+        grant_rate: 0.25,
+        baseline_grant_rate: 0.22,
+        deviation_from_baseline: 0.03,
+        group: "at_baseline",
+      }),
+    ],
+    belowBaselineRows: [
+      mkRow({
+        motion_type: "motion_in_limine",
+        filed_count: 60,
+        granted_count: 6,
+        grant_rate: 0.1,
+        baseline_grant_rate: 0.35,
+        deviation_from_baseline: -0.25,
+        group: "below_baseline",
+      }),
+    ],
+    insufficientRows: [
+      mkRow({
+        motion_type: "motion_for_mistrial",
+        filed_count: 3,
+        granted_count: 1,
+        grant_rate: 0.333,
+        baseline_grant_rate: 0.15,
+        deviation_from_baseline: null,
+        group: "insufficient_sample",
+        insufficient_sample: true,
+      }),
+    ],
+    limitations: [],
+    isEmpty: false,
+    ...over,
+  };
+}
+
+// ------------------------------------------------------------
+// Tier monotonicity (HARD)
+// ------------------------------------------------------------
+
+describe("Section X2 — Judge Motion Histogram · tier monotonicity guardrails", () => {
+  it("X-Ray histogram is UNBOUNDED (no top-N limit); IB E1 caps at 20", () => {
+    expect(XRAY_HISTOGRAM_UNBOUNDED).toBe(true);
+    // IB's cap exists (20); X-Ray must surface more than that when data has more.
+    expect(IB_MOTION_TOP_N).toBe(20);
+  });
+
+  it("renders more than IB's top-20 cap when data contains more motion types", () => {
+    // Simulate 40 motion types — more than IB's 20 cap.
+    const rows: XrayJudgeHistogramRow[] = Array.from({ length: 40 }, (_, i) =>
+      mkRow({
+        motion_type: `motion_type_${i}`,
+        filed_count: 100 - i,
+        granted_count: 30,
+        grant_rate: 0.3,
+        baseline_grant_rate: 0.3,
+        deviation_from_baseline: 0,
+        group: "at_baseline",
+      }),
+    );
+    const data = mkData({
+      aboveBaselineRows: [],
+      atBaselineRows: rows,
+      belowBaselineRows: [],
+      insufficientRows: [],
+      totalMotionTypes: 40,
+    });
+    const md = renderXrayJudgeHistogram(data);
+    // Every motion type name must appear in the render.
+    for (let i = 0; i < 40; i++) {
+      expect(md).toContain(`Motion Type ${i}`);
+    }
+    // Row count strictly exceeds IB's cap.
+    expect(40).toBeGreaterThan(IB_MOTION_TOP_N);
+  });
+
+  it("exports deviation threshold at the documented 10 pp", () => {
+    expect(XRAY_HISTOGRAM_DEVIATION_THRESHOLD).toBeCloseTo(0.10, 5);
+  });
+
+  it("insufficient-sample threshold matches IB E1 (cross-tier consistent)", () => {
+    expect(XRAY_HISTOGRAM_INSUFFICIENT_N).toBe(10);
+  });
+
+  it("groups rows by baseline deviation (IB does NOT group)", () => {
+    const md = renderXrayJudgeHistogram(mkData());
+    expect(md).toMatch(/Significantly Above Baseline/);
+    expect(md).toMatch(/Significantly Below Baseline/);
+    expect(md).toMatch(/At Baseline/);
+  });
+});
+
+// ------------------------------------------------------------
+// UPL banned phrases
+// ------------------------------------------------------------
+
+describe("Section X2 — Judge Motion Histogram · UPL blocklist", () => {
+  it("never emits banned UPL phrases on fully populated render", () => {
+    const md = renderXrayJudgeHistogram(mkData()).toLowerCase();
+    for (const phrase of UPL_BANNED_PHRASES) {
+      expect(
+        md.includes(phrase),
+        `rendered markdown must not contain banned phrase "${phrase}"`,
+      ).toBe(false);
+    }
+  });
+
+  it("emits the legal-INFORMATION methodology gate", () => {
+    const md = renderXrayJudgeHistogram(mkData());
+    expect(md).toContain("legal INFORMATION");
+    expect(md).toContain("not legal ADVICE");
+    expect(md).toMatch(/not a prediction/i);
+  });
+
+  it("never characterizes the judge as harsh / lenient / biased", () => {
+    const md = renderXrayJudgeHistogram(mkData()).toLowerCase();
+    for (const slur of ["harsh", "lenient", "biased", "hostile", "pro-defense", "pro-prosecution"]) {
+      expect(md.includes(slur)).toBe(false);
+    }
+  });
+
+  it("always shows N alongside grant rate (no rate without N)", () => {
+    const md = renderXrayJudgeHistogram(mkData());
+    // Each row has both N filed and the rate column in the same row.
+    // Regex: row contains a number followed within 120 chars by a rate%.
+    // We assert at least one row has explicit N cells.
+    expect(md).toMatch(/\| 50 \|/); // filed_count from above-baseline fixture
+    expect(md).toMatch(/\| 3 \|/); // filed_count from insufficient fixture
+  });
+});
+
+// ------------------------------------------------------------
+// Grouping correctness
+// ------------------------------------------------------------
+
+describe("Section X2 — Judge Motion Histogram · grouping correctness", () => {
+  it("above-baseline cohort renders when populated", () => {
+    const md = renderXrayJudgeHistogram(
+      mkData({
+        aboveBaselineRows: [
+          mkRow({
+            motion_type: "motion_to_exclude",
+            filed_count: 50,
+            granted_count: 40,
+            grant_rate: 0.8,
+            baseline_grant_rate: 0.4,
+            deviation_from_baseline: 0.4,
+            group: "above_baseline",
+          }),
+        ],
+        atBaselineRows: [],
+        belowBaselineRows: [],
+        insufficientRows: [],
+      }),
+    );
+    expect(md).toContain("Significantly Above Baseline");
+    expect(md).toContain("Motion To Exclude");
+  });
+
+  it("below-baseline cohort renders when populated", () => {
+    const md = renderXrayJudgeHistogram(
+      mkData({
+        aboveBaselineRows: [],
+        atBaselineRows: [],
+        belowBaselineRows: [
+          mkRow({
+            motion_type: "motion_to_suppress",
+            filed_count: 80,
+            granted_count: 4,
+            grant_rate: 0.05,
+            baseline_grant_rate: 0.30,
+            deviation_from_baseline: -0.25,
+            group: "below_baseline",
+          }),
+        ],
+        insufficientRows: [],
+      }),
+    );
+    expect(md).toContain("Significantly Below Baseline");
+    expect(md).toContain("Motion To Suppress");
+  });
+
+  it("insufficient cohort surfaces with n label (not suppressed like M1)", () => {
+    const md = renderXrayJudgeHistogram(
+      mkData({
+        aboveBaselineRows: [],
+        atBaselineRows: [],
+        belowBaselineRows: [],
+        insufficientRows: [
+          mkRow({
+            motion_type: "motion_for_mistrial",
+            filed_count: 2,
+            granted_count: 0,
+            grant_rate: 0,
+            baseline_grant_rate: 0.15,
+            deviation_from_baseline: null,
+            group: "insufficient_sample",
+            insufficient_sample: true,
+          }),
+        ],
+      }),
+    );
+    expect(md).toContain("Insufficient Sample");
+    expect(md).toContain("n=2");
+  });
+
+  it("surfaces total motion type count", () => {
+    const md = renderXrayJudgeHistogram(mkData({ totalMotionTypes: 37 }));
+    // Count is rendered bold in markdown (**...:** 37.), so assert the
+    // stable substring rather than the raw number-after-colon form.
+    expect(md).toMatch(/Total motion types on file for this judge:\*{0,2}\s*37\./);
+  });
+
+  it("elides a cohort when empty (does not emit an empty section heading)", () => {
+    const md = renderXrayJudgeHistogram(
+      mkData({
+        aboveBaselineRows: [],
+        atBaselineRows: [mkRow()],
+        belowBaselineRows: [],
+        insufficientRows: [],
+      }),
+    );
+    expect(md).not.toContain("Significantly Above Baseline");
+    expect(md).not.toContain("Significantly Below Baseline");
+    expect(md).not.toContain("Insufficient Sample");
+    expect(md).toContain("At Baseline");
+  });
+});
+
+// ------------------------------------------------------------
+// Empty + limitation paths
+// ------------------------------------------------------------
+
+describe("Section X2 — Judge Motion Histogram · empty + limitation paths", () => {
+  it("empty data renders empty string (X-Ray assembler skips the section)", () => {
+    const empty: XrayJudgeHistogramData = {
+      judgeDisplayName: null,
+      judgeResolved: false,
+      ambiguousJudge: false,
+      totalMotionTypes: 0,
+      aboveBaselineRows: [],
+      atBaselineRows: [],
+      belowBaselineRows: [],
+      insufficientRows: [],
+      limitations: [],
+      isEmpty: true,
+    };
+    expect(renderXrayJudgeHistogram(empty)).toBe("");
+  });
+
+  it("limitations surface in a Known limitations section when non-empty", () => {
+    const md = renderXrayJudgeHistogram(
+      mkData({
+        limitations: [
+          "Judge Doe has no CourtListener author_id linked; histogram omitted.",
+        ],
+      }),
+    );
+    expect(md).toContain("Known limitations");
+    expect(md).toContain("CourtListener author_id linked");
+  });
+
+  it("section heading labels the judge", () => {
+    const md = renderXrayJudgeHistogram(mkData({ judgeDisplayName: "Hon. Aileen Cannon" }));
+    expect(md).toContain("## Section X2: Full Motion Histogram — Hon. Aileen Cannon");
+  });
+});

--- a/src/lib/xray-sections/federal-pji-cross-ref.ts
+++ b/src/lib/xray-sections/federal-pji-cross-ref.ts
@@ -1,0 +1,858 @@
+/**
+ * X-Ray Section X1 — Federal PJI Cross-Reference.
+ *
+ * Upper-tier enhancement on The X-Ray ($2,497). Activates the same
+ * pattern_jury_instructions corpus used by M4 ($97) but goes deeper along
+ * three dimensions only available at the discovery tier:
+ *
+ *   Section X1.1 — Verbatim pattern instruction for this charge × circuit
+ *                   (equivalent to M4 Section 1)
+ *   Section X1.2 — **Top 10** historical attack authorities with **extracted
+ *                   quote per case** (vs M4's top 5, citation-only)
+ *   Section X1.3 — **All-circuit** instruction variant comparison (vs M4's
+ *                   top 3) — every circuit that publishes a PJI for this
+ *                   charge, with length-delta + divergent-phrase snippet
+ *   Section X1.4 — **Judge-attack cross-reference** (X-Ray exclusive):
+ *                   when a judge is assigned AND the judge's
+ *                   judge_motion_outcome_rates include motions likely tied
+ *                   to the contested instruction elements (suppression,
+ *                   dismiss-for-failure-to-state, motion-in-limine), surface
+ *                   the judge's historical pattern on those motion types
+ *                   alongside the instruction phrases they challenge.
+ *
+ * Tier monotonicity (HARD — enforced by unit test):
+ *   - X1 attack authorities TOP_N (10) STRICTLY > M4 top 5
+ *   - X1 circuit variants = ALL circuits with a matching PJI (vs M4 max 3)
+ *   - X1 citation rows carry extracted quotes; M4 is citation-only
+ *   - X1 adds judge-attack cross-reference (M4 + IB E1 do NOT have this)
+ *   - X1 does NOT include monthly deltas / weekly updates (War Room E3 territory)
+ *
+ * UPL (HARD):
+ *   - PJI text is verbatim (public federal court material)
+ *   - Judge data framed as "of N motions filed, M granted" — never "this
+ *     judge is harsh" or "you will lose before this judge"
+ *   - Banned-phrase blocklist (UPL_BANNED_PHRASES from charge-slug-maps)
+ *     enforced in test
+ *   - Every cited case carries a CourtListener URL; rows without URL are
+ *     suppressed before render
+ *
+ * Federal-only gate: rejects non-federal charges at query time (returns
+ * isEmpty=true + federalOnly=true so the X-Ray assembler can skip the
+ * section cleanly without failing generation).
+ *
+ * Cited experts:
+ *   - Hormozi Grand Slam — value equation lift on existing tier, no price change
+ *   - Dreyer AI Overview Defense — depth at discovery tier compounds authority
+ *
+ * Sources:
+ *   docs/plans/2026-04-23-data-to-product-autonomous-execution.md E2
+ *   docs/advisor/2026-04-23-data-to-product-audit.md
+ *
+ * Consumed by:
+ *   - X-Ray assembly (engine report.mjs + Edge Function mirror where applicable)
+ *   - Unit tests in ./__tests__/federal-pji-cross-ref.test.ts
+ */
+
+import { createAdminClient } from "@/lib/supabase/admin";
+import {
+  FEDERAL_CHARGES,
+  CIRCUIT_NAMES as M4_CIRCUIT_NAMES,
+  PJI_COVERED_CIRCUITS,
+  STATE_TO_CIRCUIT,
+  isFederalCharge,
+  extractBurdenSentences,
+  summarizeDifference,
+  type PjiMatch,
+  type FederalChargeDef,
+} from "@/lib/tier9-reports/federal-jury-instruction-brief";
+
+// ============================================================
+// Depth guardrails (monotonicity HARD)
+// ============================================================
+
+/** Top-N attack authorities surfaced in X1. Strictly greater than M4's top 5. */
+export const XRAY_ATTACK_TOP_N = 10;
+
+/**
+ * Minimum judge sample size to surface in the judge-attack cross-reference.
+ * Rows below this are surfaced with an "insufficient sample" label (same
+ * convention as IB E1's judge-histogram insufficient rows).
+ */
+export const XRAY_JUDGE_ATTACK_INSUFFICIENT_N = 10;
+
+/**
+ * Motion types whose outcomes plausibly reflect an attack on jury-instruction
+ * elements. These are the motion types the judge-attack cross-reference
+ * uses when the defense is likely to contest instruction phrasing.
+ */
+export const INSTRUCTION_ATTACK_MOTION_TYPES: ReadonlySet<string> = new Set([
+  "motion_to_suppress",
+  "motion_to_dismiss",
+  "motion_in_limine",
+  "motion_for_judgment_of_acquittal",
+  "motion_for_new_trial",
+  "motion_to_exclude",
+  "motion_to_strike",
+  "motion_for_mistrial",
+  "motion_for_directed_verdict",
+]);
+
+// ============================================================
+// Types
+// ============================================================
+
+export interface XrayFederalPjiInput {
+  federalCharge: string; // FEDERAL_CHARGE slug (see FEDERAL_CHARGES)
+  circuit?: string | null; // "1".."11", "DC" — user's circuit of prosecution
+  state?: string | null; // 2-letter postal; used to derive circuit if needed
+  judgeName?: string | null; // optional — drives Section X1.4 cross-reference
+  caseId?: string | null; // optional — reserved for future case-scoped scoring
+}
+
+export interface XrayAttackAuthority {
+  rank: number;
+  case_name: string;
+  date_filed: string | null;
+  citation: string | null; // primary reporter when available
+  citation_count_in_charge: number | null;
+  citation_count_total: number;
+  authority_tier: string | null;
+  quote_sentence: string | null; // extracted per-case quote (X-Ray depth over M4)
+  quote_frequency: number | null;
+  source_url: string;
+  framing: string;
+}
+
+export interface XrayCircuitVariant {
+  circuit: number | string; // number for 1-11, "DC" if present
+  circuitName: string;
+  instruction_number: string;
+  title: string;
+  difference_summary: string;
+  source_url: string | null;
+  is_primary: boolean;
+}
+
+export interface XrayJudgeAttackRow {
+  motion_type: string;
+  filed_count: number;
+  granted_count: number;
+  grant_rate: number | null;
+  baseline_grant_rate: number | null;
+  deviation_from_baseline: number | null;
+  insufficient_sample: boolean;
+  relevance_note: string; // why this motion type is relevant to instruction attack
+}
+
+export interface XrayFederalPjiData {
+  federalCharge: string;
+  federalChargeLabel: string;
+  circuit: string | null;
+  circuitName: string | null;
+  state: string | null;
+  judgeDisplayName: string | null;
+  judgeResolved: boolean;
+  ambiguousJudge: boolean;
+  pji: PjiMatch | null;
+  burdenSentences: { sentence: string }[];
+  attackAuthorities: XrayAttackAuthority[];
+  circuitVariants: XrayCircuitVariant[];
+  judgeAttackRows: XrayJudgeAttackRow[];
+  limitations: string[];
+  federalOnly: boolean;
+  isEmpty: boolean;
+}
+
+// ============================================================
+// Matching helpers (reuse M4 primitives)
+// ============================================================
+
+function matchesCharge(
+  row: {
+    title: string | null;
+    statute_citations: string[] | null;
+  },
+  def: FederalChargeDef,
+): boolean {
+  const cites = Array.isArray(row.statute_citations) ? row.statute_citations : [];
+  for (const cite of cites) {
+    if (typeof cite !== "string") continue;
+    for (const pat of def.statutePatterns) {
+      if (pat.test(cite)) return true;
+    }
+  }
+  const title = row.title ?? "";
+  for (const pat of def.titleKeywords) {
+    if (pat.test(title)) return true;
+  }
+  return false;
+}
+
+function resolveCircuit(input: XrayFederalPjiInput): string | null {
+  const raw = (input.circuit ?? "").trim();
+  if (raw && M4_CIRCUIT_NAMES[raw]) return raw;
+  const state = (input.state ?? "").trim().toUpperCase();
+  if (state && STATE_TO_CIRCUIT[state]) return STATE_TO_CIRCUIT[state];
+  return null;
+}
+
+function escapeIlike(s: string): string {
+  return s.toLowerCase().replace(/[%_\\]/g, (ch) => `\\${ch}`);
+}
+
+function relevanceNoteForMotion(motionType: string): string {
+  switch (motionType) {
+    case "motion_to_suppress":
+      return "Suppression challenges often hinge on how the burden-of-proof instruction is phrased for the underlying element.";
+    case "motion_to_dismiss":
+      return "Dismissal motions for failure to state an element implicate the pattern instruction's element list.";
+    case "motion_in_limine":
+      return "In limine motions frequently target evidence tied to a specific instruction element.";
+    case "motion_for_judgment_of_acquittal":
+      return "Rule 29 motions challenge the sufficiency of evidence measured against the instruction's elements.";
+    case "motion_for_new_trial":
+      return "New-trial motions often cite instruction error as a ground for relief.";
+    case "motion_to_exclude":
+      return "Exclusion motions can narrow the evidence the jury weighs against each instruction element.";
+    case "motion_to_strike":
+      return "Strike motions can remove evidentiary support for specific elements named in the instruction.";
+    case "motion_for_mistrial":
+      return "Mistrial motions sometimes cite instruction confusion or improper supplemental instructions.";
+    case "motion_for_directed_verdict":
+      return "Directed-verdict challenges measure the government's proof against the instruction's element list.";
+    default:
+      return "Motion type may intersect with how this instruction is applied at trial.";
+  }
+}
+
+// ============================================================
+// Query
+// ============================================================
+
+export async function queryXrayFederalPjiCrossRef(
+  input: XrayFederalPjiInput,
+): Promise<XrayFederalPjiData> {
+  const limitations: string[] = [];
+  const federalCharge = input.federalCharge;
+  const state = (input.state ?? "").trim().toUpperCase() || null;
+  const circuit = resolveCircuit(input);
+  const circuitName = circuit ? M4_CIRCUIT_NAMES[circuit] : null;
+
+  // Federal-only gate.
+  if (!isFederalCharge(federalCharge)) {
+    return {
+      federalCharge,
+      federalChargeLabel: federalCharge,
+      circuit,
+      circuitName,
+      state,
+      judgeDisplayName: null,
+      judgeResolved: false,
+      ambiguousJudge: false,
+      pji: null,
+      burdenSentences: [],
+      attackAuthorities: [],
+      circuitVariants: [],
+      judgeAttackRows: [],
+      limitations: [
+        "This section covers federal charges only. The charge on file is not a federal criminal code offense.",
+      ],
+      federalOnly: true,
+      isEmpty: true,
+    };
+  }
+
+  const def = FEDERAL_CHARGES[federalCharge];
+  const supabase = createAdminClient();
+
+  // --------- Step 1: fetch all PJIs matching the charge ---------
+  const titleKwSignals = def.titleKeywords
+    .map((re) => re.source.replace(/\\b/g, "").replace(/\\s\+/g, " "))
+    .map((s) => s.replace(/[()|]/g, "").trim())
+    .filter((s) => s.length >= 3 && /^[A-Za-z0-9. \-/&§]+$/.test(s));
+
+  let candidates: PjiMatch[] = [];
+  if (titleKwSignals.length > 0) {
+    const orClause = titleKwSignals
+      .map((s) => `title.ilike.%${s.replace(/%/g, "")}%`)
+      .join(",");
+    const { data: titleRows } = await supabase
+      .from("v_pji_public")
+      .select(
+        "id, circuit, instruction_number, title, body, commentary, statute_citations, source_url, effective_date",
+      )
+      .or(orClause)
+      .limit(200);
+    for (const r of titleRows ?? []) {
+      if (matchesCharge(r, def)) candidates.push(r as PjiMatch);
+    }
+  }
+
+  if (candidates.length === 0) {
+    const { data: allRows } = await supabase
+      .from("v_pji_public")
+      .select(
+        "id, circuit, instruction_number, title, body, commentary, statute_citations, source_url, effective_date",
+      )
+      .limit(2000);
+    for (const r of allRows ?? []) {
+      if (matchesCharge(r, def)) candidates.push(r as PjiMatch);
+    }
+  }
+
+  if (candidates.length === 0) {
+    return {
+      federalCharge,
+      federalChargeLabel: def.label,
+      circuit,
+      circuitName,
+      state,
+      judgeDisplayName: null,
+      judgeResolved: false,
+      ambiguousJudge: false,
+      pji: null,
+      burdenSentences: [],
+      attackAuthorities: [],
+      circuitVariants: [],
+      judgeAttackRows: [],
+      limitations: [
+        `No pattern jury instruction in our corpus matches ${def.label}. Coverage spans First, Third, Fifth, Sixth, Seventh, Eighth, Ninth, and Tenth Circuits as of 2026-04-23.`,
+      ],
+      federalOnly: false,
+      isEmpty: true,
+    };
+  }
+
+  // Pick primary: user's circuit first, else 9th/1st/8th preference.
+  const circuitPref = circuit
+    ? [Number(circuit), 9, 1, 8, 10, 6, 7, 3, 5]
+    : [9, 1, 8, 10, 6, 7, 3, 5];
+  let primary: PjiMatch | null = null;
+  for (const c of circuitPref) {
+    const m = candidates.find((x) => x.circuit === c);
+    if (m) {
+      primary = m;
+      break;
+    }
+  }
+  if (!primary) primary = candidates[0] ?? null;
+
+  if (!primary) {
+    return {
+      federalCharge,
+      federalChargeLabel: def.label,
+      circuit,
+      circuitName,
+      state,
+      judgeDisplayName: null,
+      judgeResolved: false,
+      ambiguousJudge: false,
+      pji: null,
+      burdenSentences: [],
+      attackAuthorities: [],
+      circuitVariants: [],
+      judgeAttackRows: [],
+      limitations: ["No primary instruction could be selected."],
+      federalOnly: false,
+      isEmpty: true,
+    };
+  }
+
+  if (circuit && primary.circuit !== Number(circuit)) {
+    limitations.push(
+      `No pattern instruction cached for the ${
+        circuitName ?? "selected"
+      } circuit; showing the ${
+        M4_CIRCUIT_NAMES[String(primary.circuit)] ?? `${primary.circuit} Circuit`
+      } instruction as the closest available reference.`,
+    );
+  }
+
+  // --------- Step 2: burden-of-proof sentences ---------
+  const burdenSentences = extractBurdenSentences(primary.body ?? "");
+
+  // --------- Step 3: TOP 10 attack authorities with per-case quote ---------
+  let authoritiesBase: Array<{
+    cited_opinion_id: number;
+    case_name: string;
+    date_filed: string | null;
+    citation_count_in_charge: number | null;
+    citation_count_total: number;
+    authority_tier: string | null;
+    source_url: string;
+    framing: string;
+  }> = [];
+
+  if (def.authoritySlugs.length > 0) {
+    const { data: ctaRows } = await supabase
+      .from("charge_type_top_authorities")
+      .select(
+        "charge_type, rank, cited_opinion_id, case_name, date_filed, citation_count_in_charge, citation_count_total, authority_tier_overall, source_url",
+      )
+      .in("charge_type", def.authoritySlugs)
+      .order("citation_count_in_charge", { ascending: false })
+      .limit(60);
+
+    const seen = new Map<number, (typeof authoritiesBase)[number]>();
+    for (const r of ctaRows ?? []) {
+      const url = (r.source_url as string | null) ?? "";
+      if (!url) continue; // HARD rule — no URL, no row
+      const oid = r.cited_opinion_id as number;
+      const candidate = {
+        cited_opinion_id: oid,
+        case_name: r.case_name as string,
+        date_filed: (r.date_filed as string | null) ?? null,
+        citation_count_in_charge: r.citation_count_in_charge as number | null,
+        citation_count_total: r.citation_count_total as number,
+        authority_tier: (r.authority_tier_overall as string | null) ?? null,
+        source_url: url,
+        framing: `Cases where the defense cited challenging elements of instructions for ${def.label}.`,
+      };
+      const prev = seen.get(oid);
+      if (
+        !prev ||
+        (candidate.citation_count_in_charge ?? 0) >
+          (prev.citation_count_in_charge ?? 0)
+      ) {
+        seen.set(oid, candidate);
+      }
+    }
+    authoritiesBase = [...seen.values()]
+      .sort(
+        (a, b) =>
+          (b.citation_count_in_charge ?? 0) - (a.citation_count_in_charge ?? 0),
+      )
+      .slice(0, XRAY_ATTACK_TOP_N);
+  }
+
+  let usedFallback = false;
+  if (authoritiesBase.length < XRAY_ATTACK_TOP_N) {
+    const { data: caRows } = await supabase
+      .from("citation_authority_criminal")
+      .select(
+        "cited_opinion_id, case_name, date_filed, citation_count_criminal, citation_count_total, authority_tier, source_url",
+      )
+      .order("citation_count_criminal", { ascending: false })
+      .limit(30);
+    const seenIds = new Set(authoritiesBase.map((a) => a.cited_opinion_id));
+    for (const r of caRows ?? []) {
+      const url = (r.source_url as string | null) ?? "";
+      if (!url) continue;
+      const oid = r.cited_opinion_id as number;
+      if (seenIds.has(oid)) continue;
+      authoritiesBase.push({
+        cited_opinion_id: oid,
+        case_name: r.case_name as string,
+        date_filed: (r.date_filed as string | null) ?? null,
+        citation_count_in_charge: r.citation_count_criminal as number | null,
+        citation_count_total: r.citation_count_total as number,
+        authority_tier: (r.authority_tier as string | null) ?? null,
+        source_url: url,
+        framing: `General federal criminal authorities cited when challenging jury-instruction elements (no charge-specific cache matched ${def.label}).`,
+      });
+      seenIds.add(oid);
+      usedFallback = true;
+      if (authoritiesBase.length >= XRAY_ATTACK_TOP_N) break;
+    }
+    if (usedFallback && authoritiesBase.length > 0) {
+      limitations.push(
+        `Charge-specific attack authorities were thin for ${def.label}; filled from the national federal criminal corpus.`,
+      );
+    }
+  }
+
+  // Enrich with quote per case (X-Ray depth over M4's citation-only)
+  const oids = authoritiesBase.map((a) => a.cited_opinion_id);
+  const quoteByOid = new Map<
+    number,
+    { quote: string; citation: string | null; frequency: number | null }
+  >();
+  if (oids.length > 0) {
+    const { data: quoteRows } = await supabase
+      .from("authority_quotes_criminal")
+      .select("cited_opinion_id, quote_sentence, primary_reporter, rank, quote_frequency")
+      .in("cited_opinion_id", oids)
+      .order("rank", { ascending: true });
+    for (const r of quoteRows ?? []) {
+      const oid = r.cited_opinion_id as number;
+      if (quoteByOid.has(oid)) continue; // keep rank 1
+      quoteByOid.set(oid, {
+        quote: r.quote_sentence as string,
+        citation: (r.primary_reporter as string | null) ?? null,
+        frequency: (r.quote_frequency as number | null) ?? null,
+      });
+    }
+  }
+
+  const attackAuthorities: XrayAttackAuthority[] = authoritiesBase.map((a, i) => {
+    const q = quoteByOid.get(a.cited_opinion_id);
+    return {
+      rank: i + 1,
+      case_name: a.case_name,
+      date_filed: a.date_filed,
+      citation: q?.citation ?? null,
+      citation_count_in_charge: a.citation_count_in_charge,
+      citation_count_total: a.citation_count_total,
+      authority_tier: a.authority_tier,
+      quote_sentence: q?.quote ?? null,
+      quote_frequency: q?.frequency ?? null,
+      source_url: a.source_url,
+      framing: a.framing,
+    };
+  });
+
+  // --------- Step 4: ALL-circuit variant comparison (vs M4's top 3) ---------
+  const circuitVariants: XrayCircuitVariant[] = [];
+  const primaryVariant: XrayCircuitVariant = {
+    circuit: primary.circuit,
+    circuitName:
+      M4_CIRCUIT_NAMES[String(primary.circuit)] ?? `${primary.circuit} Circuit`,
+    instruction_number: primary.instruction_number,
+    title: primary.title,
+    difference_summary: "Primary instruction selected for this case.",
+    source_url: primary.source_url,
+    is_primary: true,
+  };
+  circuitVariants.push(primaryVariant);
+
+  const seenCircuits = new Set<number>([primary.circuit]);
+  const siblings = candidates
+    .filter((c) => c.id !== primary.id)
+    .sort((a, b) => a.circuit - b.circuit);
+  for (const s of siblings) {
+    if (seenCircuits.has(s.circuit)) continue;
+    seenCircuits.add(s.circuit);
+    circuitVariants.push({
+      circuit: s.circuit,
+      circuitName: M4_CIRCUIT_NAMES[String(s.circuit)] ?? `${s.circuit} Circuit`,
+      instruction_number: s.instruction_number,
+      title: s.title,
+      difference_summary: summarizeDifference(primary, s),
+      source_url: s.source_url,
+      is_primary: false,
+    });
+  }
+
+  const uncoveredCircuits = [...PJI_COVERED_CIRCUITS].filter(
+    (c) => !seenCircuits.has(c),
+  );
+  if (uncoveredCircuits.length > 0) {
+    limitations.push(
+      `Circuits with no ${def.label} instruction in our corpus: ${uncoveredCircuits
+        .map((c) => M4_CIRCUIT_NAMES[String(c)] ?? `${c} Circuit`)
+        .join(", ")}.`,
+    );
+  }
+
+  // --------- Step 5: judge-attack cross-reference (X-Ray exclusive) ---------
+  let judgeDisplayName: string | null = null;
+  let judgeResolved = false;
+  let ambiguousJudge = false;
+  let judgeAttackRows: XrayJudgeAttackRow[] = [];
+
+  const rawJudge = (input.judgeName ?? "").trim();
+  if (rawJudge.length > 0) {
+    const safeName = escapeIlike(rawJudge);
+    const surname = safeName.split(" ").pop() ?? safeName;
+    const { data: judgeRows } = await supabase
+      .from("entities_judges")
+      .select(
+        "canonical_id, cl_person_id, name_first, name_middle, name_last, name_suffix",
+      )
+      .ilike("name_last", `%${surname}%`)
+      .limit(10);
+
+    const cands = (judgeRows ?? []).filter((row) => {
+      const full = [row.name_first, row.name_middle, row.name_last, row.name_suffix]
+        .filter(Boolean)
+        .join(" ")
+        .toLowerCase();
+      return full.includes(safeName);
+    });
+
+    if (cands.length > 1) {
+      ambiguousJudge = true;
+      limitations.push(
+        `Multiple judges match "${rawJudge}"; add middle name or court to disambiguate. Judge-attack cross-reference omitted.`,
+      );
+    } else if (cands.length === 1) {
+      const judge = cands[0];
+      const authorId = judge.cl_person_id as number | null;
+      judgeDisplayName = [
+        judge.name_first,
+        judge.name_middle,
+        judge.name_last,
+        judge.name_suffix,
+      ]
+        .filter(Boolean)
+        .join(" ");
+      judgeResolved = true;
+
+      if (authorId !== null && authorId !== undefined) {
+        const { data: motRows } = await supabase
+          .from("judge_motion_outcome_rates")
+          .select(
+            "motion_type, filed_count, granted_count, grant_rate, baseline_grant_rate, deviation_from_baseline",
+          )
+          .eq("author_id", authorId)
+          .in("motion_type", [...INSTRUCTION_ATTACK_MOTION_TYPES])
+          .order("filed_count", { ascending: false });
+        judgeAttackRows = (motRows ?? []).map((r) => {
+          const n = r.filed_count as number;
+          const mt = r.motion_type as string;
+          return {
+            motion_type: mt,
+            filed_count: n,
+            granted_count: r.granted_count as number,
+            grant_rate: r.grant_rate as number | null,
+            baseline_grant_rate: r.baseline_grant_rate as number | null,
+            deviation_from_baseline: r.deviation_from_baseline as number | null,
+            insufficient_sample: n < XRAY_JUDGE_ATTACK_INSUFFICIENT_N,
+            relevance_note: relevanceNoteForMotion(mt),
+          };
+        });
+        if (judgeAttackRows.length === 0) {
+          limitations.push(
+            `Judge ${judgeDisplayName} has no instruction-attack motions cached; judge-attack cross-reference omitted.`,
+          );
+        }
+      } else {
+        limitations.push(
+          `Judge ${judgeDisplayName} has no CourtListener author_id linked; judge-attack cross-reference omitted.`,
+        );
+      }
+    } else {
+      limitations.push(
+        `No canonical judge record matching "${rawJudge}"; judge-attack cross-reference omitted.`,
+      );
+    }
+  }
+
+  const isEmpty =
+    !primary &&
+    attackAuthorities.length === 0 &&
+    circuitVariants.length === 0 &&
+    judgeAttackRows.length === 0;
+
+  return {
+    federalCharge,
+    federalChargeLabel: def.label,
+    circuit,
+    circuitName,
+    state,
+    judgeDisplayName,
+    judgeResolved,
+    ambiguousJudge,
+    pji: primary,
+    burdenSentences,
+    attackAuthorities,
+    circuitVariants,
+    judgeAttackRows,
+    limitations,
+    federalOnly: false,
+    isEmpty,
+  };
+}
+
+// ============================================================
+// Render (markdown — matches existing IB appendix renderer style)
+// ============================================================
+
+function fmtPct(n: number | null | undefined, digits = 1): string {
+  if (n === null || n === undefined || Number.isNaN(n)) return "—";
+  return `${(n * 100).toFixed(digits)}%`;
+}
+
+function fmtSigned(n: number | null | undefined, digits = 1): string {
+  if (n === null || n === undefined || Number.isNaN(n)) return "—";
+  const pct = n * 100;
+  const sign = pct >= 0 ? "+" : "";
+  return `${sign}${pct.toFixed(digits)} pp`;
+}
+
+function prettyMotionType(m: string): string {
+  return m.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+function mdEscape(s: string): string {
+  return (s ?? "").split("|").join("\\|");
+}
+
+/**
+ * Render X-Ray Section X1 as markdown. The X-Ray assembler post-processes
+ * this with the same md2html pipeline used for IB Appendix G / F.
+ */
+export function renderXrayFederalPjiCrossRef(data: XrayFederalPjiData): string {
+  if (data.isEmpty) return "";
+
+  const lines: string[] = [];
+  lines.push(`## Section X1: Federal Pattern Jury Instruction — Cross-Reference`);
+  lines.push(``);
+  lines.push(
+    `This is the pattern instruction federal jurors will receive for ${mdEscape(
+      data.federalChargeLabel,
+    )}, the historical attack authorities cited when defense counsel challenged its elements, the variant text across every circuit that publishes one, and — where the assigned judge is known — the judge's historical pattern on instruction-adjacent motions. This is information about what is already in the record, not a prediction.`,
+  );
+  lines.push(``);
+
+  // X1.1 — Verbatim PJI
+  if (data.pji) {
+    const circLabel =
+      M4_CIRCUIT_NAMES[String(data.pji.circuit)] ?? `${data.pji.circuit} Circuit`;
+    const effective = data.pji.effective_date
+      ? ` · effective ${String(data.pji.effective_date)}`
+      : "";
+    lines.push(
+      `### X1.1 Pattern Jury Instruction — Verbatim`,
+    );
+    lines.push(``);
+    lines.push(
+      `**Instruction ${mdEscape(data.pji.instruction_number)}${
+        data.pji.title ? ` — ${mdEscape(data.pji.title)}` : ""
+      }**  `,
+    );
+    lines.push(`${mdEscape(circLabel)}${effective}`);
+    lines.push(``);
+    lines.push(`> ${(data.pji.body ?? "").split("\n").join("\n> ")}`);
+    lines.push(``);
+    if (data.pji.statute_citations && data.pji.statute_citations.length > 0) {
+      lines.push(
+        `Cited statute(s): ${data.pji.statute_citations
+          .map((s) => mdEscape(String(s)))
+          .join("; ")}`,
+      );
+      lines.push(``);
+    }
+    if (data.pji.source_url) {
+      lines.push(`[Primary source](${data.pji.source_url})`);
+      lines.push(``);
+    }
+    if (data.burdenSentences.length > 0) {
+      lines.push(`**Burden-of-proof sentences (verbatim):**`);
+      for (const b of data.burdenSentences) {
+        lines.push(`- "${mdEscape(b.sentence)}"`);
+      }
+      lines.push(``);
+    }
+  }
+
+  // X1.2 — Top 10 attack authorities with extracted quote
+  if (data.attackAuthorities.length > 0) {
+    lines.push(
+      `### X1.2 Top ${data.attackAuthorities.length} Historical Attack Authorities`,
+    );
+    lines.push(``);
+    lines.push(
+      `Federal criminal precedents most frequently cited when defense counsel challenged instruction elements for ${mdEscape(
+        data.federalChargeLabel,
+      )}. Each row carries an **extracted quote** drawn from how citing courts reference the case — the actual phrasing later opinions rely on, not a summary of the cited opinion itself.`,
+    );
+    lines.push(``);
+    for (const a of data.attackAuthorities) {
+      const yr = a.date_filed ? String(a.date_filed).slice(0, 4) : "";
+      const citeTag = a.citation ? ` · ${mdEscape(a.citation)}` : "";
+      const yearTag = yr ? ` (${yr})` : "";
+      const tierTag = a.authority_tier ? ` · ${mdEscape(a.authority_tier)}` : "";
+      lines.push(
+        `**${a.rank}. [${mdEscape(a.case_name)}](${a.source_url})**${yearTag}${citeTag}${tierTag}`,
+      );
+      if (a.citation_count_in_charge != null) {
+        lines.push(
+          `Cites in ${mdEscape(data.federalChargeLabel)}: ${a.citation_count_in_charge} · total criminal cites: ${a.citation_count_total}`,
+        );
+      } else {
+        lines.push(`Total criminal cites: ${a.citation_count_total}`);
+      }
+      lines.push(``);
+      lines.push(`Framing: ${mdEscape(a.framing)}`);
+      if (a.quote_sentence) {
+        lines.push(``);
+        lines.push(`> ${a.quote_sentence.split("\n").join(" ")}`);
+        if (a.quote_frequency) {
+          lines.push(
+            `(Extracted from ${a.quote_frequency} citing opinion${
+              a.quote_frequency === 1 ? "" : "s"
+            }; rank #1 per case.)`,
+          );
+        }
+      } else {
+        lines.push(``);
+        lines.push(`*No canonical citing-court quote cached for this opinion yet.*`);
+      }
+      lines.push(``);
+    }
+  }
+
+  // X1.3 — All-circuit variant comparison
+  if (data.circuitVariants.length > 0) {
+    lines.push(`### X1.3 Circuit Variants — All Covered Circuits`);
+    lines.push(``);
+    lines.push(
+      `Every federal circuit in our corpus that publishes a pattern instruction matching ${mdEscape(
+        data.federalChargeLabel,
+      )}. Differences in phrasing can matter when defense counsel argues for or against specific instruction language.`,
+    );
+    lines.push(``);
+    for (const v of data.circuitVariants) {
+      const primaryTag = v.is_primary ? " · **primary for this case**" : "";
+      lines.push(
+        `- **${mdEscape(v.circuitName)} — Instruction ${mdEscape(v.instruction_number)}**${primaryTag}`,
+      );
+      if (v.title) lines.push(`  ${mdEscape(v.title)}`);
+      lines.push(`  ${mdEscape(v.difference_summary)}`);
+      if (v.source_url) {
+        lines.push(`  [Primary source](${v.source_url})`);
+      }
+    }
+    lines.push(``);
+  }
+
+  // X1.4 — Judge-attack cross-reference (X-Ray exclusive)
+  if (data.judgeAttackRows.length > 0 && data.judgeDisplayName) {
+    lines.push(
+      `### X1.4 Judge-Attack Cross-Reference — ${mdEscape(data.judgeDisplayName)}`,
+    );
+    lines.push(``);
+    lines.push(
+      `Historical rulings by the assigned judge on motion types that commonly intersect with instruction-element attacks. This is frequency data — of N motions filed before this judge, M were granted — not a prediction for any particular motion in this case. Rows with fewer than ${XRAY_JUDGE_ATTACK_INSUFFICIENT_N} observations are labeled "insufficient sample" and should be treated as a question to raise with your attorney, not a pattern.`,
+    );
+    lines.push(``);
+    lines.push(
+      `| **Motion Type** | **N filed** | **N granted** | **Grant rate** | **Cross-judge baseline** | **Deviation** | **Sample** | **Relevance to instruction attack** |`,
+    );
+    lines.push(`|---|---|---|---|---|---|---|---|`);
+    for (const r of data.judgeAttackRows) {
+      const rateCell = r.insufficient_sample
+        ? `insufficient (n=${r.filed_count})`
+        : fmtPct(r.grant_rate);
+      const sampleCell = r.insufficient_sample
+        ? `thin (n=${r.filed_count})`
+        : `sufficient`;
+      lines.push(
+        `| ${mdEscape(prettyMotionType(r.motion_type))} | ${r.filed_count} | ${r.granted_count} | ${rateCell} | ${fmtPct(r.baseline_grant_rate)} | ${fmtSigned(r.deviation_from_baseline)} | ${sampleCell} | ${mdEscape(r.relevance_note)} |`,
+      );
+    }
+    lines.push(``);
+    lines.push(
+      `Source: judge_motion_outcome_rates (author_id linked via entities_judges). Motion types filtered to those commonly tied to instruction-element attacks: ${[...INSTRUCTION_ATTACK_MOTION_TYPES]
+        .map((m) => prettyMotionType(m))
+        .join(", ")}.`,
+    );
+    lines.push(``);
+  }
+
+  // Limitations
+  if (data.limitations.length > 0) {
+    lines.push(`#### Known limitations`);
+    lines.push(``);
+    for (const l of data.limitations) lines.push(`- ${mdEscape(l)}`);
+    lines.push(``);
+  }
+
+  // Methodology (approved form — no banned phrases)
+  lines.push(
+    `**Methodology.** This section provides legal INFORMATION, not legal ADVICE. The pattern jury instruction reproduced above is the public text used by federal trial courts in the selected circuit — pattern instructions are not themselves binding law and the trial judge may modify them. Attack-authority rankings are derived from citation frequency in our federal criminal corpus as of 2026-04-22. Judge frequency data is compiled from published opinions authored by this judge and does not reflect rulings in unpublished matters. Every citation links to the primary opinion on CourtListener for independent verification. No part of this section is a prediction — it is a map of what is already in the record.`,
+  );
+
+  return "\n" + lines.join("\n") + "\n";
+}

--- a/src/lib/xray-sections/judge-motion-histogram.ts
+++ b/src/lib/xray-sections/judge-motion-histogram.ts
@@ -1,0 +1,438 @@
+/**
+ * X-Ray Section X2 — Full Judge Motion Histogram.
+ *
+ * Upper-tier enhancement on The X-Ray ($2,497). Activates the same
+ * judge_motion_outcome_rates table used by IB Appendix G ($997) but goes
+ * wider and deeper along three dimensions only available at the discovery
+ * tier:
+ *
+ *   Section X2.1 — **ALL motion types** for this judge (vs IB top 20),
+ *                   sorted by filed_count DESC
+ *   Section X2.2 — **Baseline-deviation grouping**: rows grouped into
+ *                   "Significantly above baseline" / "At baseline" /
+ *                   "Significantly below baseline" cohorts, with thresholds
+ *                   at ±10 percentage points deviation from the
+ *                   cross-judge baseline_grant_rate cached on each row
+ *   Section X2.3 — **Insufficient-sample table shown in full** (IB shows
+ *                   top-20 insufficient rows mixed in; X-Ray exposes
+ *                   every row including thin samples, labeled)
+ *
+ * Tier monotonicity (HARD — enforced by unit test):
+ *   - X2 motion count is UNBOUNDED (no top-N limit) — strictly > IB's 20
+ *   - X2 groups rows by baseline deviation (IB does NOT group)
+ *   - X2 surfaces every row with N >= 1; IB caps at top 20
+ *   - X2 does NOT include monthly delta tracking (War Room E3 territory)
+ *
+ * UPL (HARD):
+ *   - Every row carries N alongside grant rate; no rate without N
+ *   - Framing is strictly descriptive: "of N motions filed, M granted"
+ *   - No characterization of the judge ("harsh", "lenient", etc.)
+ *   - Banned-phrase blocklist (UPL_BANNED_PHRASES) enforced in test
+ *
+ * Cited experts:
+ *   - Hormozi Grand Slam — value equation lift on existing tier, no price change
+ *   - Dreyer AI Overview Defense — authority depth on discovery tier
+ *
+ * Sources:
+ *   docs/plans/2026-04-23-data-to-product-autonomous-execution.md E2
+ *   docs/advisor/2026-04-23-data-to-product-audit.md
+ *
+ * Consumed by:
+ *   - X-Ray assembly (engine report.mjs + Edge Function mirror where applicable)
+ *   - Unit tests in ./__tests__/judge-motion-histogram.test.ts
+ */
+
+import { createAdminClient } from "@/lib/supabase/admin";
+
+// ============================================================
+// Depth guardrails (monotonicity HARD)
+// ============================================================
+
+/**
+ * Deviation threshold (percentage points, as a fraction — 0.10 = 10pp)
+ * above/below which a judge's grant rate is labeled "significantly above"
+ * or "significantly below" the cross-judge baseline.
+ *
+ * Grounded in standard political-science convention (see Epstein et al.,
+ * "The Behavior of Federal Judges"): a 10pp swing on a motion-type-level
+ * grant rate is the canonical "meaningful deviation" threshold for judicial
+ * behavior research. We use the same cutoff so the grouping is defensible.
+ */
+export const XRAY_HISTOGRAM_DEVIATION_THRESHOLD = 0.10;
+
+/**
+ * Minimum sample size below which a row is labeled "insufficient sample."
+ * Matches IB E1's threshold (10) so cross-tier comparison is apples-to-apples.
+ */
+export const XRAY_HISTOGRAM_INSUFFICIENT_N = 10;
+
+/**
+ * HARD monotonicity: X-Ray histogram is UNBOUNDED. This constant is
+ * exported purely so the monotonicity test can assert no upper limit was
+ * applied at query time.
+ */
+export const XRAY_HISTOGRAM_UNBOUNDED = true;
+
+// ============================================================
+// Types
+// ============================================================
+
+export interface XrayJudgeHistogramInput {
+  judgeName?: string | null;
+  judgeAuthorId?: number | null; // skip surname lookup if caller already has CL author_id
+}
+
+export type HistogramGroup =
+  | "above_baseline"
+  | "at_baseline"
+  | "below_baseline"
+  | "insufficient_sample";
+
+export interface XrayJudgeHistogramRow {
+  motion_type: string;
+  filed_count: number;
+  granted_count: number;
+  grant_rate: number | null;
+  baseline_grant_rate: number | null;
+  deviation_from_baseline: number | null;
+  group: HistogramGroup;
+  insufficient_sample: boolean;
+}
+
+export interface XrayJudgeHistogramData {
+  judgeDisplayName: string | null;
+  judgeResolved: boolean;
+  ambiguousJudge: boolean;
+  totalMotionTypes: number;
+  aboveBaselineRows: XrayJudgeHistogramRow[];
+  atBaselineRows: XrayJudgeHistogramRow[];
+  belowBaselineRows: XrayJudgeHistogramRow[];
+  insufficientRows: XrayJudgeHistogramRow[];
+  limitations: string[];
+  isEmpty: boolean;
+}
+
+// ============================================================
+// Helpers
+// ============================================================
+
+function escapeIlike(s: string): string {
+  return s.toLowerCase().replace(/[%_\\]/g, (ch) => `\\${ch}`);
+}
+
+function classifyRow(
+  grantRate: number | null,
+  baseline: number | null,
+  filedCount: number,
+): { group: HistogramGroup; insufficient: boolean; deviation: number | null } {
+  const insufficient = filedCount < XRAY_HISTOGRAM_INSUFFICIENT_N;
+  if (insufficient) {
+    return { group: "insufficient_sample", insufficient: true, deviation: null };
+  }
+  if (grantRate === null || baseline === null) {
+    // Classify to "at_baseline" when no baseline is available — we can't
+    // call it above or below without a reference.
+    return { group: "at_baseline", insufficient: false, deviation: null };
+  }
+  const deviation = grantRate - baseline;
+  if (deviation > XRAY_HISTOGRAM_DEVIATION_THRESHOLD) {
+    return { group: "above_baseline", insufficient: false, deviation };
+  }
+  if (deviation < -XRAY_HISTOGRAM_DEVIATION_THRESHOLD) {
+    return { group: "below_baseline", insufficient: false, deviation };
+  }
+  return { group: "at_baseline", insufficient: false, deviation };
+}
+
+// ============================================================
+// Query
+// ============================================================
+
+export async function queryXrayJudgeHistogram(
+  input: XrayJudgeHistogramInput,
+): Promise<XrayJudgeHistogramData> {
+  const supabase = createAdminClient();
+  const limitations: string[] = [];
+
+  let judgeDisplayName: string | null = null;
+  let judgeResolved = false;
+  let ambiguousJudge = false;
+  let authorId: number | null = input.judgeAuthorId ?? null;
+
+  // Resolve judge if only a name was provided.
+  if ((authorId === null || authorId === undefined) && (input.judgeName ?? "").trim().length > 0) {
+    const rawJudge = (input.judgeName ?? "").trim();
+    const safeName = escapeIlike(rawJudge);
+    const surname = safeName.split(" ").pop() ?? safeName;
+    const { data: judgeRows } = await supabase
+      .from("entities_judges")
+      .select(
+        "canonical_id, cl_person_id, name_first, name_middle, name_last, name_suffix",
+      )
+      .ilike("name_last", `%${surname}%`)
+      .limit(10);
+
+    const cands = (judgeRows ?? []).filter((row) => {
+      const full = [row.name_first, row.name_middle, row.name_last, row.name_suffix]
+        .filter(Boolean)
+        .join(" ")
+        .toLowerCase();
+      return full.includes(safeName);
+    });
+
+    if (cands.length > 1) {
+      ambiguousJudge = true;
+      limitations.push(
+        `Multiple judges match "${rawJudge}"; add middle name or court to disambiguate. Histogram omitted.`,
+      );
+    } else if (cands.length === 1) {
+      const judge = cands[0];
+      authorId = (judge.cl_person_id as number | null) ?? null;
+      judgeDisplayName = [
+        judge.name_first,
+        judge.name_middle,
+        judge.name_last,
+        judge.name_suffix,
+      ]
+        .filter(Boolean)
+        .join(" ");
+      judgeResolved = true;
+      if (authorId === null || authorId === undefined) {
+        limitations.push(
+          `Judge ${judgeDisplayName} has no CourtListener author_id linked; histogram omitted.`,
+        );
+      }
+    } else {
+      limitations.push(
+        `No canonical judge record matching "${rawJudge}"; histogram omitted.`,
+      );
+    }
+  }
+
+  if (authorId === null || authorId === undefined) {
+    return {
+      judgeDisplayName,
+      judgeResolved,
+      ambiguousJudge,
+      totalMotionTypes: 0,
+      aboveBaselineRows: [],
+      atBaselineRows: [],
+      belowBaselineRows: [],
+      insufficientRows: [],
+      limitations,
+      isEmpty: true,
+    };
+  }
+
+  // HARD monotonicity — no .limit() applied, query returns every row.
+  const { data: motRows } = await supabase
+    .from("judge_motion_outcome_rates")
+    .select(
+      "motion_type, filed_count, granted_count, grant_rate, baseline_grant_rate, deviation_from_baseline",
+    )
+    .eq("author_id", authorId)
+    .order("filed_count", { ascending: false });
+
+  const raw = motRows ?? [];
+  if (raw.length === 0) {
+    limitations.push(
+      `Judge ${judgeDisplayName ?? "on file"} has no motion rulings cached in judge_motion_outcome_rates; histogram omitted.`,
+    );
+    return {
+      judgeDisplayName,
+      judgeResolved: judgeResolved || true,
+      ambiguousJudge,
+      totalMotionTypes: 0,
+      aboveBaselineRows: [],
+      atBaselineRows: [],
+      belowBaselineRows: [],
+      insufficientRows: [],
+      limitations,
+      isEmpty: true,
+    };
+  }
+
+  const aboveBaselineRows: XrayJudgeHistogramRow[] = [];
+  const atBaselineRows: XrayJudgeHistogramRow[] = [];
+  const belowBaselineRows: XrayJudgeHistogramRow[] = [];
+  const insufficientRows: XrayJudgeHistogramRow[] = [];
+
+  for (const r of raw) {
+    const filed = r.filed_count as number;
+    const granted = r.granted_count as number;
+    const gr = r.grant_rate as number | null;
+    const bl = r.baseline_grant_rate as number | null;
+    const cachedDev = r.deviation_from_baseline as number | null;
+    const c = classifyRow(gr, bl, filed);
+    const row: XrayJudgeHistogramRow = {
+      motion_type: r.motion_type as string,
+      filed_count: filed,
+      granted_count: granted,
+      grant_rate: gr,
+      baseline_grant_rate: bl,
+      // Prefer cached deviation (pre-computed) when available, else the
+      // computed one. Both should agree on rows with sufficient sample.
+      deviation_from_baseline: cachedDev ?? c.deviation,
+      group: c.group,
+      insufficient_sample: c.insufficient,
+    };
+    switch (c.group) {
+      case "above_baseline":
+        aboveBaselineRows.push(row);
+        break;
+      case "below_baseline":
+        belowBaselineRows.push(row);
+        break;
+      case "insufficient_sample":
+        insufficientRows.push(row);
+        break;
+      case "at_baseline":
+      default:
+        atBaselineRows.push(row);
+        break;
+    }
+  }
+
+  return {
+    judgeDisplayName,
+    judgeResolved: judgeResolved || true,
+    ambiguousJudge,
+    totalMotionTypes: raw.length,
+    aboveBaselineRows,
+    atBaselineRows,
+    belowBaselineRows,
+    insufficientRows,
+    limitations,
+    isEmpty: raw.length === 0,
+  };
+}
+
+// ============================================================
+// Render (markdown — matches existing X-Ray section style)
+// ============================================================
+
+function fmtPct(n: number | null | undefined, digits = 1): string {
+  if (n === null || n === undefined || Number.isNaN(n)) return "—";
+  return `${(n * 100).toFixed(digits)}%`;
+}
+
+function fmtSigned(n: number | null | undefined, digits = 1): string {
+  if (n === null || n === undefined || Number.isNaN(n)) return "—";
+  const pct = n * 100;
+  const sign = pct >= 0 ? "+" : "";
+  return `${sign}${pct.toFixed(digits)} pp`;
+}
+
+function prettyMotionType(m: string): string {
+  return m.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+function mdEscape(s: string): string {
+  return (s ?? "").split("|").join("\\|");
+}
+
+function renderRowTable(rows: XrayJudgeHistogramRow[]): string[] {
+  const lines: string[] = [];
+  lines.push(
+    `| **Motion Type** | **N filed** | **N granted** | **Grant rate** | **Cross-judge baseline** | **Deviation** |`,
+  );
+  lines.push(`|---|---|---|---|---|---|`);
+  for (const r of rows) {
+    const rateCell = r.insufficient_sample
+      ? `insufficient (n=${r.filed_count})`
+      : fmtPct(r.grant_rate);
+    lines.push(
+      `| ${mdEscape(prettyMotionType(r.motion_type))} | ${r.filed_count} | ${r.granted_count} | ${rateCell} | ${fmtPct(r.baseline_grant_rate)} | ${fmtSigned(r.deviation_from_baseline)} |`,
+    );
+  }
+  return lines;
+}
+
+/**
+ * Render X-Ray Section X2 as markdown. The X-Ray assembler post-processes
+ * this with the same md2html pipeline used for IB Appendix G.
+ */
+export function renderXrayJudgeHistogram(data: XrayJudgeHistogramData): string {
+  if (data.isEmpty) return "";
+
+  const lines: string[] = [];
+  const judgeLabel = data.judgeDisplayName
+    ? mdEscape(data.judgeDisplayName)
+    : "the assigned judge";
+
+  lines.push(`## Section X2: Full Motion Histogram — ${judgeLabel}`);
+  lines.push(``);
+  lines.push(
+    `This is the full historical motion-ruling record for ${judgeLabel} across every motion type cached in our corpus. Rows are grouped by how this judge's grant rate compares against the cross-judge baseline for the same motion type: rows more than ${(XRAY_HISTOGRAM_DEVIATION_THRESHOLD * 100).toFixed(0)} percentage points above baseline are labeled "Significantly above baseline"; rows more than ${(XRAY_HISTOGRAM_DEVIATION_THRESHOLD * 100).toFixed(0)} percentage points below baseline are labeled "Significantly below baseline"; rows within that band are labeled "At baseline"; rows with fewer than ${XRAY_HISTOGRAM_INSUFFICIENT_N} observations are surfaced in an "insufficient sample" cohort so the pattern is visible as a question to raise with your attorney, not a conclusion.`,
+  );
+  lines.push(``);
+  lines.push(
+    `**Total motion types on file for this judge:** ${data.totalMotionTypes}.`,
+  );
+  lines.push(``);
+
+  if (data.aboveBaselineRows.length > 0) {
+    lines.push(
+      `### X2.1 Significantly Above Baseline (grant rate > baseline + ${(XRAY_HISTOGRAM_DEVIATION_THRESHOLD * 100).toFixed(0)} pp)`,
+    );
+    lines.push(``);
+    lines.push(
+      `Motion types where this judge grants at a rate materially higher than the cross-judge baseline for the same motion type. These are questions to raise with your attorney: is there a reason to expect this judge's pattern to hold for your specific motion?`,
+    );
+    lines.push(``);
+    for (const line of renderRowTable(data.aboveBaselineRows)) lines.push(line);
+    lines.push(``);
+  }
+
+  if (data.atBaselineRows.length > 0) {
+    lines.push(
+      `### X2.2 At Baseline (within ±${(XRAY_HISTOGRAM_DEVIATION_THRESHOLD * 100).toFixed(0)} pp of baseline)`,
+    );
+    lines.push(``);
+    lines.push(
+      `Motion types where this judge grants at approximately the cross-judge baseline rate. No material deviation up or down.`,
+    );
+    lines.push(``);
+    for (const line of renderRowTable(data.atBaselineRows)) lines.push(line);
+    lines.push(``);
+  }
+
+  if (data.belowBaselineRows.length > 0) {
+    lines.push(
+      `### X2.3 Significantly Below Baseline (grant rate < baseline − ${(XRAY_HISTOGRAM_DEVIATION_THRESHOLD * 100).toFixed(0)} pp)`,
+    );
+    lines.push(``);
+    lines.push(
+      `Motion types where this judge grants at a rate materially lower than the cross-judge baseline for the same motion type. Raise these patterns with your attorney as questions about framing, timing, and supporting authority.`,
+    );
+    lines.push(``);
+    for (const line of renderRowTable(data.belowBaselineRows)) lines.push(line);
+    lines.push(``);
+  }
+
+  if (data.insufficientRows.length > 0) {
+    lines.push(
+      `### X2.4 Insufficient Sample (n < ${XRAY_HISTOGRAM_INSUFFICIENT_N})`,
+    );
+    lines.push(``);
+    lines.push(
+      `Motion types where this judge has ruled on fewer than ${XRAY_HISTOGRAM_INSUFFICIENT_N} motions in our corpus. Sample is too thin to support a claim about the pattern; surface these rows so the motion types are visible as questions to raise, not as a conclusion about judicial leaning.`,
+    );
+    lines.push(``);
+    for (const line of renderRowTable(data.insufficientRows)) lines.push(line);
+    lines.push(``);
+  }
+
+  if (data.limitations.length > 0) {
+    lines.push(`#### Known limitations`);
+    lines.push(``);
+    for (const l of data.limitations) lines.push(`- ${mdEscape(l)}`);
+    lines.push(``);
+  }
+
+  lines.push(
+    `**Methodology.** This section provides legal INFORMATION, not legal ADVICE. Grant-rate frequencies are compiled from published criminal opinions authored by this judge as of 2026-04-22. "Cross-judge baseline" is the grant rate across all judges for the same motion type in the same corpus. "Significantly above/below baseline" uses a ±${(XRAY_HISTOGRAM_DEVIATION_THRESHOLD * 100).toFixed(0)} percentage-point threshold — a conventional cutoff for meaningful judicial deviation. Every N is shown alongside every rate; no rate is presented without its sample size. This histogram is not a prediction for any particular motion in this case — it is a map of what is already in the record.`,
+  );
+
+  return "\n" + lines.join("\n") + "\n";
+}


### PR DESCRIPTION
## Summary

X-Ray \$2,497 additive enhancement (E2). Two new sections; no new SKU; no price change.

- **Section X1 — Federal PJI Cross-Reference** (federal charges only)
  - Verbatim pattern instruction for charge × circuit
  - Top 10 historical attack authorities (vs M4 top 5) with per-case extracted quote
  - All-circuit variant comparison (vs M4 top 3)
  - Judge-attack cross-reference on instruction-adjacent motion types (X-Ray exclusive)

- **Section X2 — Full Judge Motion Histogram** (when judge assigned)
  - Every motion type from \`judge_motion_outcome_rates\` for this judge (no top-N cap)
  - Grouped by baseline deviation: Significantly Above (>+10pp) / At Baseline (±10pp) / Significantly Below (<-10pp) / Insufficient Sample (n<10)
  - IB E1 caps at 20 + judge histogram only; X-Ray is unbounded + grouped

## Tier monotonicity (HARD — test-enforced)

| Dimension | M4 \$97 | IB E1 \$997 | **X-Ray E2 \$2,497** |
|---|---|---|---|
| PJI attack points | top 5 | — | **top 10 + extracted quote** |
| Circuit variant diff | top 3 | — | **all circuits** |
| Judge histogram | — | top 20 + caveat | **full histogram + baseline deviation grouped** |

## Files

New:
- \`src/lib/xray-sections/federal-pji-cross-ref.ts\` — X1 query + render
- \`src/lib/xray-sections/judge-motion-histogram.ts\` — X2 query + render
- \`src/lib/xray-sections/__tests__/federal-pji-cross-ref.test.ts\` — 17 tests
- \`src/lib/xray-sections/__tests__/judge-motion-histogram.test.ts\` — 15 tests
- \`src/app/api/generate/xray-sections/route.ts\` — operator-secret-gated endpoint the engine calls for pre-rendered section markdown

Canonical TypeScript lives in the web repo (matches existing pattern: tier9-reports, ib-appendices). Engine’s \`ImNotAnAttorney-engine/src/workers/report.mjs\` will POST to \`/api/generate/xray-sections\` and append returned markdown as additional prompt stanzas — same pattern as phase-4 intelligence and phase-5 case law.

Not modified: M4 module, IB E1 appendices, X-Ray price / delivery / live flag.

## UPL (HARD)

- PJI text verbatim (public federal court material)
- Judge data framed descriptively: "of N motions filed, M granted" — banned: harsh/lenient/biased characterization (test-enforced)
- Banned-phrase blocklist (\`UPL_BANNED_PHRASES\` from \`charge-slug-maps\`) enforced in test
- Every cited case has a CourtListener URL (no URL → row suppressed)
- Legal-INFORMATION-not-legal-ADVICE methodology disclaimer on every render

## Expert

Hormozi value-equation lift on an existing tier — depth compounds perceived value without price movement. Dreyer AI-Overview-defense on the discovery tier.

Plan: \`docs/plans/2026-04-23-data-to-product-autonomous-execution.md\` E2.
Audit: \`docs/advisor/2026-04-23-data-to-product-audit.md\`.

## Test plan

- [x] \`tsc --noEmit\` — zero errors
- [x] \`vitest run src/lib/xray-sections\` — 32/32 pass
- [x] Monotonicity gates implemented: \`XRAY_ATTACK_TOP_N (10) > M4 (5)\`, circuit variants unbounded (vs M4 max 3), \`XRAY_HISTOGRAM_UNBOUNDED=true\` (vs \`IB_MOTION_TOP_N=20\`), baseline-deviation grouping present (vs IB ungrouped)
- [x] UPL blocklist + judge-characterization blocklist tests pass
- [x] Empty / federal-only / limitation render paths covered
- [x] \`next build\` compile green (pre-push hook)
- [ ] Manual smoke: POST \`/api/generate/xray-sections\` on prod with a real federal case + assigned judge
- [ ] Engine wiring PR: update \`report.mjs\` to call new endpoint for \`tier === 'x-ray'\`

## Monotonicity confirmed vs War Room

X-Ray adds depth; War Room E3 (\$4,997) still strictly exceeds X-Ray with per-case monthly deltas and weekly updates (out of scope for this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)