### PR TITLE
feat(ingest): VA state statutes seed — Phase 2 second state (595 rows live)

### DIFF
--- a/scripts/ingest/__tests__/seed-statutes-va.test.mjs
+++ b/scripts/ingest/__tests__/seed-statutes-va.test.mjs
@@ -1,0 +1,273 @@
+// Template: scripts/ingest/__tests__/seed-statutes-oh.test.mjs (Phase 2 first state)
+// Expert: openstates-team
+// Pattern: cl-bulk-data-defensive #17 + no-hallucinated-legal-data
+// csv-bulk-checked: none-exists - synthetic fixtures, no network
+//
+// Unit tests for VA state statutes seed pipeline.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
+import {
+  VA_TITLE,
+  VA_CHAPTERS,
+  StatuteRowSchema,
+  parseCliFlags,
+  buildChapterUrl,
+  buildSectionUrl,
+  buildRow,
+  textArrayLiteral,
+  fetchWithRetry,
+  _resetBreakerForTests,
+  isSectionNotFound,
+  stripHtml,
+  extractSectionNumbers,
+  parseSectionPage,
+  seedVA,
+} from '../seed-statutes-va.mjs';
+
+// Synthetic VA section page mimicking law.lis.virginia.gov real markup.
+const FIXTURE_18_2_266 = `<html><head><title>VA section 18.2-266</title></head>
+<body>
+<h1>Virginia Law</h1>
+<header>page chrome</header>
+<article id="vacode" class="content">
+<span id='va_code' class="content">
+<h2><span id='v0'>18.2-266</span>. Driving motor vehicle, engine, etc., while intoxicated, etc.</h2>
+<section class='body editable' id='edit3280' data-table='CoV' data-field='body'>
+<p>It shall be unlawful for any person to drive any motor vehicle while under the influence of alcohol.</p>
+<p>1989, cc. 554, 574; 1992, c. 862; 1994, cc. 635, 682.</p>
+</section>
+</span>
+</article>
+</body></html>`;
+
+const FIXTURE_CHAPTER_7 = `<html><body>
+<a href="/vacode/title18.2/chapter7/section18.2-265.21/">18.2-265.21</a>
+<a href="/vacode/title18.2/chapter7/section18.2-266/">18.2-266</a>
+<a href="/vacode/title18.2/chapter7/section18.2-266.1/">18.2-266.1</a>
+<!-- cross-reference to chapter 4 should NOT be picked up -->
+<p>See also <a href="/vacode/title18.2/chapter4/section18.2-50/">18.2-50</a>.</p>
+</body></html>`;
+
+const FIXTURE_NOT_FOUND = `<html><body><h1>Page not found</h1><p>The page you requested does not exist.</p></body></html>`;
+
+test('VA_CHAPTERS covers Phase 2 VA target chapters', () => {
+  for (const ch of [4, 5, 6, 7]) {
+    assert.ok(VA_CHAPTERS[ch], 'missing chapter ' + ch);
+    assert.ok(VA_CHAPTERS[ch].description.length > 0, 'missing description');
+  }
+});
+
+test('VA_TITLE is 18.2 (Crimes and Offenses Generally)', () => {
+  assert.equal(VA_TITLE, '18.2');
+});
+
+test('buildChapterUrl produces canonical VA URL (HTTPS)', () => {
+  const u = buildChapterUrl(7);
+  assert.ok(u.startsWith('https://'), 'must be HTTPS');
+  assert.ok(u.includes('law.lis.virginia.gov'));
+  assert.ok(u.endsWith('/vacode/title18.2/chapter7/'));
+});
+
+test('buildSectionUrl uses title + chapter + section path', () => {
+  const u = buildSectionUrl(7, '18.2-266');
+  assert.ok(u.startsWith('https://'));
+  assert.ok(u.endsWith('/vacode/title18.2/chapter7/section18.2-266/'));
+});
+
+test('buildChapterUrl throws for unknown chapter', () => {
+  assert.throws(() => buildChapterUrl(999), /not in VA_CHAPTERS/);
+});
+
+test('parseCliFlags handles --dry-run + --chapters + --limit', () => {
+  const f = parseCliFlags(['--dry-run', '--chapters=4,7', '--limit=10']);
+  assert.equal(f.dryRun, true);
+  assert.deepEqual(f.chapters, [4, 7]);
+  assert.equal(f.limitSections, 10);
+});
+
+test('isSectionNotFound detects VA "not found" + missing va_code', () => {
+  assert.equal(isSectionNotFound(FIXTURE_NOT_FOUND), true);
+});
+
+test('isSectionNotFound passes valid section pages', () => {
+  assert.equal(isSectionNotFound(FIXTURE_18_2_266), false);
+});
+
+test('extractSectionNumbers filters to chapter-prefix only', () => {
+  const s = extractSectionNumbers(FIXTURE_CHAPTER_7, '18.2', 7);
+  assert.ok(s.includes('18.2-266'), 'missing 18.2-266');
+  assert.ok(s.includes('18.2-266.1'), 'missing 18.2-266.1');
+  // cross-reference to chapter 4 (18.2-50) must be excluded
+  assert.ok(!s.includes('18.2-50'), '18.2-50 should be filtered out (chapter mismatch)');
+});
+
+test('parseSectionPage extracts title from h2 (separator strip)', () => {
+  const p = parseSectionPage(FIXTURE_18_2_266, '18.2-266');
+  assert.ok(p, 'parse returned null');
+  assert.ok(p.titleText.includes('Driving motor vehicle'), 'got: ' + p.titleText);
+});
+
+test('parseSectionPage extracts body scoped to body editable section', () => {
+  const p = parseSectionPage(FIXTURE_18_2_266, '18.2-266');
+  assert.ok(p.bodyText.includes('drive any motor vehicle'));
+  // legislative history block should be trimmed
+  assert.ok(!p.bodyText.includes('1989, cc.'), 'history block leaked into body');
+});
+
+test('parseSectionPage returns null for 404 page', () => {
+  assert.equal(parseSectionPage(FIXTURE_NOT_FOUND, '18.2-999'), null);
+});
+
+test('stripHtml strips tags materialized from decoded entities', () => {
+  const s = stripHtml('clean &#60;script&#62;alert(1)&#60;/script&#62; end');
+  assert.ok(!s.includes('<script'));
+  assert.ok(!s.includes('</script'));
+});
+
+test('stripHtml drops C0 controls + DEL', () => {
+  const s = stripHtml('a&#0;b&#8;c&#127;d');
+  for (let i = 0; i < s.length; i++) {
+    const c = s.charCodeAt(i);
+    const bad = (c < 0x20 && c !== 0x09 && c !== 0x0A && c !== 0x0D) || c === 0x7F;
+    assert.ok(!bad, 'control byte ' + c.toString(16) + ' survived');
+  }
+});
+
+test('buildRow produces deterministic text_hash over section_text', () => {
+  const r = buildRow({
+    section: '18.2-266',
+    titleText: 'DUI.',
+    bodyText: 'No person shall drive while intoxicated.',
+    sourceUrl: 'https://law.lis.virginia.gov/vacode/title18.2/chapter7/section18.2-266/',
+    scrapedAt: '2026-04-24T12:00:00.000Z',
+  });
+  const expected = crypto.createHash('sha256')
+    .update('DUI.\n\nNo person shall drive while intoxicated.')
+    .digest('hex');
+  assert.equal(r.text_hash, expected);
+});
+
+test('buildRow omits canonical_id (DB auto-generates UUID), uses VA_TITLE', () => {
+  const r = buildRow({
+    section: '18.2-266',
+    titleText: 'DUI.',
+    bodyText: 'long enough body text to pass zod min length',
+    sourceUrl: 'https://law.lis.virginia.gov/x',
+  });
+  assert.equal(r.canonical_id, undefined);
+  assert.equal(r.jurisdiction, 'VA');
+  assert.equal(r.title, '18.2');
+  assert.equal(r.subsection, null);
+  assert.equal(r.is_current, true);
+});
+
+test('StatuteRowSchema accepts a valid VA row', () => {
+  const r = buildRow({
+    section: '18.2-266',
+    titleText: 'DUI.',
+    bodyText: 'No person shall drive while intoxicated.',
+    sourceUrl: 'https://law.lis.virginia.gov/vacode/title18.2/chapter7/section18.2-266/',
+    scrapedAt: '2026-04-24T12:00:00.000Z',
+  });
+  const check = StatuteRowSchema.safeParse(r);
+  assert.ok(check.success, JSON.stringify(check.error?.issues));
+});
+
+test('StatuteRowSchema accepts subsection-numbered VA section (18.2-266.1)', () => {
+  const r = buildRow({
+    section: '18.2-266.1',
+    titleText: 'Persons under age 21.',
+    bodyText: 'long enough body text for zod minimum length',
+    sourceUrl: 'https://law.lis.virginia.gov/x',
+  });
+  const check = StatuteRowSchema.safeParse(r);
+  assert.ok(check.success, JSON.stringify(check.error?.issues));
+});
+
+test('StatuteRowSchema rejects non-law.lis.virginia.gov primary URL', () => {
+  const r = buildRow({
+    section: '18.2-266',
+    titleText: 'P.',
+    bodyText: 'long enough body text to pass zod minimum',
+    sourceUrl: 'https://law.justia.com/codes/virginia/2024/18.2-266',
+  });
+  const check = StatuteRowSchema.safeParse(r);
+  assert.equal(check.success, false);
+});
+
+test('StatuteRowSchema host check rejects substring spoofing', () => {
+  const r = buildRow({
+    section: '18.2-266',
+    titleText: 'P.',
+    bodyText: 'long enough body text to pass zod minimum',
+    sourceUrl: 'https://attacker.example.com/law.lis.virginia.gov/fake',
+  });
+  assert.equal(StatuteRowSchema.safeParse(r).success, false);
+});
+
+test('textArrayLiteral escapes CR/LF/quotes/backslashes', () => {
+  const lit = textArrayLiteral(['a"b\\c\nd\re']);
+  assert.ok(!lit.includes('\n'));
+  assert.ok(!lit.includes('\r'));
+  assert.ok(lit.includes('\\"'));
+  assert.ok(lit.includes('\\\\'));
+});
+
+test('fetchWithRetry rejects non-allowed host', async () => {
+  _resetBreakerForTests();
+  await assert.rejects(() => fetchWithRetry('https://evil.example.com/x', {
+    fetchImpl: async () => ({ ok: true, status: 200, text: async () => '' }),
+  }), /Host not allowed/);
+});
+
+test('fetchWithRetry returns body on first success', async () => {
+  _resetBreakerForTests();
+  const out = await fetchWithRetry('https://law.lis.virginia.gov/x', {
+    fetchImpl: async () => ({ ok: true, status: 200, async text() { return 'hello'; } }),
+  });
+  assert.equal(out, 'hello');
+});
+
+test('fetchWithRetry does NOT retry on 404', async () => {
+  _resetBreakerForTests();
+  let calls = 0;
+  await assert.rejects(() => fetchWithRetry('https://law.lis.virginia.gov/x', {
+    fetchImpl: async () => { calls += 1; return { ok: false, status: 404, async text() { return ''; } }; },
+  }), /HTTP 404/);
+  assert.equal(calls, 1);
+});
+
+test('seedVA dry-run parses fixtures end-to-end', async () => {
+  _resetBreakerForTests();
+  const fetchImpl = async (url) => {
+    const u = String(url);
+    if (u.endsWith('/chapter7/')) return { ok: true, status: 200, async text() { return FIXTURE_CHAPTER_7; } };
+    return { ok: true, status: 200, async text() { return FIXTURE_18_2_266; } };
+  };
+  const out = await seedVA({
+    dryRun: true,
+    chapters: [7],
+    limitSections: 3,
+    fetchImpl,
+  });
+  assert.ok(out.rows.length > 0, 'expected at least 1 row, got ' + out.rows.length);
+  for (const r of out.rows) {
+    const check = StatuteRowSchema.safeParse(r);
+    assert.ok(check.success, 'row failed schema: ' + JSON.stringify(check.error?.issues));
+    assert.ok(r.source_urls[0].includes('law.lis.virginia.gov'));
+  }
+});
+
+test('seedVA non-dry-run with zero rows throws WITHOUT touching dbFactory', async () => {
+  _resetBreakerForTests();
+  const fetchImpl = async () => ({ ok: true, status: 200, async text() { return FIXTURE_NOT_FOUND; } });
+  let factoryCalls = 0;
+  const dbFactory = async () => { factoryCalls += 1; throw new Error('factory should not be called'); };
+  await assert.rejects(
+    () => seedVA({ dryRun: false, chapters: [7], limitSections: 2, fetchImpl, dbFactory }),
+    /no rows parsed/,
+  );
+  assert.equal(factoryCalls, 0);
+});

--- a/scripts/ingest/lib/va-html.mjs
+++ b/scripts/ingest/lib/va-html.mjs
@@ -1,0 +1,135 @@
+// HTML parsing helpers for Virginia Code (law.lis.virginia.gov) section pages.
+// Mirrors fl-html.mjs / oh-html.mjs / cornell-html.mjs for hash-integrity
+// (tags-first / decode-second / second-pass / drop C0+DEL+surrogates).
+
+/** Detect non-existent / error section pages. */
+export function isSectionNotFound(html) {
+  if (!html) return true;
+  if (html.length < 500) return true;
+  if (html.toLowerCase().indexOf('not found') >= 0 && html.indexOf('id=\'va_code\'') < 0 && html.indexOf('id="va_code"') < 0) return true;
+  // Real VA section pages always have the va_code container.
+  if (html.indexOf('va_code') < 0) return true;
+  return false;
+}
+
+/** Strip HTML tags, decode entities, drop control chars, collapse whitespace. */
+export function stripHtml(html) {
+  if (!html) return '';
+  let s = html;
+  s = s.replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, ' ');
+  s = s.replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, ' ');
+  s = s.replace(/<!--[\s\S]*?-->/g, ' ');
+  s = s.replace(/<br\s*\/?\s*>/gi, '\n');
+  s = s.replace(/<\/p>/gi, '\n\n');
+  s = s.replace(/<\/div>/gi, '\n');
+  s = s.replace(/<[^>]+>/g, ' ');
+  s = s
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&amp;/gi, '&')
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+    .replace(/&quot;/gi, '"')
+    .replace(/&#(\d+);/g, (_, n) => {
+      const code = Number(n);
+      if (!Number.isInteger(code) || code < 0 || code > 0x10FFFF) return '';
+      if (code < 0x20 && code !== 0x09 && code !== 0x0A && code !== 0x0D) return '';
+      if (code === 0x7F) return '';
+      if (code >= 0xD800 && code <= 0xDFFF) return '';
+      return String.fromCodePoint(code);
+    })
+    .replace(/&#x([0-9a-f]+);/gi, (_, n) => {
+      const code = Number.parseInt(n, 16);
+      if (!Number.isInteger(code) || code < 0 || code > 0x10FFFF) return '';
+      if (code < 0x20 && code !== 0x09 && code !== 0x0A && code !== 0x0D) return '';
+      if (code === 0x7F) return '';
+      if (code >= 0xD800 && code <= 0xDFFF) return '';
+      return String.fromCodePoint(code);
+    });
+  s = s.replace(/<[^>]+>/g, ' ');
+  s = s.split('').filter((ch) => {
+    const c = ch.charCodeAt(0);
+    if (c === 9 || c === 10 || c === 13) return true;
+    if (c < 32) return false;
+    if (c === 127) return false;
+    return true;
+  }).join('');
+  return s.split(/\s+/).filter(Boolean).join(' ').trim();
+}
+
+/** Discover section IDs from a Title-X chapter index page.
+ *  Section IDs match `<title>.<dashed-section>` like 18.2-266 or 18.2-266.1.
+ *  Filters to the current title prefix. */
+export function extractSectionNumbers(html, title, chapter) {
+  if (!html) return [];
+  const seen = new Set();
+  // VA section URLs: /vacode/title<T>/chapter<C>/section<id>/
+  const re = /\/vacode\/title(\d+(?:\.\d+)?)\/chapter(\d+(?:\.\d+)?)\/section([\w.-]+?)\//g;
+  let m;
+  while ((m = re.exec(html)) !== null) {
+    const t = m[1], c = m[2], sec = m[3];
+    if (t !== String(title)) continue;
+    if (c !== String(chapter)) continue;
+    // Section ID must be like "18.2-266" or "18.2-266.1"
+    if (!/^\d+(?:\.\d+)?-\d+(?:\.\d+)?$/.test(sec)) continue;
+    seen.add(sec);
+  }
+  return [...seen].sort((a, b) => {
+    // Sort by numeric suffix after the dash.
+    const as = Number.parseFloat((a.split('-')[1] || '0'));
+    const bs = Number.parseFloat((b.split('-')[1] || '0'));
+    return as - bs;
+  });
+}
+
+/** Parse a VA section page into {titleText, bodyText, effectiveDate}. */
+export function parseSectionPage(html, section) {
+  if (isSectionNotFound(html)) return null;
+
+  // Title from <h2><span id='v0'>§ <number></span>. <Title>.</h2> within
+  // the va_code container. Strip the leading "§ <num>. " prefix.
+  let titleText = null;
+  // Scope to va_code container first.
+  const codeStart = html.search(/id=['"]va_code['"]/);
+  const workHtml = codeStart >= 0 ? html.slice(codeStart) : html;
+  const h2 = workHtml.match(/<h2[^>]*>([\s\S]*?)<\/h2>/i);
+  if (h2) {
+    let h2Text = stripHtml(h2[1]).trim();
+    // Strip "§ <num>. " prefix (allow §, en-dash for separator).
+    const stripPrefixRe = new RegExp('^§\\s*' + section.replace(/[.\\-]/g, '\\$&') + '\\s*[.:\\-]\\s*');
+    h2Text = h2Text.replace(stripPrefixRe, '').trim();
+    // Drop leading § + any-number form if section-specific strip didn't match
+    if (h2Text.startsWith('§ ')) {
+      h2Text = h2Text.replace(/^§\s*[\d.\-]+\s*[.:\-]\s*/, '').trim();
+    }
+    // Drop trailing period.
+    h2Text = h2Text.replace(/\s*\.$/, '').trim();
+    titleText = h2Text;
+  }
+  if (!titleText) titleText = 'Section ' + section;
+
+  // Body: scope to <section class='body editable'>...</section> within va_code.
+  let bodyText = null;
+  const bodyStart = workHtml.search(/<section\b[^>]*class=['"][^'"]*body editable[^'"]*['"]/i);
+  if (bodyStart >= 0) {
+    const afterOpen = workHtml.indexOf('>', bodyStart) + 1;
+    const closeIdx = workHtml.indexOf('</section>', afterOpen);
+    const slice = closeIdx > 0 ? workHtml.slice(afterOpen, closeIdx) : workHtml.slice(afterOpen);
+    bodyText = stripHtml(slice);
+  } else {
+    bodyText = stripHtml(workHtml);
+  }
+
+  // Trim trailing legislative-history block (years + chapter citations).
+  // Pattern: starts with a year like "1989, cc." or "1994, c."
+  const histMatch = bodyText.match(/\b(19|20)\d{2},\s+cc?\./);
+  if (histMatch && histMatch.index !== undefined && histMatch.index > 50) {
+    bodyText = bodyText.slice(0, histMatch.index).trim();
+  }
+
+  if (bodyText.length > 20000) bodyText = bodyText.slice(0, 20000).trim();
+  if (!bodyText || bodyText.length < 20) return null;
+
+  // Effective date: VA pages don't typically expose a "Effective MM/DD/YYYY"
+  // marker in the section body — they use legislative-session metadata. Skip.
+  return { titleText, bodyText, effectiveDate: null };
+}

--- a/scripts/ingest/seed-statutes-va.mjs
+++ b/scripts/ingest/seed-statutes-va.mjs
@@ -1,0 +1,356 @@
+// Template: scripts/ingest/seed-statutes-oh.mjs (Phase 2 first) + seed-statutes-fl.mjs (Phase 1 base)
+// Expert: openstates-team (per-state scraper class pattern)
+// Pattern: cl-bulk-data-defensive #18 + no-hallucinated-legal-data
+// csv-bulk-checked: none-exists — Code of Virginia is web-only (developer page mentions REST API but path not discoverable)
+//
+// VA state statutes seed — Phase 2 second state (after OH PR #128).
+// Source: Code of Virginia (https://law.lis.virginia.gov/vacode/).
+// Target: entities_statutes (one row per section).
+// Coverage: Title 18.2 (Crimes and Offenses Generally), 4 high-signal chapters:
+//   ch4 (Crimes Against the Person), ch5 (Crimes Against Property),
+//   ch6 (Crimes Involving Fraud), ch7 (Crimes Involving Health and Safety — DUI/drugs).
+//
+// Usage:
+//   node scripts/ingest/seed-statutes-va.mjs --dry-run
+//   node scripts/ingest/seed-statutes-va.mjs --chapters=7 --limit=5
+//   node scripts/ingest/seed-statutes-va.mjs
+
+import fs from 'node:fs';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import { pathToFileURL, fileURLToPath } from 'node:url';
+import { z } from 'zod';
+import { createBulkClient, bulkCopyRows } from '../lib/pg-bulk-defaults.mjs';
+import { isSectionNotFound, stripHtml, extractSectionNumbers, parseSectionPage } from './lib/va-html.mjs';
+
+export { isSectionNotFound, stripHtml, extractSectionNumbers, parseSectionPage };
+
+// ── Env loader (web-repo only, # skip, trim, quote strip) ────────────────
+const envPaths = ['C:/Users/email/projects/ImNotAnAttorney-web/.env.local'];
+const VALID_KEY_RX = /^[A-Z_][A-Z0-9_]*$/;
+for (const p of envPaths) {
+  if (!fs.existsSync(p)) continue;
+  const txt = fs.readFileSync(p, 'utf-8');
+  for (const rawLine of txt.split('\n')) {
+    let line = rawLine.endsWith('\r') ? rawLine.slice(0, -1) : rawLine;
+    line = line.trim();
+    if (!line || line[0] === '#') continue;
+    const eq = line.indexOf('=');
+    if (eq <= 0) continue;
+    const key = line.slice(0, eq).trim();
+    let val = line.slice(eq + 1).trim();
+    if (val.length >= 2 && ((val[0] === '"' && val[val.length - 1] === '"') ||
+        (val[0] === "'" && val[val.length - 1] === "'"))) {
+      val = val.slice(1, -1);
+    }
+    if (!VALID_KEY_RX.test(key)) continue;
+    if (!process.env[key]) process.env[key] = val;
+  }
+}
+
+// ── Coverage: VA Title 18.2 chapters 4-7 (criminal high-signal) ─────────
+// VA section IDs embed the title (18.2-266), so we store title='18.2' on
+// every row regardless of chapter — chapter is structural in the URL only.
+export const VA_TITLE = '18.2';
+export const VA_CHAPTERS = {
+  4: { description: 'Crimes Against the Person' },
+  5: { description: 'Crimes Against Property' },
+  6: { description: 'Crimes Involving Fraud' },
+  7: { description: 'Crimes Involving Health and Safety (incl. DUI 18.2-266)' },
+};
+
+const USER_AGENT = 'INAA-legal-research/1.0 (+https://imnotanattorney.com/about)';
+const RATE_MIN_MS = 500;
+const RATE_MAX_MS = 2000;
+const RETRY_BACKOFFS_MS = [5000, 30000, 120000];
+const CIRCUIT_BREAKER_FAILURES = 3;
+const CIRCUIT_BREAKER_PAUSE_MS = 120000;
+const VA_BASE = 'https://law.lis.virginia.gov/vacode/';
+const ALLOWED_HOSTS = new Set(['law.lis.virginia.gov']);
+
+// ── CLI flags ────────────────────────────────────────────────────────────
+export function parseCliFlags(argv) {
+  const flags = { dryRun: false, chapters: null, limitSections: null };
+  for (const arg of argv) {
+    if (arg === '--dry-run') flags.dryRun = true;
+    else if (arg.startsWith('--chapters=')) {
+      flags.chapters = arg.slice('--chapters='.length).split(',')
+        .map((s) => Number.parseInt(s.trim(), 10))
+        .filter((n) => Number.isInteger(n));
+    } else if (arg.startsWith('--limit=')) {
+      flags.limitSections = Number.parseInt(arg.slice('--limit='.length), 10);
+    }
+  }
+  return flags;
+}
+
+// ── Zod contract (reject-before-INSERT) ──────────────────────────────────
+export const StatuteRowSchema = z.object({
+  jurisdiction: z.literal('VA'),
+  // VA "title" stores the full Title 18.2 ID since VA section IDs already
+  // embed the title (18.2-266). Chapter is structural in URL only.
+  title: z.string().regex(/^\d+(?:\.\d+)?$/),
+  // VA section format: <title>-<num> e.g. "18.2-266" or "18.2-266.1"
+  section: z.string().regex(/^\d+(?:\.\d+)?-\d+(?:\.\d+)?$/),
+  subsection: z.null(),
+  section_text: z.string().min(20).max(50000),
+  is_current: z.literal(true),
+  source_urls: z.array(z.string().url().max(2048)).min(1).max(10)
+    .refine((urls) => {
+      try {
+        const host = new URL(urls[0]).hostname.toLowerCase();
+        return host === 'law.lis.virginia.gov';
+      } catch { return false; }
+    }, 'Primary source_url host must be law.lis.virginia.gov'),
+  text_hash: z.string().regex(/^[a-f0-9]{64}$/),
+  effective_date: z.union([
+    z.string().regex(/^\d{4}-\d{2}-\d{2}$/).refine((s) => {
+      const d = new Date(s + 'T00:00:00Z');
+      return !Number.isNaN(d.getTime()) && d.toISOString().slice(0, 10) === s;
+    }, 'effective_date must be a valid calendar date'),
+    z.null(),
+  ]),
+  scraped_at: z.string().datetime().max(40),
+});
+
+// ── URL builders ─────────────────────────────────────────────────────────
+export function buildChapterUrl(chapter) {
+  if (!VA_CHAPTERS[chapter]) throw new Error('Chapter ' + chapter + ' not in VA_CHAPTERS');
+  return VA_BASE + 'title' + VA_TITLE + '/chapter' + chapter + '/';
+}
+
+export function buildSectionUrl(chapter, section) {
+  if (!VA_CHAPTERS[chapter]) throw new Error('Chapter ' + chapter + ' not in VA_CHAPTERS');
+  return VA_BASE + 'title' + VA_TITLE + '/chapter' + chapter + '/section' + section + '/';
+}
+
+function isAllowedHost(urlStr) {
+  try {
+    const u = new URL(urlStr);
+    if (u.protocol !== 'https:') return false;
+    return ALLOWED_HOSTS.has(u.hostname.toLowerCase());
+  } catch { return false; }
+}
+
+void isAllowedHost; // referenced inside fetchWithRetry
+
+// ── Fetch with retry + circuit breaker ───────────────────────────────────
+let consecutiveFailures = 0;
+let circuitOpenUntil = 0;
+function sleep(ms) { return new Promise((r) => setTimeout(r, ms)); }
+function randomDelay() { return RATE_MIN_MS + Math.floor(Math.random() * (RATE_MAX_MS - RATE_MIN_MS)); }
+
+export async function fetchWithRetry(url, { fetchImpl } = {}) {
+  if (!isAllowedHost(url)) throw new Error('Host not allowed: ' + url);
+  const doFetch = fetchImpl || fetch;
+  if (circuitOpenUntil > Date.now()) {
+    await sleep(circuitOpenUntil - Date.now());
+    consecutiveFailures = 0;
+  }
+  let lastError = null;
+  for (let attempt = 0; attempt < RETRY_BACKOFFS_MS.length; attempt++) {
+    await sleep(randomDelay());
+    let resp;
+    try {
+      resp = await doFetch(url, {
+        headers: { 'User-Agent': USER_AGENT, 'Accept': 'text/html,application/xhtml+xml' },
+        redirect: 'follow',
+      });
+    } catch (e) {
+      lastError = e;
+      if (attempt < RETRY_BACKOFFS_MS.length - 1) await sleep(RETRY_BACKOFFS_MS[attempt]);
+      continue;
+    }
+    if (resp.ok) {
+      const body = await resp.text();
+      consecutiveFailures = 0;
+      return body;
+    }
+    lastError = new Error('HTTP ' + resp.status);
+    const retryable = resp.status >= 500 || resp.status === 429;
+    if (!retryable) {
+      consecutiveFailures = 0;
+      throw lastError;
+    }
+    if (attempt < RETRY_BACKOFFS_MS.length - 1) await sleep(RETRY_BACKOFFS_MS[attempt]);
+  }
+  consecutiveFailures += 1;
+  if (consecutiveFailures >= CIRCUIT_BREAKER_FAILURES) {
+    circuitOpenUntil = Date.now() + CIRCUIT_BREAKER_PAUSE_MS;
+    console.warn('  circuit breaker OPEN');
+  }
+  throw lastError || new Error('exhausted retries');
+}
+
+export function _resetBreakerForTests() { consecutiveFailures = 0; circuitOpenUntil = 0; }
+
+// ── Row builder ──────────────────────────────────────────────────────────
+export function buildRow({ section, titleText, bodyText, sourceUrl, scrapedAt }) {
+  const sectionText = (titleText ? titleText.trim() + '\n\n' : '') + bodyText.trim();
+  const textHash = crypto.createHash('sha256').update(sectionText).digest('hex');
+  return {
+    jurisdiction: 'VA',
+    title: VA_TITLE,
+    section,
+    subsection: null,
+    section_text: sectionText,
+    is_current: true,
+    source_urls: [sourceUrl],
+    text_hash: textHash,
+    effective_date: null,
+    scraped_at: scrapedAt || new Date().toISOString(),
+  };
+}
+
+export function textArrayLiteral(arr) {
+  if (!arr || arr.length === 0) return '{}';
+  const parts = arr.map((u) => {
+    const safe = String(u).split('\\').join('\\\\').split('"').join('\\"').split('\r').join(' ').split('\n').join(' ');
+    return '"' + safe + '"';
+  });
+  return '{' + parts.join(',') + '}';
+}
+
+// ── Orchestrator ─────────────────────────────────────────────────────────
+export async function seedVA({ dryRun, chapters, limitSections, fetchImpl, dbFactory } = {}) {
+  const targets = chapters && chapters.length ? chapters : Object.keys(VA_CHAPTERS).map(Number);
+  console.log('=== seed-statutes-va ' + new Date().toISOString() + ' ===');
+  console.log('  chapters: [' + targets.join(', ') + ']');
+  console.log('  dry-run: ' + !!dryRun);
+  if (limitSections) console.log('  limit per chapter: ' + limitSections);
+
+  const allRows = [];
+  const byChapter = {};
+  const rejected = [];
+
+  for (const chapter of targets) {
+    if (!VA_CHAPTERS[chapter]) {
+      console.warn('  skipping chapter ' + chapter + ' (not in map)');
+      continue;
+    }
+    console.log('\n--- Title ' + VA_TITLE + ' Chapter ' + chapter + ' (' + VA_CHAPTERS[chapter].description + ') ---');
+    const chapterUrl = buildChapterUrl(chapter);
+    let chapterHtml;
+    try {
+      chapterHtml = await fetchWithRetry(chapterUrl, { fetchImpl });
+    } catch (e) {
+      console.warn('  WARN ch ' + chapter + ': fetch failed — ' + e.message);
+      byChapter[chapter] = { parsed: 0, rejected: 0, status: 'index_failed' };
+      continue;
+    }
+    let sections = extractSectionNumbers(chapterHtml, VA_TITLE, chapter);
+    if (limitSections) sections = sections.slice(0, limitSections);
+    console.log('  discovered ' + sections.length + ' sections');
+
+    let ok = 0, bad = 0;
+    for (const section of sections) {
+      const sectionUrl = buildSectionUrl(chapter, section);
+      let html;
+      try {
+        html = await fetchWithRetry(sectionUrl, { fetchImpl });
+      } catch (e) {
+        console.warn('    section ' + section + ': fetch failed — ' + e.message);
+        bad += 1; continue;
+      }
+      const parsed = parseSectionPage(html, section);
+      if (!parsed) {
+        bad += 1; continue;
+      }
+      const row = buildRow({
+        section,
+        titleText: parsed.titleText,
+        bodyText: parsed.bodyText,
+        sourceUrl: sectionUrl,
+      });
+      const check = StatuteRowSchema.safeParse(row);
+      if (!check.success) {
+        rejected.push({ chapter, section, issues: check.error.issues.map((i) => i.path.join('.') + ': ' + i.message) });
+        bad += 1; continue;
+      }
+      allRows.push(row);
+      ok += 1;
+      if (ok <= 3) console.log('    OK ' + section + ' — ' + parsed.titleText.slice(0, 60) + ' — ' + parsed.bodyText.length + 'ch');
+    }
+    byChapter[chapter] = { parsed: ok, rejected: bad, total: sections.length };
+    console.log('  chapter ' + chapter + ': ' + ok + ' parsed, ' + bad + ' rejected/failed');
+  }
+
+  console.log('\n=== TOTAL: ' + allRows.length + ' rows across ' + Object.keys(byChapter).length + ' chapters ===');
+  console.log(JSON.stringify(byChapter, null, 2));
+  if (rejected.length > 0) {
+    console.log('\nREJECTED (' + rejected.length + '):');
+    for (const r of rejected.slice(0, 10)) console.log('  ch' + r.chapter + ' §' + r.section + ': ' + r.issues.join('; '));
+  }
+
+  // Dedupe on full natural key.
+  const seen = new Map();
+  for (const r of allRows) {
+    const key = r.title + ':' + r.section + ':' + (r.subsection || '') + ':' + (r.effective_date || '');
+    if (!seen.has(key)) seen.set(key, r);
+  }
+  const deduped = [...seen.values()];
+
+  if (dryRun) {
+    console.log('\n=== DRY RUN — no DB write ===');
+    const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+    const stamp = new Date().toISOString().split(':').join('-').split('.').join('-');
+    const previewPath = path.join(repoRoot, 'data', 'statutes-va-' + stamp + '.jsonl');
+    try {
+      fs.mkdirSync(path.dirname(previewPath), { recursive: true });
+      fs.writeFileSync(previewPath, deduped.map((r) => JSON.stringify(r)).join('\n'));
+      console.log('preview: ' + previewPath);
+    } catch (e) { console.warn('  WARN: ' + e.message); }
+    return { rows: deduped, byChapter, rejected };
+  }
+
+  if (deduped.length === 0) throw new Error('seedVA: no rows parsed');
+
+  const makeClient = dbFactory || createBulkClient;
+  const { client, cleanup } = await makeClient();
+  try {
+    console.log('\nwriting ' + deduped.length + ' rows...');
+    await client.query('BEGIN');
+    try {
+      const sectionStrs = deduped.map((r) => r.section);
+      const { rowCount: deleted } = await client.query(
+        'DELETE FROM entities_statutes WHERE jurisdiction = $1 AND title = $2 AND section = ANY($3::text[])',
+        ['VA', VA_TITLE, sectionStrs],
+      );
+      if (deleted) console.log('  cleared ' + deleted + ' prior VA rows');
+      const COLS = ['jurisdiction','title','section','subsection','section_text','is_current','source_urls','text_hash','effective_date','scraped_at'];
+      async function* rowsGen() {
+        for (const r of deduped) {
+          yield [r.jurisdiction, r.title, r.section, r.subsection, r.section_text, r.is_current, textArrayLiteral(r.source_urls), r.text_hash, r.effective_date, r.scraped_at];
+        }
+      }
+      const { rowCount, durationMs } = await bulkCopyRows(client, 'entities_statutes', COLS, rowsGen());
+      console.log('  COPYd ' + rowCount + ' rows in ' + (durationMs / 1000).toFixed(1) + 's');
+      const { rows: verify } = await client.query(
+        "SELECT count(*)::int AS n, sum(CASE WHEN array_length(source_urls,1) IS NULL THEN 1 ELSE 0 END)::int AS missing_sources, sum(CASE WHEN section_text IS NULL OR section_text='' THEN 1 ELSE 0 END)::int AS empty_body FROM entities_statutes WHERE jurisdiction='VA'"
+      );
+      console.log('pre-commit verify: ' + JSON.stringify(verify[0]));
+      if (verify[0].missing_sources > 0) throw new Error(verify[0].missing_sources + ' missing source_urls');
+      if (verify[0].empty_body > 0) throw new Error(verify[0].empty_body + ' empty section_text');
+      await client.query('COMMIT');
+    } catch (e) {
+      await client.query('ROLLBACK');
+      throw e;
+    }
+  } finally {
+    await cleanup();
+  }
+  return { rows: deduped, byChapter, rejected };
+}
+
+async function main() {
+  const flags = parseCliFlags(process.argv.slice(2));
+  await seedVA(flags);
+  console.log('\n=== done ===');
+}
+
+const invokedDirectly = (() => {
+  if (!process.argv[1]) return false;
+  try { return import.meta.url === pathToFileURL(process.argv[1]).href; }
+  catch { return false; }
+})();
+if (invokedDirectly) main().catch((e) => { console.error('FATAL:', e); process.exit(1); });


### PR DESCRIPTION
## Summary

Second Phase 2 state after OH (PR #128). **595 VA statute rows** live — largest single-state seed yet. 4 high-signal chapters from Code of Virginia Title 18.2 (Crimes and Offenses Generally).

| Chapter | Description | Sections parsed |
|---|---|---|
| ch4 | Crimes Against the Person | 115 |
| ch5 | Crimes Against Property | 149 |
| ch6 | Crimes Involving Fraud | 134 |
| ch7 | Crimes Involving Health and Safety (incl DUI 18.2-266) | 197 |
| **Total** | | **595** |

## VA-specific markup learnings

- Section URL: `/vacode/title<T>/chapter<C>/section<sectionID>/` (sections embed title — `18.2-266` not `266`)
- Outer page chrome `<h1>Virginia Law</h1>` — actual content nested in `<article id="vacode">` > `<span id='va_code'>`
- Section header in `<h2><span id='v0'>§ <num></span>. <Title></h2>`
- Body in `<section class='body editable' id='editN'>`
- Legislative history block trimmed via `\b(19|20)\d{2},\s+cc?\.` marker
- `effective_date` not exposed in section body (always null)

## Architecture

Mirror of FL (#104) + OH (#128) per-state scraper class pattern from OpenStates-team expert. Same R1+R2 hardening from sibling PRs:
- HTTPS-only fetch + `isAllowedHost` preflight
- 0.5-2s random delay + 3-retry exponential + circuit breaker
- Pupa-style Zod row contract (reject-before-INSERT)
- Per-section DELETE (VA stores all sections under title 18.2)
- Pre-commit verify INSIDE transaction
- `stripHtml` tags-first / decode-second / second-pass + C0+DEL+surrogate drop

## Live verification

```
=== TOTAL: 595 rows across 4 chapters ===
writing 595 rows...
  COPYd 595 rows in 1.0s
pre-commit verify: {"n":595,"missing_sources":0,"empty_body":0}
```

Hash MATCH on 4 random spot-checks (18.2-222, 18.2-119, 18.2-183, 18.2-168). All URLs `https://law.lis.virginia.gov/vacode/title18.2/chapter<N>/section<id>/`.

## Cumulative state (post-merge)

**1,348 verified statute rows live across 4 jurisdictions:**

| Jurisdiction | Rows |
|---|---|
| FL | 470 |
| VA | 595 |
| OH | 247 |
| US | 36 |
| **Total** | **1,348** |

## Test plan

- [x] 26/26 unit tests (`node --test`)
- [x] `tsc --noEmit --skipLibCheck` — 0 errors
- [x] Live seed: 595 rows committed; hash + URL integrity verified
- [ ] Post-merge: build & ship VA weekly refresh cron (separate PR — mirror of `statutes-refresh-fl` per-chapter pattern from #120)

## Out-of-scope follow-ups

- **VA weekly refresh cron** — 4 endpoints staggered (mirror of `statutes-refresh-fl`)
- **Parser extraction** — now **4-file lockstep** (FL + USC + OH + VA parsers) on hash-integrity. Deserves dedicated refactor PR.
- **Phase 2 next states** — TX still SPA-blocked; CA/NY recon-needed. See `reference-state-statute-source-status.md` memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)