### PR TITLE
feat(ingest): NY AD body-backfill round 2 — HTML-strip → +612 events (99→711)

### DIFF
--- a/docs/handoff/2026-04-24-ny-bar-html-strip-backfill.md
+++ b/docs/handoff/2026-04-24-ny-bar-html-strip-backfill.md
@@ -1,0 +1,108 @@
+# Handoff: NY Bar — HTML→Plaintext Re-Backfill (Round 2)
+
+**Context 2026-04-24:** Round-1 backfill via `scripts/ingest/backfill-cl-opinion-bodies-nyappdiv.mjs`
+fetched 3,721 CL v4 opinions for NY AD "Matter of X" clusters and wrote them
+to `cl_opinion_bodies`. Result was only **+30 NY discipline events** (69 → 99)
+because 3,643 of 3,721 opinions had `plain_text: null` — the actual text lives
+in `html_with_citations` / `html` variants that the script didn't capture.
+
+## Expected upside after round 2
+
+Round-1 processor stats on the 357 clusters that DID have plain_text:
+- 96 attorneys upserted
+- 100 parsed / 4031 candidates (skipped: 3672 no-body, 162 no-bar-no, 0 no-name, 97 no-discipline)
+- 30 new discipline events landed (ON CONFLICT DO NOTHING deduped the 69 pre-existing)
+
+Extrapolating the 100/357 ≈ 28% hit rate to all 3,643 null-text rows gives
+**≈1,020 additional discipline events** — pushing NY from 99 → ≈1,120 total.
+
+## Root-cause fix (hook-compliant per root-cause-first.md)
+
+Modify `scripts/ingest/backfill-cl-opinion-bodies-nyappdiv.mjs` to fall back
+to HTML-stripping when `plain_text` is null:
+
+```js
+// In fetchOpinion(), replace the plain_text extraction block with:
+let text = body.plain_text || '';
+if (!text && body.html_with_citations) {
+  text = stripHtmlToText(body.html_with_citations);
+} else if (!text && body.html) {
+  text = stripHtmlToText(body.html);
+}
+// Then store `text` as plain_text in cl_opinion_bodies.
+```
+
+Where `stripHtmlToText` is a simple regex-based stripper:
+
+```js
+function stripHtmlToText(html) {
+  return html
+    .replace(/<(script|style)[\s\S]*?<\/\1>/gi, '')
+    .replace(/<br\s*\/?>/gi, ' ')
+    .replace(/<\/?p[^>]*>/gi, ' ')
+    .replace(/<\/?div[^>]*>/gi, ' ')
+    .replace(/<[^>]+>/g, '')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&#8217;|&rsquo;/g, "'")
+    .replace(/&#8220;|&#8221;|&ldquo;|&rdquo;/g, '"')
+    .replace(/&#8211;|&ndash;/g, '-')
+    .replace(/&#8212;|&mdash;/g, '-')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+```
+
+Then re-run only for the rows with null plain_text (not a full re-backfill):
+
+```sql
+-- Target selection: 3,643 clusters with bodies but null plain_text
+SELECT b.cluster_id
+FROM cl_opinion_bodies b
+JOIN cl_opinion_clusters cc ON cc.id = b.cluster_id
+JOIN cl_dockets d ON d.id = cc.docket_id
+WHERE d.court_id IN ('nyappdiv','nyappterm')
+  AND cc.case_name ~ '^Matter of [A-Z][a-zA-Z.-]+$'
+  AND cc.date_filed >= '2014-01-01'
+  AND b.plain_text IS NULL;
+```
+
+Add a `--update-null-text-only` flag to the backfill script that selects from
+that query instead of the "missing bodies" query, then UPDATE (not INSERT) the
+existing rows.
+
+## Runtime estimate
+
+- 3,643 rows × 1.2s/req = ~73 minutes (same as round 1)
+- CL v4 rate limit: 5,000/hr authenticated — fits within one hour run
+
+## Idempotency
+
+`process-nybar-discipline.mjs` has ON CONFLICT DO NOTHING on
+`(jurisdiction, bar_number, order_date, discipline_type)` — safe to re-run any
+number of times.
+
+## Ready-to-paste prompt
+
+```
+Execute round 2 of NY AD opinion body backfill per
+  C:\Users\email\projects\ImNotAnAttorney\docs\handoff\2026-04-24-ny-bar-html-strip-backfill.md
+
+1. Add stripHtmlToText helper + HTML-fallback logic to
+   C:\Users\email\projects\ImNotAnAttorney-web\scripts\ingest\backfill-cl-opinion-bodies-nyappdiv.mjs
+2. Add --update-null-text-only flag that re-fetches rows where
+   cl_opinion_bodies.plain_text IS NULL for NY AD Matter-of-X clusters
+3. Run the backfill (1.2s pace, ~75 min, 3,643 rows)
+4. Re-run scripts/ingest/process-nybar-discipline.mjs --start-date 2014-01-01 --apply
+5. Verify: SELECT jurisdiction, count(*) FROM attorney_discipline_events
+   WHERE jurisdiction = 'NY' GROUP BY jurisdiction;
+   Expected: ~1,100 events (up from 99).
+
+HARD CONSTRAINTS:
+  - Do NOT re-run for clusters already with plain_text IS NOT NULL (357 rows
+    fine as-is, would waste rate-limit budget)
+  - COPY FROM STDIN via bulkCopyRows for the staging+UPDATE join
+  - Rate limit: 1.2s between CL requests (5,000/hr safe zone)
+
+Budget: 1.5 hours.
+```

--- a/scripts/ingest/backfill-cl-opinion-bodies-nyappdiv.mjs
+++ b/scripts/ingest/backfill-cl-opinion-bodies-nyappdiv.mjs
@@ -1,0 +1,272 @@
+// csv-bulk-checked: https://www.courtlistener.com/api/rest/v4/opinions/ — CL publishes opinion bodies via v4 REST API; v3 deprecated 2026+ per gotcha-courtlistener-v3-deprecated.
+// Template: scripts/ingest/process-nybar-discipline.mjs (bulkCopyRows + CL v4 pattern)
+// Expert: chris-dreyer (Attorney-Vetting NY coverage depth)
+// Pattern: cl-bulk-data-defensive #18 (COPY FROM STDIN)
+//
+// Backfill cl_opinion_bodies for NY Appellate Division discipline candidates.
+//
+// Round 1 context (2026-04-24): prior bulk-load of cl_opinion_bodies was
+// criminal-filtered, so 3,714 of 4,031 "Matter of X" clusters in nyappdiv
+// had NO body row. Round 1 fetched bodies for 3,721 clusters; 3,643 of them
+// landed with plain_text=null because CL stored the text in
+// html_with_citations or html, not plain_text.
+//
+// Round 2 (2026-04-24): re-fetch the 3,643 null-plain_text rows, fall back
+// to HTML→plaintext stripping when plain_text is empty, and UPDATE existing
+// cl_opinion_bodies rows in place.
+//
+// Usage:
+//   # Round-1 mode (insert missing bodies):
+//   node scripts/ingest/backfill-cl-opinion-bodies-nyappdiv.mjs                  # dry-run
+//   node scripts/ingest/backfill-cl-opinion-bodies-nyappdiv.mjs --apply
+//   node scripts/ingest/backfill-cl-opinion-bodies-nyappdiv.mjs --apply --limit 200
+//
+//   # Round-2 mode (update null-text rows with HTML-stripped fallback):
+//   node scripts/ingest/backfill-cl-opinion-bodies-nyappdiv.mjs --update-null-text-only --apply
+//   node scripts/ingest/backfill-cl-opinion-bodies-nyappdiv.mjs --update-null-text-only --apply --limit 20
+
+import fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { setTimeout as sleep } from 'node:timers/promises';
+
+import { createBulkClient, bulkCopyRows } from '../lib/pg-bulk-defaults.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+
+const CL_API = 'https://www.courtlistener.com/api/rest/v4/opinions/';
+const TOKEN = process.env.COURTLISTENER_TOKEN;
+if (!TOKEN) {
+  console.error('ERROR: COURTLISTENER_TOKEN not set in env');
+  process.exit(1);
+}
+const USER_AGENT = 'INAA-Crawler/1.0 (+https://imnotanattorney.com; contact: noreply-legal@inaa.com)';
+// Polite pace — CL authed users get 5000/hour = ~1.4/s. 1.2s/req leaves headroom.
+const REQ_INTERVAL_MS = 1200;
+
+// HTML→plaintext stripper for cases where CL stored the opinion body in
+// html_with_citations or html instead of plain_text. Order matters: strip
+// script/style first (their contents are noise), then convert block-level
+// tags to spaces so words on separate lines don't fuse, then strip remaining
+// tags, then resolve common entities, then collapse whitespace.
+function stripHtmlToText(html) {
+  if (!html || typeof html !== 'string') return '';
+  return html
+    .replace(/<(script|style)[\s\S]*?<\/\1>/gi, '')
+    .replace(/<br\s*\/?>/gi, ' ')
+    .replace(/<\/?p[^>]*>/gi, ' ')
+    .replace(/<\/?div[^>]*>/gi, ' ')
+    .replace(/<[^>]+>/g, '')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&#8217;|&rsquo;/g, "'")
+    .replace(/&#8220;|&#8221;|&ldquo;|&rdquo;/g, '"')
+    .replace(/&#8211;|&ndash;/g, '-')
+    .replace(/&#8212;|&mdash;/g, '-')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function parseArgs(argv) {
+  const args = argv.slice(2);
+  const out = { apply: false, limit: Infinity, batch: 200, updateNullTextOnly: false };
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === '--apply') out.apply = true;
+    else if (a === '--limit') out.limit = parseInt(args[++i], 10);
+    else if (a === '--batch') out.batch = parseInt(args[++i], 10);
+    else if (a === '--update-null-text-only') out.updateNullTextOnly = true;
+    else if (a === '--help' || a === '-h') {
+      console.log(fs.readFileSync(__filename, 'utf8').split('\n').slice(0, 30).join('\n'));
+      process.exit(0);
+    }
+  }
+  return out;
+}
+const OPTS = parseArgs(process.argv);
+
+async function fetchOpinion(clusterId) {
+  const url = `${CL_API}?cluster=${clusterId}`;
+  const resp = await fetch(url, {
+    headers: { Authorization: `Token ${TOKEN}`, 'User-Agent': USER_AGENT },
+  });
+  if (!resp.ok) {
+    return { ok: false, status: resp.status, body: null };
+  }
+  const json = await resp.json();
+  if (!json.results || json.results.length === 0) {
+    return { ok: true, status: resp.status, body: null };
+  }
+  // Multi-opinion clusters (concurrence, dissent): prefer 010combined → 020lead → first.
+  const byType = new Map(json.results.map((o) => [o.type, o]));
+  const opinion = byType.get('010combined') || byType.get('020lead') || json.results[0];
+
+  // Extract text with HTML fallback. CL's "Matter of X" bodies routinely
+  // store the opinion in html_with_citations or html with plain_text=null.
+  let text = opinion.plain_text || '';
+  if (!text && opinion.html_with_citations) {
+    text = stripHtmlToText(opinion.html_with_citations);
+  } else if (!text && opinion.html) {
+    text = stripHtmlToText(opinion.html);
+  }
+  // Attach derived text to the opinion object so downstream sees a unified shape.
+  opinion._derived_text = text || null;
+  return { ok: true, status: resp.status, body: opinion };
+}
+
+async function main() {
+  console.error(`[cl-body-backfill-nyappdiv] start — apply=${OPTS.apply} limit=${OPTS.limit} batch=${OPTS.batch} updateNullTextOnly=${OPTS.updateNullTextOnly}`);
+
+  const { client, cleanup } = await createBulkClient();
+  try {
+    // 1) Pick target cluster set based on mode.
+    let targetQuery;
+    if (OPTS.updateNullTextOnly) {
+      // Round-2 mode: re-fetch clusters that have a body row but null plain_text.
+      // Round 1 wrote the row but couldn't extract text — round 2 strips HTML.
+      targetQuery = `
+        SELECT b.cluster_id
+        FROM cl_opinion_bodies b
+        JOIN cl_opinion_clusters cc ON cc.id = b.cluster_id
+        JOIN cl_dockets d ON d.id = cc.docket_id
+        WHERE d.court_id IN ('nyappdiv','nyappterm')
+          AND cc.case_name ~ '^Matter of [A-Z][a-zA-Z.''-]+$'
+          AND cc.date_filed >= '2014-01-01'
+          AND b.plain_text IS NULL
+        ORDER BY cc.date_filed DESC
+      `;
+    } else {
+      // Round-1 mode: fetch clusters with no body row at all.
+      targetQuery = `
+        SELECT cc.id AS cluster_id
+        FROM cl_opinion_clusters cc
+        JOIN cl_dockets d ON d.id = cc.docket_id
+        LEFT JOIN cl_opinion_bodies b ON b.cluster_id = cc.id
+        WHERE d.court_id IN ('nyappdiv','nyappterm')
+          AND cc.case_name ~ '^Matter of [A-Z][a-zA-Z.''-]+$'
+          AND cc.date_filed >= '2014-01-01'
+          AND b.cluster_id IS NULL
+        ORDER BY cc.date_filed DESC
+      `;
+    }
+    const missing = await client.query(targetQuery);
+    console.error(`[cl-body-backfill-nyappdiv] target rows: ${missing.rows.length}`);
+
+    const target = Math.min(missing.rows.length, OPTS.limit);
+    console.error(`[cl-body-backfill-nyappdiv] will fetch: ${target}`);
+
+    // 2) Fetch in sequence at REQ_INTERVAL_MS pace.
+    const bodies = [];
+    let notFound = 0;
+    let httpErrors = 0;
+    let emptyAfterStrip = 0;
+    const startedMs = Date.now();
+    for (let i = 0; i < target; i++) {
+      const clusterId = Number(missing.rows[i].cluster_id);
+      const start = Date.now();
+      const { ok, status, body } = await fetchOpinion(clusterId);
+      if (!ok) {
+        httpErrors++;
+        console.error(`[http] ${clusterId} → ${status}`);
+      } else if (!body) {
+        notFound++;
+      } else {
+        const text = body._derived_text;
+        if (!text) emptyAfterStrip++;
+        bodies.push({
+          opinion_id: body.id,
+          cluster_id: clusterId,
+          opinion_type: body.type || 'unknown',
+          author_id: body.author_id || null,
+          author_str: body.author_str || null,
+          per_curiam: body.per_curiam ?? null,
+          page_count: body.page_count || null,
+          plain_text: text && text.length > 0 ? text : null,
+          text_length: text ? text.length : null,
+          sha1: body.sha1 || null,
+          date_created: body.date_created || null,
+        });
+      }
+      if ((i + 1) % 100 === 0) {
+        const elapsedMs = Date.now() - startedMs;
+        const elapsed = (elapsedMs / 1000).toFixed(1);
+        const rate = ((i + 1) / elapsedMs * 1000).toFixed(2);
+        console.error(`[progress] ${i + 1}/${target} — ok=${bodies.length} 404=${notFound} http=${httpErrors} empty=${emptyAfterStrip} elapsed=${elapsed}s (${rate} req/s)`);
+      }
+      const elapsed = Date.now() - start;
+      if (elapsed < REQ_INTERVAL_MS && i + 1 < target) {
+        await sleep(REQ_INTERVAL_MS - elapsed);
+      }
+    }
+    console.error(`[cl-body-backfill-nyappdiv] fetched ${bodies.length} bodies, ${notFound} empty, ${httpErrors} http errors, ${emptyAfterStrip} empty after strip`);
+
+    if (!OPTS.apply) {
+      console.error(`[cl-body-backfill-nyappdiv] dry-run — pass --apply to write to DB`);
+      return;
+    }
+
+    if (bodies.length === 0) {
+      console.error(`[cl-body-backfill-nyappdiv] no bodies to load`);
+      return;
+    }
+
+    // 3) Bulk-load via staging.
+    await client.query(`DROP TABLE IF EXISTS public._stg_cl_opinion_bodies`);
+    await client.query(`
+      CREATE UNLOGGED TABLE public._stg_cl_opinion_bodies (
+        opinion_id    bigint,
+        cluster_id    bigint,
+        opinion_type  text,
+        author_id     bigint,
+        author_str    text,
+        per_curiam    boolean,
+        page_count    int,
+        plain_text    text,
+        text_length   int,
+        sha1          text,
+        date_created  timestamptz
+      );
+    `);
+
+    await bulkCopyRows(
+      client,
+      '_stg_cl_opinion_bodies',
+      ['opinion_id','cluster_id','opinion_type','author_id','author_str','per_curiam','page_count','plain_text','text_length','sha1','date_created'],
+      bodies.map((b) => [
+        b.opinion_id, b.cluster_id, b.opinion_type, b.author_id, b.author_str,
+        b.per_curiam, b.page_count, b.plain_text, b.text_length, b.sha1, b.date_created,
+      ]),
+    );
+
+    if (OPTS.updateNullTextOnly) {
+      // Round-2 mode: UPDATE existing rows by cluster_id with the new plain_text.
+      const upd = await client.query(`
+        UPDATE public.cl_opinion_bodies b
+        SET plain_text  = s.plain_text,
+            text_length = s.text_length
+        FROM _stg_cl_opinion_bodies s
+        WHERE b.cluster_id = s.cluster_id
+          AND b.plain_text IS NULL
+          AND s.plain_text IS NOT NULL
+      `);
+      console.error(`[db] cl_opinion_bodies updated: ${upd.rowCount}`);
+    } else {
+      // Round-1 mode: INSERT new rows with ON CONFLICT (opinion_id) DO NOTHING.
+      const ins = await client.query(`
+        INSERT INTO public.cl_opinion_bodies
+          (opinion_id, cluster_id, opinion_type, author_id, author_str, per_curiam, page_count, plain_text, text_length, sha1, date_created)
+        SELECT opinion_id, cluster_id, opinion_type, author_id, author_str, per_curiam, page_count, plain_text, text_length, sha1, date_created
+        FROM _stg_cl_opinion_bodies
+        ON CONFLICT (opinion_id) DO NOTHING
+        RETURNING cluster_id;
+      `);
+      console.error(`[db] cl_opinion_bodies inserted: ${ins.rowCount}`);
+    }
+
+    await client.query(`DROP TABLE IF EXISTS public._stg_cl_opinion_bodies`);
+    console.error(`[cl-body-backfill-nyappdiv] done`);
+  } finally {
+    await cleanup();
+  }
+}
+
+main().catch((err) => { console.error(err); process.exit(1); });


### PR DESCRIPTION
## Summary

Round 2 of the NY Appellate Division opinion-body backfill. Round 1 (PR #103, commit \`4e6433e5\`) added bodies for 3,721 "Matter of X" clusters but **3,643 landed with \`plain_text=null\`** because CL stored the actual opinion text in \`html_with_citations\` / \`html\` variants — round 1's script only captured \`plain_text\`. Round 2 re-fetches those rows, strips HTML to plain text, and UPDATEs the existing \`cl_opinion_bodies\` rows in place.

## Numbers (verified live)

| Metric | Value |
|---|---|
| NY discipline events before | 99 |
| **NY discipline events after** | **711 (+612)** |
| NY date range | 2014-08-27 → 2026-03-12 (~12 years) |
| Backfill wall-clock | 4,720 s |
| Fetch rate | 0.78 req/s (CL v4 polite pace) |
| HTTP errors absorbed | 2 transient 502s |
| Strip-empty rows skipped | 4 |
| Reprocessor parsed | 782 / 4,031 candidates |

### NY discipline-type histogram

```
disbarment              503
public_reprimand        107
suspension               99
interim_suspension        1
resignation_with_charges  1
```

## Total state coverage post-merge

| State | Events | Date range |
|-------|-------:|-----------|
| CA | 2,525 | 2025-07 → 2026-04 |
| FL | 430 | 2018-11 → 2026-03 |
| **NY (this PR)** | **711** | **2014-08 → 2026-03** |
| PA | 3,027 | 2000-01 → 2026-04 |
| TX | 393 | 2012-07 → 2017-10 |
| **Total** | **7,086 events / ~4,500 attorneys** | ~44% US population |

## What changed in the script

\`scripts/ingest/backfill-cl-opinion-bodies-nyappdiv.mjs\` gains:
- \`stripHtmlToText()\` helper (entity decode + tag strip + whitespace collapse)
- HTML fallback in \`fetchOpinion()\`: \`plain_text\` → \`html_with_citations\` → \`html\`
- \`--update-null-text-only\` CLI flag selecting clusters with body row but null plain_text
- UPDATE path that touches existing \`cl_opinion_bodies\` rows (vs INSERT path of round 1)

## Why 1,709 candidates skipped no-bar-no

NY AD's "Matter of X" pattern is shared between attorney-discipline matters and probate/guardianship/child-custody matters. Attorney discipline cases have \`OCA Atty. Reg. No.\` in the opinion body; the others don't. The processor filters on that — exactly the right behavior. The ~1,533 no-discipline rows are similarly correct (reinstatement, status-change orders that lack a discipline keyword).

## How this happened

Parent session (auto-mode) wrote a handoff after round 1 surfaced the under-yield, then dispatched a Senior Developer agent to implement the HTML fallback. Agent's nohup'd backfill died with the agent context, so parent session re-launched the backfill from a stable shell. Backfill ran 4,720s. Reprocessor confirmed +612 events. PR rebased onto current master (PR #130 VA seed had landed).

## Test plan

- [ ] CI tsc + next build pass
- [ ] DB: \`SELECT count(*) FROM attorney_discipline_events WHERE jurisdiction='NY';\` returns 711
- [ ] DB: \`SELECT count(*) FROM cl_opinion_bodies b JOIN cl_opinion_clusters cc ON cc.id=b.cluster_id JOIN cl_dockets d ON d.id=cc.docket_id WHERE d.court_id='nyappdiv' AND b.plain_text IS NOT NULL;\` returns ≥3,950 (was 357 before round 2)
- [ ] Spot-check 3 attorneys via courtlistener.com URLs preserved in source_url

## SKIP_TSC + SKIP_BUILD context

Cherry-pick worktree lacks \`node_modules\`. Script verified to work in main worktree before cherry-pick (612 rows already landed in DB). Vercel CI will run full tsc + build.

🤖 Agent-implemented; reviewed by parent session before push.