### PR TITLE
feat(ingest): USC seed v3 — +7 sections from wider audit (29 → 36)

### DIFF
--- a/scripts/ingest/__tests__/seed-statutes-us-cornell.test.mjs
+++ b/scripts/ingest/__tests__/seed-statutes-us-cornell.test.mjs
@@ -68,16 +68,47 @@ test('USC_SECTIONS covers the high-signal federal criminal sections', () => {
   ]) {
     assert.ok(byPair.has(pair), 'missing ' + pair);
   }
+  // v3 expansion (wider audit gaps).
+  for (const pair of [
+    '18:1028A', '18:1111', '18:2244', '18:3161', '18:3282', '18:3293',
+    '21:862',
+  ]) {
+    assert.ok(byPair.has(pair), 'missing ' + pair);
+  }
 });
 
-test('USC_SECTIONS count matches refresh-route USC_TARGETS (29 sections)', () => {
-  assert.equal(USC_SECTIONS.length, 29, 'USC_SECTIONS must equal 29 (v2 expansion); drift-lock in refresh route test also asserts 29');
+test('USC_SECTIONS count matches refresh-route USC_TARGETS (36 sections)', () => {
+  assert.equal(USC_SECTIONS.length, 36, 'USC_SECTIONS must equal 36 (v3 expansion); drift-lock in refresh route test also asserts 36');
+});
+
+test('Zod section regex accepts trailing capital letter (1028A)', () => {
+  // 18 USC 1028A is a real distinct section from 1028 — aggravated identity
+  // theft enhancement. Section regex must accept the "A" suffix.
+  const r = USC_SECTIONS.find((s) => s.title === '18' && s.section === '1028A');
+  assert.ok(r, 'USC_SECTIONS missing 18:1028A');
+  // Build a representative row + run through StatuteRowSchema to confirm
+  // regex acceptance (avoids false-pass if regex was loosened too far).
+  const row = {
+    jurisdiction: 'US',
+    title: '18',
+    section: '1028A',
+    subsection: null,
+    section_text: 'Aggravated identity theft\n\nWhoever, during and in relation to any felony violation enumerated.',
+    is_current: true,
+    source_urls: ['https://www.law.cornell.edu/uscode/text/18/1028A'],
+    text_hash: 'a'.repeat(64),
+    effective_date: null,
+    scraped_at: '2026-04-24T12:00:00.000Z',
+  };
+  const check = StatuteRowSchema.safeParse(row);
+  assert.ok(check.success, 'StatuteRowSchema must accept section 1028A: ' + JSON.stringify(check.error?.issues));
 });
 
 test('every USC_SECTIONS entry has numeric title + section + label', () => {
   for (const s of USC_SECTIONS) {
     assert.match(s.title, /^\d+$/, 'bad title: ' + s.title);
-    assert.match(s.section, /^\d+$/, 'bad section: ' + s.section);
+    // v3: section may have a trailing capital letter (1028A enhancement).
+    assert.match(s.section, /^\d+[A-Z]?$/, 'bad section: ' + s.section);
     assert.ok(s.label && s.label.length > 0, 'missing label for ' + s.title + ':' + s.section);
   }
 });

--- a/scripts/ingest/seed-statutes-us-cornell.mjs
+++ b/scripts/ingest/seed-statutes-us-cornell.mjs
@@ -84,12 +84,22 @@ export const USC_SECTIONS = [
   { title: '18', section: '1621', label: 'Perjury' },
   { title: '18', section: '1962', label: 'RICO — racketeering' },
   { title: '18', section: '2252', label: 'Child pornography possession' },
+  // v3 expansion (2026-04-24): wider audit caught additional prompt-and-
+  // content references. 18:1028A is distinct from 18:1028 — the "A" suffix
+  // is the aggravated-identity-theft enhancement (mandatory 2-year consec).
+  { title: '18', section: '1028A', label: 'Aggravated identity theft (mandatory consecutive 2y)' },
+  { title: '18', section: '1111',  label: 'Federal murder' },
+  { title: '18', section: '2244',  label: 'Abusive sexual contact' },
+  { title: '18', section: '3161',  label: 'Speedy Trial Act — 70-day clock' },
+  { title: '18', section: '3282',  label: 'Statute of limitations — non-capital federal offenses (5y default)' },
+  { title: '18', section: '3293',  label: 'Statute of limitations — financial institution / terrorism' },
 
   // Title 21 — drugs
   { title: '21', section: '841',  label: 'Controlled substance — manufacture/distribute' },
   { title: '21', section: '844',  label: 'Controlled substance — simple possession' },
   { title: '21', section: '846',  label: 'Controlled substance — conspiracy' },
   { title: '21', section: '853',  label: 'Controlled substance — forfeiture' },
+  { title: '21', section: '862',  label: 'Drug-conviction federal-benefits bar' },
 
   // Title 26 — tax
   { title: '26', section: '7201', label: 'Tax evasion' },
@@ -130,7 +140,9 @@ export function parseCliFlags(argv) {
 export const StatuteRowSchema = z.object({
   jurisdiction: z.literal('US'),
   title: z.string().regex(/^\d+$/),
-  section: z.string().regex(/^\d+$/),
+  // Section allows optional trailing capital letter (e.g. 1028A — Aggravated
+  // Identity Theft). Matches Cornell URL pattern /uscode/text/<title>/<sec>.
+  section: z.string().regex(/^\d+[A-Z]?$/),
   subsection: z.null(),
   section_text: z.string().min(20).max(50000),
   is_current: z.literal(true),

--- a/src/app/api/cron/statutes-refresh-us/__tests__/route.test.ts
+++ b/src/app/api/cron/statutes-refresh-us/__tests__/route.test.ts
@@ -39,10 +39,10 @@ describe("USC_TARGETS drift-lock", () => {
   it("coverage lock string matches expected version", () => {
     // If this fails, the seed script + refresh route + this lock constant
     // need to be updated together in the same PR.
-    expect(USC_TARGETS_COVERAGE_LOCK).toBe("v2:29-sections");
+    expect(USC_TARGETS_COVERAGE_LOCK).toBe("v3:36-sections");
   });
-  it("USC_TARGETS has exactly 29 entries", () => {
-    expect(USC_TARGETS.length).toBe(29);
+  it("USC_TARGETS has exactly 36 entries", () => {
+    expect(USC_TARGETS.length).toBe(36);
   });
   it("USC_TARGETS contains all high-signal federal criminal sections", () => {
     const byPair = new Set(USC_TARGETS.map((t) => `${t.title}:${t.section}`));
@@ -55,6 +55,13 @@ describe("USC_TARGETS drift-lock", () => {
       "18:2", "18:201", "18:1201", "18:1341", "18:1347", "18:1503",
       "18:1519", "18:1546", "18:1621", "18:1962", "18:2252",
       "26:7201", "8:1101", "8:1227",
+    ]) {
+      expect(byPair.has(must)).toBe(true);
+    }
+    // v3 expansion — wider audit gaps
+    for (const must of [
+      "18:1028A", "18:1111", "18:2244", "18:3161", "18:3282", "18:3293",
+      "21:862",
     ]) {
       expect(byPair.has(must)).toBe(true);
     }

--- a/src/app/api/cron/statutes-refresh-us/route.ts
+++ b/src/app/api/cron/statutes-refresh-us/route.ts
@@ -61,10 +61,19 @@ const USC_TARGETS: UscTarget[] = [
   { title: "18", section: "1621", label: "Perjury" },
   { title: "18", section: "1962", label: "RICO - racketeering" },
   { title: "18", section: "2252", label: "Child pornography possession" },
+  // v3 expansion (2026-04-24): wider audit caught additional references.
+  // 1028A is distinct from 1028 — aggravated identity theft enhancement.
+  { title: "18", section: "1028A", label: "Aggravated identity theft" },
+  { title: "18", section: "1111",  label: "Federal murder" },
+  { title: "18", section: "2244",  label: "Abusive sexual contact" },
+  { title: "18", section: "3161",  label: "Speedy Trial Act" },
+  { title: "18", section: "3282",  label: "Statute of limitations - non-capital (5y default)" },
+  { title: "18", section: "3293",  label: "Statute of limitations - financial / terrorism" },
   { title: "21", section: "841", label: "Controlled substance - manufacture/distribute" },
   { title: "21", section: "844", label: "Controlled substance - simple possession" },
   { title: "21", section: "846", label: "Controlled substance - conspiracy" },
   { title: "21", section: "853", label: "Controlled substance - forfeiture" },
+  { title: "21", section: "862", label: "Drug-conviction federal-benefits bar" },
   { title: "26", section: "7201", label: "Tax evasion" },
   { title: "8", section: "1101", label: "Immigration - definitions" },
   { title: "8", section: "1227", label: "Deportable aliens" },
@@ -75,7 +84,7 @@ const USC_TARGETS: UscTarget[] = [
 // Lock string — exported for the drift-lock unit test to pin against.
 // Increment when intentionally changing USC_TARGETS (and update the seed
 // script + its test fixture in the same PR).
-export const USC_TARGETS_COVERAGE_LOCK = "v2:29-sections";
+export const USC_TARGETS_COVERAGE_LOCK = "v3:36-sections";
 
 const ALLOWED_HOSTNAMES = new Set(["www.law.cornell.edu", "law.cornell.edu"]);
 


### PR DESCRIPTION
## Summary

Wider USC citation audit (1,264 files vs v2's 4) caught 7 more prompt-and-content references that had escaped earlier passes. Adds them to the seed + refresh-route lists. Loosens the section regex to accept the "A" suffix needed for `18 USC 1028A` (Aggravated Identity Theft — distinct USC section from 1028).

## New sections

| Title | Section | Label |
|---|---|---|
| 18 | 1028A | Aggravated identity theft (mandatory consec 2y) |
| 18 | 1111 | Federal murder |
| 18 | 2244 | Abusive sexual contact |
| 18 | 3161 | Speedy Trial Act (70-day clock) |
| 18 | 3282 | Statute of limitations: non-capital federal (5y default) |
| 18 | 3293 | Statute of limitations: financial / terrorism |
| 21 | 862 | Drug-conviction federal-benefits bar |

Skipped from audit:
- `15:1681` (FCRA) — civil statute "et seq" reference, not defense citation
- `15:7704` (CAN-SPAM) — infrastructure comment, not prosecutable

## Changes

- `scripts/ingest/seed-statutes-us-cornell.mjs`: USC_SECTIONS 29 → 36; section regex `/^\d+$/` → `/^\d+[A-Z]?$/`
- `src/app/api/cron/statutes-refresh-us/route.ts`: USC_TARGETS 29 → 36; coverage lock `v2:29` → `v3:36`
- Tests: count assertions, drift-lock membership, new Zod 1028A round-trip test, numeric-format regex permits trailing capital

## Live verification (ran seed before commit)

```
=== TOTAL: 36/36 rows parsed ===
writing 36 rows to entities_statutes...
  cleared 29 prior US Cornell rows
  COPYd 36 rows in 0.6s
pre-commit verify (Cornell-sourced US rows): {"n":36,"missing_sources":0,"empty_body":0}
```

Hash MATCH on 18:1028A, 18:3161, 18:3282, 21:862. All URLs `https://www.law.cornell.edu/uscode/text/<title>/<sec>`.

## Test plan

- [x] 31/31 seed unit (`node --test`)
- [x] 21/21 refresh route unit (vitest)
- [x] `tsc --noEmit --skipLibCheck` — 0 errors
- [x] Live seed: 36 rows, hash integrity verified

## Cumulative state

Six PRs shipped today closing the no-hallucinated-legal-data gap + drift detection + comprehensive citation coverage:
- #104 FL Phase 1 seed (470 rows)
- #115 USC seed + query-time filter (15)
- #117 USC weekly refresh cron
- #119 USC v2 expansion (+14 → 29)
- #120 FL per-chapter weekly refresh
- #(this) USC v3 expansion (+7 → 36)

🤖 Generated with [Claude Code](https://claude.com/claude-code)