### PR TITLE
fix(report): omit Mandatory Minimum line when NULL (was hallucinating "None")

### DIFF
--- a/supabase/functions/generate-report/__tests__/no-mandatory-min-fallback.test.ts
+++ b/supabase/functions/generate-report/__tests__/no-mandatory-min-fallback.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Regression lock for the mandatory_minimum NULL→"None" hallucination.
+ *
+ * Audit 2026-04-24 found that 80% of jurisdiction_statutes rows have NULL
+ * mandatory_minimum, but the previous fallback `|| "None"` rendered
+ * "Mandatory Minimum: None" — a confident factual claim where truth was
+ * "we don't know yet". For DUI/drug/firearms charges that's potentially
+ * life-altering misinformation (federal cocaine distribution HAS mandatory
+ * minimums; state statutes vary).
+ *
+ * The fix: omit the Mandatory Minimum line entirely when the column is
+ * NULL, instead of rendering "None". The model can't assert facts about
+ * data we don't have.
+ *
+ * This test is a static-content lock: re-introducing the bad pattern in
+ * the Deno function will fail this test at vitest time.
+ */
+import { describe, it, expect } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+
+const SOURCE = path.resolve(
+  __dirname,
+  "..",
+  "index.ts",
+);
+
+describe("generate-report Edge Function — mandatory_minimum hallucination guard", () => {
+  it("does NOT use `|| \"None\"` fallback on mandatory_minimum", () => {
+    const src = fs.readFileSync(SOURCE, "utf-8");
+    // Must not contain the previous bug pattern.
+    const banned = /mandatory_minimum\s*\|\|\s*["']None["']/i;
+    expect(banned.test(src)).toBe(false);
+  });
+
+  it("does NOT use `|| \"none\"` (case-insensitive) on mandatory_minimum", () => {
+    const src = fs.readFileSync(SOURCE, "utf-8");
+    const banned = /mandatory_minimum\s*\|\|\s*["']none["']/i;
+    expect(banned.test(src)).toBe(false);
+  });
+
+  it("guards Mandatory Minimum line behind a truthy check", () => {
+    const src = fs.readFileSync(SOURCE, "utf-8");
+    // The current implementation should look something like
+    // `if (statute.mandatory_minimum) { chargeLines.push(...) }`
+    // Lock that the line is NEVER pushed unconditionally.
+    const unconditionalPush =
+      /chargeLines\.push\([^)]*Mandatory Minimum/;
+    const guardedPush =
+      /if\s*\(\s*statute\.mandatory_minimum\s*\)\s*{[\s\S]*?chargeLines\.push\([^)]*Mandatory Minimum/;
+    if (unconditionalPush.test(src)) {
+      expect(guardedPush.test(src)).toBe(true);
+    }
+  });
+});

--- a/supabase/functions/generate-report/index.ts
+++ b/supabase/functions/generate-report/index.ts
@@ -2152,11 +2152,29 @@ async function getChargeContext(
           if (statute.elements && statute.elements.length > 0) {
             chargeLines.push(`- Elements prosecution must prove: ${statute.elements.join("; ")}`);
           }
-          const penaltyMin = statute.penalty_min || "unknown";
-          const penaltyMax = statute.penalty_max || "unknown";
-          const finePart = statute.fine_max ? `, fine up to ${statute.fine_max}` : "";
-          chargeLines.push(`- Penalty Range: ${penaltyMin} to ${penaltyMax}${finePart}`);
-          chargeLines.push(`- Mandatory Minimum: ${statute.mandatory_minimum || "None"}`);
+          // Penalty + mandatory-minimum: NO false confident assertions when
+          // data is unseeded. Audit 2026-04-24 found 80% of jurisdiction_
+          // statutes rows have NULL mandatory_minimum, but the previous
+          // `|| "None"` fallback rendered "Mandatory Minimum: None" — a
+          // confident factual claim where truth is "we don't know yet".
+          // For DUI/drug/firearms charges this is potentially life-altering
+          // misinformation (federal cocaine distribution HAS mandatory
+          // minimums; state statutes vary). Per no-hallucinated-legal-data
+          // rule: omit the line when NULL. The model can't assert facts
+          // about data we don't have.
+          if (statute.penalty_min || statute.penalty_max) {
+            const penaltyMin = statute.penalty_min || "unknown";
+            const penaltyMax = statute.penalty_max || "unknown";
+            const finePart = statute.fine_max ? `, fine up to ${statute.fine_max}` : "";
+            chargeLines.push(`- Penalty Range: ${penaltyMin} to ${penaltyMax}${finePart}`);
+          }
+          if (statute.mandatory_minimum) {
+            chargeLines.push(`- Mandatory Minimum: ${statute.mandatory_minimum}`);
+          }
+          // When mandatory_minimum is NULL (i.e. unseeded for this charge/
+          // jurisdiction), the line is omitted entirely. Downstream prompt
+          // explicitly tells the model to write "verify with attorney" when
+          // sentencing data is absent rather than asserting a default.
           if (statute.enhancements && statute.enhancements.length > 0) {
             chargeLines.push(`- Enhancements: ${statute.enhancements.join("; ")}`);
           }


### PR DESCRIPTION
## The bug

`supabase/functions/generate-report/index.ts:2159`:

```ts
chargeLines.push(`- Mandatory Minimum: ${statute.mandatory_minimum || "None"}`);
```

When `mandatory_minimum` is NULL (truth: we just don't have the data seeded yet), this rendered `"Mandatory Minimum: None"` as a confident factual claim in EVERY tier-paid report (Case Decoder $197, Intelligence Brief $997, X-Ray $2,497, etc.).

## Why it matters — 80% hit rate

Audit of `jurisdiction_statutes` (2026-04-24): only **20.4% of 4,700 active rows have `mandatory_minimum` populated**. The other 79.6% fell through to `"None"`.

By INAA's primary intake states:

| State | mandatory_minimum coverage | "None" hallucination rate |
|---|---|---|
| FL | 28% | 72% |
| CA | 12% | **88%** |
| NY | 24% | 76% |
| TX | 9% | **91%** |
| KY | 6% | **94%** |

Only NJ + MI hit 100% coverage. Most states are below 30%.

## Real-world impact

Federal cocaine distribution (21 USC 841) carries mandatory minimums of 5/10/20 years depending on quantity. State cocaine possession sometimes does too. A defendant getting a paid report saying "Mandatory Minimum: None" when truth is "we don't know — could be 5 years federal" makes life-altering decisions on wrong data. Direct violation of `no-hallucinated-legal-data.md`.

## The fix

Omit the Mandatory Minimum line entirely when NULL. The model can't assert facts about data we don't have. Same logic applied to Penalty Range (only render when at least one of penalty_min/penalty_max is populated).

`penalty_min`/`penalty_max` keep their `"unknown"` fallback — that string in context (`"Penalty Range: unknown to 5 years"`) reads as honest uncertainty, not a factual claim.

## Test

3 regression-lock tests scan `index.ts` for the banned pattern `mandatory_minimum || "None"` and assert the Mandatory Minimum line is guarded behind a truthy check. Re-introducing the bug fails the test at vitest time.

Tests pass: 3/3.

## Out of scope (tracked)

The DATA gap (80% of rows missing mandatory_minimum) is a separate problem. This PR addresses the prompt-layer hallucination ONLY — the model now correctly says nothing when data is absent, instead of asserting "None." Backfilling penalty data per (charge × jurisdiction) is a multi-PR effort; tracked in `reference-state-statute-source-status.md` follow-ups.

## Cumulative

This is the 9th PR shipped today in the statute-data thread. The seeding work (PRs #104/#115/#117/#119/#120/#124/#128/#130) raised the floor on what data exists. This audit + fix surfaces a long-standing prompt-layer issue that the data work made visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)