### PR TITLE
chore(docs): full docs-freshness sync — 4 line refs + 6 Scripts entries (supersedes #109)

### DIFF
--- a/scripts/CONTEXT.md
+++ b/scripts/CONTEXT.md
@@ -29,6 +29,7 @@
 | `apply-sms-suspensions-rls.mjs` | Applies `20260415c_sms_suspensions_rls.sql`; verifies RLS is enabled |
 | `register-resend-bounce-webhook.mjs` | Registers bounce/complaint webhook on Resend; returns signing_secret for RESEND_WEBHOOK_SECRET env |
 | `register-sms-health-check-cron.mjs` | Registers `/api/cron/sms-health-check` on cron-job.org (daily 10:00 UTC) |
+| `register-dpic-sync-cron.mjs` | Registers `/api/cron/dpic-sync` on cron-job.org (weekly Monday 13:00 UTC, after DPIC's noon ET weekday refresh) |
 | `update-vercel-env.mjs` | Sets a single Vercel env var on the production `imnotanattorney` project (bypasses stale `.env.local` project ref) |
 
 ### Validation & Linting
@@ -59,7 +60,9 @@
 | `diagnose-content-gaps-dups.mjs` | Inspects content_gaps status CHECK constraint + dup distribution pre-consolidation |
 | `check-posted-answers-state.mjs` | Inspects posted_answers columns, moderation_status CHECK, and function ACL post-migration |
 | `inspect-ga-officer-intel.mjs` | Samples officer_external_intel by sources for GA (npi/brady/decertified coverage) |
+| `inspect-authority-schemas.mjs` | One-shot live-schema inspector for the 4 tables backing the $97 Charge Authority Pack — dumps column shapes + sample rows via supabase-js |
 | `sanity-bondsman-modes.mjs` | Pre-migration sanity: confirms zero non-bondsman partners own check-ins |
+| `score-observations-index.mjs` | Scans `src/lib/score.ts`, emits `docs/audits/2026-04-24-score-observations-line-index.json` indexing every observation-string return site with charge-branch / attorney-state / time-window context (Hagan A2J UPL audit methodology) |
 
 ### Report Generation
 | File | Purpose |

--- a/src/lib/CONTEXT.md
+++ b/src/lib/CONTEXT.md
@@ -135,6 +135,9 @@
 |------|---------|
 | `ussc-mappings.ts` | Mappers from INAA intake values to USSC matview codes (demographics + offense, no state→district) |
 | `ussc-similar-cases.ts` | Query lib for `ussc_similar_cases_summary` matview powering $297 Similar Cases + plea/sentencing calculator |
+| `ussc-offguide-charge-map.ts` | Bridge USSC numeric offguide codes (1-30, "UNK") to internal `motion_outcome_rates.charge_type` slugs; source of truth for tier9 reports + IB appendices |
+| `ussc-similar-cases-motion-context.ts` | `motion_context` footer query for $297 Similar Cases Analyzer (top 3 motions, charge-level aggregate — stays strictly below $197 MSR + $997 IB tier monotonicity) |
+| `charge-slug-maps.ts` | Shared `CHARGE_TYPE_MOR_MAP` + `CHARGE_TYPE_AUTHORITY_MAP` lookups bridging user-facing intake slugs to internal dataset slugs; consumed by motion-success-report, charge-authority-pack, IB Appendix G+H |
 
 ### SMS
 | File | Purpose |
@@ -195,12 +198,12 @@ No passwords. Flow: `POST /api/customer/magic-link` → token stored in `magic_l
 | Witness Pack | $297 add-on | `tiers.ts:401-415` |
 | **Scoring** | | |
 | Base score | 50 (neutral midpoint) | `score.ts:92` |
-| Score bands | Critical 0-30, Concerning 31-50, Average 51-70, Adequate 71-85, Excellent 86-100 | `score.ts:315-319` |
-| Motions weight | 20% | `score.ts:133` |
+| Score bands | Critical 0-30, Concerning 31-50, Average 51-70, Adequate 71-85, Excellent 86-100 | `score.ts:306-310` |
+| Motions weight | 20% | `score.ts:130` |
 | Discovery weight | 15% | `score.ts:160` |
-| Communication weight | 15% | `score.ts:182` |
+| Communication weight | 15% | `score.ts:176` |
 | Attorney type weight | 10% | `score.ts:108` |
-| Strategy weight | 10% | `score.ts:206` |
+| Strategy weight | 10% | `score.ts:197` |
 | Time modifier weight | 30% | `score.ts:96` |
 | **Rate Limiting** | | |
 | Memory window | 60 seconds | `rate-limit.ts:28` |


### PR DESCRIPTION
## Summary
Full `docs/verify-architecture.js` sync. Brings the gate to **0 drifted / 0 missing / 0 undocumented** so it stops cascading failures into every unrelated PR's CI.

**Supersedes #109** (same line-ref fixes + 6 additional Scripts entries). Close #109 when this merges.

## Line-ref fixes (4)
Same as #109 — constants unchanged, only file positions shifted after #99 (worry-to-pristine Phase 5):

| Constant | Old | New |
|----------|-----|-----|
| Score bands | `score.ts:315-319` | `score.ts:306-310` |
| Motions weight | `score.ts:133` | `score.ts:130` |
| Communication weight | `score.ts:182` | `score.ts:176` |
| Strategy weight | `score.ts:206` | `score.ts:197` |

## New Scripts-table entries (6)
Previously-undocumented code files, each added under its most appropriate subsection:

**`src/lib/CONTEXT.md`** (USSC / Sentencing Data section):
| File | Purpose |
|------|---------|
| `ussc-offguide-charge-map.ts` | Bridge USSC numeric offguide codes (1-30, UNK) → internal `motion_outcome_rates.charge_type` slugs. Source of truth for tier9 reports + IB appendices. |
| `ussc-similar-cases-motion-context.ts` | `motion_context` footer query for $297 Similar Cases Analyzer (top-3 motions, charge-level aggregate — stays strictly below $197 MSR + $997 IB tier monotonicity). |
| `charge-slug-maps.ts` | Shared `CHARGE_TYPE_MOR_MAP` + `CHARGE_TYPE_AUTHORITY_MAP` lookups bridging user-facing intake slugs to internal dataset slugs; consumed by motion-success-report, charge-authority-pack, IB Appendix G+H. |

**`scripts/CONTEXT.md`**:
| File | Section | Purpose |
|------|---------|---------|
| `register-dpic-sync-cron.mjs` | Setup & Registration | Registers `/api/cron/dpic-sync` on cron-job.org (weekly Mon 13:00 UTC, after DPIC's noon-ET refresh). |
| `inspect-authority-schemas.mjs` | Diagnostic & Inspection | One-shot live-schema inspector for the 4 tables backing the $97 Charge Authority Pack. |
| `score-observations-index.mjs` | Diagnostic & Inspection | Scans `src/lib/score.ts`, emits `docs/audits/2026-04-24-score-observations-line-index.json` indexing every observation return site (Hagan A2J UPL audit methodology). |

## Why supersede #109
#109 only fixed the 4 drifts. Undocumented warnings remain on master → noisy CI. This PR handles both in one pass, resulting in a single clean slate instead of two incremental sweeps.

## Test plan
- [x] `node docs/verify-architecture.js --json` → `{verified: 365, drifted: 0, missing: 0, undocumented: 0, errors: []}` exit 0
- [x] `npx tsc --noEmit --skipLibCheck` exit 0
- [x] `npm run build:local` (pre-push hook, webpack compile-only) exit 0 — full route table prints
- [x] No touches to score.ts itself — purely doc line-ref + new entries

## Unblocks
Every in-flight PR whose red docs-freshness was pre-existing:
- #107 (free-data P0 follow-up)
- #108 (fedreg cron)
- #110 (ACS county)
- #111 (CPD Invisible Institute)

Generated with [Claude Code](https://claude.com/claude-code)
