### PR TITLE
feat(cron): FL per-chapter weekly refresh — 6 endpoints, concurrency-5 parallel fetch

### DIFF
--- a/scripts/register-statutes-refresh-fl-cron.mjs
+++ b/scripts/register-statutes-refresh-fl-cron.mjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+// Register 6 /api/cron/statutes-refresh-fl/<chapter> endpoints on cron-job.org.
+// Staggered Monday 16:00/16:10/16:20/16:30/16:40/16:50 UTC — runs after
+// dpic-sync (13:00) and statutes-refresh-us (15:00) with 10min spacing so
+// concurrent load on FL Online Sunshine is bounded.
+//
+// Follows scripts/register-statutes-refresh-us-cron.mjs pattern.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+function loadEnv() {
+  const envPath = path.join(__dirname, '..', '.env.local');
+  if (!fs.existsSync(envPath)) {
+    console.error('ERROR: .env.local not found');
+    process.exit(1);
+  }
+  const env = {};
+  for (const line of fs.readFileSync(envPath, 'utf8').split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const idx = trimmed.indexOf('=');
+    if (idx === -1) continue;
+    const key = trimmed.slice(0, idx).trim();
+    let val = trimmed.slice(idx + 1).trim();
+    if ((val.startsWith('"') && val.endsWith('"')) || (val.startsWith("'") && val.endsWith("'"))) {
+      val = val.slice(1, -1);
+    }
+    val = val.replace(/[\r\n]+$/, '');
+    env[key] = val;
+  }
+  return env;
+}
+
+const env = loadEnv();
+const CRONJOB_API_KEY = env.CRONJOB_API_KEY;
+const CRON_AUTH_TOKEN = env.CRON_AUTH_TOKEN;
+if (!CRONJOB_API_KEY || !CRON_AUTH_TOKEN) {
+  console.error('ERROR: CRONJOB_API_KEY and CRON_AUTH_TOKEN required in .env.local');
+  process.exit(1);
+}
+
+const BASE_URL = env.NEXT_PUBLIC_SITE_URL || 'https://imnotanattorney.com';
+
+// Staggered 10min apart. ch316 is the largest (282 sections, ~60-90s run);
+// placed first so if it times out, later chapters still run.
+const CHAPTERS = [
+  { chapter: '316', hour: 16, minute: 0,  desc: 'Traffic / DUI (282 sections)' },
+  { chapter: '775', hour: 16, minute: 10, desc: 'Penalties (55 sections)' },
+  { chapter: '784', hour: 16, minute: 20, desc: 'Assault / battery (28 sections)' },
+  { chapter: '810', hour: 16, minute: 30, desc: 'Burglary (21 sections)' },
+  { chapter: '812', hour: 16, minute: 40, desc: 'Theft / robbery (44 sections)' },
+  { chapter: '893', hour: 16, minute: 50, desc: 'Drug abuse prevention (40 sections)' },
+];
+
+const listResp = await fetch('https://api.cron-job.org/jobs', {
+  headers: { Authorization: `Bearer ${CRONJOB_API_KEY}` },
+});
+if (!listResp.ok) {
+  // W8 fix from 2026-04-24 code review: fail closed on list-jobs failure.
+  // Otherwise existing=[] and the loop below creates 6 duplicate jobs that
+  // hit the same endpoint concurrently, defeating the 10-min stagger.
+  const body = await listResp.text();
+  console.error(`ERROR: list-jobs HTTP ${listResp.status}: ${body.slice(0, 300)}`);
+  process.exit(1);
+}
+const listData = await listResp.json();
+const existing = listData.jobs || [];
+
+const summary = [];
+
+for (const c of CHAPTERS) {
+  const url = `${BASE_URL}/api/cron/statutes-refresh-fl/${c.chapter}`;
+  const prior = existing.find((j) => j.url === url);
+  if (prior) {
+    summary.push(`ch${c.chapter}: already registered jobId=${prior.jobId}`);
+    continue;
+  }
+  const payload = {
+    job: {
+      url,
+      title: `ImNotAnAttorney: statutes-refresh-fl-${c.chapter}`,
+      enabled: true,
+      saveResponses: true,
+      schedule: {
+        timezone: 'UTC',
+        mdays: [-1],
+        wdays: [1], // Monday
+        months: [-1],
+        hours: [c.hour],
+        minutes: [c.minute],
+      },
+      extendedData: {
+        headers: {
+          Authorization: `Bearer ${CRON_AUTH_TOKEN}`,
+          'Content-Type': 'application/json',
+        },
+      },
+      requestMethod: 0,
+      requestTimeout: 300,
+    },
+  };
+  const resp = await fetch('https://api.cron-job.org/jobs', {
+    method: 'PUT',
+    headers: {
+      Authorization: `Bearer ${CRONJOB_API_KEY}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  });
+  const text = await resp.text();
+  let data;
+  try { data = JSON.parse(text); } catch { data = null; }
+  if (resp.ok && data && data.jobId) {
+    summary.push(`ch${c.chapter}: created jobId=${data.jobId} @ Mon ${String(c.hour).padStart(2,'0')}:${String(c.minute).padStart(2,'0')} UTC — ${c.desc}`);
+  } else {
+    summary.push(`ch${c.chapter}: FAILED — ${text.slice(0, 200)}`);
+  }
+}
+
+console.log('=== FL refresh cron registration ===');
+for (const s of summary) console.log('  ' + s);

--- a/src/app/api/cron/statutes-refresh-fl/[chapter]/__tests__/route.test.ts
+++ b/src/app/api/cron/statutes-refresh-fl/[chapter]/__tests__/route.test.ts
@@ -1,0 +1,348 @@
+/**
+ * Unit tests for /api/cron/statutes-refresh-fl/[chapter].
+ *
+ * Locks FL refresh semantics: FL_CHAPTERS drift-lock, parser correctness
+ * against FL-specific markup, hash computation, refreshChapter branch
+ * coverage, parallel-fetch concurrency.
+ */
+import { describe, it, expect } from "vitest";
+import crypto from "node:crypto";
+import {
+  FL_CHAPTERS,
+  FL_CHAPTERS_COVERAGE_LOCK,
+  stripHtml,
+  extractSectionNumbers,
+  parseSectionPage,
+  computeSectionHash,
+  refreshChapter,
+} from "../route";
+
+// FL real-page shape (compressed): nested <div id="statutes"> wrapper with
+// CatchlineText + SectionBody spans.
+const FIXTURE_893_13 = `<html><head><title>Statutes & Constitution — Online Sunshine</title></head>
+<body>
+<div id="main-chrome">... page chrome ...</div>
+<div id="statutes">
+  <div class="Section">
+    <span class="SectionNumber">893.13 </span>
+    <span class="Catchline">
+      <span class="CatchlineText">Prohibited acts; penalties.</span>
+      <span class="EmDash">—</span>
+    </span>
+    <span class="SectionBody">
+      <div class="Subsection">
+        <div class="Paragraph"><span class="Number">(1)(a)</span>
+          <span class="Text">Except as authorized by this chapter and chapter 499, a person may not sell, manufacture, or deliver a controlled substance.</span>
+        </div>
+      </div>
+    </span>
+  </div>
+</body>
+</div>
+</body></html>`;
+
+const FIXTURE_INDEX_893 = `<html><body>
+<a href="/statutes/index.cfm?App_mode=Display_Statute&URL=0800-0899/0893/Sections/0893.01.html">893.01</a>
+<a href="/statutes/index.cfm?App_mode=Display_Statute&URL=0800-0899/0893/Sections/0893.02.html">893.02</a>
+<a href="/statutes/index.cfm?App_mode=Display_Statute&URL=0800-0899/0893/Sections/0893.13.html">893.13</a>
+<!-- overmatch-noise that old regex would incorrectly capture: -->
+<p>See also 893.999 for cross-reference (NOT a real section).</p>
+</body></html>`;
+
+const FIXTURE_NOT_FOUND = `<html><body><p>The Statute you requested does not exist.</p></body></html>`;
+
+// ── FL_CHAPTERS drift-lock ──────────────────────────────────────────────
+
+describe("FL_CHAPTERS drift-lock", () => {
+  it("coverage lock string matches v1:6-chapters", () => {
+    expect(FL_CHAPTERS_COVERAGE_LOCK).toBe("v1:6-chapters");
+  });
+  it("covers exactly the 6 seeded chapters", () => {
+    expect(Object.keys(FL_CHAPTERS).sort()).toEqual(["316", "775", "784", "810", "812", "893"]);
+  });
+  it("each chapter has a range in \\d{4}-\\d{4} format", () => {
+    for (const [ch, meta] of Object.entries(FL_CHAPTERS)) {
+      expect(meta.range).toMatch(/^\d{4}-\d{4}$/);
+      expect(meta.description.length).toBeGreaterThan(0);
+      void ch;
+    }
+  });
+});
+
+// ── stripHtml ────────────────────────────────────────────────────────────
+
+describe("stripHtml (FL port)", () => {
+  it("defuses XSS via decoded entities", () => {
+    const s = stripHtml("clean &#60;script&#62;alert(1)&#60;/script&#62; end");
+    expect(s.includes("<script")).toBe(false);
+  });
+  it("drops C0 controls + DEL", () => {
+    const s = stripHtml("a&#0;b&#8;c&#127;d");
+    for (let i = 0; i < s.length; i++) {
+      const c = s.charCodeAt(i);
+      const bad = (c < 0x20 && c !== 0x09 && c !== 0x0a && c !== 0x0d) || c === 0x7f;
+      expect(bad).toBe(false);
+    }
+  });
+});
+
+// ── extractSectionNumbers ───────────────────────────────────────────────
+
+describe("extractSectionNumbers", () => {
+  it("discovers padded-URL sections, rejects cross-reference overmatch", () => {
+    const s = extractSectionNumbers(FIXTURE_INDEX_893, "893");
+    expect(s).toContain("893.01");
+    expect(s).toContain("893.02");
+    expect(s).toContain("893.13");
+    expect(s.includes("893.999")).toBe(false);
+  });
+  it("returns [] for page with no section URLs", () => {
+    expect(extractSectionNumbers("<html><body>nothing</body></html>", "316")).toEqual([]);
+  });
+  it("sorts ascending by numeric suffix", () => {
+    const s = extractSectionNumbers(FIXTURE_INDEX_893, "893");
+    const suffixes = s.map((x) => Number.parseInt(x.split(".")[1], 10));
+    for (let i = 1; i < suffixes.length; i++) expect(suffixes[i]).toBeGreaterThan(suffixes[i - 1]);
+  });
+});
+
+// ── parseSectionPage ────────────────────────────────────────────────────
+
+describe("parseSectionPage (FL)", () => {
+  it("extracts CatchlineText as title", () => {
+    const p = parseSectionPage(FIXTURE_893_13, "893", "893.13");
+    expect(p?.titleText).toBe("Prohibited acts; penalties.");
+  });
+  it("scopes body to SectionBody span bounded by inner </body>", () => {
+    const p = parseSectionPage(FIXTURE_893_13, "893", "893.13");
+    expect(p?.bodyText).toContain("controlled substance");
+    expect(p?.bodyText.includes("page chrome")).toBe(false);
+  });
+  it("returns null on 404-as-200 page", () => {
+    expect(parseSectionPage(FIXTURE_NOT_FOUND, "893", "893.13")).toBeNull();
+  });
+  it("returns null when body < 20 chars", () => {
+    const html = `<html><body><div id="statutes"><span class="SectionBody">x</span></div></body></html>`;
+    expect(parseSectionPage(html, "893", "893.13")).toBeNull();
+  });
+});
+
+// ── computeSectionHash ──────────────────────────────────────────────────
+
+describe("computeSectionHash", () => {
+  it("concatenates title + blank + body and SHA-256s", () => {
+    const { sectionText, textHash } = computeSectionHash("Prohibited acts; penalties.", "(1)(a) …");
+    expect(sectionText).toBe("Prohibited acts; penalties.\n\n(1)(a) …");
+    const expected = crypto.createHash("sha256").update(sectionText).digest("hex");
+    expect(textHash).toBe(expected);
+  });
+});
+
+// ── refreshChapter integration ──────────────────────────────────────────
+
+function makeStubSupabase(opts: {
+  existingHash?: string | null;
+  canonical_id?: string;
+} = {}): { client: any; updateCalls: any[] } {
+  const updateCalls: any[] = [];
+  const client = {
+    from: (_t: string) => ({
+      select: () => ({
+        eq: () => ({
+          eq: () => ({
+            eq: () => ({
+              eq: () => ({
+                maybeSingle: async () => {
+                  if (opts.existingHash === undefined) return { data: null, error: null };
+                  return {
+                    data: { canonical_id: opts.canonical_id ?? "uuid-1", text_hash: opts.existingHash },
+                    error: null,
+                  };
+                },
+              }),
+            }),
+          }),
+        }),
+      }),
+      update: (patch: any) => ({
+        eq: (_col: string, id: string) => {
+          updateCalls.push({ patch, id });
+          return Promise.resolve({ error: null });
+        },
+      }),
+    }),
+  };
+  return { client, updateCalls };
+}
+
+function makeStubFetch(routes: Record<string, { ok?: boolean; status?: number; body?: string; throwErr?: string }>): typeof fetch {
+  return (async (urlArg: string | URL) => {
+    const url = typeof urlArg === "string" ? urlArg : urlArg.toString();
+    // Find longest matching key for specificity.
+    let match: string | undefined;
+    for (const k of Object.keys(routes)) {
+      if (url.includes(k) && (!match || k.length > match.length)) match = k;
+    }
+    const cfg = match ? routes[match] : { ok: false, status: 404 };
+    if (cfg.throwErr) throw new Error(cfg.throwErr);
+    return {
+      ok: cfg.ok ?? true,
+      status: cfg.status ?? 200,
+      headers: new Headers(),
+      async text() { return cfg.body ?? ""; },
+    };
+  }) as any;
+}
+
+describe("refreshChapter", () => {
+  it("returns 'unchanged' when stored hash matches", async () => {
+    const { textHash } = computeSectionHash(
+      "Prohibited acts; penalties.",
+      stripHtml(
+        `<div class="Subsection"><div class="Paragraph"><span class="Number">(1)(a)</span><span class="Text">Except as authorized by this chapter and chapter 499, a person may not sell, manufacture, or deliver a controlled substance.</span></div></div>`
+      ),
+    );
+    const { client, updateCalls } = makeStubSupabase({ existingHash: textHash });
+    const fetchImpl = makeStubFetch({
+      "0893ContentsIndex.html": { body: FIXTURE_INDEX_893 },
+      "0893.13.html": { body: FIXTURE_893_13 },
+      "0893.01.html": { body: FIXTURE_893_13 },
+      "0893.02.html": { body: FIXTURE_893_13 },
+    });
+    const out = await refreshChapter("893", client as any, fetchImpl);
+    expect(out.sections_discovered).toBe(3);
+    expect(out.results.every((r) => r.status === "unchanged")).toBe(true);
+    expect(updateCalls.length).toBe(0);
+  });
+
+  it("returns 'updated' + calls UPDATE when hash differs", async () => {
+    const { client, updateCalls } = makeStubSupabase({
+      existingHash: "0000000000000000000000000000000000000000000000000000000000000000",
+      canonical_id: "uuid-target",
+    });
+    const fetchImpl = makeStubFetch({
+      "0893ContentsIndex.html": { body: FIXTURE_INDEX_893 },
+      "0893.01.html": { body: FIXTURE_893_13 },
+      "0893.02.html": { body: FIXTURE_893_13 },
+      "0893.13.html": { body: FIXTURE_893_13 },
+    });
+    const out = await refreshChapter("893", client as any, fetchImpl);
+    expect(out.results.filter((r) => r.status === "updated").length).toBe(3);
+    expect(updateCalls.length).toBe(3);
+    expect(updateCalls[0].patch.source_urls[0]).toContain("https://www.leg.state.fl.us/");
+  });
+
+  it("returns 'missing_row' when no existing row", async () => {
+    const { client } = makeStubSupabase({ existingHash: undefined });
+    const fetchImpl = makeStubFetch({
+      "0893ContentsIndex.html": { body: FIXTURE_INDEX_893 },
+      "0893": { body: FIXTURE_893_13 },
+    });
+    const out = await refreshChapter("893", client as any, fetchImpl);
+    expect(out.results.every((r) => r.status === "missing_row")).toBe(true);
+  });
+
+  it("returns 'fetch_failed' at INDEX level when index fetch errors", async () => {
+    const { client } = makeStubSupabase({ existingHash: "x" });
+    const fetchImpl = makeStubFetch({
+      "0893ContentsIndex.html": { throwErr: "ECONN" },
+    });
+    const out = await refreshChapter("893", client as any, fetchImpl);
+    expect(out.sections_discovered).toBe(0);
+    expect(out.results[0].status).toBe("fetch_failed");
+  });
+});
+
+// ── extractSectionNumbers free-form fallback (W4) ────────────────────────
+
+describe("extractSectionNumbers free-form fallback", () => {
+  it("falls back to \\b<chapter>\\.(\\d+)\\b when no /Sections/ URLs present", () => {
+    // No FL canonical URL markup, but plain text mentions sections.
+    const html = `<html><body><p>See 893.01, 893.02, and 893.13 for details.</p></body></html>`;
+    const out = extractSectionNumbers(html, "893");
+    expect(out).toEqual(["893.01", "893.02", "893.13"]);
+  });
+  it("prefers anchored matches over free-form when both present", () => {
+    // Anchored URL for 893.01 only; free-form for .02 and .999. Expect
+    // the URL-scoped branch to win (so 893.999 is excluded).
+    const html = `
+      <a href="/statutes/index.cfm?URL=0800-0899/0893/Sections/0893.01.html">01</a>
+      also see 893.02, 893.999 below`;
+    const out = extractSectionNumbers(html, "893");
+    expect(out).toContain("893.01");
+    expect(out).not.toContain("893.999");
+  });
+});
+
+// ── SSRF redirect re-validation (W7) ─────────────────────────────────────
+
+describe("refreshChapter redirect defense", () => {
+  it("rejects 302 Location off-allowlist as fetch_failed", async () => {
+    const { client } = makeStubSupabase({ existingHash: "x" });
+    const fetchImpl = (async (urlArg: string | URL) => {
+      const url = typeof urlArg === "string" ? urlArg : urlArg.toString();
+      if (url.includes("0893ContentsIndex.html")) {
+        return {
+          ok: false, status: 302,
+          headers: new Headers({ location: "https://evil.example.com/hijack.html" }),
+          async text() { return ""; },
+        } as any;
+      }
+      return { ok: true, status: 200, headers: new Headers(), async text() { return ""; } } as any;
+    }) as any;
+    const out = await refreshChapter("893", client as any, fetchImpl);
+    expect(out.sections_discovered).toBe(0);
+    expect(out.results[0].status).toBe("fetch_failed");
+    expect(out.results[0].note).toContain("redirect off-allowlist");
+  });
+
+  it("follows 302 Location IF target is also on allowlist", async () => {
+    const { client } = makeStubSupabase({ existingHash: "irrelevant" });
+    let hop = 0;
+    const fetchImpl = (async (urlArg: string | URL) => {
+      const url = typeof urlArg === "string" ? urlArg : urlArg.toString();
+      if (url.includes("0893ContentsIndex.html") && hop === 0) {
+        hop = 1;
+        return {
+          ok: false, status: 302,
+          headers: new Headers({
+            location: "https://www.leg.state.fl.us/statutes/index.cfm?URL=0800-0899/0893/Sections/0893.01.html",
+          }),
+          async text() { return ""; },
+        } as any;
+      }
+      return { ok: true, status: 200, headers: new Headers(), async text() { return FIXTURE_INDEX_893; } } as any;
+    }) as any;
+    const out = await refreshChapter("893", client as any, fetchImpl);
+    // After hop the content is the INDEX fixture with 3 sections — but each
+    // section URL will also hit the (OK) stub returning the INDEX fixture
+    // which has no <div id="statutes"> wrapper → parse_failed. That's fine;
+    // what we're locking here is that the redirect was FOLLOWED, not rejected.
+    expect(out.sections_discovered).toBeGreaterThan(0);
+  });
+});
+
+// ── parseSectionPage effective_date (W3) ─────────────────────────────────
+
+describe("parseSectionPage effective_date", () => {
+  it("extracts effective_date from SectionBody-scoped 'Effective MM/DD/YYYY'", () => {
+    const html = `<html><body><div id="statutes"><div class="Section">
+      <span class="Catchline"><span class="CatchlineText">DUI penalties.</span></span>
+      <span class="SectionBody">Effective 7/1/2024. A person who drives under the influence commits a misdemeanor.</span>
+    </div></body></div></body></html>`;
+    const p = parseSectionPage(html, "316", "316.193");
+    expect(p?.effectiveDate).toBe("2024-07-01");
+  });
+  it("rejects invalid calendar date (Feb 30)", () => {
+    const html = `<html><body><div id="statutes"><div class="Section">
+      <span class="Catchline"><span class="CatchlineText">Bad date test.</span></span>
+      <span class="SectionBody">Effective 2/30/2024. Some body text long enough to pass the 20-char minimum.</span>
+    </div></body></div></body></html>`;
+    const p = parseSectionPage(html, "316", "316.001");
+    expect(p?.effectiveDate).toBeNull();
+  });
+  it("returns null effective_date when absent", () => {
+    const p = parseSectionPage(FIXTURE_893_13, "893", "893.13");
+    expect(p?.effectiveDate).toBeNull();
+  });
+});

--- a/src/app/api/cron/statutes-refresh-fl/[chapter]/route.ts
+++ b/src/app/api/cron/statutes-refresh-fl/[chapter]/route.ts
@@ -1,0 +1,405 @@
+/**
+ * @file /api/cron/statutes-refresh-fl/[chapter] — Weekly FL per-chapter refresh.
+ *
+ * One endpoint per FL statute chapter from the seed (316, 775, 784, 810, 812,
+ * 893). Fetches the index, discovers section numbers, parallel-fetches each
+ * section, recomputes SHA-256 over (titleText + blank + bodyText), compares
+ * to stored text_hash, UPDATEs only drifted rows.
+ *
+ * Parallel fetch (concurrency=5) keeps ch316 (282 sections) inside the
+ * maxDuration=300 budget. Rate courtesy to FL Online Sunshine is preserved:
+ * 5 concurrent × 0.5-2s random delay ≈ 1 req/100-400ms sustained, same-scale
+ * as the seed script that FL already accepted.
+ *
+ * Source of truth for FL coverage:
+ *   scripts/ingest/seed-statutes-fl.mjs FL_CHAPTERS constant.
+ *   This route duplicates the 6 chapter→range pairs intentionally (same
+ *   scoping decision as statutes-refresh-us — TS routes can't cleanly
+ *   import .mjs across the build boundary).
+ *
+ * Auth: requireCron (Bearer CRON_AUTH_TOKEN).
+ * Schedule: Monday 16:00-16:50 UTC staggered (one slot per chapter,
+ *   registered by scripts/register-statutes-refresh-fl-cron.mjs).
+ * SSRF defense: hostname allowlist on www.leg.state.fl.us only + redirect
+ *   manual + re-validate Location.
+ * Idempotency: acquireCronLock per-chapter + hash-diff UPDATE is
+ *   idempotent-by-construction (concurrent runs converge on same state).
+ */
+import { type NextRequest, NextResponse } from "next/server";
+import { requireCron } from "@/lib/auth/guards";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { acquireCronLock, releaseCronLock } from "@/lib/cron-idempotency";
+import crypto from "node:crypto";
+
+export const runtime = "nodejs";
+// ch316 has 282 sections. At 5-way parallel + 0.5-2s random delay per
+// fetch, worst case is ~60-90s. 300s leaves comfortable headroom.
+export const maxDuration = 300;
+
+interface FlChapterMeta {
+  range: string;
+  description: string;
+}
+
+// Mirrors FL_CHAPTERS in scripts/ingest/seed-statutes-fl.mjs. Drift-locked
+// by FL_CHAPTERS_COVERAGE_LOCK below + test assertion.
+export const FL_CHAPTERS: Record<string, FlChapterMeta> = {
+  "316": { range: "0300-0399", description: "Traffic / DUI" },
+  "775": { range: "0700-0799", description: "Penalties" },
+  "784": { range: "0700-0799", description: "Assault / battery" },
+  "810": { range: "0800-0899", description: "Burglary" },
+  "812": { range: "0800-0899", description: "Theft / robbery" },
+  "893": { range: "0800-0899", description: "Drug abuse prevention" },
+};
+
+export const FL_CHAPTERS_COVERAGE_LOCK = "v1:6-chapters";
+
+const ALLOWED_HOSTNAMES = new Set(["www.leg.state.fl.us", "leg.state.fl.us"]);
+const FL_BASE = "https://www.leg.state.fl.us/statutes/index.cfm?App_mode=Display_Statute&URL=";
+
+const USER_AGENT = "INAA-legal-research/1.0 (+https://imnotanattorney.com/about)";
+const FETCH_CONCURRENCY = 5;
+
+function buildChapterIndexUrl(chapter: string): string {
+  const meta = FL_CHAPTERS[chapter];
+  if (!meta) throw new Error(`Unknown chapter ${chapter}`);
+  const pad = chapter.padStart(4, "0");
+  return FL_BASE + meta.range + "/" + pad + "/" + pad + "ContentsIndex.html";
+}
+
+function buildSectionUrl(chapter: string, section: string): string {
+  const meta = FL_CHAPTERS[chapter];
+  if (!meta) throw new Error(`Unknown chapter ${chapter}`);
+  const pad = chapter.padStart(4, "0");
+  // FL section filenames use padded chapter: 0893.13.html, NOT 893.13.html.
+  // Unpadded returns a generic fallback (200 OK with wrong body).
+  const dot = section.indexOf(".");
+  const rest = dot >= 0 ? section.slice(dot) : "." + section;
+  return FL_BASE + meta.range + "/" + pad + "/Sections/" + pad + rest + ".html";
+}
+
+function isAllowedHost(urlStr: string): boolean {
+  try {
+    const u = new URL(urlStr);
+    if (u.protocol !== "https:") return false;
+    return ALLOWED_HOSTNAMES.has(u.hostname.toLowerCase());
+  } catch {
+    return false;
+  }
+}
+
+// ── Inline parser (scoped to FL refresh only) ───────────────────────────
+// Must stay in lockstep with scripts/ingest/lib/fl-html.mjs so the hash
+// computed here matches the stored one. Same semantic ports as the Cornell
+// parser in statutes-refresh-us: tags-first / decode-second / second-pass
+// strip / drop C0+DEL+surrogates.
+function decodeNumEntity(code: number): string {
+  if (!Number.isInteger(code) || code < 0 || code > 0x10ffff) return "";
+  if (code < 0x20 && code !== 0x09 && code !== 0x0a && code !== 0x0d) return "";
+  if (code === 0x7f) return "";
+  if (code >= 0xd800 && code <= 0xdfff) return "";
+  return String.fromCodePoint(code);
+}
+
+export function stripHtml(html: string): string {
+  if (!html) return "";
+  let s = html;
+  s = s.replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, " ");
+  s = s.replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, " ");
+  s = s.replace(/<!--[\s\S]*?-->/g, " ");
+  s = s.replace(/<br\s*\/?\s*>/gi, "\n");
+  s = s.replace(/<\/p>/gi, "\n\n");
+  s = s.replace(/<\/div>/gi, "\n");
+  s = s.replace(/<[^>]+>/g, " ");
+  s = s
+    .replace(/&nbsp;/gi, " ")
+    .replace(/&amp;/gi, "&")
+    .replace(/&lt;/gi, "<")
+    .replace(/&gt;/gi, ">")
+    .replace(/&quot;/gi, '"')
+    .replace(/&#(\d+);/g, (_m, n) => decodeNumEntity(Number(n)))
+    .replace(/&#x([0-9a-f]+);/gi, (_m, n) => decodeNumEntity(Number.parseInt(String(n), 16)));
+  s = s.replace(/<[^>]+>/g, " ");
+  let out = "";
+  for (const ch of s) {
+    const c = ch.charCodeAt(0);
+    if (c === 9 || c === 10 || c === 13) { out += ch; continue; }
+    if (c < 32 || c === 127) continue;
+    out += ch;
+  }
+  return out.split(/\s+/).filter(Boolean).join(" ").trim();
+}
+
+function isSectionNotFound(html: string): boolean {
+  if (!html) return true;
+  if (html.length < 200) return true;
+  if (html.indexOf("Statute does not exist") >= 0) return true;
+  if (html.indexOf("The Statute you requested does not exist") >= 0) return true;
+  return false;
+}
+
+export function extractSectionNumbers(html: string, chapter: string): string[] {
+  if (!html) return [];
+  const seen = new Set<string>();
+  const pad = chapter.padStart(4, "0");
+  const urlRx = new RegExp("/Sections/" + pad + "\\.([\\w]+)\\.html", "gi");
+  let m: RegExpExecArray | null;
+  while ((m = urlRx.exec(html)) !== null) {
+    if (!/^\d+$/.test(m[1])) continue;
+    seen.add(chapter + "." + m[1]);
+  }
+  // W4 fix: free-form fallback if anchor-scoped URL regex finds nothing.
+  // Matches fl-html.mjs:96-102 so seed + refresh discovery stay symmetric
+  // under non-standard FL chapter-index markup.
+  if (seen.size === 0) {
+    const sectionRx = new RegExp("\\b" + chapter + "\\.(\\d+)\\b", "g");
+    let mm: RegExpExecArray | null;
+    while ((mm = sectionRx.exec(html)) !== null) {
+      seen.add(chapter + "." + mm[1]);
+    }
+  }
+  return [...seen].sort((a, b) => {
+    const as = Number.parseInt(a.split(".")[1] ?? "0", 10);
+    const bs = Number.parseInt(b.split(".")[1] ?? "0", 10);
+    return as - bs;
+  });
+}
+
+export interface ParsedSection {
+  titleText: string;
+  bodyText: string;
+  effectiveDate: string | null;
+}
+
+export function parseSectionPage(html: string, chapter: string, section: string): ParsedSection | null {
+  if (isSectionNotFound(html)) return null;
+
+  const statutesStart = html.indexOf('<div id="statutes"');
+  const workHtml = statutesStart >= 0 ? html.slice(statutesStart) : html;
+
+  let titleText: string | null = null;
+  const catchMatch = workHtml.match(/<span\b[^>]*class="[^"]*CatchlineText[^"]*"[^>]*>([\s\S]*?)<\/span>/i);
+  if (catchMatch) titleText = stripHtml(catchMatch[1]);
+  if (!titleText) {
+    const titleMatch = html.match(/<title>\s*([^<]*?)\s*<\/title>/i);
+    if (titleMatch) {
+      let t = titleMatch[1].trim();
+      t = t.replace(/^F\.S\.\s+/i, "").trim();
+      t = t.replace(new RegExp("^" + chapter + "\\.\\d+\\s*[—\\-–]?\\s*"), "").trim();
+      t = t.replace(/\s*[-–—]\s*Florida\s+Statutes?\s*$/i, "").trim();
+      if (/Online\s+Sunshine/i.test(t) || /Statutes\s*&\s*Constitution/i.test(t)) titleText = null;
+      else titleText = t;
+    }
+  }
+  if (!titleText) titleText = `Section ${section}`;
+
+  let bodyText: string | null = null;
+  const bodyStart = workHtml.search(/<span\b[^>]*class="[^"]*SectionBody[^"]*"[^>]*>/i);
+  if (bodyStart >= 0) {
+    const afterOpen = workHtml.indexOf(">", bodyStart) + 1;
+    const closeIdx = workHtml.toLowerCase().indexOf("</body>", afterOpen);
+    const slice = closeIdx > 0 ? workHtml.slice(afterOpen, closeIdx) : workHtml.slice(afterOpen);
+    bodyText = stripHtml(slice);
+  } else {
+    bodyText = stripHtml(workHtml);
+  }
+
+  const historyMatch = bodyText.match(/History\.\s*[—–-]/);
+  if (historyMatch && historyMatch.index !== undefined && historyMatch.index > 20) {
+    bodyText = bodyText.slice(0, historyMatch.index).trim();
+  }
+  if (bodyStart < 0) {
+    const sectionIdx = bodyText.indexOf(section);
+    if (sectionIdx > 0 && sectionIdx < bodyText.length / 3) bodyText = bodyText.slice(sectionIdx).trim();
+  }
+  if (bodyText.length > 20000) bodyText = bodyText.slice(0, 20000).trim();
+  if (!bodyText || bodyText.length < 20) return null;
+
+  // W3 fix: parse effective_date too so refresh doesn't leave it stale
+  // forever after FL amends a statute. Mirrors fl-html.mjs:201-219.
+  let effectiveDate: string | null = null;
+  let effHaystack = workHtml;
+  if (bodyStart >= 0) {
+    const afterOpen = workHtml.indexOf(">", bodyStart) + 1;
+    const closeIdx = workHtml.toLowerCase().indexOf("</body>", afterOpen);
+    effHaystack = closeIdx > 0 ? workHtml.slice(afterOpen, closeIdx) : workHtml.slice(afterOpen);
+  }
+  const em = effHaystack.match(/Effective\s+(\d{1,2})\/(\d{1,2})\/(\d{4})/i);
+  if (em) {
+    const mm = String(em[1]).padStart(2, "0");
+    const dd = String(em[2]).padStart(2, "0");
+    const candidate = em[3] + "-" + mm + "-" + dd;
+    const d = new Date(candidate + "T00:00:00Z");
+    if (!Number.isNaN(d.getTime()) && d.toISOString().slice(0, 10) === candidate) {
+      effectiveDate = candidate;
+    }
+  }
+
+  return { titleText, bodyText, effectiveDate };
+}
+
+export function computeSectionHash(titleText: string, bodyText: string) {
+  const sectionText = (titleText ? `${titleText.trim()}\n\n` : "") + bodyText.trim();
+  const textHash = crypto.createHash("sha256").update(sectionText).digest("hex");
+  return { sectionText, textHash };
+}
+
+// ── Fetch with redirect-manual SSRF defense ──────────────────────────────
+async function safeFetch(url: string, fetchImpl: typeof fetch): Promise<{ html?: string; note?: string }> {
+  if (!isAllowedHost(url)) return { note: "host_denied" };
+  try {
+    const r = await fetchImpl(url, {
+      headers: { "User-Agent": USER_AGENT, Accept: "text/html,application/xhtml+xml" },
+      redirect: "manual",
+    });
+    if (r.status >= 300 && r.status < 400) {
+      const loc = r.headers.get("location");
+      if (!loc || !isAllowedHost(loc)) return { note: "redirect off-allowlist" };
+      const r2 = await fetchImpl(loc, {
+        headers: { "User-Agent": USER_AGENT, Accept: "text/html,application/xhtml+xml" },
+        redirect: "manual",
+      });
+      if (!r2.ok) return { note: `HTTP ${r2.status} (after redirect)` };
+      return { html: await r2.text() };
+    }
+    if (!r.ok) return { note: `HTTP ${r.status}` };
+    return { html: await r.text() };
+  } catch (e) {
+    return { note: e instanceof Error ? e.message.slice(0, 80) : "err" };
+  }
+}
+
+// Concurrency-limited parallel map.
+async function parallelMap<T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let idx = 0;
+  async function worker() {
+    while (true) {
+      const i = idx++;
+      if (i >= items.length) return;
+      results[i] = await fn(items[i], i);
+    }
+  }
+  const workers = Array.from({ length: Math.min(limit, items.length) }, () => worker());
+  await Promise.all(workers);
+  return results;
+}
+
+interface RefreshResult {
+  section: string;
+  status: "unchanged" | "updated" | "parse_failed" | "fetch_failed" | "missing_row";
+  note?: string;
+}
+
+export async function refreshChapter(
+  chapter: string,
+  supabase: ReturnType<typeof createAdminClient>,
+  fetchImpl: typeof fetch,
+): Promise<{ sections_discovered: number; results: RefreshResult[] }> {
+  const indexUrl = buildChapterIndexUrl(chapter);
+  const indexFetch = await safeFetch(indexUrl, fetchImpl);
+  if (!indexFetch.html) {
+    return { sections_discovered: 0, results: [{ section: "INDEX", status: "fetch_failed", note: indexFetch.note }] };
+  }
+  const sections = extractSectionNumbers(indexFetch.html, chapter);
+  if (sections.length === 0) {
+    return { sections_discovered: 0, results: [] };
+  }
+
+  const results = await parallelMap(sections, FETCH_CONCURRENCY, async (section) => {
+    // W2 fix: 0.5-2s rate parity with the seed script. Under 5-way
+    // concurrency sustained throughput is ≈4-10 req/s — courtesy-aligned
+    // with what FL Online Sunshine accepted during the original seed.
+    await new Promise((r) => setTimeout(r, 500 + Math.floor(Math.random() * 1500)));
+    const url = buildSectionUrl(chapter, section);
+    const f = await safeFetch(url, fetchImpl);
+    if (!f.html) return { section, status: "fetch_failed" as const, note: f.note };
+    const parsed = parseSectionPage(f.html, chapter, section);
+    if (!parsed) return { section, status: "parse_failed" as const };
+    const { sectionText, textHash } = computeSectionHash(parsed.titleText, parsed.bodyText);
+
+    const { data: existing, error: selErr } = await supabase
+      .from("entities_statutes")
+      .select("canonical_id, text_hash")
+      .eq("jurisdiction", "FL")
+      .eq("title", chapter)
+      .eq("section", section)
+      .eq("is_current", true)
+      .maybeSingle();
+    if (selErr) return { section, status: "fetch_failed" as const, note: `select: ${selErr.message.slice(0, 60)}` };
+    if (!existing) return { section, status: "missing_row" as const };
+    if (existing.text_hash === textHash) return { section, status: "unchanged" as const };
+
+    const updatePatch: Record<string, unknown> = {
+      section_text: sectionText,
+      text_hash: textHash,
+      scraped_at: new Date().toISOString(),
+      source_urls: [url],
+    };
+    // W3 fix: if the page exposes an effective_date, keep the DB column
+    // current. When absent (common on older sections) leave the existing
+    // value alone rather than NULL-wiping verified seed data.
+    if (parsed.effectiveDate) updatePatch.effective_date = parsed.effectiveDate;
+
+    const { error: updErr } = await supabase
+      .from("entities_statutes")
+      .update(updatePatch)
+      .eq("canonical_id", existing.canonical_id);
+    if (updErr) return { section, status: "fetch_failed" as const, note: `update: ${updErr.message.slice(0, 60)}` };
+    return { section, status: "updated" as const };
+  });
+
+  return { sections_discovered: sections.length, results };
+}
+
+export async function GET(req: NextRequest, ctx: { params: Promise<{ chapter: string }> }) {
+  const auth = requireCron(req);
+  if (!auth.authorized) return auth.error;
+
+  const { chapter } = await ctx.params;
+  if (!chapter || !FL_CHAPTERS[chapter]) {
+    return NextResponse.json(
+      { error: `Chapter ${chapter} not recognized. Valid: ${Object.keys(FL_CHAPTERS).join(",")}` },
+      { status: 400 },
+    );
+  }
+
+  // W1 fix from 2026-04-24 code review: staleThresholdMs must exceed
+  // maxDuration so a long-running ch316 (~60-90s) isn't prematurely declared
+  // stale and steamrolled by a cron-job.org retry.
+  const lock = await acquireCronLock(
+    `statutes-refresh-fl-${chapter}`,
+    23 * 60 * 60 * 1000,
+    { staleThresholdMs: 360_000 },
+  );
+  if (!lock.shouldRun) {
+    return NextResponse.json({ skipped: true, reason: lock.reason });
+  }
+
+  const startedAt = Date.now();
+  const supabase = createAdminClient();
+  try {
+    const { sections_discovered, results } = await refreshChapter(chapter, supabase, fetch);
+    const summary = {
+      chapter,
+      sections_discovered,
+      updated: results.filter((r) => r.status === "updated").length,
+      unchanged: results.filter((r) => r.status === "unchanged").length,
+      parse_failed: results.filter((r) => r.status === "parse_failed").length,
+      fetch_failed: results.filter((r) => r.status === "fetch_failed").length,
+      missing_row: results.filter((r) => r.status === "missing_row").length,
+      duration_ms: Date.now() - startedAt,
+    };
+    await releaseCronLock(lock.executionId, "completed");
+    return NextResponse.json({ ok: true, summary, results });
+  } catch (e) {
+    await releaseCronLock(lock.executionId, "failed");
+    throw e;
+  }
+}
+
+// FL_CHAPTERS exported at declaration (line 46).


### PR DESCRIPTION
## Summary

Last remaining piece from the refresh-cron scope: weekly hash-diff refresh for all 470 FL statute rows across 6 chapters.

- 6 cron endpoints at `/api/cron/statutes-refresh-fl/[chapter]` (dynamic segment, chapter allowlist-validated)
- Parallel fetch with concurrency 5 — ch316 (282 sections) fits in maxDuration=300
- Hash-diff UPDATE preserves canonical_id, refreshes section_text + text_hash + scraped_at + source_urls + effective_date
- 6 cron-job.org jobs staggered Mon 16:00/10/20/30/40/50 UTC

## Files

| File | Status |
|---|---|
| `src/app/api/cron/statutes-refresh-fl/[chapter]/route.ts` | new |
| `src/app/api/cron/statutes-refresh-fl/[chapter]/__tests__/route.test.ts` | new (24 tests) |
| `scripts/register-statutes-refresh-fl-cron.mjs` | new (6-job registration) |

## Swarm review

**security-auditor: PRISTINE** across A01-A10 (auth + SSRF + parser defense + parameterized update + env CRLF safety all clean).

**code-reviewer: 7 WARN + 6 SUGG**, addressed pre-commit:

- **W1 stale lock**: `staleThresholdMs: 360_000` added so long ch316 run isn't declared stale under cron-job.org retry
- **W2 rate inflation**: 0-399ms jitter → 500+random(1500), matching the seed-script rate that FL Online Sunshine already accepted
- **W3 effective_date stale**: refresh now parses + conditionally UPDATEs `effective_date`, preventing silent staleness after FL amendments
- **W4 extractSectionNumbers fallback**: free-form `\b<chapter>\.\d+\b` fallback added, matching `fl-html.mjs:96-102` for seed/refresh parser symmetry
- **W6 GET handler tests**: added redirect SSRF tests + effective_date tests + extract fallback tests (17 → 24)
- **W7 redirect re-validation**: test locks off-allowlist rejection + same-host hop happy path
- **W8 register script fail-open**: added `listResp.ok` guard with exit(1) to prevent duplicate-job creation on list-jobs failure

## Deferred (tracked follow-ups)

- **W5 parser lockstep across 3 files** — factor to `src/lib/statutes/parsers.ts` in separate refactor PR (scope: move + type-port + rewrite `seed-statutes-fl.mjs` import). Current duplication is load-bearing on hash integrity; worth its own swarm review.
- SUGG: parallelMap ordering test, `buildSectionUrl` throw-on-invalid-section, `MAX_BODY_CHARS` constant, FL_CHAPTERS mechanical cross-check.

## Test plan

- [x] 24/24 unit tests (vitest)
- [x] 74/74 related-suite run clean (USC refresh + FL refresh + entity whitelist + generate-report)
- [x] `tsc --noEmit --skipLibCheck` — 0 errors
- [ ] Post-merge: `node scripts/register-statutes-refresh-fl-cron.mjs` — registers 6 cron-job.org jobs
- [ ] Post-merge: next Monday 16:00 UTC first fire (ch316, the largest) — expect `{unchanged: 282, updated: 0, ...}`

## Session-cumulative after this merge

Five PRs shipped today fully closing the no-hallucinated-legal-data gap AND the drift-detection follow-up:
- #104: FL Phase 1 seed (470 rows)
- #115: USC seed + query-time filter (15 rows + filter)
- #117: USC weekly refresh cron
- #119: USC v2 expansion (+14 → 29 total USC)
- #(this): FL per-chapter weekly refresh (6 endpoints)

## SKIP_BUILD note

Worktree has no `node_modules` so `next build` can't resolve `next`. `tsc` + full vitest suite ran clean in main checkout before commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)