### PR TITLE
feat(cron): weekly source-health uptime monitor for data pipelines

### DIFF
--- a/scripts/register-source-health-cron.mjs
+++ b/scripts/register-source-health-cron.mjs
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+// Register the /api/cron/source-health endpoint on cron-job.org.
+// Weekly Monday 14:00 UTC — runs after DPIC sync (13:00) so any breakage there
+// is caught here. Follows the pattern of scripts/register-dpic-sync-cron.mjs.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+function loadEnv() {
+  const envPath = path.join(__dirname, '..', '.env.local');
+  if (!fs.existsSync(envPath)) {
+    console.error('ERROR: .env.local not found');
+    process.exit(1);
+  }
+  const env = {};
+  for (const line of fs.readFileSync(envPath, 'utf8').split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const idx = trimmed.indexOf('=');
+    if (idx === -1) continue;
+    const key = trimmed.slice(0, idx).trim();
+    let val = trimmed.slice(idx + 1).trim();
+    if ((val.startsWith('"') && val.endsWith('"')) || (val.startsWith("'") && val.endsWith("'"))) {
+      val = val.slice(1, -1);
+    }
+    env[key] = val;
+  }
+  return env;
+}
+
+const env = loadEnv();
+const CRONJOB_API_KEY = env.CRONJOB_API_KEY;
+const CRON_AUTH_TOKEN = env.CRON_AUTH_TOKEN;
+if (!CRONJOB_API_KEY || !CRON_AUTH_TOKEN) {
+  console.error('ERROR: CRONJOB_API_KEY and CRON_AUTH_TOKEN required in .env.local');
+  process.exit(1);
+}
+
+const BASE_URL = env.NEXT_PUBLIC_SITE_URL || 'https://imnotanattorney.com';
+const URL = `${BASE_URL}/api/cron/source-health`;
+
+const listResp = await fetch('https://api.cron-job.org/jobs', {
+  headers: { Authorization: `Bearer ${CRONJOB_API_KEY}` },
+});
+const listData = await listResp.json();
+const existing = (listData.jobs || []).find((j) => j.url === URL);
+if (existing) {
+  console.log('Already registered:');
+  console.log('  jobId:', existing.jobId);
+  console.log('  url:', existing.url);
+  console.log('  enabled:', existing.enabled);
+  console.log('  wdays:', JSON.stringify(existing.schedule?.wdays));
+  console.log('  hours:', JSON.stringify(existing.schedule?.hours));
+  console.log('  timezone:', existing.schedule?.timezone);
+  process.exit(0);
+}
+
+const payload = {
+  job: {
+    url: URL,
+    title: 'ImNotAnAttorney: source-health',
+    enabled: true,
+    saveResponses: true,
+    schedule: {
+      timezone: 'UTC',
+      mdays: [-1],
+      wdays: [1],         // Monday
+      months: [-1],
+      hours: [14],        // 14:00 UTC — 1hr after DPIC sync
+      minutes: [0],
+    },
+    extendedData: {
+      headers: {
+        Authorization: `Bearer ${CRON_AUTH_TOKEN}`,
+        'Content-Type': 'application/json',
+      },
+    },
+    requestMethod: 0,
+    requestTimeout: 120,
+  },
+};
+
+const resp = await fetch('https://api.cron-job.org/jobs', {
+  method: 'PUT',
+  headers: {
+    Authorization: `Bearer ${CRONJOB_API_KEY}`,
+    'Content-Type': 'application/json',
+  },
+  body: JSON.stringify(payload),
+});
+const text = await resp.text();
+let data;
+try {
+  data = JSON.parse(text);
+} catch {
+  console.error('Invalid JSON response:', text.slice(0, 300));
+  process.exit(1);
+}
+if (resp.ok && data.jobId) {
+  console.log('OK created:');
+  console.log('  jobId:', data.jobId);
+  console.log('  url:', URL);
+  console.log('  schedule: weekly Mon 14:00 UTC');
+} else {
+  console.error('FAILED:', JSON.stringify(data));
+  process.exit(1);
+}

--- a/src/app/api/cron/source-health/route.ts
+++ b/src/app/api/cron/source-health/route.ts
@@ -1,0 +1,196 @@
+/**
+ * @file /api/cron/source-health — Weekly uptime HEAD check on public data sources.
+ *
+ * Enforces the "no-hallucinated-legal-data.md" HARD RULE invariant: every
+ * verified row has a source_url that MUST remain live. If a source dies, we
+ * need to know before the next scraper run fails silently.
+ *
+ * For each registered source:
+ *   1. HEAD request (30s timeout, polite UA)
+ *   2. Classify status: 200/202/301/302/304 → healthy; everything else → unhealthy
+ *   3. Compute consecutive_failures from prior rows
+ *   4. Insert into data_source_health_checks
+ *
+ * After all checks:
+ *   - If any source flipped healthy → unhealthy, fire a Telegram alert (new breakage)
+ *   - If any source flipped unhealthy → healthy, fire a Telegram alert (recovery)
+ *
+ * Auth: requireCron (Bearer CRON_AUTH_TOKEN).
+ * Schedule: weekly Mon 14:00 UTC via cron-job.org.
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { requireCron } from "@/lib/auth/guards";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+export const runtime = "nodejs";
+export const maxDuration = 120;
+
+const USER_AGENT = "ImNotAnAttorney source-health bot (support@imnotanattorney.com)";
+
+const HEALTHY_STATUSES = new Set([200, 202, 301, 302, 304]);
+
+// Registered sources — add new rows here when we onboard a new data source.
+// Keep URLs canonical (no query strings that change) so consecutive_failures is
+// meaningful over time.
+const SOURCES: Array<{ slug: string; url: string }> = [
+  { slug: "calbar-recent-discipline", url: "https://www.calbar.ca.gov/public/concerns-about-attorney/recent-disciplinary-actions" },
+  { slug: "flbar-news-discipline-index", url: "https://www.floridabar.org/news-release-category/disciplinary-action/" },
+  { slug: "uh-tx-discipline-archive", url: "https://www.law.uh.edu/libraries/ethics/attydiscipline/" },
+  { slug: "ppi-parole-rates", url: "https://www.prisonpolicy.org/data/parolerates_2019_2022.html" },
+  { slug: "ao-stfj-caseload-index", url: "https://www.uscourts.gov/statistics-reports/caseload-statistics-data-tables" },
+  { slug: "dpic-executions-csv", url: "http://deathpenaltyinfo.org/query/executions.csv" },
+  { slug: "courtlistener-api-v4", url: "https://www.courtlistener.com/api/rest/v4/opinions/?limit=1" },
+  { slug: "fec-bulk-index", url: "https://www.fec.gov/files/bulk-downloads/" },
+  { slug: "cl-bulk-data-root", url: "https://storage.courtlistener.com/bulk-data/" },
+];
+
+async function sendTelegram(message: string): Promise<void> {
+  const token = process.env.TELEGRAM_ATLAS_BOT_TOKEN;
+  const chat = process.env.TELEGRAM_RAHIM_CHAT_ID;
+  if (!token || !chat) return;
+  try {
+    await fetch(`https://api.telegram.org/bot${token}/sendMessage`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ chat_id: chat, text: message, parse_mode: "Markdown" }),
+    });
+  } catch {
+    /* swallow — Telegram failure must not break the cron itself */
+  }
+}
+
+interface CheckResult {
+  slug: string;
+  url: string;
+  status: number | null;
+  responseTimeMs: number;
+  contentLength: number | null;
+  errorMessage: string | null;
+  isHealthy: boolean;
+}
+
+async function checkOne(source: { slug: string; url: string }): Promise<CheckResult> {
+  const start = Date.now();
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 30000);
+  try {
+    const resp = await fetch(source.url, {
+      method: "HEAD",
+      headers: { "User-Agent": USER_AGENT },
+      redirect: "follow",
+      signal: controller.signal,
+    });
+    clearTimeout(timer);
+    const lenHeader = resp.headers.get("content-length");
+    return {
+      slug: source.slug,
+      url: source.url,
+      status: resp.status,
+      responseTimeMs: Date.now() - start,
+      contentLength: lenHeader ? Number(lenHeader) : null,
+      errorMessage: null,
+      isHealthy: HEALTHY_STATUSES.has(resp.status),
+    };
+  } catch (e) {
+    clearTimeout(timer);
+    const msg = e instanceof Error ? e.message : String(e);
+    return {
+      slug: source.slug,
+      url: source.url,
+      status: null,
+      responseTimeMs: Date.now() - start,
+      contentLength: null,
+      errorMessage: msg.slice(0, 500),
+      isHealthy: false,
+    };
+  }
+}
+
+export async function GET(req: NextRequest) {
+  const authed = requireCron(req);
+  if (!authed.authorized) return authed.error;
+
+  const started = Date.now();
+  const supabase = createAdminClient();
+
+  // 1) Run all checks in parallel (max 30s each, 9 sources → ~30s worst case).
+  const results = await Promise.all(SOURCES.map((s) => checkOne(s)));
+
+  // 2) For each result, fetch prior state to compute consecutive_failures
+  //    + detect transitions.
+  const rowsToInsert = [] as Array<Record<string, unknown>>;
+  const transitions: string[] = [];
+
+  for (const r of results) {
+    const { data: priorRow } = await supabase
+      .from("data_source_health_checks")
+      .select("is_healthy, consecutive_failures")
+      .eq("source_slug", r.slug)
+      .order("checked_at", { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    const priorHealthy = priorRow?.is_healthy ?? true; // first run → assume was healthy
+    const priorFailures = priorRow?.consecutive_failures ?? 0;
+    const consecutiveFailures = r.isHealthy ? 0 : priorFailures + 1;
+
+    rowsToInsert.push({
+      source_slug: r.slug,
+      source_url: r.url,
+      http_status: r.status,
+      response_time_ms: r.responseTimeMs,
+      content_length: r.contentLength,
+      error_message: r.errorMessage,
+      is_healthy: r.isHealthy,
+      consecutive_failures: consecutiveFailures,
+    });
+
+    if (priorHealthy && !r.isHealthy) {
+      transitions.push(
+        `❌ *${r.slug}* DOWN — status=${r.status ?? "no-response"}${r.errorMessage ? ` (${r.errorMessage})` : ""} — ${r.url}`,
+      );
+    } else if (!priorHealthy && r.isHealthy) {
+      transitions.push(
+        `✅ *${r.slug}* RECOVERED after ${priorFailures} consecutive failures — status=${r.status}`,
+      );
+    }
+  }
+
+  // 3) Bulk insert this run.
+  if (rowsToInsert.length > 0) {
+    const { error } = await supabase.from("data_source_health_checks").insert(rowsToInsert);
+    if (error) {
+      return NextResponse.json({ error: `insert failed: ${error.message}` }, { status: 500 });
+    }
+  }
+
+  // 4) Telegram alert on any transition.
+  if (transitions.length > 0) {
+    const healthy = results.filter((r) => r.isHealthy).length;
+    const msg = [
+      `*Source-health transitions* (${transitions.length}):`,
+      ...transitions,
+      ``,
+      `Overall: ${healthy}/${results.length} sources healthy`,
+    ].join("\n");
+    await sendTelegram(msg);
+  }
+
+  const healthyCount = results.filter((r) => r.isHealthy).length;
+
+  return NextResponse.json({
+    ok: true,
+    checked_at: new Date().toISOString(),
+    total_sources: results.length,
+    healthy: healthyCount,
+    unhealthy: results.length - healthyCount,
+    transitions: transitions.length,
+    elapsed_ms: Date.now() - started,
+    results: results.map((r) => ({
+      slug: r.slug,
+      status: r.status,
+      healthy: r.isHealthy,
+      ms: r.responseTimeMs,
+    })),
+  });
+}

--- a/supabase/migrations/20260424f_data_source_health.sql
+++ b/supabase/migrations/20260424f_data_source_health.sql
@@ -1,0 +1,33 @@
+-- 20260424f_data_source_health.sql
+--
+-- Weekly uptime ledger for the public data sources we rely on (state bar pages,
+-- PPI, AO STFJ, DPIC, UH Law archive, CourtListener, etc.). Powers
+-- /api/cron/source-health, which HEAD-checks each URL once per week and alerts
+-- via Telegram when a source flips from 200 → non-200 or back.
+--
+-- Enforcement of "no-hallucinated-legal-data.md" HARD RULE requires that the
+-- source URLs we stored beside every verified row remain live. This table is
+-- the observability ledger for that invariant.
+
+CREATE TABLE IF NOT EXISTS public.data_source_health_checks (
+  id                    BIGSERIAL   PRIMARY KEY,
+  source_slug           TEXT        NOT NULL,     -- 'calbar-recent', 'flbar-news', 'uh-tx-archive', 'ppi-parole', 'ao-stfj-d3', 'dpic-csv', etc.
+  source_url            TEXT        NOT NULL,
+  checked_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  http_status           INT,                       -- NULL when the HEAD call threw pre-response (timeout, DNS, etc.)
+  response_time_ms      INT,
+  content_length        BIGINT,
+  error_message         TEXT,
+  is_healthy            BOOLEAN     NOT NULL,      -- computed client-side: 200/202/301/302/304 → healthy
+  consecutive_failures  INT         NOT NULL DEFAULT 0
+);
+
+CREATE INDEX IF NOT EXISTS data_source_health_slug_checked_at_idx
+  ON public.data_source_health_checks (source_slug, checked_at DESC);
+
+CREATE INDEX IF NOT EXISTS data_source_health_unhealthy_idx
+  ON public.data_source_health_checks (source_slug, checked_at DESC)
+  WHERE is_healthy = false;
+
+COMMENT ON TABLE public.data_source_health_checks
+  IS 'Weekly uptime ledger for public data-source URLs INAA relies on (state bars, PPI, AO STFJ, DPIC, UH Law archive, CourtListener). Feeds source-health cron alerts. Retention: 1 year (older rows pruned by cleanup).';


### PR DESCRIPTION
## Summary

Adds a weekly cron that HEAD-checks every public data source INAA relies on and writes uptime per source to `data_source_health_checks`. Telegram alert fires on healthy↔unhealthy transitions.

### Why this matters

The `no-hallucinated-legal-data.md` HARD RULE requires every verified row to carry a `source_url` that remains live. Silent source-death (URL 404s, host flips to Cloudflare-gate, etc.) poisons downstream trust without being visible until the next scraper run fails. This cron surfaces that failure mode the week it happens.

### What ships

- **Migration**: `supabase/migrations/20260424f_data_source_health.sql` — `data_source_health_checks` table with uptime ledger + indexes. Applied live.
- **Route**: `src/app/api/cron/source-health/route.ts` — `requireCron` auth, 9 parallel HEAD checks (30s timeout, polite UA), computes `consecutive_failures`, fires Telegram on transitions.
- **Registrar**: `scripts/register-source-health-cron.mjs` — cron-job.org job, Mon 14:00 UTC (1hr after DPIC sync). **Registered live — jobId `7523607`.**

### Sources covered (extensible)

`calbar-recent-discipline`, `flbar-news-discipline-index`, `uh-tx-discipline-archive`, `ppi-parole-rates`, `ao-stfj-caseload-index`, `dpic-executions-csv`, `courtlistener-api-v4`, `fec-bulk-index`, `cl-bulk-data-root` — append to the `SOURCES` array in `route.ts` to add any future source.

### Test plan

- [ ] CI tsc + next build pass on Vercel
- [ ] Smoke: `curl -H "Authorization: Bearer \$CRON_AUTH_TOKEN" https://imnotanattorney.com/api/cron/source-health` returns `{ok: true, healthy: 9/9, transitions: 0}` (first run, all-green baseline)
- [ ] Verify cron-job.org jobId 7523607 executes Mon 2026-04-27 14:00 UTC with 200 response
- [ ] DB: `SELECT source_slug, bool_and(is_healthy) FROM data_source_health_checks WHERE checked_at > NOW() - INTERVAL '2 days' GROUP BY source_slug` returns 9 rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)