### PR TITLE
chore(docs): sync 4 score.ts line refs (unblock Docs Freshness CI)

### DIFF
--- a/src/lib/CONTEXT.md
+++ b/src/lib/CONTEXT.md
@@ -195,12 +195,12 @@ No passwords. Flow: `POST /api/customer/magic-link` → token stored in `magic_l
 | Witness Pack | $297 add-on | `tiers.ts:401-415` |
 | **Scoring** | | |
 | Base score | 50 (neutral midpoint) | `score.ts:92` |
-| Score bands | Critical 0-30, Concerning 31-50, Average 51-70, Adequate 71-85, Excellent 86-100 | `score.ts:315-319` |
-| Motions weight | 20% | `score.ts:133` |
+| Score bands | Critical 0-30, Concerning 31-50, Average 51-70, Adequate 71-85, Excellent 86-100 | `score.ts:306-310` |
+| Motions weight | 20% | `score.ts:130` |
 | Discovery weight | 15% | `score.ts:160` |
-| Communication weight | 15% | `score.ts:182` |
+| Communication weight | 15% | `score.ts:176` |
 | Attorney type weight | 10% | `score.ts:108` |
-| Strategy weight | 10% | `score.ts:206` |
+| Strategy weight | 10% | `score.ts:197` |
 | Time modifier weight | 30% | `score.ts:96` |
 | **Rate Limiting** | | |
 | Memory window | 60 seconds | `rate-limit.ts:28` |


### PR DESCRIPTION
## Summary
Unblocks the `Docs Freshness` CI gate that's been failing on every recent PR (#104, #105, #106, #107, ppi-parole, fedreg-cron). Root cause: 4 line refs in `src/lib/CONTEXT.md` shifted after #99 (worry-to-pristine Phase 5) but the docs were never re-synced.

| Constant | Old line | New line |
|----------|----------|----------|
| Score bands | `score.ts:315-319` | `score.ts:306-310` |
| Motions weight | `score.ts:133` | `score.ts:130` |
| Communication weight | `score.ts:182` | `score.ts:176` |
| Strategy weight | `score.ts:206` | `score.ts:197` |

**The constants themselves are unchanged** — same 20% / 15% / 10% weights, same band thresholds (Critical 0-30 ... Excellent 86-100). Only the file positions moved as the score function body grew.

## Why this is high leverage
Single 4-line edit unblocks the CI gate for every in-flight PR. Before this PR, docs-freshness was red on:
- #104 (FL state statutes)
- #105 (NIST forensic)
- #106 (PPI parole + AO caseload — already merged with red CI)
- #107 (free-data P0 follow-up)
- fedreg-cron, ppi-parole-ao-caseload

After this PR, all in-flight PRs go green on docs-freshness.

## Out of scope (warn-only, separate cleanup)
6 undocumented files in `src/lib` and `scripts/`:
- `charge-slug-maps.ts`, `ussc-offguide-charge-map.ts`, `ussc-similar-cases-motion-context.ts`
- `inspect-authority-schemas.mjs`, `register-dpic-sync-cron.mjs`, `score-observations-index.mjs`

`docs/verify-architecture.js` treats these as warnings, doesn't fail CI. Adding them is `document-architecture` skill territory — separate PR with proper Scripts table entries + descriptions for each.

## Test plan
- [x] `node docs/verify-architecture.js --json` -> `{verified:359, drifted:0, missing:0, undocumented:6, errors:[]}` exit 0
- [x] `npx tsc --noEmit --skipLibCheck` exit 0
- [x] `npm run build:local` (pre-push hook, webpack compile-only) exit 0 — full route table prints

Generated with [Claude Code](https://claude.com/claude-code)
