### PR TITLE
feat(ingest): USC seed v2 — +14 sections from prompt-reference audit

### DIFF
--- a/scripts/ingest/__tests__/seed-statutes-us-cornell.test.mjs
+++ b/scripts/ingest/__tests__/seed-statutes-us-cornell.test.mjs
@@ -56,10 +56,22 @@ const FIXTURE_THIN = `<html><body>short</body></html>`;
 
 test('USC_SECTIONS covers the high-signal federal criminal sections', () => {
   const byPair = new Set(USC_SECTIONS.map((s) => s.title + ':' + s.section));
-  // Spot-check a handful of must-have sections.
+  // v1 core coverage.
   for (const pair of ['18:922', '18:924', '21:841', '21:846', '18:371']) {
     assert.ok(byPair.has(pair), 'missing ' + pair);
   }
+  // v2 expansion (prompt-audit gaps — must stay present).
+  for (const pair of [
+    '18:2', '18:201', '18:1201', '18:1341', '18:1347', '18:1503',
+    '18:1519', '18:1546', '18:1621', '18:1962', '18:2252',
+    '26:7201', '8:1101', '8:1227',
+  ]) {
+    assert.ok(byPair.has(pair), 'missing ' + pair);
+  }
+});
+
+test('USC_SECTIONS count matches refresh-route USC_TARGETS (29 sections)', () => {
+  assert.equal(USC_SECTIONS.length, 29, 'USC_SECTIONS must equal 29 (v2 expansion); drift-lock in refresh route test also asserts 29');
 });
 
 test('every USC_SECTIONS entry has numeric title + section + label', () => {

--- a/scripts/ingest/seed-statutes-us-cornell.mjs
+++ b/scripts/ingest/seed-statutes-us-cornell.mjs
@@ -69,6 +69,21 @@ export const USC_SECTIONS = [
   { title: '18', section: '1951', label: 'Hobbs Act — robbery / extortion' },
   { title: '18', section: '2113', label: 'Bank robbery' },
   { title: '18', section: '3553', label: 'Sentencing factors' },
+  // v2 expansion (2026-04-24): gaps found by prompt audit grepping
+  // src/lib/intelligence-brief/ + supabase/functions/generate-report/ for
+  // `\d+ U.S.C. § \d+` references. Each section below is cited by at least
+  // one prompt file and previously hit the (filtered) empty federal fallback.
+  { title: '18', section: '2',    label: 'Aiding and abetting' },
+  { title: '18', section: '201',  label: 'Bribery of a public official' },
+  { title: '18', section: '1201', label: 'Federal kidnapping' },
+  { title: '18', section: '1341', label: 'Mail fraud' },
+  { title: '18', section: '1347', label: 'Health care fraud' },
+  { title: '18', section: '1503', label: 'Obstruction of justice' },
+  { title: '18', section: '1519', label: 'Destruction of records / federal investigation' },
+  { title: '18', section: '1546', label: 'Immigration document fraud' },
+  { title: '18', section: '1621', label: 'Perjury' },
+  { title: '18', section: '1962', label: 'RICO — racketeering' },
+  { title: '18', section: '2252', label: 'Child pornography possession' },
 
   // Title 21 — drugs
   { title: '21', section: '841',  label: 'Controlled substance — manufacture/distribute' },
@@ -76,7 +91,12 @@ export const USC_SECTIONS = [
   { title: '21', section: '846',  label: 'Controlled substance — conspiracy' },
   { title: '21', section: '853',  label: 'Controlled substance — forfeiture' },
 
-  // Title 8 — immigration crimes
+  // Title 26 — tax
+  { title: '26', section: '7201', label: 'Tax evasion' },
+
+  // Title 8 — immigration (criminal + INA definitions often cited)
+  { title: '8',  section: '1101', label: 'Immigration — definitions (aggravated felony etc.)' },
+  { title: '8',  section: '1227', label: 'Deportable aliens — criminal-immigration crossover' },
   { title: '8',  section: '1325', label: 'Illegal entry' },
   { title: '8',  section: '1326', label: 'Illegal reentry' },
 ];

--- a/src/app/api/cron/statutes-refresh-us/__tests__/route.test.ts
+++ b/src/app/api/cron/statutes-refresh-us/__tests__/route.test.ts
@@ -39,14 +39,23 @@ describe("USC_TARGETS drift-lock", () => {
   it("coverage lock string matches expected version", () => {
     // If this fails, the seed script + refresh route + this lock constant
     // need to be updated together in the same PR.
-    expect(USC_TARGETS_COVERAGE_LOCK).toBe("v1:15-sections");
+    expect(USC_TARGETS_COVERAGE_LOCK).toBe("v2:29-sections");
   });
-  it("USC_TARGETS has exactly 15 entries", () => {
-    expect(USC_TARGETS.length).toBe(15);
+  it("USC_TARGETS has exactly 29 entries", () => {
+    expect(USC_TARGETS.length).toBe(29);
   });
   it("USC_TARGETS contains all high-signal federal criminal sections", () => {
     const byPair = new Set(USC_TARGETS.map((t) => `${t.title}:${t.section}`));
+    // v1 core
     for (const must of ["18:922", "18:924", "21:841", "21:846", "18:371"]) {
+      expect(byPair.has(must)).toBe(true);
+    }
+    // v2 expansion — prompt-audit gaps
+    for (const must of [
+      "18:2", "18:201", "18:1201", "18:1341", "18:1347", "18:1503",
+      "18:1519", "18:1546", "18:1621", "18:1962", "18:2252",
+      "26:7201", "8:1101", "8:1227",
+    ]) {
       expect(byPair.has(must)).toBe(true);
     }
   });

--- a/src/app/api/cron/statutes-refresh-us/route.ts
+++ b/src/app/api/cron/statutes-refresh-us/route.ts
@@ -49,10 +49,25 @@ const USC_TARGETS: UscTarget[] = [
   { title: "18", section: "1951", label: "Hobbs Act - robbery / extortion" },
   { title: "18", section: "2113", label: "Bank robbery" },
   { title: "18", section: "3553", label: "Sentencing factors" },
+  // v2 expansion (2026-04-24): prompt-reference gaps per audit.
+  { title: "18", section: "2",    label: "Aiding and abetting" },
+  { title: "18", section: "201",  label: "Bribery of a public official" },
+  { title: "18", section: "1201", label: "Federal kidnapping" },
+  { title: "18", section: "1341", label: "Mail fraud" },
+  { title: "18", section: "1347", label: "Health care fraud" },
+  { title: "18", section: "1503", label: "Obstruction of justice" },
+  { title: "18", section: "1519", label: "Destruction of records" },
+  { title: "18", section: "1546", label: "Immigration document fraud" },
+  { title: "18", section: "1621", label: "Perjury" },
+  { title: "18", section: "1962", label: "RICO - racketeering" },
+  { title: "18", section: "2252", label: "Child pornography possession" },
   { title: "21", section: "841", label: "Controlled substance - manufacture/distribute" },
   { title: "21", section: "844", label: "Controlled substance - simple possession" },
   { title: "21", section: "846", label: "Controlled substance - conspiracy" },
   { title: "21", section: "853", label: "Controlled substance - forfeiture" },
+  { title: "26", section: "7201", label: "Tax evasion" },
+  { title: "8", section: "1101", label: "Immigration - definitions" },
+  { title: "8", section: "1227", label: "Deportable aliens" },
   { title: "8", section: "1325", label: "Illegal entry" },
   { title: "8", section: "1326", label: "Illegal reentry" },
 ];
@@ -60,7 +75,7 @@ const USC_TARGETS: UscTarget[] = [
 // Lock string — exported for the drift-lock unit test to pin against.
 // Increment when intentionally changing USC_TARGETS (and update the seed
 // script + its test fixture in the same PR).
-export const USC_TARGETS_COVERAGE_LOCK = "v1:15-sections";
+export const USC_TARGETS_COVERAGE_LOCK = "v2:29-sections";
 
 const ALLOWED_HOSTNAMES = new Set(["www.law.cornell.edu", "law.cornell.edu"]);
 


### PR DESCRIPTION
## Summary

Closes the USC seed coverage gap found by auditing `src/lib/intelligence-brief/` + `supabase/functions/generate-report/` for `\d+ U\.?S\.?C\.?` citations.

**Before:** 15 USC rows with source_urls (from #115). Of the statutes referenced in report prompt files, **14 were missing** — those citations silently filtered out of the federal fallback path after #115.

**After:** 29 USC rows. Every statute cited in the prompt files now has a verified Cornell LII source_url, so the model can ground its output.

## New sections (all Cornell LII, HTTPS, verified at seed-time)

| Title | Section | Label |
|---|---|---|
| 18 | 2 | Aiding and abetting |
| 18 | 201 | Bribery of a public official |
| 18 | 1201 | Federal kidnapping |
| 18 | 1341 | Mail fraud |
| 18 | 1347 | Health care fraud |
| 18 | 1503 | Obstruction of justice |
| 18 | 1519 | Destruction of records |
| 18 | 1546 | Immigration document fraud |
| 18 | 1621 | Perjury |
| 18 | 1962 | RICO — racketeering |
| 18 | 2252 | Child pornography possession |
| 26 | 7201 | Tax evasion |
| 8 | 1101 | Immigration — definitions (aggravated felony etc.) |
| 8 | 1227 | Deportable aliens (criminal-immigration crossover) |

## Changes

- `scripts/ingest/seed-statutes-us-cornell.mjs` — USC_SECTIONS grows 15 → 29
- `src/app/api/cron/statutes-refresh-us/route.ts` — USC_TARGETS grows 15 → 29, `USC_TARGETS_COVERAGE_LOCK` bumped `"v1:15-sections"` → `"v2:29-sections"`
- Both test files — drift-lock count + expanded membership checks for all 14 new (title:section) pairs

## Live verification (ran seed before commit)

```
=== TOTAL: 29/29 rows parsed ===
writing 29 rows to entities_statutes...
  cleared 15 prior US Cornell rows
  COPYd 29 rows in 0.6s
pre-commit verify (Cornell-sourced US rows): {"n":29,"missing_sources":0,"empty_body":0}
```

Hash integrity MATCH on 18:2, 18:1201, 26:7201 spot-checks. All URLs under `https://www.law.cornell.edu/uscode/text/`.

## Test plan

- [x] 30/30 seed unit tests (`node --test`)
- [x] 21/21 refresh route unit tests (vitest)
- [x] `tsc --noEmit --skipLibCheck` — 0 errors
- [x] Live seed ran end-to-end: 29 rows committed, pre-commit verify clean
- [ ] Post-merge: next cron fire (Mon 15:00 UTC) will refresh-hash against all 29 sections

## SKIP_BUILD commit note

Worktree has no `node_modules` so `next build` can't resolve. `tsc --noEmit --skipLibCheck` and 51/51 tests ran clean in main checkout (same file contents) before commit.

## Not included

Zero app-code changes. This is pure data expansion (seed list + test drift-lock + refresh route target list). The query-time filter from #115 and the hash-diff cron from #117 both pick up the new rows automatically — no downstream code changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)