### PR TITLE
docs(scripts): remove stale diag-supabase-resource-audit.mjs ref

### DIFF
--- a/scripts/CONTEXT.md
+++ b/scripts/CONTEXT.md
@@ -53,7 +53,6 @@
 ### Diagnostic & Inspection
 | File | Purpose |
 |------|---------|
-| `diag-supabase-resource-audit.mjs` | Zombie backend detection via pg_stat_activity (Albe pattern); session-mode port 5432 |
 | `diagnose-content-gaps-dups.mjs` | Inspects content_gaps status CHECK constraint + dup distribution pre-consolidation |
 | `check-posted-answers-state.mjs` | Inspects posted_answers columns, moderation_status CHECK, and function ACL post-migration |
 | `inspect-ga-officer-intel.mjs` | Samples officer_external_intel by sources for GA (npi/brady/decertified coverage) |


### PR DESCRIPTION
## Summary

One-line fix to unblock Docs Freshness CI. PR #84 added a doc reference to `diag-supabase-resource-audit.mjs` but the script itself was never committed to master (exists only as untracked content in a parallel session's worktree). Docs Freshness has been failing on this across recent PRs.

## Evidence

- `git log --all --oneline -- scripts/diag-supabase-resource-audit.mjs` → zero hits
- `git status` in the main checkout shows `?? scripts/diag-supabase-resource-audit.mjs` (untracked — Session A's WIP)
- Docs Freshness workflow output: `✗ diag-supabase-resource-audit.mjs MISSING from scripts (doc: scripts/CONTEXT.md)` → `Process completed with exit code 1`

## Fix

Remove the stale ref from `scripts/CONTEXT.md`. When Session A commits the actual script, they can re-add the row in the same PR.

## Diff

1 line removed, docs-only.

## Unblocks

- PR #99 (/score worry-to-pristine Phase 5) currently red on Docs Freshness due to this pre-existing drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)