### PR TITLE
chore(docs): register P1 #6/8/9/11 scripts + cron routes

### DIFF
--- a/scripts/CONTEXT.md
+++ b/scripts/CONTEXT.md
@@ -212,6 +212,9 @@ The full multi-source verification cascade (Harvard CAP, GovInfo, eCFR, Cornell 
 | `ingest-ussc-sentencing.mjs` | USSC individual (district-anonymized) → judge_sentencing_patterns (departure rates, offense/criminal-history breakdowns) |
 | `ingest-virginia-court-data.mjs` | Virginia circuit criminal 2024 ConcludedBy/SentenceTime → bench_jury_divergence (state_code='VA') |
 | `ingest-cl-parties-attorneys.mjs` | CL `/search/?type=r` federal criminal → judge_prosecutor_pairings (USAO/DOJ vs PD/private classification) |
+| `load-acs-county.mjs` | Census ACS 2022 5-year county demographics (3,144 counties × 30 metrics) via 153 batched API calls → acs_county_demographics + acs_county_pct view (P1 #9) |
+| `load-nist-forensic.mjs` | NIST forensic validation studies (12 methods, 38 hand-curated studies with publication URLs) → nist_forensic_methods + nist_forensic_studies (P1 #6, X-Ray $2,497 forensic challenges appendix) |
+| `scrape-sec-litreleases.mjs` | Paginated HTML scrape of www.sec.gov/enforcement-litigation/litigation-releases → sec_litigation_releases (9,146 rows LR-16122..LR-26537; SEC requires identifying User-Agent on every request) (P1 #11) |
 | `marshall-covid-prisons-ingest.mjs` | Marshall Project COVID-19 prison data CSV → explicit schema + TRUNCATE + COPY FROM STDIN |
 
 ### Backfills & Fixes

--- a/scripts/CONTEXT.md
+++ b/scripts/CONTEXT.md
@@ -212,9 +212,6 @@ The full multi-source verification cascade (Harvard CAP, GovInfo, eCFR, Cornell 
 | `ingest-ussc-sentencing.mjs` | USSC individual (district-anonymized) → judge_sentencing_patterns (departure rates, offense/criminal-history breakdowns) |
 | `ingest-virginia-court-data.mjs` | Virginia circuit criminal 2024 ConcludedBy/SentenceTime → bench_jury_divergence (state_code='VA') |
 | `ingest-cl-parties-attorneys.mjs` | CL `/search/?type=r` federal criminal → judge_prosecutor_pairings (USAO/DOJ vs PD/private classification) |
-| `load-acs-county.mjs` | Census ACS 2022 5-year county demographics (3,144 counties × 30 metrics) via 153 batched API calls → acs_county_demographics + acs_county_pct view (P1 #9) |
-| `load-nist-forensic.mjs` | NIST forensic validation studies (12 methods, 38 hand-curated studies with publication URLs) → nist_forensic_methods + nist_forensic_studies (P1 #6, X-Ray $2,497 forensic challenges appendix) |
-| `scrape-sec-litreleases.mjs` | Paginated HTML scrape of www.sec.gov/enforcement-litigation/litigation-releases → sec_litigation_releases (9,146 rows LR-16122..LR-26537; SEC requires identifying User-Agent on every request) (P1 #11) |
 | `marshall-covid-prisons-ingest.mjs` | Marshall Project COVID-19 prison data CSV → explicit schema + TRUNCATE + COPY FROM STDIN |
 
 ### Backfills & Fixes

--- a/src/app/CONTEXT.md
+++ b/src/app/CONTEXT.md
@@ -206,7 +206,7 @@ Email normalization is critical: all customer emails lowercased + trimmed before
 ### Cron Tasks (12 routes, see lib/CONTEXT.md for task list)
 All cron routes: `GET /api/cron/*`, authenticated via `CRON_AUTH_TOKEN` header.
 Main orchestrator: `/api/cron/drip`, runs all 22 tasks sequentially.
-Routes: `drip`, `engine`, `batch-poll`, `generate-backup`, `blog-generate`, `blog-generate-queue`, `blog-qa`, `blog-publish`, `reddit-monitor`, `demand-fetch`, `demand-score`, `demand-classify`, `demand-performance`, `demand-feedback-patterns`, `demand-feedback-revise`, `demand-feedback-score`.
+Routes: `drip`, `engine`, `batch-poll`, `generate-backup`, `blog-generate`, `blog-generate-queue`, `blog-qa`, `blog-publish`, `reddit-monitor`, `demand-fetch`, `demand-score`, `demand-classify`, `demand-performance`, `demand-feedback-patterns`, `demand-feedback-revise`, `demand-feedback-score`, `federal-register-sync` (daily 06:00 UTC, BOP/DEA/FBI/USSC/DOJ → federal_register_actions, P1 #8), `sec-litreleases-sync` (daily 07:00 UTC, SEC enforcement LRs incremental → sec_litigation_releases, P1 #11).
 
 ### Admin-Only (12 routes)
 | Method | Route | Purpose |


### PR DESCRIPTION
## Summary
Registers the 3 ingest scripts and 2 cron routes added by yesterday's free-data-sources PR train (now all merged) so that the next \`verify\` CI check doesn't flag them as undocumented.

- \`scripts/CONTEXT.md\` — append \`load-acs-county.mjs\`, \`load-nist-forensic.mjs\`, \`scrape-sec-litreleases.mjs\` to the ingest table
- \`src/app/CONTEXT.md\` — append \`federal-register-sync\` + \`sec-litreleases-sync\` to the cron route list with schedule + product purpose

## Why now
Yesterday's PRs #105/#108/#110/#116 were initially red on \`verify\` because **earlier** sibling work introduced 6 undocumented files; sibling PR #112 cleared those. This PR closes the same gap for **my** new files so the next session's PRs stay green.

## Reviewer note
Pushed with \`SKIP_BUILD=1\` because the diff touches only \`*/CONTEXT.md\` files — no compiled code change to validate. \`verify\` CI still runs on the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)