### PR TITLE
feat(officer-bg-check): CPD Invisible Institute depth integration

### DIFF
--- a/scripts/verify-officer-render-chicago.mjs
+++ b/scripts/verify-officer-render-chicago.mjs
@@ -1,0 +1,155 @@
+/**
+ * Verify Officer Background Check CPD depth path end-to-end.
+ *
+ * Mirrors src/lib/tier9-reports/cpd-match.ts + query.ts::queryCpdProfile.
+ * For known CPD officers (Finnigan + Evans), asserts:
+ *   1. cpd_officers has at least one matching row
+ *   2. matcher returns status='single' given name-only input (Evans is unique;
+ *      Finnigan was convicted so should also be uniquely identifiable by name)
+ *   3. cpd_complaints has >0 rows joined by uid
+ *   4. summarize() produces a well-formed totals block
+ *
+ * Feature flag is NOT checked here — the script bypasses the queryCpdProfile
+ * gate and probes tables directly so operator can confirm data integrity
+ * before flipping officer_bg_check_cpd_enhanced=true.
+ */
+import { createClient } from '@supabase/supabase-js';
+import { config } from 'dotenv';
+
+config({ path: '.env.local' });
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL;
+const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+if (!SUPABASE_URL || !SUPABASE_KEY) {
+  console.error('Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY in .env.local');
+  process.exit(1);
+}
+const sb = createClient(SUPABASE_URL, SUPABASE_KEY, {
+  auth: { persistSession: false },
+});
+
+// Mirror of chooseMatch() in src/lib/tier9-reports/cpd-match.ts.
+function normalizeBadge(raw) {
+  if (!raw) return null;
+  const digits = String(raw).replace(/\D+/g, '');
+  return digits.length > 0 ? digits : null;
+}
+
+function chooseMatch(candidates, badge) {
+  if (candidates.length === 0) return { status: 'none', matchedUid: null };
+  if (candidates.length === 1) return { status: 'single', matchedUid: candidates[0].uid };
+  const normBadge = normalizeBadge(badge);
+  if (normBadge !== null) {
+    const byBadge = candidates.filter((c) => normalizeBadge(c.current_star) === normBadge);
+    if (byBadge.length === 1) return { status: 'single', matchedUid: byBadge[0].uid };
+    if (byBadge.length > 1) return { status: 'ambiguous', matchedUid: null };
+  }
+  return { status: 'ambiguous', matchedUid: null };
+}
+
+async function fetchCandidates({ firstName, lastName }) {
+  let q = sb
+    .from('cpd_officers')
+    .select('uid, first_name, last_name, current_star, current_rank, current_status, appointed_date')
+    .filter('last_name', 'ilike', lastName.toLowerCase());
+  if (firstName) {
+    q = q.filter('first_name', 'ilike', firstName.toLowerCase());
+  }
+  const { data, error } = await q.limit(20);
+  if (error) throw new Error(`cpd_officers query failed: ${error.message}`);
+  return data || [];
+}
+
+async function fetchComplaints(uid) {
+  const { data, error } = await sb
+    .from('cpd_complaints')
+    .select('cr_id, incident_date, complaint_date, complaint_category, complaint_categories, complainant_type, investigating_agency, final_finding, final_outcome, final_outcome_desc, disciplined')
+    .eq('uid', uid)
+    .limit(500);
+  if (error) throw new Error(`cpd_complaints query failed: ${error.message}`);
+  return data || [];
+}
+
+function summarize(complaints) {
+  const counts = new Map();
+  let disciplined = 0;
+  let sustained = 0;
+  let earliest = null;
+  let latest = null;
+  for (const c of complaints) {
+    const cat = (c.complaint_category ?? 'Uncategorized').trim() || 'Uncategorized';
+    const slot = counts.get(cat) ?? { total: 0, disciplined: 0 };
+    slot.total += 1;
+    if (c.disciplined) slot.disciplined += 1;
+    counts.set(cat, slot);
+    if (c.disciplined) disciplined += 1;
+    const finding = (c.final_finding ?? '').toLowerCase();
+    if (finding === 'su' || finding === 'sustained') sustained += 1;
+    const d = c.incident_date ?? c.complaint_date;
+    if (d) {
+      if (!earliest || d < earliest) earliest = d;
+      if (!latest || d > latest) latest = d;
+    }
+  }
+  const byCategory = [...counts.entries()]
+    .map(([category, v]) => ({ category, total: v.total, disciplined: v.disciplined }))
+    .sort((a, b) => b.total - a.total);
+  return { total: complaints.length, disciplined, sustained, byCategory, earliest, latest };
+}
+
+const FIXTURES = [
+  { first: 'Jerome', last: 'Finnigan', note: 'convicted officer, expected unique' },
+  { first: 'Glenn',  last: 'Evans',    note: 'documented wrongful-conduct cases, expected unique' },
+];
+
+let passed = 0;
+let failed = 0;
+
+for (const f of FIXTURES) {
+  const label = `${f.first} ${f.last}`;
+  console.log(`\n==== ${label} (${f.note}) ====`);
+  try {
+    const candidates = await fetchCandidates({ firstName: f.first, lastName: f.last });
+    console.log(`  cpd_officers candidates: ${candidates.length}`);
+    if (candidates.length === 0) {
+      console.log(`  [FAIL] no candidates returned — data load incomplete or name wrong`);
+      failed += 1;
+      continue;
+    }
+    const match = chooseMatch(candidates, null);
+    console.log(`  match status: ${match.status} uid=${match.matchedUid ?? '-'}`);
+    if (match.status !== 'single') {
+      console.log(`  [WARN] not a clean single match by name alone (badge required for disambiguation)`);
+      // Not a hard fail — matcher correctly surfaces the ambiguous path.
+      passed += 1;
+      continue;
+    }
+    const complaints = await fetchComplaints(match.matchedUid);
+    const totals = summarize(complaints);
+    console.log(`  complaints: total=${totals.total} sustained=${totals.sustained} disciplined=${totals.disciplined} categories=${totals.byCategory.length}`);
+    console.log(`  window: ${totals.earliest ?? '-'} to ${totals.latest ?? '-'}`);
+    console.log(`  top categories: ${totals.byCategory.slice(0, 3).map((c) => `${c.category}=${c.total}`).join(', ')}`);
+    if (totals.total === 0) {
+      console.log(`  [WARN] uid matched but zero complaints — data shape ok, but no signal for report`);
+    } else {
+      console.log(`  [PASS] matcher + complaint query + summarize end-to-end`);
+    }
+    passed += 1;
+  } catch (err) {
+    console.log(`  [FAIL] ${err.message}`);
+    failed += 1;
+  }
+}
+
+console.log(`\n==== SUMMARY ====`);
+console.log(`passed: ${passed}  failed: ${failed}  of ${FIXTURES.length}`);
+
+// Also assert total row counts match memory doc (sanity)
+const [{ count: officerCount }, { count: complaintCount }] = await Promise.all([
+  sb.from('cpd_officers').select('uid', { count: 'exact', head: true }),
+  sb.from('cpd_complaints').select('id', { count: 'exact', head: true }),
+]);
+console.log(`cpd_officers rows: ${officerCount}  (expected: 37,545)`);
+console.log(`cpd_complaints rows: ${complaintCount}  (expected: 263,315)`);
+
+process.exit(failed === 0 ? 0 : 1);

--- a/src/app/api/intake/standalone/[slug]/route.ts
+++ b/src/app/api/intake/standalone/[slug]/route.ts
@@ -200,6 +200,10 @@ const OPTIONAL_FIELDS_BY_SLUG: Record<string, Set<string>> = {
   // `district` is cascaded from state in the intake form (1-4 options per state)
   // and narrows the sample to a specific federal court when supplied.
   "similar-cases-analyzer": new Set(["priorConvictions", "citizenship", "ageBucket", "district"]),
+  // Officer Background Check — agency + badgeNumber optional disambiguators
+  // for CPD depth. Empty values flow through as "" and the query skips CPD
+  // when agency is non-CPD and state != IL.
+  "officer-background-check": new Set(["agency", "badgeNumber"]),
   // Federal Sentencing Distribution — district is optional (widens to
   // national); criminalHistoryCategory is optional (derived from
   // priorConvictions when absent). state is required to populate the

--- a/src/app/intake/standalone/[slug]/IntakeFormClient.tsx
+++ b/src/app/intake/standalone/[slug]/IntakeFormClient.tsx
@@ -2128,6 +2128,31 @@ const FIELD_SETS: Record<string, FieldConfig[]> = {
       options: US_STATES,
       required: true,
     },
+    {
+      kind: "optional-group",
+      name: "agency-disambiguation",
+      summary: "Agency / badge number (optional — recommended for Chicago)",
+      helpText:
+        "If the officer is Chicago PD, adding the department and star (badge) number unlocks the full FOIA complaint history (Invisible Institute dataset, 2000–mid-2018). For other agencies these help disambiguate common names.",
+      fields: [
+        {
+          kind: "text",
+          name: "agency",
+          label: "Agency (e.g., Chicago PD)",
+          placeholder: "e.g., Chicago PD",
+          maxLength: 100,
+          required: false,
+        },
+        {
+          kind: "text",
+          name: "badgeNumber",
+          label: "Badge / star number",
+          placeholder: "e.g., 8051",
+          maxLength: 30,
+          required: false,
+        },
+      ],
+    },
   ],
   "similar-cases-analyzer": [
     {

--- a/src/app/officer-background-check/page.tsx
+++ b/src/app/officer-background-check/page.tsx
@@ -41,6 +41,7 @@ const FEATURES = [
   "Employment history timeline (NPI officer-level: AZ, CA, GA)",
   "Wandering officer detection (terminated → rehired pattern)",
   "Agency incident data from Fatal Encounters database",
+  "Chicago PD: full FOIA complaint history per officer (Invisible Institute, 2000–mid-2018)",
   "Prior complaints and disciplinary actions from court records",
   "Every finding linked to its source URL",
 ] as const;
@@ -98,6 +99,11 @@ const FAQ_ITEMS = [
     question: "Will my attorney be upset that I looked this up?",
     answer:
       "Good defense attorneys welcome prepared clients. Officer reliability is the kind of information attorneys research themselves \u2014 having it ready saves them time and shows you\u2019re engaged in your defense.",
+  },
+  {
+    question: "Do you have enhanced data for Chicago PD officers?",
+    answer:
+      "Yes. For Chicago Police Department officers we include the full misconduct complaint history from the Invisible Institute FOIA dataset covering 2000 through mid-2018, roughly 263,000 complaints across 37,000 officers. You get total complaints on file, sustained findings, complaints by category, and a complaint-level detail table. Officers appointed after mid-2018 may not appear; if your officer is a common name, adding their star (badge) number during intake disambiguates. Source: github.com/invinst/chicago-police-data.",
   },
 ] as const;
 

--- a/src/components/tier9/AvailabilityChecker.tsx
+++ b/src/components/tier9/AvailabilityChecker.tsx
@@ -135,6 +135,8 @@ const COVERAGE_LABELS: Record<string, string> = {
   judges: 'federal judges in database',
   benchmarks: 'outcome benchmark records',
   agencies: 'agencies with incident data',
+  cpdOfficers: 'Chicago PD officer records (FOIA)',
+  cpdComplaints: 'Chicago PD misconduct complaints',
 };
 
 const LOCALSTORAGE_KEY = 'inna_email';

--- a/src/lib/products.ts
+++ b/src/lib/products.ts
@@ -1208,7 +1208,7 @@ export const STANDALONE_PRODUCTS: Record<string, StandaloneProduct> = {
       "Your Officer Background Check is generated on demand from cross-case court records within 60 seconds.",
     description:
       "Cross-case officer reliability, credibility challenges, and discreditation history from verified court records.",
-    intakeFields: ["officerName", "state"],
+    intakeFields: ["officerName", "state", "agency", "badgeNumber"],
     stripePriceId: null,
     upsellTier: "case-decoder",
     upsellText:

--- a/src/lib/tier9-reports/coverage.ts
+++ b/src/lib/tier9-reports/coverage.ts
@@ -5,6 +5,8 @@
  */
 
 import { createAdminClient } from "@/lib/supabase/admin";
+import { isFeatureEnabled } from "@/lib/feature-flags";
+import { parseOfficerName } from "./cpd-match";
 
 function escapeIlike(input: string): string {
   return input.replace(/[%_\\]/g, (ch) => `\\${ch}`);
@@ -110,10 +112,67 @@ export async function checkOfficerCoverage(
   }
 
   const count = result.count ?? 0;
+  const coverage: Record<string, number> = { officers: count };
+
+  // CPD depth probe — only when state=IL AND the feature flag is on. Adds a
+  // separate "cpdComplaints" count to the coverage dict so the Availability
+  // checker surfaces "Includes Chicago PD complaint history" automatically.
+  if (state.toUpperCase() === "IL") {
+    const cpdEnabled = await isFeatureEnabled("officer_bg_check_cpd_enhanced");
+    if (cpdEnabled) {
+      const { lastName, firstName } = parseOfficerName(officerName);
+      if (lastName) {
+        const last = lastName.toLowerCase();
+        let officerProbe = supabase
+          .from("cpd_officers")
+          .select("uid", { count: "exact", head: true })
+          .filter("last_name", "ilike", last);
+        if (firstName) {
+          officerProbe = officerProbe.filter(
+            "first_name",
+            "ilike",
+            firstName.toLowerCase(),
+          );
+        }
+        const { count: cpdOfficerCount } = await officerProbe;
+
+        if ((cpdOfficerCount ?? 0) > 0) {
+          // Sum of complaints across all name-matched uids. Fetch the matching
+          // uids once, count complaints by membership. One extra round-trip
+          // but avoids exposing per-uid breakdown to the pre-purchase surface.
+          const { data: uidRows } = await supabase
+            .from("cpd_officers")
+            .select("uid")
+            .filter("last_name", "ilike", last)
+            .filter(
+              "first_name",
+              "ilike",
+              firstName ? firstName.toLowerCase() : "%",
+            )
+            .limit(20);
+          const uids = (uidRows ?? [])
+            .map((r) => r.uid)
+            .filter((u): u is number => typeof u === "number");
+          let cpdComplaintCount = 0;
+          if (uids.length > 0) {
+            const { count: cc } = await supabase
+              .from("cpd_complaints")
+              .select("id", { count: "exact", head: true })
+              .in("uid", uids);
+            cpdComplaintCount = cc ?? 0;
+          }
+          coverage.cpdOfficers = cpdOfficerCount ?? 0;
+          coverage.cpdComplaints = cpdComplaintCount;
+        }
+      }
+    }
+  }
+
+  const hasCpd = (coverage.cpdComplaints ?? 0) > 0;
 
   return {
-    available: count >= 1,
-    coverage: { officers: count },
+    available: count >= 1 || hasCpd,
+    coverage,
     matchedName: null,
     matchedCourt: null,
   };

--- a/src/lib/tier9-reports/cpd-match.ts
+++ b/src/lib/tier9-reports/cpd-match.ts
@@ -1,0 +1,176 @@
+/**
+ * CPD Invisible Institute officer matcher.
+ *
+ * Deterministic name + badge + agency matching against public.cpd_officers.
+ * No LLM. No fuzzy match beyond case/whitespace/punct normalization.
+ *
+ * Contract:
+ *   - agency signal: explicit match against a short CPD whitelist. Never match
+ *     on generic "police" / other-agency strings — wrong-officer risk.
+ *   - name match: case-insensitive exact on (last_name, first_name).
+ *   - badge disambiguator: exact digit-only compare against cpd_officers.current_star.
+ *   - ambiguity: if more than one officer shares a name and no badge disambiguates,
+ *     return status='ambiguous'; callers suppress the CPD report section and
+ *     direct the customer to email support with badge#.
+ *
+ * Data window: 2000 through mid-2018 (Invisible Institute FOIA dump). Officers
+ * appointed after that gap may be absent; that is a disclosure, not a bug.
+ */
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+export type CpdMatchStatus = "single" | "ambiguous" | "none";
+
+export interface CpdCandidate {
+  uid: number;
+  first_name: string | null;
+  last_name: string | null;
+  current_star: string | null;
+  current_rank: string | null;
+  current_status: string | null;
+  appointed_date: string | null;
+}
+
+export interface CpdMatchResult {
+  status: CpdMatchStatus;
+  candidates: CpdCandidate[];
+  matchedUid: number | null;
+}
+
+/** Agency strings that route to CPD depth. Exact (normalized) match only. */
+const CPD_AGENCY_WHITELIST = new Set([
+  "cpd",
+  "chicago pd",
+  "chicago police",
+  "chicago police department",
+  "city of chicago police",
+  "city of chicago police department",
+]);
+
+/** Normalize an agency free-text input to either "cpd" or null (no match). */
+export function normalizeAgencyToCpd(raw: string | null | undefined): "cpd" | null {
+  if (!raw) return null;
+  const normalized = raw
+    .toLowerCase()
+    .replace(/\./g, "")
+    .replace(/\bdept\b/g, "department")
+    .replace(/[^a-z0-9 ]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  return CPD_AGENCY_WHITELIST.has(normalized) ? "cpd" : null;
+}
+
+/**
+ * Determine whether to run a CPD probe at all.
+ * Prefer explicit agency. Fall back to state=IL as a softer signal (customers
+ * who don't know/enter an agency but are in Illinois).
+ */
+export function isChicagoSignal(opts: {
+  agency?: string | null;
+  state?: string | null;
+}): boolean {
+  if (normalizeAgencyToCpd(opts.agency ?? null) === "cpd") return true;
+  const state = (opts.state ?? "").trim().toUpperCase();
+  return state === "IL";
+}
+
+/** Split a free-text full name into first + last. Last token wins for surname. */
+export function parseOfficerName(fullName: string): {
+  firstName: string;
+  lastName: string;
+} {
+  const cleaned = fullName.trim().replace(/\s+/g, " ");
+  if (!cleaned) return { firstName: "", lastName: "" };
+  const parts = cleaned.split(" ");
+  if (parts.length === 1) return { firstName: "", lastName: parts[0]! };
+  return {
+    firstName: parts.slice(0, -1).join(" "),
+    lastName: parts[parts.length - 1]!,
+  };
+}
+
+/** Strip anything that isn't a digit. CPD star numbers are integer-valued. */
+export function normalizeBadge(raw: string | null | undefined): string | null {
+  if (!raw) return null;
+  const digits = raw.replace(/\D+/g, "");
+  return digits.length > 0 ? digits : null;
+}
+
+/**
+ * Pure candidate-selection logic. Extracted from the DB layer so unit tests
+ * can cover every branch without mocking Supabase.
+ */
+export function chooseMatch(
+  candidates: CpdCandidate[],
+  badge: string | null,
+): CpdMatchResult {
+  if (candidates.length === 0) {
+    return { status: "none", candidates: [], matchedUid: null };
+  }
+
+  if (candidates.length === 1) {
+    const [c] = candidates;
+    return { status: "single", candidates, matchedUid: c!.uid };
+  }
+
+  const normBadge = normalizeBadge(badge);
+  if (normBadge !== null) {
+    const byBadge = candidates.filter(
+      (c) => normalizeBadge(c.current_star) === normBadge,
+    );
+    if (byBadge.length === 1) {
+      return { status: "single", candidates: byBadge, matchedUid: byBadge[0]!.uid };
+    }
+    if (byBadge.length > 1) {
+      return {
+        status: "ambiguous",
+        candidates: byBadge,
+        matchedUid: null,
+      };
+    }
+  }
+
+  return { status: "ambiguous", candidates, matchedUid: null };
+}
+
+/**
+ * Fetch candidates matching (last_name, first_name) case-insensitively. Exact
+ * normalized match (no wildcards) — wrong-officer data causes real harm on a
+ * customer-facing report.
+ *
+ * If `firstName` is empty (single-token input), match on last_name alone;
+ * disambiguation falls through to badge or ambiguous-status.
+ */
+export async function fetchCpdCandidates(
+  supabase: SupabaseClient,
+  opts: { firstName: string; lastName: string },
+): Promise<CpdCandidate[]> {
+  const last = opts.lastName.trim().toLowerCase();
+  if (!last) return [];
+
+  let query = supabase
+    .from("cpd_officers")
+    .select(
+      "uid, first_name, last_name, current_star, current_rank, current_status, appointed_date",
+    )
+    .filter("last_name", "ilike", last);
+
+  const first = opts.firstName.trim().toLowerCase();
+  if (first) {
+    query = query.filter("first_name", "ilike", first);
+  }
+
+  const { data, error } = await query.limit(20);
+  if (error) {
+    return [];
+  }
+  return (data ?? []) as CpdCandidate[];
+}
+
+/** Run fetch + chooseMatch in one call. */
+export async function matchCpdOfficer(
+  supabase: SupabaseClient,
+  opts: { firstName: string; lastName: string; badge: string | null },
+): Promise<CpdMatchResult> {
+  const candidates = await fetchCpdCandidates(supabase, opts);
+  return chooseMatch(candidates, opts.badge);
+}

--- a/src/lib/tier9-reports/generate.ts
+++ b/src/lib/tier9-reports/generate.ts
@@ -190,6 +190,9 @@ export async function generateTier9Report(
         const data = await queryOfficerBackground({
           officerName: intake.officerName as string,
           state: intake.state as string,
+          agency: typeof intake.agency === "string" ? intake.agency : null,
+          badgeNumber:
+            typeof intake.badgeNumber === "string" ? intake.badgeNumber : null,
         });
         if (data.isEmpty) {
           await notifyInsufficientData(order.email, productName, orderId, intake);

--- a/src/lib/tier9-reports/prepopulated-intake.ts
+++ b/src/lib/tier9-reports/prepopulated-intake.ts
@@ -15,6 +15,11 @@ export interface PrepopulatedIntakeMetadata {
   charge_type?: string;
   state?: string;
   courthouse?: string;
+  /** Free-text agency (e.g., "Chicago PD"). Used by Officer BG Check to
+   *  route to CPD-depth data when the agency matches the CPD whitelist. */
+  agency?: string;
+  /** Optional badge / star number — disambiguates common names within CPD. */
+  badge_number?: string;
 }
 
 export function buildPrePopulatedIntake(
@@ -36,9 +41,13 @@ export function buildPrePopulatedIntake(
         state,
         chargeType: chargeType || "other",
       };
-    case "officer-background-check":
+    case "officer-background-check": {
       if (!officerName || !state) return null;
-      return { officerName, state };
+      const out: Record<string, string> = { officerName, state };
+      if (metadata.agency) out.agency = metadata.agency;
+      if (metadata.badge_number) out.badgeNumber = metadata.badge_number;
+      return out;
+    }
     case "similar-cases-analyzer":
       if (!chargeType || !state) return null;
       return { chargeType, state };

--- a/src/lib/tier9-reports/query.ts
+++ b/src/lib/tier9-reports/query.ts
@@ -6,6 +6,14 @@
 
 import { createAdminClient } from "@/lib/supabase/admin";
 import type { JustfairJudgeData } from "@/lib/defense-intelligence/query";
+import { isFeatureEnabled } from "@/lib/feature-flags";
+import {
+  isChicagoSignal,
+  parseOfficerName,
+  matchCpdOfficer,
+  type CpdCandidate,
+  type CpdMatchStatus,
+} from "./cpd-match";
 
 // ============================================================
 // TYPES
@@ -86,6 +94,61 @@ export interface JudgeReportCardData {
   isEmpty: boolean;
 }
 
+/**
+ * Chicago PD (Invisible Institute) depth profile, attached to
+ * OfficerBackgroundData when the intake routes to CPD (state=IL or agency match)
+ * and the feature flag `officer_bg_check_cpd_enhanced` is enabled.
+ *
+ * Status mirrors the matcher:
+ *   - "single"    → officer + full complaint history
+ *   - "ambiguous" → count-only; report tells the customer to email with badge#
+ *   - "none"      → no CPD record; report renders a "no record on file" note
+ */
+export interface CpdComplaintRow {
+  cr_id: string;
+  incident_date: string | null;
+  complaint_date: string | null;
+  complaint_category: string | null;
+  complaint_categories: string | null;
+  complainant_type: string | null;
+  investigating_agency: string | null;
+  final_finding: string | null;
+  final_outcome: string | null;
+  final_outcome_desc: string | null;
+  disciplined: boolean | null;
+}
+
+export interface CpdCategorySummary {
+  category: string;
+  total: number;
+  disciplined: number;
+}
+
+export interface CpdProfileSingle {
+  status: "single";
+  officer: CpdCandidate;
+  complaints: CpdComplaintRow[];
+  totals: {
+    total: number;
+    disciplined: number;
+    sustained: number;
+    byCategory: CpdCategorySummary[];
+    earliest: string | null;
+    latest: string | null;
+  };
+}
+
+export interface CpdProfileAmbiguous {
+  status: "ambiguous";
+  candidateCount: number;
+}
+
+export interface CpdProfileNone {
+  status: "none";
+}
+
+export type CpdProfile = CpdProfileSingle | CpdProfileAmbiguous | CpdProfileNone;
+
 export interface OfficerBackgroundData {
   officers: Array<{
     officer_name: string;
@@ -120,6 +183,7 @@ export interface OfficerBackgroundData {
     use_of_force_count: number;
     source_urls: string[];
   }>;
+  cpd?: CpdProfile | null;
   isEmpty: boolean;
 }
 
@@ -184,6 +248,18 @@ export interface JudgeReportCardIntake {
 export interface OfficerBackgroundIntake {
   officerName: string;
   state: string;
+  /**
+   * Optional agency free-text (e.g., "Chicago PD", "CPD"). When present and
+   * it normalizes to CPD, routes to Chicago-depth matcher. Optional because
+   * older intakes pre-dating agency capture won't carry it.
+   */
+  agency?: string | null;
+  /**
+   * Optional badge/star number. Used to disambiguate common names (e.g., two
+   * "John Smith"s in cpd_officers). Stored as free-text — matcher strips to
+   * digits before compare.
+   */
+  badgeNumber?: string | null;
 }
 
 export interface SimilarCasesIntake {
@@ -207,6 +283,119 @@ function escapeIlike(input: string): string {
 }
 
 const BENCH_JURY_SELECT = "charge_slug, bench_acquittal_rate, jury_acquittal_rate, bench_sample, jury_sample, source_urls, district, bench_median_sentence, jury_median_sentence, trial_penalty_pct, offense_category, fiscal_year_range, plea_median_sentence, plea_sample";
+
+const CPD_COMPLAINT_SELECT =
+  "cr_id, incident_date, complaint_date, complaint_category, complaint_categories, complainant_type, investigating_agency, final_finding, final_outcome, final_outcome_desc, disciplined";
+
+/**
+ * Fetch complaint history for a matched CPD officer uid. Ordered by incident
+ * date desc; falls back to complaint_date when incident_date is null.
+ */
+async function queryCpdComplaints(
+  supabase: ReturnType<typeof createAdminClient>,
+  uid: number,
+): Promise<CpdComplaintRow[]> {
+  const { data, error } = await supabase
+    .from("cpd_complaints")
+    .select(CPD_COMPLAINT_SELECT)
+    .eq("uid", uid)
+    .limit(500);
+
+  if (error || !data) return [];
+
+  const rows = data as CpdComplaintRow[];
+  return [...rows].sort((a, b) => {
+    const da = a.incident_date ?? a.complaint_date ?? "";
+    const db = b.incident_date ?? b.complaint_date ?? "";
+    return db.localeCompare(da);
+  });
+}
+
+/**
+ * Aggregate complaints into the totals block the renderer consumes.
+ * Pure function — also exported for test fixtures.
+ */
+export function summarizeCpdComplaints(
+  complaints: CpdComplaintRow[],
+): CpdProfileSingle["totals"] {
+  const counts = new Map<string, { total: number; disciplined: number }>();
+  let disciplined = 0;
+  let sustained = 0;
+  let earliest: string | null = null;
+  let latest: string | null = null;
+
+  for (const c of complaints) {
+    const cat = (c.complaint_category ?? "Uncategorized").trim() || "Uncategorized";
+    const slot = counts.get(cat) ?? { total: 0, disciplined: 0 };
+    slot.total += 1;
+    if (c.disciplined) slot.disciplined += 1;
+    counts.set(cat, slot);
+
+    if (c.disciplined) disciplined += 1;
+    const finding = (c.final_finding ?? "").toLowerCase();
+    if (finding === "su" || finding === "sustained") sustained += 1;
+
+    const d = c.incident_date ?? c.complaint_date;
+    if (d) {
+      if (!earliest || d < earliest) earliest = d;
+      if (!latest || d > latest) latest = d;
+    }
+  }
+
+  const byCategory: CpdCategorySummary[] = [...counts.entries()]
+    .map(([category, v]) => ({ category, total: v.total, disciplined: v.disciplined }))
+    .sort((a, b) => b.total - a.total);
+
+  return {
+    total: complaints.length,
+    disciplined,
+    sustained,
+    byCategory,
+    earliest,
+    latest,
+  };
+}
+
+/**
+ * Load the CPD profile for a Chicago-routing intake. Gated behind feature
+ * flag `officer_bg_check_cpd_enhanced`. Returns null when flag off or when
+ * the intake doesn't route to Chicago.
+ */
+async function queryCpdProfile(
+  supabase: ReturnType<typeof createAdminClient>,
+  intake: OfficerBackgroundIntake,
+): Promise<CpdProfile | null> {
+  if (!isChicagoSignal({ agency: intake.agency, state: intake.state })) {
+    return null;
+  }
+  const enabled = await isFeatureEnabled("officer_bg_check_cpd_enhanced");
+  if (!enabled) return null;
+
+  const { firstName, lastName } = parseOfficerName(intake.officerName);
+  if (!lastName) return { status: "none" };
+
+  const match = await matchCpdOfficer(supabase, {
+    firstName,
+    lastName,
+    badge: intake.badgeNumber ?? null,
+  });
+
+  const status: CpdMatchStatus = match.status;
+  if (status === "none") return { status: "none" };
+  if (status === "ambiguous") {
+    return { status: "ambiguous", candidateCount: match.candidates.length };
+  }
+
+  const matchedUid = match.matchedUid!;
+  const officer = match.candidates.find((c) => c.uid === matchedUid) ?? match.candidates[0]!;
+  const complaints = await queryCpdComplaints(supabase, matchedUid);
+  return {
+    status: "single",
+    officer,
+    complaints,
+    totals: summarizeCpdComplaints(complaints),
+  };
+}
 
 // ============================================================
 // QUERIES
@@ -393,13 +582,18 @@ export async function queryOfficerBackground(
     agencyIncidents = (agencyData ?? []).filter((r) => r.use_of_force_count > 0) as typeof agencyIncidents;
   }
 
-  const hasData = (reliability.data?.length ?? 0) > 0 || (external.data?.length ?? 0) > 0;
+  const cpd = await queryCpdProfile(supabase, intake);
+
+  const hasCorePath =
+    (reliability.data?.length ?? 0) > 0 || (external.data?.length ?? 0) > 0;
+  const hasCpdDepth = cpd?.status === "single" && cpd.complaints.length > 0;
 
   return {
     officers: reliability.data ?? [],
     externalIntel: external.data ?? [],
     agencyIncidents,
-    isEmpty: !hasData,
+    cpd,
+    isEmpty: !hasCorePath && !hasCpdDepth,
   };
 }
 

--- a/src/lib/tier9-reports/render.ts
+++ b/src/lib/tier9-reports/render.ts
@@ -9,6 +9,8 @@ import type {
   JudgeReportCardData,
   OfficerBackgroundData,
   SimilarCasesData,
+  CpdProfile,
+  CpdComplaintRow,
 } from "./query";
 import type {
   DefenseIntelligenceData,
@@ -579,6 +581,188 @@ export function renderJudgeReportCard(
 // OFFICER BACKGROUND CHECK
 // ============================================================
 
+/** Data window disclosed on every CPD section — Invisible Institute FOIA dump. */
+const CPD_DATA_WINDOW =
+  "2000 through mid-2018 (Invisible Institute FOIA dataset)";
+const CPD_SOURCE_URL = "https://github.com/invinst/chicago-police-data";
+
+/** Sample cap so the HTML email stays under the Gmail 102 KB clip threshold. */
+const CPD_TABLE_ROW_CAP = 30;
+
+function renderCpdComplaintsTable(complaints: CpdComplaintRow[]): string {
+  if (complaints.length === 0) return "";
+
+  const rows = complaints.slice(0, CPD_TABLE_ROW_CAP);
+  const overflow = complaints.length - rows.length;
+
+  const head = `
+    <table style="width: 100%; border-collapse: collapse; margin: 0 0 12px; font-size: 13px;">
+      <thead>
+        <tr style="background: #1C1917;">
+          <th style="padding: 8px 12px; text-align: left; color: #F59E0B;">Date</th>
+          <th style="padding: 8px 12px; text-align: left; color: #F59E0B;">Category</th>
+          <th style="padding: 8px 12px; text-align: left; color: #F59E0B;">Finding</th>
+          <th style="padding: 8px 12px; text-align: left; color: #F59E0B;">Outcome</th>
+          <th style="padding: 8px 12px; text-align: left; color: #F59E0B;">Disciplined</th>
+        </tr>
+      </thead><tbody>
+  `;
+
+  const body = rows
+    .map((c) => {
+      const date = c.incident_date ?? c.complaint_date ?? "—";
+      const category = c.complaint_category ?? "Uncategorized";
+      const finding = c.final_finding ?? "—";
+      const outcome = c.final_outcome_desc ?? c.final_outcome ?? "—";
+      const disciplined = c.disciplined
+        ? '<span style="color: #EF4444; font-weight: bold;">Yes</span>'
+        : '<span style="color: #A1A1AA;">No</span>';
+      return `
+        <tr style="border-bottom: 1px solid #1C1917;">
+          <td style="padding: 8px 12px; color: #D4D4D8; white-space: nowrap;">${escapeHtml(date)}</td>
+          <td style="padding: 8px 12px; color: #D4D4D8;">${escapeHtml(category)}</td>
+          <td style="padding: 8px 12px; color: #A1A1AA;">${escapeHtml(finding)}</td>
+          <td style="padding: 8px 12px; color: #A1A1AA;">${escapeHtml(outcome)}</td>
+          <td style="padding: 8px 12px;">${disciplined}</td>
+        </tr>
+      `;
+    })
+    .join("");
+
+  const footer =
+    overflow > 0
+      ? `<p style="color: #71717A; font-size: 12px; margin: 4px 0 16px;">Showing ${rows.length} of ${complaints.length} complaints (oldest truncated for readability). Full record set available on request.</p>`
+      : "";
+
+  return `${head}${body}</tbody></table>${footer}`;
+}
+
+function renderCpdCategoryBreakdown(
+  totals: { byCategory: Array<{ category: string; total: number; disciplined: number }> },
+): string {
+  if (totals.byCategory.length === 0) return "";
+
+  const rows = totals.byCategory
+    .slice(0, 15)
+    .map((c) => `
+      <tr style="border-bottom: 1px solid #1C1917;">
+        <td style="padding: 6px 12px; color: #D4D4D8;">${escapeHtml(c.category)}</td>
+        <td style="padding: 6px 12px; color: #FAFAF9; text-align: right; font-variant-numeric: tabular-nums;">${c.total}</td>
+        <td style="padding: 6px 12px; color: ${c.disciplined > 0 ? "#EF4444" : "#A1A1AA"}; text-align: right; font-variant-numeric: tabular-nums;">${c.disciplined}</td>
+      </tr>
+    `)
+    .join("");
+
+  return `
+    <h4 style="color: #D4D4D8; margin: 16px 0 8px;">Complaints by category</h4>
+    <table style="width: 100%; border-collapse: collapse; margin-bottom: 16px; font-size: 13px;">
+      <thead>
+        <tr style="background: #1C1917;">
+          <th style="padding: 6px 12px; text-align: left; color: #F59E0B;">Category</th>
+          <th style="padding: 6px 12px; text-align: right; color: #F59E0B;">Complaints</th>
+          <th style="padding: 6px 12px; text-align: right; color: #F59E0B;">Disciplined</th>
+        </tr>
+      </thead><tbody>${rows}</tbody>
+    </table>
+  `;
+}
+
+/**
+ * Render the Chicago PD depth section. Pure factual counts + category +
+ * complaint table. No editorial framing. Every section cites the FOIA source.
+ * Renders one of three variants based on match status.
+ */
+function renderCpdSection(cpd: CpdProfile | null | undefined): {
+  html: string;
+  sources: number;
+} {
+  if (!cpd) return { html: "", sources: 0 };
+
+  if (cpd.status === "none") {
+    return {
+      html: `
+        ${sectionHeader("Chicago PD Complaint History")}
+        <p style="color: #A1A1AA; font-size: 13px; margin-bottom: 12px;">
+          No Chicago Police Department misconduct complaint record matched this officer name in the Invisible Institute FOIA dataset (${escapeHtml(CPD_DATA_WINDOW)}).
+        </p>
+        <p style="color: #71717A; font-size: 12px; margin: 0 0 24px;">
+          Officers appointed after mid-2018 may not appear in this dataset. Source: <a href="${CPD_SOURCE_URL}" style="color: #60A5FA;">${escapeHtml(CPD_SOURCE_URL)}</a>
+        </p>
+      `,
+      sources: 1,
+    };
+  }
+
+  if (cpd.status === "ambiguous") {
+    return {
+      html: `
+        ${sectionHeader("Chicago PD Complaint History")}
+        <div style="background: #1C1917; border: 1px solid #422006; border-radius: 8px; padding: 16px; margin-bottom: 24px;">
+          <p style="color: #F59E0B; font-weight: bold; margin: 0 0 8px;">Multiple officers match this name (${cpd.candidateCount})</p>
+          <p style="color: #D4D4D8; margin: 0 0 8px;">
+            Chicago PD has more than one officer with this name in the Invisible Institute FOIA dataset (${escapeHtml(CPD_DATA_WINDOW)}). To avoid returning the wrong officer&rsquo;s record, we have not included the CPD complaint history in this report.
+          </p>
+          <p style="color: #A1A1AA; font-size: 13px; margin: 0;">
+            Reply to your delivery email with the officer&rsquo;s star (badge) number and we will regenerate this section at no charge. Source: <a href="${CPD_SOURCE_URL}" style="color: #60A5FA;">${escapeHtml(CPD_SOURCE_URL)}</a>
+          </p>
+        </div>
+      `,
+      sources: 1,
+    };
+  }
+
+  const { officer, complaints, totals } = cpd;
+  const fullName = [officer.first_name, officer.last_name]
+    .filter(Boolean)
+    .join(" ") || "CPD officer";
+  const star = officer.current_star ? `Star #${escapeHtml(officer.current_star)}` : "";
+  const rank = officer.current_rank ? escapeHtml(officer.current_rank) : "";
+  const status = officer.current_status ? escapeHtml(officer.current_status) : "";
+  const metaLine = [star, rank, status].filter(Boolean).join(" &middot; ");
+
+  const range =
+    totals.earliest && totals.latest
+      ? ` (${escapeHtml(totals.earliest)} to ${escapeHtml(totals.latest)})`
+      : "";
+
+  const headline = `
+    <p style="color: #D4D4D8; margin-bottom: 8px;">
+      ${escapeHtml(fullName)}${metaLine ? ` &mdash; ${metaLine}` : ""}
+    </p>
+    <table style="width: 100%; border-collapse: collapse; margin-bottom: 16px;">
+      <tr>
+        <td style="padding: 8px 16px; color: #A1A1AA; border-bottom: 1px solid #1C1917;">Total complaints on file</td>
+        <td style="padding: 8px 16px; color: #FAFAF9; border-bottom: 1px solid #1C1917; font-weight: bold;">${totals.total}${range}</td>
+      </tr>
+      <tr>
+        <td style="padding: 8px 16px; color: #A1A1AA; border-bottom: 1px solid #1C1917;">Sustained findings</td>
+        <td style="padding: 8px 16px; color: ${totals.sustained > 0 ? "#EF4444" : "#FAFAF9"}; border-bottom: 1px solid #1C1917; font-weight: bold;">${totals.sustained}</td>
+      </tr>
+      <tr>
+        <td style="padding: 8px 16px; color: #A1A1AA;">Complaints with discipline imposed</td>
+        <td style="padding: 8px 16px; color: ${totals.disciplined > 0 ? "#EF4444" : "#FAFAF9"}; font-weight: bold;">${totals.disciplined}</td>
+      </tr>
+    </table>
+  `;
+
+  return {
+    html: `
+      ${sectionHeader("Chicago PD Complaint History")}
+      <p style="color: #A1A1AA; font-size: 13px; margin-bottom: 12px;">
+        Misconduct complaints filed with CPD / COPA / IPRA, ${escapeHtml(CPD_DATA_WINDOW)}. Factual records only; findings and outcomes as reported by the investigating agency.
+      </p>
+      ${headline}
+      ${renderCpdCategoryBreakdown(totals)}
+      <h4 style="color: #D4D4D8; margin: 16px 0 8px;">Complaint detail</h4>
+      ${renderCpdComplaintsTable(complaints)}
+      <p style="color: #71717A; font-size: 12px; margin: 0 0 24px;">
+        Source: <a href="${CPD_SOURCE_URL}" style="color: #60A5FA;">${escapeHtml(CPD_SOURCE_URL)}</a> (public FOIA dump, MIT-licensed code).
+      </p>
+    `,
+    sources: 1,
+  };
+}
+
 export function renderOfficerBackground(data: OfficerBackgroundData): string {
   let totalSources = 0;
   let body = "";
@@ -759,7 +943,20 @@ export function renderOfficerBackground(data: OfficerBackgroundData): string {
     }
   }
 
-  const primaryName = data.officers[0]?.officer_name ?? data.externalIntel[0]?.officer_name ?? "Officer";
+  const cpdSection = renderCpdSection(data.cpd);
+  body += cpdSection.html;
+  totalSources += cpdSection.sources;
+
+  const cpdName =
+    data.cpd?.status === "single"
+      ? [data.cpd.officer.first_name, data.cpd.officer.last_name]
+          .filter(Boolean)
+          .join(" ")
+      : "";
+  const primaryName =
+    data.officers[0]?.officer_name ??
+    data.externalIntel[0]?.officer_name ??
+    (cpdName || "Officer");
   return wrapReport(`Officer Background Check, ${primaryName}`, body, totalSources);
 }
 

--- a/supabase/migrations/20260424g_officer_bg_check_cpd_flag.sql
+++ b/supabase/migrations/20260424g_officer_bg_check_cpd_flag.sql
@@ -1,0 +1,28 @@
+-- 20260424g_officer_bg_check_cpd_flag.sql
+-- Feature flag gating the Chicago PD (Invisible Institute) depth section in
+-- /officer-background-check. Default OFF. Operator flips via
+-- /api/admin/feature-flags after the E2E fixture in
+-- scripts/verify-officer-render-chicago.mjs passes against Finnigan + Evans.
+--
+-- Data source:       public.cpd_officers + public.cpd_complaints
+--                    (migration 20260424b_cpd_invisible_institute.sql,
+--                     branch feat/ingest-cpd-invisible-institute commit 65ba342f)
+-- Query site:        src/lib/tier9-reports/query.ts → queryCpdProfile
+-- Coverage site:     src/lib/tier9-reports/coverage.ts → checkOfficerCoverage
+-- Render site:       src/lib/tier9-reports/render.ts → renderCpdSection
+-- Pristine-gate ref: docs/plans/2026-04-24-officer-bg-check-chicago-integration.md
+--
+-- Flip to ON:
+--   UPDATE public.feature_flags
+--   SET is_enabled = true, updated_at = NOW()
+--   WHERE flag_key = 'officer_bg_check_cpd_enhanced';
+--
+-- Feature-flag cache TTL is 5 minutes, see src/lib/feature-flags.ts.
+
+INSERT INTO public.feature_flags (flag_key, is_enabled, description) VALUES
+  (
+    'officer_bg_check_cpd_enhanced',
+    false,
+    'Officer Background Check Tier 9: attach Chicago PD FOIA complaint history (Invisible Institute, 2000-mid-2018) when agency matches CPD whitelist or state=IL. Dark launch 2026-04-24.'
+  )
+ON CONFLICT (flag_key) DO NOTHING;

--- a/tests/lib/cpd-match.test.ts
+++ b/tests/lib/cpd-match.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Unit tests for the CPD matcher pure logic.
+ *
+ * Exercises normalization + selection branches without touching Supabase.
+ * fetchCpdCandidates / matchCpdOfficer (DB path) covered by the integration
+ * fixture in scripts/verify-officer-render-chicago.mjs.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  normalizeAgencyToCpd,
+  isChicagoSignal,
+  parseOfficerName,
+  normalizeBadge,
+  chooseMatch,
+  type CpdCandidate,
+} from "@/lib/tier9-reports/cpd-match";
+
+function candidate(overrides: Partial<CpdCandidate>): CpdCandidate {
+  return {
+    uid: 1,
+    first_name: "Jerome",
+    last_name: "Finnigan",
+    current_star: "2012",
+    current_rank: "PO",
+    current_status: "resigned",
+    appointed_date: "1988-01-01",
+    ...overrides,
+  };
+}
+
+describe("normalizeAgencyToCpd", () => {
+  it("maps canonical CPD strings to 'cpd'", () => {
+    expect(normalizeAgencyToCpd("CPD")).toBe("cpd");
+    expect(normalizeAgencyToCpd("Chicago PD")).toBe("cpd");
+    expect(normalizeAgencyToCpd("Chicago Police")).toBe("cpd");
+    expect(normalizeAgencyToCpd("Chicago Police Department")).toBe("cpd");
+    expect(normalizeAgencyToCpd("City of Chicago Police")).toBe("cpd");
+    expect(normalizeAgencyToCpd("City of Chicago Police Department")).toBe("cpd");
+  });
+
+  it("absorbs case / punct / 'Dept.' variants", () => {
+    expect(normalizeAgencyToCpd("chicago pd.")).toBe("cpd");
+    expect(normalizeAgencyToCpd("Chicago   Police   Dept.")).toBe("cpd");
+    expect(normalizeAgencyToCpd("CITY OF CHICAGO POLICE DEPT.")).toBe("cpd");
+  });
+
+  it("rejects non-CPD agencies", () => {
+    expect(normalizeAgencyToCpd("Cook County Sheriff")).toBeNull();
+    expect(normalizeAgencyToCpd("Illinois State Police")).toBeNull();
+    expect(normalizeAgencyToCpd("Evanston Police")).toBeNull();
+    expect(normalizeAgencyToCpd("Police")).toBeNull();
+  });
+
+  it("handles null / empty", () => {
+    expect(normalizeAgencyToCpd(null)).toBeNull();
+    expect(normalizeAgencyToCpd(undefined)).toBeNull();
+    expect(normalizeAgencyToCpd("")).toBeNull();
+    expect(normalizeAgencyToCpd("   ")).toBeNull();
+  });
+});
+
+describe("isChicagoSignal", () => {
+  it("routes on explicit CPD agency even when state differs", () => {
+    expect(isChicagoSignal({ agency: "Chicago PD", state: "WI" })).toBe(true);
+  });
+
+  it("routes on state=IL when no agency given", () => {
+    expect(isChicagoSignal({ state: "IL" })).toBe(true);
+    expect(isChicagoSignal({ state: "il" })).toBe(true);
+  });
+
+  it("does not route on state alone when it isn't IL", () => {
+    expect(isChicagoSignal({ state: "CA" })).toBe(false);
+    expect(isChicagoSignal({})).toBe(false);
+  });
+
+  it("does not route on non-CPD agency even when state=IL is absent", () => {
+    expect(isChicagoSignal({ agency: "Cook County Sheriff" })).toBe(false);
+  });
+});
+
+describe("parseOfficerName", () => {
+  it("splits multi-token names with last-token-wins", () => {
+    expect(parseOfficerName("Jerome Finnigan")).toEqual({
+      firstName: "Jerome",
+      lastName: "Finnigan",
+    });
+    expect(parseOfficerName("Mary Ann Smith")).toEqual({
+      firstName: "Mary Ann",
+      lastName: "Smith",
+    });
+  });
+
+  it("collapses whitespace", () => {
+    expect(parseOfficerName("  Glenn   Evans  ")).toEqual({
+      firstName: "Glenn",
+      lastName: "Evans",
+    });
+  });
+
+  it("single-token names land on last_name for matcher fallback", () => {
+    expect(parseOfficerName("Finnigan")).toEqual({
+      firstName: "",
+      lastName: "Finnigan",
+    });
+  });
+
+  it("empty input produces empty fields", () => {
+    expect(parseOfficerName("")).toEqual({ firstName: "", lastName: "" });
+    expect(parseOfficerName("   ")).toEqual({ firstName: "", lastName: "" });
+  });
+});
+
+describe("normalizeBadge", () => {
+  it("strips non-digits", () => {
+    expect(normalizeBadge("Star #2012")).toBe("2012");
+    expect(normalizeBadge("  8051 ")).toBe("8051");
+    expect(normalizeBadge("B-2012")).toBe("2012");
+  });
+
+  it("returns null when nothing digit-like", () => {
+    expect(normalizeBadge("no badge")).toBeNull();
+    expect(normalizeBadge("")).toBeNull();
+    expect(normalizeBadge(null)).toBeNull();
+    expect(normalizeBadge(undefined)).toBeNull();
+  });
+});
+
+describe("chooseMatch", () => {
+  it("returns 'none' on empty candidates", () => {
+    const r = chooseMatch([], null);
+    expect(r.status).toBe("none");
+    expect(r.matchedUid).toBeNull();
+  });
+
+  it("returns 'single' when exactly one candidate", () => {
+    const r = chooseMatch([candidate({ uid: 42 })], null);
+    expect(r.status).toBe("single");
+    expect(r.matchedUid).toBe(42);
+  });
+
+  it("disambiguates multiple candidates via badge", () => {
+    const cands = [
+      candidate({ uid: 1, current_star: "2012" }),
+      candidate({ uid: 2, current_star: "8051" }),
+      candidate({ uid: 3, current_star: "9999" }),
+    ];
+    const r = chooseMatch(cands, "8051");
+    expect(r.status).toBe("single");
+    expect(r.matchedUid).toBe(2);
+  });
+
+  it("stays ambiguous when no badge given and multiple candidates", () => {
+    const cands = [
+      candidate({ uid: 1, current_star: "2012" }),
+      candidate({ uid: 2, current_star: "8051" }),
+    ];
+    const r = chooseMatch(cands, null);
+    expect(r.status).toBe("ambiguous");
+    expect(r.matchedUid).toBeNull();
+    expect(r.candidates).toHaveLength(2);
+  });
+
+  it("stays ambiguous when badge matches zero candidates", () => {
+    const cands = [
+      candidate({ uid: 1, current_star: "2012" }),
+      candidate({ uid: 2, current_star: "8051" }),
+    ];
+    const r = chooseMatch(cands, "0000");
+    expect(r.status).toBe("ambiguous");
+    expect(r.candidates).toHaveLength(2);
+  });
+
+  it("stays ambiguous when badge matches 2+ candidates (data glitch)", () => {
+    const cands = [
+      candidate({ uid: 1, current_star: "2012" }),
+      candidate({ uid: 2, current_star: "2012" }),
+    ];
+    const r = chooseMatch(cands, "2012");
+    expect(r.status).toBe("ambiguous");
+    expect(r.candidates).toHaveLength(2);
+  });
+
+  it("ignores non-digit noise in input badge", () => {
+    const cands = [
+      candidate({ uid: 1, current_star: "2012" }),
+      candidate({ uid: 2, current_star: "8051" }),
+    ];
+    const r = chooseMatch(cands, "Star #8051");
+    expect(r.matchedUid).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
- Wires the `cpd_officers` + `cpd_complaints` tables (loaded by #111) into the existing $97 Officer Background Check Tier 9 product
- No new SKU — same price, deeper report when agency matches CPD whitelist or state=IL
- Feature-flagged via `officer_bg_check_cpd_enhanced` (default OFF in Supabase, dark launch)
- Implementation per `docs/plans/2026-04-24-officer-bg-check-chicago-integration.md`

### Surfaces touched
- New: `src/lib/tier9-reports/cpd-match.ts` (matcher + 21 unit tests), `tests/lib/cpd-match.test.ts`, `scripts/verify-officer-render-chicago.mjs`, `supabase/migrations/20260424g_officer_bg_check_cpd_flag.sql`
- Edit: `query.ts` (`queryCpdProfile`), `render.ts` (`renderCpdSection`), `coverage.ts` (CPD probe), `AvailabilityChecker.tsx` (labels), `IntakeFormClient.tsx` + `products.ts` + `prepopulated-intake.ts` + intake route (optional `agency` + `badgeNumber`), `officer-background-check/page.tsx` (FEATURES + FAQ)

### UPL posture
- Pure factual counts + category breakdown + complaint detail table (capped at 30 rows for Gmail clip)
- No editorial framing ("this officer is unreliable" — banned)
- Every section cites the FOIA source (github.com/invinst/chicago-police-data)
- Disambiguation path: when name is ambiguous, render shows count-only + email-support CTA (no wrong-officer disclosure)

## Test plan
- [x] vitest: 31/31 pass (21 cpd-match + 10 officer-render regression)
- [x] tsc --noEmit clean
- [x] webpack compile clean (40s)
- [x] E2E real-DB fixture: Finnigan (162 complaints, 9 sustained) + Evans (131 complaints, 14 sustained) both resolve to single uid by name-only
- [x] Row-count sanity: cpd_officers=37,545 / cpd_complaints=263,315 (matches memory)
- [x] Security audit (security-auditor agent on the migration): zero findings

## Go-live
1. Merge after #111 is in master
2. Vercel auto-deploys from master push
3. Flip `feature_flags.officer_bg_check_cpd_enhanced = true` via `/api/admin/feature-flags`

🤖 Generated with [Claude Code](https://claude.com/claude-code)