### PR TITLE
fix(wave-pristine-r1): 7 findings from Round 1 adversarial audit

### DIFF
--- a/src/app/api/cron/precedent-watchlist-emails/route.ts
+++ b/src/app/api/cron/precedent-watchlist-emails/route.ts
@@ -19,8 +19,12 @@
  * acquireCronLock() before running; duplicate hits within 5min silently skip.
  *
  * Primary-domain guard per HARD rule never-cold-email-from-primary-domain
- * is not applicable here — this is a POST-purchase transactional-adjacent
- * drip to a verified customer. sendEmail() handles the CAN-SPAM footer.
+ * IS applied here (2026-04-23 wave-pristine-r1 WARNING #5). Even though
+ * this is a post-purchase transactional-adjacent drip to a verified
+ * customer, a misconfigured RESEND_FROM_EMAIL pointing at a primary
+ * brand domain would still burn sender reputation on our warm primary —
+ * the hardest-to-recover asset we own. Mirrors the guard pattern in
+ * `warroom-monthly-precedent-delta/route.ts`.
  *
  * Protected by CRON_AUTH_TOKEN via requireCron.
  */
@@ -49,6 +53,23 @@ const ORDER_CONCURRENCY = 5;
 // "significant enough to notify." Chaperon trust-engine principle:
 // over-notifying erodes trust; only send when the picture actually changed.
 const RANK_DELTA_THRESHOLD = 3;
+
+// Primary-domain guard per HARD rule never-cold-email-from-primary-domain.
+// Mirrors `warroom-monthly-precedent-delta/route.ts`. Prevents a
+// misconfigured RESEND_FROM_EMAIL from burning the warm primary domain
+// via post-purchase drip at scale.
+const FORBIDDEN_FROM_DOMAINS = [
+  "imnotanattorney.com",
+  "inaa.com",
+  "tastedrop.com",
+  "cloudculture.com",
+  "myculture.cloud",
+];
+
+function isForbiddenFromAddress(from: string): boolean {
+  const domain = from.split("@")[1]?.toLowerCase() || "";
+  return FORBIDDEN_FROM_DOMAINS.some((d) => domain === d || domain.endsWith("." + d));
+}
 
 interface SnapshotEntry {
   cited_opinion_id: number;
@@ -173,6 +194,25 @@ function buildEmailHtml(params: {
 export async function GET(req: NextRequest) {
   const guard = requireCron(req);
   if (!guard.authorized) return guard.error;
+
+  // Primary-domain guard — wave-pristine-r1 WARNING #5.
+  // Reject the run if Resend config is missing or the FROM address sits on
+  // a protected primary brand domain. We fail BEFORE touching the DB so
+  // nothing is marked "sent" against a blocked send.
+  const resendKey = process.env.RESEND_API_KEY;
+  const fromEmail = process.env.RESEND_FROM_EMAIL;
+  if (!resendKey) {
+    return NextResponse.json(
+      { ok: false, error: "resend-unconfigured" },
+      { status: 500 },
+    );
+  }
+  if (!fromEmail || isForbiddenFromAddress(fromEmail)) {
+    return NextResponse.json(
+      { ok: false, error: "resend-from-invalid" },
+      { status: 500 },
+    );
+  }
 
   const supabase = createAdminClient();
   const started = Date.now();

--- a/src/lib/charge-slug-maps.ts
+++ b/src/lib/charge-slug-maps.ts
@@ -274,8 +274,25 @@ export function resolveCircuitFromStateOrCircuit(
 }
 
 // ============================================================
-// UPL phrase blocklist (shared across tier9 + IB appendices)
+// UPL phrase blocklist (shared across tier9 + IB appendices + playbook)
 // ============================================================
+//
+// Canonical 11-phrase blocklist — consolidates prior 6-phrase local copies
+// spread across tier9-reports/, xray-sections/, ib-appendices/, and
+// playbook-addendum/. Extended 2026-04-23 per Round 1 wave-pristine audit:
+//   +"will likely", +"almost certainly"           (predictive language)
+//   +"your attorney must"                         (directive to counsel)
+//   +"best course of action"                      (advice framing)
+//   +"consult your attorney"                      (advice-adjacent — was
+//    already present in warroom-precedent-delta's local copy; keeping it
+//    here canonical prevents drift and satisfies the warroom test-suite's
+//    contain-check)
+//
+// `scanForUplPhrases` returns every banned phrase found in the supplied
+// HTML/markdown (lower-cased match). Callers SHOULD pre-strip any
+// framing/quote blocks whose text is intentionally verbatim public record
+// (e.g. pattern jury instructions) — see `federal-jury-instruction-brief`
+// and `federal-pji-cross-ref` for the PJI-body carve-out pattern.
 export const UPL_BANNED_PHRASES = [
   "you should",
   "we recommend",
@@ -283,4 +300,14 @@ export const UPL_BANNED_PHRASES = [
   "your best option",
   "ask your attorney",
   "publicly available",
+  "will likely",
+  "almost certainly",
+  "your attorney must",
+  "best course of action",
+  "consult your attorney",
 ] as const;
+
+export function scanForUplPhrases(html: string): readonly string[] {
+  const lower = (html ?? "").toLowerCase();
+  return UPL_BANNED_PHRASES.filter((p) => lower.includes(p));
+}

--- a/src/lib/ib-appendices/__tests__/motion-strategy.test.ts
+++ b/src/lib/ib-appendices/__tests__/motion-strategy.test.ts
@@ -244,6 +244,44 @@ describe("Appendix G — Motion Strategy · empty + limitation paths", () => {
 // Cross-reference note (task spec)
 // ------------------------------------------------------------
 
+// ------------------------------------------------------------
+// Monotonicity regression — CRITICAL #1 (Round 1 wave-pristine)
+// ------------------------------------------------------------
+//
+// The previous `.filter(v => v.filed >= 5)` dropped sparse rows that M1
+// ($197) was still rendering — inverting the IB > M1 depth promise. For
+// sparse charges, M1 rendered 10 rows and IB rendered 0. This test pins
+// the monotonicity property at the render layer (query layer covered
+// by the removal of the filter in queryMotionStrategy).
+// ------------------------------------------------------------
+describe("Appendix G — Motion Strategy · sparse-row monotonicity (CRITICAL #1 regression)", () => {
+  it("renders ALL 12 motion rows with filed_count 1..4 (no >=5 floor)", () => {
+    const sparseMotions: MotionRateRow[] = Array.from({ length: 12 }, (_, i) => ({
+      motion_type: `motion_type_${i + 1}`,
+      filed_count: (i % 4) + 1, // 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4
+      granted_count: 0,
+      denied_count: (i % 4) + 1,
+      grant_rate: 0,
+      baseline_grant_rate: 0.25,
+      deviation_from_baseline: -0.25,
+      data_scope: "charge_national",
+    }));
+    const md = renderMotionStrategy(
+      mkData({
+        chargeType: "arson",
+        motions: sparseMotions,
+        judgeMotions: [],
+        citations: [],
+      }),
+    );
+    // All 12 rows must appear in the rendered table — none silently dropped.
+    // prettyMotionType("motion_type_1") -> "Motion Type 1".
+    for (let i = 1; i <= 12; i++) {
+      expect(md).toContain(`Motion Type ${i} `);
+    }
+  });
+});
+
 describe("Appendix G — Motion Strategy · cross-reference", () => {
   it("includes the War Room cross-ref note", () => {
     const md = renderMotionStrategy(mkData());

--- a/src/lib/ib-appendices/motion-strategy.ts
+++ b/src/lib/ib-appendices/motion-strategy.ts
@@ -163,8 +163,11 @@ export async function queryMotionStrategy(
     }
 
     if (agg.size > 0) {
+      // 2026-04-23 wave-pristine-r1 CRITICAL #1: removed `.filter(v => v.filed >= 5)`
+      // which silently inverted tier monotonicity. M1 ($197) surfaces motion
+      // rows with filed_count >= 1; IB ($997) must surface STRICTLY more, not
+      // less. IB_MOTION_TOP_N=20 already caps row count; we do not also filter.
       motions = [...agg.entries()]
-        .filter(([, v]) => v.filed >= 5) // task spec: include motion types appearing >=5x
         .map(([motion_type, v]) => ({
           motion_type,
           filed_count: v.filed,

--- a/src/lib/playbook-addendum/render.ts
+++ b/src/lib/playbook-addendum/render.ts
@@ -22,17 +22,12 @@ import {
 } from "./generate";
 
 // ============================================================
-// UPL blocklist (exported for tests)
+// UPL blocklist — re-exported from the canonical source
 // ============================================================
-
-export const UPL_BANNED_PHRASES = [
-  "you should",
-  "we recommend",
-  "we advise",
-  "your best option",
-  "ask your attorney",
-  "publicly available",
-];
+// Consolidated 2026-04-23 per Round 1 wave-pristine (WARNING #3). Local
+// copy removed; canonical list lives in `@/lib/charge-slug-maps`. Re-export
+// preserves the public API for existing test imports.
+export { UPL_BANNED_PHRASES, scanForUplPhrases } from "@/lib/charge-slug-maps";
 
 // ============================================================
 // Helpers

--- a/src/lib/tier9-reports/__tests__/federal-jury-instruction-brief.test.ts
+++ b/src/lib/tier9-reports/__tests__/federal-jury-instruction-brief.test.ts
@@ -182,7 +182,20 @@ describe("Federal Jury Instruction Brief — render layer", () => {
     expect(html).not.toContain("Top 5 Historical Attack Authorities");
   });
 
-  it("no UPL-banned phrase renders in assembled output", () => {
+  // Helper — strip the PJI framing + body wrappers before UPL scanning.
+  // The PJI body is verbatim public federal court text and CAN legitimately
+  // contain jury-voice phrases ("you should", "the jury should"). The
+  // framing disclaimer itself quotes those phrases to disambiguate their
+  // source. Both are carved out of UPL scanning (wave-pristine-r1 WARNING
+  // #3 special-case). All other rendered content — headings, our prose,
+  // attack-table rows, methodology — must still be clean.
+  function stripPjiRegions(html: string): string {
+    return html
+      .replace(/<div class="pji-framing">[\s\S]*?<\/div>/g, "")
+      .replace(/<div class="pji-body">[\s\S]*?<\/div>/g, "");
+  }
+
+  it("no UPL-banned phrase renders in assembled output (outside PJI carve-out)", () => {
     const html = renderFederalJuryInstructionBrief(
       mkData({
         burdenSentences: [
@@ -201,10 +214,38 @@ describe("Federal Jury Instruction Brief — render layer", () => {
         ],
       }),
     );
-    const lower = html.toLowerCase();
+    const lower = stripPjiRegions(html).toLowerCase();
     for (const banned of UPL_BANNED_PHRASES) {
       expect(lower).not.toContain(banned);
     }
+  });
+
+  it("PJI framing block + body wrapper render, and framing disambiguates jury voice (CRITICAL #2)", () => {
+    // PJI body is verbatim court text; this one contains a jury-voice
+    // "you should" phrase, which is the exact scenario CRITICAL #2 targets.
+    const html = renderFederalJuryInstructionBrief(
+      mkData({
+        pji: mkPji({
+          body:
+            "You should consider all the evidence. The jury should deliberate together. " +
+            "The presumption of innocence applies throughout.",
+        }),
+      }),
+    );
+    // Framing block present
+    expect(html).toContain('<div class="pji-framing">');
+    // Framing disambiguation message present
+    expect(html).toContain("jury&rsquo;s deliberation duty");
+    expect(html).toContain("NOT legal advice from us to you");
+    // Body wrapper present
+    expect(html).toContain('<div class="pji-body">');
+    // Body text (escaped) preserved verbatim
+    expect(html).toContain("You should consider all the evidence");
+    expect(html).toContain("The jury should deliberate together");
+    // Outside PJI regions — no "you should" leaks
+    const outside = stripPjiRegions(html).toLowerCase();
+    expect(outside).not.toContain("you should");
+    expect(outside).not.toContain("the jury should");
   });
 
   it("every rendered attack-authority row has a valid href (URL HARD rule)", () => {

--- a/src/lib/tier9-reports/charge-authority-pack.ts
+++ b/src/lib/tier9-reports/charge-authority-pack.ts
@@ -32,6 +32,7 @@
  */
 
 import { createAdminClient } from "@/lib/supabase/admin";
+import { CHARGE_TYPE_AUTHORITY_MAP } from "@/lib/charge-slug-maps";
 
 // ============================================================
 // Types
@@ -83,52 +84,11 @@ export interface ChargeAuthorityPackData {
 // charge_type_top_authorities (2026-04-23). Unmapped charges fall through to
 // citation_authority_criminal national fallback with a limitation note.
 
-export const CHARGE_TYPE_AUTHORITY_MAP: Record<string, string[]> = {
-  "drug-possession": [
-    "drug-possession-marijuana",
-    "drug-possession-cocaine",
-    "drug-possession-opioids",
-    "drug-possession-prescription",
-  ],
-  "drug-trafficking": ["drug-trafficking", "drug-distribution", "drug-manufacturing"],
-  dui: ["dui-dwi", "dui-drugs", "dui-felony-injury", "refusing-breath-test"],
-  "dui-first": ["dui-dwi"],
-  "dui-repeat": ["dui-dwi", "dui-felony-injury"],
-  assault: ["simple-assault", "aggravated-assault", "aggravated-battery", "assault-firearm", "assault-police-officer", "battery"],
-  "domestic-violence": [],
-  theft: ["theft-larceny"],
-  "sex-offense": ["sex-offense-contact", "sex-offense-digital", "sexual-assault", "indecent-exposure"],
-  "sex-offense-contact": ["sex-offense-contact", "sexual-assault"],
-  "sex-offense-digital": ["sex-offense-digital", "child-exploitation"],
-  weapons: ["weapons-possession", "felon-in-possession", "illegal-discharge"],
-  "white-collar": ["fraud-general", "embezzlement", "forgery"],
-  federal: [],
-  "probation-violation": ["supervised-release-violation"],
-  "self-defense": [],
-  other: ["other"],
-  murder: ["murder-second-degree"],
-  manslaughter: ["voluntary-manslaughter", "vehicular-homicide"],
-  kidnapping: ["kidnapping", "unlawful-imprisonment"],
-  arson: [],
-  stalking: ["stalking"],
-  "child-abuse": ["child-endangerment"],
-  "hit-and-run": ["hit-and-run"],
-  contempt: ["contempt-of-court"],
-  robbery: ["robbery", "home-invasion"],
-  burglary: ["burglary"],
-  fraud: ["fraud-general", "embezzlement", "forgery"],
-  drug: [
-    "drug-possession-marijuana",
-    "drug-possession-cocaine",
-    "drug-possession-opioids",
-    "drug-possession-prescription",
-    "drug-trafficking",
-    "drug-distribution",
-    "drug-manufacturing",
-  ],
-  "other-felony": [],
-  "other-misdemeanor": ["disorderly-conduct", "loitering", "vandalism"],
-};
+// CHARGE_TYPE_AUTHORITY_MAP imported from @/lib/charge-slug-maps (top of file).
+// Canonical source lives there; previous inline copy removed 2026-04-23
+// per Round 1 wave-pristine (WARNING #4). Re-exported for backwards
+// compatibility with any external caller importing from this module.
+export { CHARGE_TYPE_AUTHORITY_MAP };
 
 // ============================================================
 // Circuit/state mapping (display context only — authorities are national)
@@ -502,14 +462,9 @@ export function renderChargeAuthorityPack(data: ChargeAuthorityPackData): string
 }
 
 // ============================================================
-// UPL phrase blocklist — exported for test-time verification
+// UPL phrase blocklist — re-exported from the canonical source
 // ============================================================
-
-export const UPL_BANNED_PHRASES = [
-  "you should",
-  "we recommend",
-  "we advise",
-  "your best option",
-  "ask your attorney",
-  "publicly available",
-];
+// Consolidated 2026-04-23 per Round 1 wave-pristine (WARNING #3). Local
+// copy removed; canonical list lives in `@/lib/charge-slug-maps`. Re-export
+// preserves the public API for existing test imports.
+export { UPL_BANNED_PHRASES, scanForUplPhrases } from "@/lib/charge-slug-maps";

--- a/src/lib/tier9-reports/federal-jury-instruction-brief.ts
+++ b/src/lib/tier9-reports/federal-jury-instruction-brief.ts
@@ -770,6 +770,15 @@ export function renderFederalJuryInstructionBrief(
     </header>
   `;
 
+  // PJI body framing — Round 1 wave-pristine CRITICAL #2.
+  // Pattern jury instruction body text is verbatim public-record court
+  // material. It routinely contains phrasing such as "you should" or "the
+  // jury should" — that's jury-deliberation voice, NOT advice from us to
+  // the defendant. The framing block disambiguates before the body, so
+  // no reader can conflate pattern-instruction language with our voice.
+  // The body itself is emitted inside `<div class="pji-body">`; UPL
+  // scanners carve out both the framing and body wrappers before checking
+  // the rest of the render (see `scanForUplPhrases` caller sites).
   const pjiSection = data.pji
     ? `
     <section class="fjb-section">
@@ -778,7 +787,11 @@ export function renderFederalJuryInstructionBrief(
         <strong>Instruction ${htmlEscape(data.pji.instruction_number)}${data.pji.title ? ` &mdash; ${htmlEscape(data.pji.title)}` : ""}</strong><br/>
         <span class="fjb-meta">${htmlEscape(CIRCUIT_NAMES[String(data.pji.circuit)] ?? `${data.pji.circuit} Circuit`)}${data.pji.effective_date ? ` · effective ${htmlEscape(String(data.pji.effective_date))}` : ""}</span>
       </p>
-      <blockquote class="fjb-verbatim">${htmlEscape(data.pji.body ?? "")}</blockquote>
+      <div class="pji-framing">
+        <p><strong>Pattern Jury Instruction &mdash; Verbatim</strong></p>
+        <p>The text below is the pattern instruction as issued by the Circuit Court, read verbatim to the jury for this charge. Phrases like &ldquo;you should&rdquo; or &ldquo;the jury should&rdquo; refer to the jury&rsquo;s deliberation duty &mdash; they are NOT legal advice from us to you.</p>
+      </div>
+      <div class="pji-body"><blockquote class="fjb-verbatim">${htmlEscape(data.pji.body ?? "")}</blockquote></div>
       ${data.pji.statute_citations && data.pji.statute_citations.length > 0
         ? `<p class="fjb-cite">Cited statute(s): ${data.pji.statute_citations.map((s) => htmlEscape(String(s))).join("; ")}</p>`
         : ""}
@@ -913,14 +926,9 @@ export function renderFederalJuryInstructionBrief(
 }
 
 // ============================================================
-// UPL phrase blocklist — exported for test-time verification
+// UPL phrase blocklist — re-exported from the canonical source
 // ============================================================
-
-export const UPL_BANNED_PHRASES = [
-  "you should",
-  "we recommend",
-  "we advise",
-  "your best option",
-  "ask your attorney",
-  "publicly available",
-];
+// Consolidated 2026-04-23 per Round 1 wave-pristine (WARNING #3). Local
+// copy removed; canonical list lives in `@/lib/charge-slug-maps`. Re-export
+// preserves the public API for existing test imports.
+export { UPL_BANNED_PHRASES, scanForUplPhrases } from "@/lib/charge-slug-maps";

--- a/src/lib/tier9-reports/motion-success-report.ts
+++ b/src/lib/tier9-reports/motion-success-report.ts
@@ -32,6 +32,7 @@
  */
 
 import { createAdminClient } from "@/lib/supabase/admin";
+import { CHARGE_TYPE_MOR_MAP } from "@/lib/charge-slug-maps";
 
 // ============================================================
 // Types
@@ -103,53 +104,11 @@ export interface MotionSuccessReportData {
 // motion_outcome_rates as of 2026-04-22. Unmapped charges fall through to
 // the national "(all)" baseline rather than fabricating a match.
 
-export const CHARGE_TYPE_MOR_MAP: Record<string, string[]> = {
-  "drug-possession": [
-    "drug-possession",
-    "drug-possession-marijuana",
-    "drug-possession-cocaine",
-    "drug-possession-meth",
-    "drug-possession-opioids",
-    "drug-possession-prescription",
-    "drug-possession-with-intent",
-  ],
-  "drug-trafficking": ["drug-trafficking", "drug-distribution", "drug-manufacturing"],
-  dui: ["dui", "dui-dwi", "dui-first-offense", "dui-repeat-offense", "dui-third-offense", "dui-drugs", "dui-felony-injury"],
-  "dui-first": ["dui-first-offense", "dui-dwi"],
-  "dui-repeat": ["dui-repeat-offense", "dui-third-offense"],
-  assault: ["assault", "simple-assault", "aggravated-assault", "aggravated-battery", "assault-with-deadly-weapon", "assault-firearm", "assault-police-officer", "battery"],
-  "domestic-violence": ["domestic-violence", "domestic-battery", "violation-protective-order"],
-  theft: ["theft", "theft-larceny", "grand-theft", "petty-theft", "shoplifting", "receiving-stolen-property", "motor-vehicle-theft"],
-  "sex-offense": ["sex-offense", "sex-offense-contact", "sex-offense-digital", "sexual-assault", "sexual-battery", "rape", "statutory-rape", "indecent-exposure"],
-  "sex-offense-contact": ["sex-offense-contact", "sexual-assault", "sexual-battery", "rape", "statutory-rape"],
-  "sex-offense-digital": ["sex-offense-digital", "child-exploitation", "production-child-pornography"],
-  weapons: ["weapons-possession", "felony-firearm", "felon-in-possession", "possession-prohibited-weapon", "weapons-school-zone", "illegal-discharge"],
-  "white-collar": ["fraud-general", "wire-fraud", "securities-fraud", "tax-fraud", "insurance-fraud", "credit-card-fraud", "prescription-fraud", "money-laundering", "embezzlement", "identity-theft", "forgery", "bad-checks"],
-  federal: [],
-  "probation-violation": ["probation-violation-technical", "probation-violation-substantive", "parole-violation", "community-control-violation", "supervised-release-violation"],
-  "self-defense": [],
-  other: ["other"],
-  murder: ["murder", "murder-first-degree", "murder-second-degree", "attempted-murder"],
-  manslaughter: ["voluntary-manslaughter", "involuntary-manslaughter", "vehicular-manslaughter", "vehicular-homicide"],
-  kidnapping: ["kidnapping", "unlawful-imprisonment"],
-  arson: ["arson"],
-  stalking: ["stalking", "aggravated-stalking"],
-  "child-abuse": ["child-abuse", "child-endangerment"],
-  "hit-and-run": ["hit-and-run"],
-  contempt: ["contempt-of-court", "criminal-contempt"],
-  robbery: ["robbery", "armed-robbery", "home-invasion"],
-  burglary: ["burglary", "residential-burglary", "commercial-burglary"],
-  fraud: ["fraud-general", "wire-fraud", "securities-fraud", "tax-fraud", "insurance-fraud", "credit-card-fraud", "prescription-fraud", "identity-theft"],
-  drug: [
-    "drug-possession",
-    "drug-trafficking",
-    "drug-distribution",
-    "drug-manufacturing",
-    "drug-paraphernalia",
-  ],
-  "other-felony": [],
-  "other-misdemeanor": [],
-};
+// CHARGE_TYPE_MOR_MAP imported from @/lib/charge-slug-maps (top of file).
+// Canonical source lives there; previous inline copy removed 2026-04-23
+// per Round 1 wave-pristine (WARNING #4). Re-exported for backwards
+// compatibility with any external caller importing from this module.
+export { CHARGE_TYPE_MOR_MAP };
 
 // ============================================================
 // State → Circuit mapping (federal circuits for appellate motion data)
@@ -718,14 +677,9 @@ export function renderMotionSuccessReport(data: MotionSuccessReportData): string
 }
 
 // ============================================================
-// UPL phrase blocklist — exported for test-time verification
+// UPL phrase blocklist — re-exported from the canonical source
 // ============================================================
-
-export const UPL_BANNED_PHRASES = [
-  "you should",
-  "we recommend",
-  "we advise",
-  "your best option",
-  "ask your attorney",
-  "publicly available",
-];
+// Consolidated 2026-04-23 per Round 1 wave-pristine (WARNING #3). Local
+// copy removed; canonical list lives in `@/lib/charge-slug-maps`. Re-export
+// preserves the public API for existing test imports.
+export { UPL_BANNED_PHRASES, scanForUplPhrases } from "@/lib/charge-slug-maps";

--- a/src/lib/tier9-reports/precedent-watchlist.ts
+++ b/src/lib/tier9-reports/precedent-watchlist.ts
@@ -132,17 +132,12 @@ const RISING_CANDIDATE_POOL = 30;
 const FALLING_CANDIDATE_POOL = 20;
 
 // ============================================================
-// UPL phrase blocklist — exported for test-time verification
+// UPL phrase blocklist — re-exported from the canonical source
 // ============================================================
-
-export const UPL_BANNED_PHRASES = [
-  "you should",
-  "we recommend",
-  "we advise",
-  "your best option",
-  "ask your attorney",
-  "publicly available",
-];
+// Consolidated 2026-04-23 per Round 1 wave-pristine (WARNING #3). Local
+// copy removed; canonical list lives in `@/lib/charge-slug-maps`. Re-export
+// preserves the public API for existing test imports.
+export { UPL_BANNED_PHRASES, scanForUplPhrases } from "@/lib/charge-slug-maps";
 
 // ============================================================
 // Charge-type resolution

--- a/src/lib/tier9-reports/warroom-precedent-delta.ts
+++ b/src/lib/tier9-reports/warroom-precedent-delta.ts
@@ -60,15 +60,10 @@ export const MIN_CADENCE_DAYS = 28;
 // UPL blocklist — asserted in tests
 // ============================================================
 
-export const UPL_BANNED_PHRASES = [
-  "you should",
-  "we recommend",
-  "we advise",
-  "your best option",
-  "ask your attorney",
-  "publicly available",
-  "consult your attorney",
-];
+// Re-exported from canonical source — wave-pristine-r1 WARNING #3.
+// `consult your attorney` is now part of the canonical 11-phrase list,
+// so this re-export remains a superset-safe drop-in.
+export { UPL_BANNED_PHRASES, scanForUplPhrases } from "@/lib/charge-slug-maps";
 
 // ============================================================
 // Types

--- a/src/lib/xray-sections/__tests__/federal-pji-cross-ref.test.ts
+++ b/src/lib/xray-sections/__tests__/federal-pji-cross-ref.test.ts
@@ -210,8 +210,19 @@ describe("Section X1 — Federal PJI Cross-Reference · tier monotonicity guardr
 // UPL banned phrases
 // ------------------------------------------------------------
 
+// Helper — strip PJI framing + body wrappers before UPL scanning.
+// The PJI body is verbatim public federal court text and CAN legitimately
+// contain jury-voice phrases. The framing disclaimer itself quotes those
+// phrases to disambiguate their source. Both are carved out of UPL
+// scanning (wave-pristine-r1 WARNING #3 special-case).
+function stripPjiRegionsXray(md: string): string {
+  return md
+    .replace(/<div class="pji-framing">[\s\S]*?<\/div>/g, "")
+    .replace(/<div class="pji-body">[\s\S]*?<\/div>/g, "");
+}
+
 describe("Section X1 — Federal PJI Cross-Reference · UPL blocklist", () => {
-  it("never emits banned UPL phrases on fully populated render", () => {
+  it("never emits banned UPL phrases on fully populated render (outside PJI carve-out)", () => {
     const data = mkData({
       attackAuthorities: Array.from({ length: XRAY_ATTACK_TOP_N }, (_, i) =>
         mkAuth({ rank: i + 1, case_name: `Case ${i}` }),
@@ -224,13 +235,38 @@ describe("Section X1 — Federal PJI Cross-Reference · UPL blocklist", () => {
         "No pattern instruction cached for the Third Circuit; showing the Ninth Circuit instruction as the closest available reference.",
       ],
     });
-    const md = renderXrayFederalPjiCrossRef(data).toLowerCase();
+    const md = stripPjiRegionsXray(renderXrayFederalPjiCrossRef(data)).toLowerCase();
     for (const phrase of UPL_BANNED_PHRASES) {
       expect(
         md.includes(phrase),
         `rendered markdown must not contain banned phrase "${phrase}"`,
       ).toBe(false);
     }
+  });
+
+  it("PJI framing block + body wrapper render, and framing disambiguates jury voice (CRITICAL #2)", () => {
+    // PJI body is verbatim court text; this one contains a jury-voice
+    // "you should" phrase — the exact scenario CRITICAL #2 targets.
+    const data = mkData({
+      pji: mkPji({
+        body:
+          "You should weigh all the evidence carefully. The jury should deliberate with an open mind. " +
+          "The presumption of innocence applies.",
+      }),
+    });
+    const md = renderXrayFederalPjiCrossRef(data);
+    // Framing + body wrappers present
+    expect(md).toContain('<div class="pji-framing">');
+    expect(md).toContain('<div class="pji-body">');
+    // Framing disambiguation present
+    expect(md).toContain("NOT legal advice from us to you");
+    // Body preserved verbatim
+    expect(md).toContain("You should weigh all the evidence carefully");
+    expect(md).toContain("The jury should deliberate with an open mind");
+    // Outside PJI regions — no "you should" leaks
+    const outside = stripPjiRegionsXray(md).toLowerCase();
+    expect(outside).not.toContain("you should");
+    expect(outside).not.toContain("the jury should");
   });
 
   it("emits the legal-INFORMATION methodology gate on every non-empty render", () => {

--- a/src/lib/xray-sections/federal-pji-cross-ref.ts
+++ b/src/lib/xray-sections/federal-pji-cross-ref.ts
@@ -713,7 +713,27 @@ export function renderXrayFederalPjiCrossRef(data: XrayFederalPjiData): string {
     );
     lines.push(`${mdEscape(circLabel)}${effective}`);
     lines.push(``);
+    // PJI body framing — Round 1 wave-pristine CRITICAL #2.
+    // The PJI body is verbatim public-record court text. It contains
+    // jury-voice phrases like "you should" / "the jury should" that are
+    // NOT advice from us to the defendant. The framing block disambiguates
+    // before the body. `<div class="pji-framing">` / `<div class="pji-body">`
+    // pass through md2html unchanged and mark the UPL carve-out for scanners.
+    lines.push(`<div class="pji-framing">`);
+    lines.push(``);
+    lines.push(`**Pattern Jury Instruction — Verbatim**`);
+    lines.push(``);
+    lines.push(
+      `The text below is the pattern instruction as issued by the Circuit Court, read verbatim to the jury for this charge. Phrases like "you should" or "the jury should" refer to the jury's deliberation duty — they are NOT legal advice from us to you.`,
+    );
+    lines.push(``);
+    lines.push(`</div>`);
+    lines.push(``);
+    lines.push(`<div class="pji-body">`);
+    lines.push(``);
     lines.push(`> ${(data.pji.body ?? "").split("\n").join("\n> ")}`);
+    lines.push(``);
+    lines.push(`</div>`);
     lines.push(``);
     if (data.pji.statute_citations && data.pji.statute_citations.length > 0) {
       lines.push(

--- a/supabase/migrations/20260424b_orders_restrictive_authenticated_policy.sql
+++ b/supabase/migrations/20260424b_orders_restrictive_authenticated_policy.sql
@@ -1,0 +1,33 @@
+-- 2026-04-24: Defense-in-depth RESTRICTIVE policy on public.orders
+--
+-- Source: Round 1 wave-pristine adversarial audit, SUGGESTION #6.
+-- Per ARCHITECTURE.md Invariant #4, all DB access flows through the
+-- service-role admin client; RLS is defense-in-depth, not primary auth.
+-- This migration adds an explicit RESTRICTIVE policy so that if a future
+-- permissive policy is ever added for the `authenticated` role (e.g. a
+-- mistake in a later migration), it cannot accidentally unlock the
+-- sensitive columns on `orders`: token hashes, JSONB state blobs,
+-- standalone intake payloads, refund state.
+--
+-- In Postgres RLS, a row passes iff EVERY restrictive policy returns true
+-- AND at least one permissive policy returns true. Setting RESTRICTIVE
+-- USING (false) guarantees authenticated-role access is always denied,
+-- regardless of what permissive policies exist now or are added later.
+--
+-- Deliberately NOT applied to production in the PR that lands this file.
+-- See docs/plans/2026-04-23-worry-wave-pristine.md for the deferred-apply
+-- plan. Applying requires explicit run via `npx supabase db push` against
+-- the linked prod project once the next service-role-only audit confirms
+-- no `authenticated` code path is still in use for `orders`.
+
+CREATE POLICY "authenticated_no_access_orders"
+  ON public.orders
+  AS RESTRICTIVE
+  FOR ALL
+  TO authenticated
+  USING (false);
+
+COMMENT ON POLICY "authenticated_no_access_orders" ON public.orders IS
+  'Defense-in-depth (wave-pristine-r1 SUGGESTION #6). Blocks any future '
+  'permissive policy from accidentally unlocking token hashes + JSONB '
+  'state columns for the authenticated role. Orders are service-role only.';


### PR DESCRIPTION
## Summary

Closes 7 code-side findings from Round 1 wave-pristine adversarial audit (plan at `docs/plans/2026-04-23-worry-wave-pristine.md`).

### CRITICALs (3)

- **IB motion-strategy runtime monotonicity inversion.** Deleted `.filter(v => v.filed >= 5)` in `src/lib/ib-appendices/motion-strategy.ts`. Sparse-charge scenarios (e.g. charge with 12 motion types each aggregated `filed=1..4`) were silently rendering IB=0 while M1=10. `IB_MOTION_TOP_N=20` cap alone preserves tier ladder.
- **PJI body UPL leak in M4** (`src/lib/tier9-reports/federal-jury-instruction-brief.ts`). `pattern_jury_instructions.body` rows contain jury-voice "you should" verbatim. Wrapped body emission in `<div class="pji-framing">` (explicit disambiguation: phrases like "you should" refer to the jury's deliberation duty, not legal advice from us) and `<div class="pji-body">` (the verbatim block). UPL scanners can now carve out both regions safely.
- **PJI body UPL leak in X-Ray E2** (`src/lib/xray-sections/federal-pji-cross-ref.ts`). Same fix ported to the markdown renderer. `<div>` wrappers pass through md2html unchanged.

### WARNINGs (3)

- **UPL blocklist consolidation.** Canonical `UPL_BANNED_PHRASES` now lives only in `src/lib/charge-slug-maps.ts` (11 phrases — adds "will likely", "almost certainly", "your attorney must", "best course of action", absorbs "consult your attorney" from warroom's local copy). Added `scanForUplPhrases(html)` helper. Replaced 7 local copies with `export { UPL_BANNED_PHRASES, scanForUplPhrases } from "@/lib/charge-slug-maps"`.
- **Inline charge-slug maps in M1/M2.** `CHARGE_TYPE_MOR_MAP` and `CHARGE_TYPE_AUTHORITY_MAP` now imported from `charge-slug-maps` instead of redefined inline.
- **Primary-domain guard missing on precedent-watchlist cron.** Mirrored the `isForbiddenFromAddress` pattern from `warroom-monthly-precedent-delta/route.ts`. Rejects the run with `resend-from-invalid` if `RESEND_FROM_EMAIL` points at `imnotanattorney.com`, `inaa.com`, `tastedrop.com`, `cloudculture.com`, or `myculture.cloud`.

### SUGGESTION (1)

- **Defense-in-depth RESTRICTIVE RLS policy.** New migration `supabase/migrations/20260424b_orders_restrictive_authenticated_policy.sql` adds `USING (false)` for `authenticated` role on `public.orders`. NOT applied to prod in this PR per plan.

## Test plan

- [x] `npx tsc --noEmit --skipLibCheck` — 0 errors
- [x] `vitest run` on the 10 affected files — 175/175 passing
- [x] PJI framing block + body wrapper render correctly when body contains "you should"
- [x] Sparse-charge motion-strategy renders all 12 rows (was dropping them)
- [x] UPL scan outside PJI regions stays clean on both M4 and X-Ray E2
- [x] `warroom-precedent-delta` test (expects "consult your attorney" in blocklist) still passes
- [ ] Manual verify the RLS migration in a staging project before prod apply
- [ ] Warn follow-up: `src/lib/playbook-configs.ts:1101` contains "your attorney must" which is now UPL-banned. Out of scope for code-side Round 1 fixes — flagged as a content-side follow-up.

## Baseline test failures (pre-existing, unrelated)

5 failing tests on master baseline (verified on `origin/master` b3f3c89b, not caused by this PR):
- `src/lib/score.test.ts` — 4 failures on observation-string matching
- `tests/compliance/upl-partner-copy.test.ts` — 1 failure on partner page containing "legal advice"

🤖 Generated with [Claude Code](https://claude.com/claude-code)