### PR TITLE
feat(ingest): OH state statutes seed — Phase 2 first state (247 rows live)

### DIFF
--- a/scripts/ingest/__tests__/seed-statutes-oh.test.mjs
+++ b/scripts/ingest/__tests__/seed-statutes-oh.test.mjs
@@ -1,0 +1,297 @@
+// Template: scripts/ingest/__tests__/seed-statutes-fl.test.mjs
+// Expert: openstates-team + Cornell LII pattern parity
+// Pattern: cl-bulk-data-defensive #17 + no-hallucinated-legal-data
+// csv-bulk-checked: none-exists — synthetic fixtures, no network
+//
+// Unit tests for OH state statutes seed pipeline.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
+import {
+  OH_CHAPTERS,
+  StatuteRowSchema,
+  parseCliFlags,
+  buildChapterUrl,
+  buildSectionUrl,
+  buildRow,
+  textArrayLiteral,
+  fetchWithRetry,
+  _resetBreakerForTests,
+  isSectionNotFound,
+  stripHtml,
+  extractSectionNumbers,
+  parseSectionPage,
+  seedOH,
+} from '../seed-statutes-oh.mjs';
+
+// ── Fixtures ─────────────────────────────────────────────────────────────
+// Synthetic OH page mimicking codes.ohio.gov real markup: <h1> with section
+// number + name + separator, <div class="laws-body"> with <p> paragraphs,
+// then <div class="laws-section-info"> module below.
+
+const FIXTURE_2925_11 = `<html lang="en"><head><title>Section 2925.11 - Ohio Revised Code</title></head>
+<body>
+<main>
+<h1>Section 2925.11 <span class='codes-separator'>|</span> Possession of controlled substances.</h1>
+<div class="content-layout-body">
+<div class="laws-body">
+<span><p>(A) No person shall knowingly obtain, possess, or use a controlled substance or a controlled substance analog.</p>
+<p>(B)(1) This section does not apply to manufacturers, licensed health professionals, pharmacists, owners of pharmacies.</p></span>
+</div>
+<div class="laws-section-info">
+<p>Effective Date: 09/30/2024</p>
+</div>
+</main>
+</body></html>`;
+
+const FIXTURE_CHAPTER_2925 = `<html><body>
+<a href="/ohio-revised-code/section-2925.01">2925.01</a>
+<a href="/ohio-revised-code/section-2925.03">2925.03</a>
+<a href="/ohio-revised-code/section-2925.11">2925.11</a>
+<!-- cross-references that should NOT be picked up: -->
+<p>See also <a href="/ohio-revised-code/section-2913.01">2913.01</a> for theft offenses.</p>
+<p>And <a href="/ohio-revised-code/section-3719.01">3719.01</a> for separate definitions.</p>
+</body></html>`;
+
+const FIXTURE_NOT_FOUND = `<html><body><h1>Page not found</h1><p>The section you requested does not exist.</p></body></html>`;
+
+// ── OH_CHAPTERS coverage ─────────────────────────────────────────────────
+
+test('OH_CHAPTERS covers Phase 2 OH target chapters', () => {
+  for (const ch of [2903, 2911, 2913, 2923, 2925, 4511]) {
+    assert.ok(OH_CHAPTERS[ch], 'missing chapter ' + ch);
+    assert.ok(OH_CHAPTERS[ch].description.length > 0, 'missing description for ' + ch);
+  }
+});
+
+// ── URL construction ────────────────────────────────────────────────────
+
+test('buildChapterUrl produces canonical OH URL (HTTPS)', () => {
+  const u = buildChapterUrl(2925);
+  assert.ok(u.startsWith('https://'), 'must be HTTPS: ' + u);
+  assert.ok(u.includes('codes.ohio.gov'));
+  assert.ok(u.endsWith('/chapter-2925'));
+});
+
+test('buildSectionUrl uses section path', () => {
+  const u = buildSectionUrl('2925.11');
+  assert.ok(u.startsWith('https://'), 'must be HTTPS');
+  assert.ok(u.endsWith('/section-2925.11'));
+});
+
+test('buildChapterUrl throws for unknown chapter', () => {
+  assert.throws(() => buildChapterUrl(9999), /not in OH_CHAPTERS/);
+});
+
+// ── CLI flags ────────────────────────────────────────────────────────────
+
+test('parseCliFlags handles --dry-run + --chapters + --limit', () => {
+  const f = parseCliFlags(['--dry-run', '--chapters=2925,4511', '--limit=10']);
+  assert.equal(f.dryRun, true);
+  assert.deepEqual(f.chapters, [2925, 4511]);
+  assert.equal(f.limitSections, 10);
+});
+
+// ── 404 detection ────────────────────────────────────────────────────────
+
+test('isSectionNotFound detects OH "not found" + missing laws-body', () => {
+  assert.equal(isSectionNotFound(FIXTURE_NOT_FOUND), true);
+});
+
+test('isSectionNotFound passes valid section pages', () => {
+  assert.equal(isSectionNotFound(FIXTURE_2925_11), false);
+});
+
+// ── Section discovery ──────────────────────────────────────────────────
+
+test('extractSectionNumbers filters to chapter-prefix only (rejects cross-refs)', () => {
+  const s = extractSectionNumbers(FIXTURE_CHAPTER_2925, 2925);
+  assert.deepEqual(s, ['2925.01', '2925.03', '2925.11']);
+  // Confirm cross-references to chapters 2913 + 3719 were rejected.
+  assert.ok(!s.some((x) => x.startsWith('2913.')));
+  assert.ok(!s.some((x) => x.startsWith('3719.')));
+});
+
+// ── Section page parse ──────────────────────────────────────────────────
+
+test('parseSectionPage extracts title via h1 separator-strip', () => {
+  const p = parseSectionPage(FIXTURE_2925_11, 2925, '2925.11');
+  assert.equal(p.titleText, 'Possession of controlled substances.');
+});
+
+test('parseSectionPage extracts body scoped to laws-body class', () => {
+  const p = parseSectionPage(FIXTURE_2925_11, 2925, '2925.11');
+  assert.ok(p.bodyText.includes('controlled substance'));
+  assert.ok(!p.bodyText.includes('Effective Date'), 'effective-date module leaked into body');
+});
+
+test('parseSectionPage extracts effective_date from laws-section-info', () => {
+  const p = parseSectionPage(FIXTURE_2925_11, 2925, '2925.11');
+  assert.equal(p.effectiveDate, '2024-09-30');
+});
+
+test('parseSectionPage returns null for 404 page', () => {
+  assert.equal(parseSectionPage(FIXTURE_NOT_FOUND, 2925, '2925.99'), null);
+});
+
+// ── stripHtml XSS + control-char defense ────────────────────────────────
+
+test('stripHtml strips tags materialized from decoded entities', () => {
+  const s = stripHtml('clean &#60;script&#62;alert(1)&#60;/script&#62; end');
+  assert.ok(!s.includes('<script'));
+  assert.ok(!s.includes('</script'));
+});
+
+test('stripHtml drops C0 controls + DEL', () => {
+  const s = stripHtml('a&#0;b&#8;c&#127;d');
+  for (let i = 0; i < s.length; i++) {
+    const c = s.charCodeAt(i);
+    const bad = (c < 0x20 && c !== 0x09 && c !== 0x0A && c !== 0x0D) || c === 0x7F;
+    assert.ok(!bad, 'control byte ' + c.toString(16) + ' survived');
+  }
+});
+
+// ── Row builder ──────────────────────────────────────────────────────────
+
+test('buildRow produces deterministic text_hash over section_text', () => {
+  const r = buildRow({
+    chapter: 2925, section: '2925.11',
+    titleText: 'Possession.', bodyText: 'No person shall knowingly possess a controlled substance.',
+    effectiveDate: '2024-09-30',
+    sourceUrl: 'https://codes.ohio.gov/ohio-revised-code/section-2925.11',
+    scrapedAt: '2026-04-24T12:00:00.000Z',
+  });
+  const expected = crypto.createHash('sha256')
+    .update('Possession.\n\nNo person shall knowingly possess a controlled substance.')
+    .digest('hex');
+  assert.equal(r.text_hash, expected);
+});
+
+test('buildRow omits canonical_id (DB auto-generates UUID)', () => {
+  const r = buildRow({
+    chapter: 2925, section: '2925.11',
+    titleText: 'Possession.', bodyText: 'long enough body text to pass zod min length',
+    effectiveDate: null,
+    sourceUrl: 'https://codes.ohio.gov/ohio-revised-code/section-2925.11',
+  });
+  assert.equal(r.canonical_id, undefined);
+  assert.equal(r.jurisdiction, 'OH');
+  assert.equal(r.title, '2925');
+  assert.equal(r.subsection, null);
+  assert.equal(r.is_current, true);
+});
+
+// ── Zod contract ─────────────────────────────────────────────────────────
+
+test('StatuteRowSchema accepts a valid OH row', () => {
+  const r = buildRow({
+    chapter: 2925, section: '2925.11',
+    titleText: 'Possession.', bodyText: 'No person shall knowingly possess a controlled substance.',
+    effectiveDate: '2024-09-30',
+    sourceUrl: 'https://codes.ohio.gov/ohio-revised-code/section-2925.11',
+    scrapedAt: '2026-04-24T12:00:00.000Z',
+  });
+  const check = StatuteRowSchema.safeParse(r);
+  assert.ok(check.success, JSON.stringify(check.error?.issues));
+});
+
+test('StatuteRowSchema rejects non-codes.ohio.gov primary URL', () => {
+  const r = buildRow({
+    chapter: 2925, section: '2925.11',
+    titleText: 'P.', bodyText: 'long enough body text to pass zod minimum',
+    effectiveDate: null,
+    sourceUrl: 'https://law.justia.com/codes/ohio/2925.11',
+  });
+  const check = StatuteRowSchema.safeParse(r);
+  assert.equal(check.success, false);
+});
+
+test('StatuteRowSchema rejects invalid calendar date in effective_date', () => {
+  const r = buildRow({
+    chapter: 2925, section: '2925.11',
+    titleText: 'P.', bodyText: 'long enough body text to pass zod minimum',
+    effectiveDate: '2024-02-30', // Feb 30 doesn't exist
+    sourceUrl: 'https://codes.ohio.gov/x',
+  });
+  assert.equal(StatuteRowSchema.safeParse(r).success, false);
+});
+
+test('StatuteRowSchema host check rejects substring spoofing', () => {
+  const r = buildRow({
+    chapter: 2925, section: '2925.11',
+    titleText: 'P.', bodyText: 'long enough body text to pass zod minimum',
+    effectiveDate: null,
+    sourceUrl: 'https://attacker.example.com/codes.ohio.gov/fake',
+  });
+  assert.equal(StatuteRowSchema.safeParse(r).success, false);
+});
+
+// ── TEXT[] literal ──────────────────────────────────────────────────────
+
+test('textArrayLiteral escapes CR/LF/quotes/backslashes', () => {
+  const lit = textArrayLiteral(['a"b\\c\nd\re']);
+  assert.ok(!lit.includes('\n'));
+  assert.ok(!lit.includes('\r'));
+  assert.ok(lit.includes('\\"'));
+  assert.ok(lit.includes('\\\\'));
+});
+
+// ── fetchWithRetry ──────────────────────────────────────────────────────
+
+test('fetchWithRetry rejects non-allowed host', async () => {
+  _resetBreakerForTests();
+  await assert.rejects(() => fetchWithRetry('https://evil.example.com/x', { fetchImpl: async () => ({ ok: true, status: 200, text: async () => '' }) }), /Host not allowed/);
+});
+
+test('fetchWithRetry returns body on first success', async () => {
+  _resetBreakerForTests();
+  const out = await fetchWithRetry('https://codes.ohio.gov/x', {
+    fetchImpl: async () => ({ ok: true, status: 200, async text() { return 'hello'; } }),
+  });
+  assert.equal(out, 'hello');
+});
+
+test('fetchWithRetry does NOT retry on 404', async () => {
+  _resetBreakerForTests();
+  let calls = 0;
+  await assert.rejects(() => fetchWithRetry('https://codes.ohio.gov/x', {
+    fetchImpl: async () => { calls += 1; return { ok: false, status: 404, async text() { return ''; } }; },
+  }), /HTTP 404/);
+  assert.equal(calls, 1);
+});
+
+// ── seedOH orchestrator smoke ──────────────────────────────────────────
+
+test('seedOH dry-run parses fixtures end-to-end', async () => {
+  _resetBreakerForTests();
+  const fetchImpl = async (url) => {
+    const u = String(url);
+    if (u.includes('chapter-2925')) return { ok: true, status: 200, async text() { return FIXTURE_CHAPTER_2925; } };
+    return { ok: true, status: 200, async text() { return FIXTURE_2925_11; } };
+  };
+  const out = await seedOH({
+    dryRun: true,
+    chapters: [2925],
+    limitSections: 3,
+    fetchImpl,
+  });
+  assert.equal(out.rows.length, 3);
+  for (const r of out.rows) {
+    const check = StatuteRowSchema.safeParse(r);
+    assert.ok(check.success, 'row failed schema');
+    assert.ok(r.source_urls[0].includes('codes.ohio.gov'));
+  }
+});
+
+test('seedOH non-dry-run with zero rows throws WITHOUT touching dbFactory', async () => {
+  _resetBreakerForTests();
+  const fetchImpl = async () => ({ ok: true, status: 200, async text() { return FIXTURE_NOT_FOUND; } });
+  let factoryCalls = 0;
+  const dbFactory = async () => { factoryCalls += 1; throw new Error('factory should not be called'); };
+  await assert.rejects(
+    () => seedOH({ dryRun: false, chapters: [2925], limitSections: 2, fetchImpl, dbFactory }),
+    /no rows parsed/,
+  );
+  assert.equal(factoryCalls, 0);
+});

--- a/scripts/ingest/lib/oh-html.mjs
+++ b/scripts/ingest/lib/oh-html.mjs
@@ -1,0 +1,146 @@
+// HTML parsing helpers for Ohio Revised Code (codes.ohio.gov) section pages.
+// Pure in-memory string processing — no file I/O. Mirrors fl-html.mjs +
+// cornell-html.mjs semantics for hash-integrity (tags-first / decode-second
+// / second-pass strip / drop C0+DEL+surrogates).
+
+/** Detect "page not found" / non-existent section. */
+export function isSectionNotFound(html) {
+  if (!html) return true;
+  if (html.length < 500) return true;
+  // OH 404 returns 200 OK with "not found" banner + no laws-body container.
+  if (html.toLowerCase().indexOf('not found') >= 0 && html.indexOf('laws-body') < 0) return true;
+  return false;
+}
+
+/** Strip HTML tags, decode entities, drop control chars, collapse whitespace. */
+export function stripHtml(html) {
+  if (!html) return '';
+  let s = html;
+  s = s.replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, ' ');
+  s = s.replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, ' ');
+  s = s.replace(/<!--[\s\S]*?-->/g, ' ');
+  s = s.replace(/<br\s*\/?\s*>/gi, '\n');
+  s = s.replace(/<\/p>/gi, '\n\n');
+  s = s.replace(/<\/div>/gi, '\n');
+  s = s.replace(/<[^>]+>/g, ' ');
+  s = s
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&amp;/gi, '&')
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+    .replace(/&quot;/gi, '"')
+    .replace(/&#(\d+);/g, (_, n) => {
+      const code = Number(n);
+      if (!Number.isInteger(code) || code < 0 || code > 0x10FFFF) return '';
+      if (code < 0x20 && code !== 0x09 && code !== 0x0A && code !== 0x0D) return '';
+      if (code === 0x7F) return '';
+      if (code >= 0xD800 && code <= 0xDFFF) return '';
+      return String.fromCodePoint(code);
+    })
+    .replace(/&#x([0-9a-f]+);/gi, (_, n) => {
+      const code = Number.parseInt(n, 16);
+      if (!Number.isInteger(code) || code < 0 || code > 0x10FFFF) return '';
+      if (code < 0x20 && code !== 0x09 && code !== 0x0A && code !== 0x0D) return '';
+      if (code === 0x7F) return '';
+      if (code >= 0xD800 && code <= 0xDFFF) return '';
+      return String.fromCodePoint(code);
+    });
+  s = s.replace(/<[^>]+>/g, ' ');
+  s = s.split('').filter((ch) => {
+    const c = ch.charCodeAt(0);
+    if (c === 9 || c === 10 || c === 13) return true;
+    if (c < 32) return false;
+    if (c === 127) return false;
+    return true;
+  }).join('');
+  return s.split(/\s+/).filter(Boolean).join(' ').trim();
+}
+
+/** Discover section numbers from a chapter page. Filters to chapter-prefix
+ *  sections only (chapter pages cite cross-chapter references). */
+export function extractSectionNumbers(html, chapter) {
+  if (!html) return [];
+  const seen = new Set();
+  // OH section URL pattern: /ohio-revised-code/section-<chapter>.<num>
+  const re = /\/ohio-revised-code\/section-(\d+)\.([\w]+)/g;
+  let m;
+  while ((m = re.exec(html)) !== null) {
+    if (m[1] !== String(chapter)) continue;
+    if (!/^\d+$/.test(m[2])) continue;
+    seen.add(m[1] + '.' + m[2]);
+  }
+  return [...seen].sort((a, b) => {
+    const as = Number.parseInt(a.split('.')[1], 10);
+    const bs = Number.parseInt(b.split('.')[1], 10);
+    return as - bs;
+  });
+}
+
+/** Parse an OH section page into {titleText, bodyText, effectiveDate}. */
+export function parseSectionPage(html, chapter, section) {
+  if (isSectionNotFound(html)) return null;
+
+  // Title from h1: "Section 2925.11 <span>|</span> Possession of controlled substances."
+  let titleText = null;
+  const h1 = html.match(/<h1[^>]*>([\s\S]*?)<\/h1>/i);
+  if (h1) {
+    const h1Text = stripHtml(h1[1]).trim();
+    let t = h1Text.replace(/^Section\s+\d+\.\w+\s*[|\-–—]\s*/, '').trim();
+    if (!t || t === 'Ohio Revised Code') t = h1Text;
+    titleText = t;
+  }
+  if (!titleText) titleText = 'Section ' + section;
+
+  // Body: scope to <... class="laws-body">...</...>. Container is a div on
+  // most sections but we anchor on the class attr to be robust.
+  let bodyText = null;
+  const bodyStart = html.search(/class="[^"]*laws-body[^"]*"/i);
+  if (bodyStart >= 0) {
+    const afterOpen = html.indexOf('>', bodyStart) + 1;
+    // End boundary: anchor on the OPENING TAG of laws-section-info (W4 fix
+    // — `class="laws-section-info` matches inside the tag attr; the body
+    // slice should end at the START of that tag, not inside its attribute).
+    const candidates = [
+      html.indexOf('<div class="laws-section-info', afterOpen),
+      html.indexOf('<section class="laws-section-info', afterOpen),
+      html.indexOf('</main>', afterOpen),
+      html.indexOf('<footer', afterOpen),
+    ].filter((n) => n > 0);
+    const end = candidates.length ? Math.min(...candidates) : html.length;
+    bodyText = stripHtml(html.slice(afterOpen, end));
+  } else {
+    bodyText = stripHtml(html);
+  }
+
+  if (bodyText.length > 20000) bodyText = bodyText.slice(0, 20000).trim();
+  if (!bodyText || bodyText.length < 20) return null;
+
+  // SUGG fix from 2026-04-24 review: scope effective-date search to the
+  // laws-section-info module (mirrors fl-html.mjs:202-208). Prevents body
+  // text like "Effective 1/1/2020 if the defendant ..." from clobbering
+  // the row's effective_date with an internal cross-reference.
+  let effectiveDate = null;
+  let effHaystack = html;
+  const infoStart = html.indexOf('class="laws-section-info');
+  if (infoStart >= 0) {
+    const afterOpen = html.indexOf('>', infoStart) + 1;
+    const candidates = [
+      html.indexOf('</main>', afterOpen),
+      html.indexOf('<footer', afterOpen),
+    ].filter((n) => n > 0);
+    const end = candidates.length ? Math.min(...candidates) : html.length;
+    effHaystack = html.slice(afterOpen, end);
+  }
+  const em = effHaystack.match(/Effective(?:\s+Date)?:\s*(\d{1,2})\/(\d{1,2})\/(\d{4})/i);
+  if (em) {
+    const mm = String(em[1]).padStart(2, '0');
+    const dd = String(em[2]).padStart(2, '0');
+    const candidate = em[3] + '-' + mm + '-' + dd;
+    const d = new Date(candidate + 'T00:00:00Z');
+    if (!Number.isNaN(d.getTime()) && d.toISOString().slice(0, 10) === candidate) {
+      effectiveDate = candidate;
+    }
+  }
+
+  return { titleText, bodyText, effectiveDate };
+}

--- a/scripts/ingest/seed-statutes-oh.mjs
+++ b/scripts/ingest/seed-statutes-oh.mjs
@@ -1,0 +1,356 @@
+// Template: scripts/ingest/seed-statutes-fl.mjs
+// Expert: openstates-team (per-state scraper class pattern)
+// Pattern: cl-bulk-data-defensive #18 + no-hallucinated-legal-data
+// csv-bulk-checked: none-exists — Ohio Revised Code is web-only via codes.ohio.gov
+//
+// OH state statutes seed — Phase 2 first state companion to FL (PR #104).
+// Source: Ohio Revised Code (https://codes.ohio.gov/ohio-revised-code/).
+// Target: entities_statutes (one row per section).
+// Coverage: 6 chapters covering ~75% of INAA OH-relevant intake:
+//   2903 (Homicide/Assault), 2911 (Burglary/Trespass), 2913 (Theft/Fraud),
+//   2923 (Weapons/Conspiracy), 2925 (Drug offenses), 4511 (Traffic/OVI).
+//
+// Every row carries non-empty source_urls[] pointing to the URL we actually
+// fetched. Zod contract rejects any row that fails integrity BEFORE INSERT
+// (OpenStates Rule 2).
+//
+// Usage:
+//   node scripts/ingest/seed-statutes-oh.mjs --dry-run
+//   node scripts/ingest/seed-statutes-oh.mjs --chapters=4511 --limit=5
+//   node scripts/ingest/seed-statutes-oh.mjs
+
+import fs from 'node:fs';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import { pathToFileURL, fileURLToPath } from 'node:url';
+import { z } from 'zod';
+import { createBulkClient, bulkCopyRows } from '../lib/pg-bulk-defaults.mjs';
+import { isSectionNotFound, stripHtml, extractSectionNumbers, parseSectionPage } from './lib/oh-html.mjs';
+
+export { isSectionNotFound, stripHtml, extractSectionNumbers, parseSectionPage };
+
+// ── Env loader (web-repo only, # skip, trim, quote strip) ────────────────
+const envPaths = ['C:/Users/email/projects/ImNotAnAttorney-web/.env.local'];
+const VALID_KEY_RX = /^[A-Z_][A-Z0-9_]*$/;
+for (const p of envPaths) {
+  if (!fs.existsSync(p)) continue;
+  const txt = fs.readFileSync(p, 'utf-8');
+  for (const rawLine of txt.split('\n')) {
+    let line = rawLine.endsWith('\r') ? rawLine.slice(0, -1) : rawLine;
+    line = line.trim();
+    if (!line || line[0] === '#') continue;
+    const eq = line.indexOf('=');
+    if (eq <= 0) continue;
+    const key = line.slice(0, eq).trim();
+    let val = line.slice(eq + 1).trim();
+    if (val.length >= 2 && ((val[0] === '"' && val[val.length - 1] === '"') ||
+        (val[0] === "'" && val[val.length - 1] === "'"))) {
+      val = val.slice(1, -1);
+    }
+    if (!VALID_KEY_RX.test(key)) continue;
+    if (!process.env[key]) process.env[key] = val;
+  }
+}
+
+// ── Coverage: 6 high-signal OH chapters ──────────────────────────────────
+export const OH_CHAPTERS = {
+  2903: { description: 'Homicide / Assault' },
+  2911: { description: 'Burglary / Aggravated trespass' },
+  2913: { description: 'Theft / Fraud' },
+  2923: { description: 'Conspiracy / Weapons' },
+  2925: { description: 'Drug offenses' },
+  4511: { description: 'Traffic / OVI (Operating a Vehicle Impaired)' },
+};
+
+const USER_AGENT = 'INAA-legal-research/1.0 (+https://imnotanattorney.com/about)';
+const RATE_MIN_MS = 500;
+const RATE_MAX_MS = 2000;
+const RETRY_BACKOFFS_MS = [5000, 30000, 120000];
+const CIRCUIT_BREAKER_FAILURES = 3;
+const CIRCUIT_BREAKER_PAUSE_MS = 120000;
+const OH_BASE = 'https://codes.ohio.gov/ohio-revised-code/';
+const ALLOWED_HOSTS = new Set(['codes.ohio.gov']);
+
+// ── CLI flags ────────────────────────────────────────────────────────────
+export function parseCliFlags(argv) {
+  const flags = { dryRun: false, chapters: null, limitSections: null };
+  for (const arg of argv) {
+    if (arg === '--dry-run') flags.dryRun = true;
+    else if (arg.startsWith('--chapters=')) {
+      flags.chapters = arg.slice('--chapters='.length).split(',')
+        .map((s) => Number.parseInt(s.trim(), 10))
+        .filter((n) => Number.isInteger(n));
+    } else if (arg.startsWith('--limit=')) {
+      flags.limitSections = Number.parseInt(arg.slice('--limit='.length), 10);
+    }
+  }
+  return flags;
+}
+
+// ── Zod contract (reject-before-INSERT) ──────────────────────────────────
+export const StatuteRowSchema = z.object({
+  jurisdiction: z.literal('OH'),
+  title: z.string().regex(/^\d+$/),
+  // W2 fix: tighten to match what extractSectionNumbers emits — pure numeric
+  // chapter.subsection. OH section IDs on codes.ohio.gov are all-digit.
+  section: z.string().regex(/^\d+\.\d+$/),
+  subsection: z.null(),
+  section_text: z.string().min(20).max(50000),
+  is_current: z.literal(true),
+  source_urls: z.array(z.string().url().max(2048)).min(1).max(10)
+    .refine((urls) => {
+      try {
+        const host = new URL(urls[0]).hostname.toLowerCase();
+        return host === 'codes.ohio.gov';
+      } catch { return false; }
+    }, 'Primary source_url host must be codes.ohio.gov'),
+  text_hash: z.string().regex(/^[a-f0-9]{64}$/),
+  effective_date: z.union([
+    z.string().regex(/^\d{4}-\d{2}-\d{2}$/).refine((s) => {
+      const d = new Date(s + 'T00:00:00Z');
+      return !Number.isNaN(d.getTime()) && d.toISOString().slice(0, 10) === s;
+    }, 'effective_date must be a valid calendar date'),
+    z.null(),
+  ]),
+  scraped_at: z.string().datetime().max(40),
+});
+
+// ── URL builders ─────────────────────────────────────────────────────────
+export function buildChapterUrl(chapter) {
+  if (!OH_CHAPTERS[chapter]) throw new Error('Chapter ' + chapter + ' not in OH_CHAPTERS');
+  return OH_BASE + 'chapter-' + chapter;
+}
+
+export function buildSectionUrl(section) {
+  return OH_BASE + 'section-' + section;
+}
+
+function isAllowedHost(urlStr) {
+  try {
+    const u = new URL(urlStr);
+    if (u.protocol !== 'https:') return false;
+    return ALLOWED_HOSTS.has(u.hostname.toLowerCase());
+  } catch { return false; }
+}
+
+// ── Fetch with retry + circuit breaker ───────────────────────────────────
+let consecutiveFailures = 0;
+let circuitOpenUntil = 0;
+function sleep(ms) { return new Promise((r) => setTimeout(r, ms)); }
+function randomDelay() { return RATE_MIN_MS + Math.floor(Math.random() * (RATE_MAX_MS - RATE_MIN_MS)); }
+
+export async function fetchWithRetry(url, { fetchImpl } = {}) {
+  if (!isAllowedHost(url)) throw new Error('Host not allowed: ' + url);
+  const doFetch = fetchImpl || fetch;
+  if (circuitOpenUntil > Date.now()) {
+    await sleep(circuitOpenUntil - Date.now());
+    consecutiveFailures = 0;
+  }
+  let lastError = null;
+  for (let attempt = 0; attempt < RETRY_BACKOFFS_MS.length; attempt++) {
+    await sleep(randomDelay());
+    let resp;
+    try {
+      resp = await doFetch(url, {
+        headers: { 'User-Agent': USER_AGENT, 'Accept': 'text/html,application/xhtml+xml' },
+        redirect: 'follow',
+      });
+    } catch (e) {
+      lastError = e;
+      if (attempt < RETRY_BACKOFFS_MS.length - 1) await sleep(RETRY_BACKOFFS_MS[attempt]);
+      continue;
+    }
+    if (resp.ok) {
+      const body = await resp.text();
+      consecutiveFailures = 0;
+      return body;
+    }
+    lastError = new Error('HTTP ' + resp.status);
+    const retryable = resp.status >= 500 || resp.status === 429;
+    if (!retryable) {
+      consecutiveFailures = 0;
+      throw lastError;
+    }
+    if (attempt < RETRY_BACKOFFS_MS.length - 1) await sleep(RETRY_BACKOFFS_MS[attempt]);
+  }
+  consecutiveFailures += 1;
+  if (consecutiveFailures >= CIRCUIT_BREAKER_FAILURES) {
+    circuitOpenUntil = Date.now() + CIRCUIT_BREAKER_PAUSE_MS;
+    console.warn('  circuit breaker OPEN');
+  }
+  throw lastError || new Error('exhausted retries');
+}
+
+export function _resetBreakerForTests() { consecutiveFailures = 0; circuitOpenUntil = 0; }
+
+// ── Row builder ──────────────────────────────────────────────────────────
+export function buildRow({ chapter, section, titleText, bodyText, effectiveDate, sourceUrl, scrapedAt }) {
+  const sectionText = (titleText ? titleText.trim() + '\n\n' : '') + bodyText.trim();
+  const textHash = crypto.createHash('sha256').update(sectionText).digest('hex');
+  return {
+    jurisdiction: 'OH',
+    title: String(chapter),
+    section,
+    subsection: null,
+    section_text: sectionText,
+    is_current: true,
+    source_urls: [sourceUrl],
+    text_hash: textHash,
+    effective_date: effectiveDate,
+    scraped_at: scrapedAt || new Date().toISOString(),
+  };
+}
+
+export function textArrayLiteral(arr) {
+  if (!arr || arr.length === 0) return '{}';
+  const parts = arr.map((u) => {
+    const safe = String(u).split('\\').join('\\\\').split('"').join('\\"').split('\r').join(' ').split('\n').join(' ');
+    return '"' + safe + '"';
+  });
+  return '{' + parts.join(',') + '}';
+}
+
+// ── Orchestrator ─────────────────────────────────────────────────────────
+export async function seedOH({ dryRun, chapters, limitSections, fetchImpl, dbFactory } = {}) {
+  const targets = chapters && chapters.length ? chapters : Object.keys(OH_CHAPTERS).map(Number);
+  console.log('=== seed-statutes-oh ' + new Date().toISOString() + ' ===');
+  console.log('  chapters: [' + targets.join(', ') + ']');
+  console.log('  dry-run: ' + !!dryRun);
+  if (limitSections) console.log('  limit per chapter: ' + limitSections);
+
+  const allRows = [];
+  const byChapter = {};
+  const rejected = [];
+
+  for (const chapter of targets) {
+    if (!OH_CHAPTERS[chapter]) {
+      console.warn('  skipping chapter ' + chapter + ' (not in map)');
+      continue;
+    }
+    console.log('\n--- Chapter ' + chapter + ' (' + OH_CHAPTERS[chapter].description + ') ---');
+    const chapterUrl = buildChapterUrl(chapter);
+    let chapterHtml;
+    try {
+      chapterHtml = await fetchWithRetry(chapterUrl, { fetchImpl });
+    } catch (e) {
+      console.warn('  WARN ch ' + chapter + ': fetch failed — ' + e.message);
+      byChapter[chapter] = { parsed: 0, rejected: 0, status: 'index_failed' };
+      continue;
+    }
+    let sections = extractSectionNumbers(chapterHtml, chapter);
+    if (limitSections) sections = sections.slice(0, limitSections);
+    console.log('  discovered ' + sections.length + ' sections');
+
+    let ok = 0, bad = 0;
+    for (const section of sections) {
+      const sectionUrl = buildSectionUrl(section);
+      let html;
+      try {
+        html = await fetchWithRetry(sectionUrl, { fetchImpl });
+      } catch (e) {
+        console.warn('    section ' + section + ': fetch failed — ' + e.message);
+        bad += 1; continue;
+      }
+      const parsed = parseSectionPage(html, chapter, section);
+      if (!parsed) {
+        bad += 1; continue;
+      }
+      const row = buildRow({
+        chapter, section,
+        titleText: parsed.titleText,
+        bodyText: parsed.bodyText,
+        effectiveDate: parsed.effectiveDate,
+        sourceUrl: sectionUrl,
+      });
+      const check = StatuteRowSchema.safeParse(row);
+      if (!check.success) {
+        rejected.push({ chapter, section, issues: check.error.issues.map((i) => i.path.join('.') + ': ' + i.message) });
+        bad += 1; continue;
+      }
+      allRows.push(row);
+      ok += 1;
+      if (ok <= 3) console.log('    OK ' + section + ' — ' + parsed.titleText.slice(0, 60) + ' — ' + parsed.bodyText.length + 'ch');
+    }
+    byChapter[chapter] = { parsed: ok, rejected: bad, total: sections.length };
+    console.log('  chapter ' + chapter + ': ' + ok + ' parsed, ' + bad + ' rejected/failed');
+  }
+
+  console.log('\n=== TOTAL: ' + allRows.length + ' rows across ' + Object.keys(byChapter).length + ' chapters ===');
+  console.log(JSON.stringify(byChapter, null, 2));
+  if (rejected.length > 0) {
+    console.log('\nREJECTED (' + rejected.length + '):');
+    for (const r of rejected.slice(0, 10)) console.log('  ch' + r.chapter + ' §' + r.section + ': ' + r.issues.join('; '));
+  }
+
+  // Dedupe on full natural key.
+  const seen = new Map();
+  for (const r of allRows) {
+    const key = r.title + ':' + r.section + ':' + (r.subsection || '') + ':' + (r.effective_date || '');
+    if (!seen.has(key)) seen.set(key, r);
+  }
+  const deduped = [...seen.values()];
+
+  if (dryRun) {
+    console.log('\n=== DRY RUN — no DB write ===');
+    const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+    const stamp = new Date().toISOString().split(':').join('-').split('.').join('-');
+    const previewPath = path.join(repoRoot, 'data', 'statutes-oh-' + stamp + '.jsonl');
+    try {
+      fs.mkdirSync(path.dirname(previewPath), { recursive: true });
+      fs.writeFileSync(previewPath, deduped.map((r) => JSON.stringify(r)).join('\n'));
+      console.log('preview: ' + previewPath);
+    } catch (e) { console.warn('  WARN: ' + e.message); }
+    return { rows: deduped, byChapter, rejected };
+  }
+
+  if (deduped.length === 0) throw new Error('seedOH: no rows parsed');
+
+  const makeClient = dbFactory || createBulkClient;
+  const { client, cleanup } = await makeClient();
+  try {
+    console.log('\nwriting ' + deduped.length + ' rows...');
+    await client.query('BEGIN');
+    try {
+      const titleStrs = targets.map(String);
+      const { rowCount: deleted } = await client.query(
+        'DELETE FROM entities_statutes WHERE jurisdiction = $1 AND title = ANY($2::text[])',
+        ['OH', titleStrs],
+      );
+      if (deleted) console.log('  cleared ' + deleted + ' prior OH rows');
+      const COLS = ['jurisdiction','title','section','subsection','section_text','is_current','source_urls','text_hash','effective_date','scraped_at'];
+      async function* rowsGen() {
+        for (const r of deduped) {
+          yield [r.jurisdiction, r.title, r.section, r.subsection, r.section_text, r.is_current, textArrayLiteral(r.source_urls), r.text_hash, r.effective_date, r.scraped_at];
+        }
+      }
+      const { rowCount, durationMs } = await bulkCopyRows(client, 'entities_statutes', COLS, rowsGen());
+      console.log('  COPYd ' + rowCount + ' rows in ' + (durationMs / 1000).toFixed(1) + 's');
+      const { rows: verify } = await client.query(
+        "SELECT count(*)::int AS n, sum(CASE WHEN array_length(source_urls,1) IS NULL THEN 1 ELSE 0 END)::int AS missing_sources, sum(CASE WHEN section_text IS NULL OR section_text='' THEN 1 ELSE 0 END)::int AS empty_body FROM entities_statutes WHERE jurisdiction='OH'"
+      );
+      console.log('pre-commit verify: ' + JSON.stringify(verify[0]));
+      if (verify[0].missing_sources > 0) throw new Error(verify[0].missing_sources + ' missing source_urls');
+      if (verify[0].empty_body > 0) throw new Error(verify[0].empty_body + ' empty section_text');
+      await client.query('COMMIT');
+    } catch (e) {
+      await client.query('ROLLBACK');
+      throw e;
+    }
+  } finally {
+    await cleanup();
+  }
+  return { rows: deduped, byChapter, rejected };
+}
+
+async function main() {
+  const flags = parseCliFlags(process.argv.slice(2));
+  await seedOH(flags);
+  console.log('\n=== done ===');
+}
+
+const invokedDirectly = (() => {
+  if (!process.argv[1]) return false;
+  try { return import.meta.url === pathToFileURL(process.argv[1]).href; }
+  catch { return false; }
+})();
+if (invokedDirectly) main().catch((e) => { console.error('FATAL:', e); process.exit(1); });


### PR DESCRIPTION
## Summary

First Phase 2 state. Mirrors FL pattern (PR #104) for `codes.ohio.gov` markup. **247 OH statute rows** live, every row with verified HTTPS source_urls.

Coverage (6 chapters covering ~75% of INAA OH-relevant intake):

| Chapter | Description | Sections parsed |
|---|---|---|
| 2903 | Homicide / Assault | 28 |
| 2911 | Burglary / Aggravated trespass | 3 |
| 2913 | Theft / Fraud | 25 |
| 2923 | Conspiracy / Weapons | 32 |
| 2925 | Drug offenses | 24 |
| 4511 | Traffic / OVI | 135 |
| **Total** | | **247** |

## OH-specific markup learnings

- `<h1>Section NNN.NN <span>|</span> Title</h1>` — separator-strip parses title cleanly
- `<div class="laws-body">` body container; nested `<p>` paragraphs
- `<div class="laws-section-info">` effective-date module sits BELOW body
- 404-as-200 returns "not found" + missing laws-body container

## Swarm review

**security-auditor: PRISTINE** across A01-A10. Three INFO-level cosmetic deviations (single UA, no AbortSignal, abbreviated breaker log) — none are security gaps. Reviewer also noted OH adds STRONGER defense-in-depth than FL via `isAllowedHost(url)` preflight inside `fetchWithRetry`.

**code-reviewer: 7 WARN + 9 SUGG** — addressed pre-commit:

- **High-impact**: `effective_date` regex was unscoped (same bug class FL fixed). Body cross-references like "Effective 1/1/2020 if defendant ..." would clobber the row. Now scoped to `laws-section-info` module below body.
- **W2**: Zod section regex tightened `/^\d+\.\w[\w.-]*$/` → `/^\d+\.\d+$/` to match what `extractSectionNumbers` actually emits.
- **W4**: Body-end boundary anchored on `<div class="laws-section-info` opening tag instead of bare `class=` attr substring (defends against false truncation).
- **+1 new test**: Zod rejects invalid calendar date (Feb 30 round-trip).

## Live verification (re-seeded after parser fixes)

```
=== TOTAL: 247 rows across 6 chapters ===
writing 247 rows...
  cleared 247 prior OH rows
  COPYd 247 rows in 4.2s
pre-commit verify: {"n":247,"missing_sources":0,"empty_body":0}
```

Hash MATCH on 2923.1214, 2923.121, 2925.02. Spot-checks confirmed real statute content (4511.095 deployment-of-device, 4511.211 dwelling-units speed-limit) match source pages verbatim — not hallucinated.

## Cumulative state (post-merge)

**753 verified statute rows live** across 3 jurisdictions:
- FL: 470
- OH: 247
- US: 36

## Test plan

- [x] 26/26 unit tests (`node --test`)
- [x] `tsc --noEmit --skipLibCheck` — 0 errors
- [x] Live re-seed: 247 rows committed, hash + content + URL integrity verified
- [ ] Post-merge: build & ship OH weekly refresh cron (separate PR — mirror of `statutes-refresh-fl` per-chapter pattern from #120)

## Out-of-scope follow-ups

- **OH weekly refresh cron** — 6 endpoints staggered (mirror of `statutes-refresh-fl`)
- **Parser extraction** to `src/lib/statutes/parsers.ts` — 3-file lockstep (FL + USC + OH parsers) is now load-bearing on hash integrity. Worth dedicated refactor PR.
- **Phase 2 next states** — see `reference-state-statute-source-status.md` memory for per-state recon. CA/NY ⏸ unrecon, TX ❌ blocked (SPA + Cloudflare on alternates).

## Expert

`~/.claude/experts/openstates-team.md` — per-state scraper class pattern. Phase 2 is officially the unsolved space at multi-state scale (per OpenStates lead). OH is tractable; TX/CA likely require headless browser engine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)