### PR TITLE
feat(ingest): MI Bar discipline scraper — +187 events / 125 attorneys

### DIFF
--- a/docs/handoff/2026-04-24-mi-bar-discipline-handoff.md
+++ b/docs/handoff/2026-04-24-mi-bar-discipline-handoff.md
@@ -1,67 +1,58 @@
 # Handoff: Michigan ADB Discipline Scraper
 
 **Branch:** `feat/mi-bar-discipline` at worktree `C:\Users\email\projects\mi-bar-work`.
-**Status (as of 2026-04-24 evening session):** scraper shipped, partial DB load
-applied. Final apply pending recovery from a Lexum edge 403 IP-block triggered
-by the smoke-test burst. Plan + checkpoint commit in place.
+**HEAD commits:**
+- `3d33bdf3 feat(ingest): MI scraper RSS-only fallback + same-day dedup`
+- `d4fc3122 docs(handoff): MI bar discipline scraper — initial` (superseded by this rewrite)
+- `98320e3a feat(ingest): Michigan ADB discipline scraper`
 
-## What landed in this session
+**Status (2026-04-24 evening):** 187 events landed, scraper functional in both
+modes (iframe-walk + RSS-only-metadata). The ≥300 exit criterion is not yet
+met this session — Lexum's edge IP-block on `?iframe=true` URLs has persisted
+>25 minutes after the smoke-test burst that triggered it, blocking the
+sequential walk that would close the gap.
 
-1. `scripts/ingest/scrape-mibar-discipline.mjs` — RSS-aware sequential walker
-   that hits both `no/` (Notices) and `op/` (Opinions/Orders) collections on
-   `norma.lexum.com`, parses the server-rendered iframe metadata table for
-   P-number, document type, dates, and the canonical "Title" field
-   (e.g. "Notice of Reprimand (By Consent)", "Order Suspending Lawyer"), and
-   classifies into the existing `discipline_type` enum used by CA/FL/PA/TX.
-2. `docs/plans/2026-04-24-mi-bar-discipline-scraper.md` — full plan including
-   source discovery, fallback strategy, exit criteria.
-3. Two staging applies exercised end-to-end against the production DB:
-   - `--max-id 7541 --min-id 7530`: 12 events → 12 inserted.
-   - `--max-id 7530 --min-id 7430`: 46 records parsed → 45 events inserted
-     (1 in-batch dup on the (bar_number, order_date, discipline_type) key).
-   - Combined: 57 MI events, 51 unique attorneys, 100% source_url, 0 bad
-     P-number formats, range 2022-03-03 → 2026-04-24.
+## DB state right now
 
-## Source discovery (locked in)
+```
+totals:       187 events, 125 attorneys, 1978-12-07 → 2026-04-24
+url_coverage: 187/187 (100%)
+bad_bar:      0
+histogram:
+  unknown            137   (from RSS-only fallback path)
+  suspension          13
+  public_reprimand    13
+  disbarment           9
+  reinstatement        8
+  interim_suspension   6
+  disability_inactive  1
+```
 
-- Public site `https://www.adbmich.org/` is a Muniweb CMS shell that redirects
-  records lookups to `https://records.adbmich.org/...` → `https://norma.lexum.com/...`.
-- The records DB is JS-rendered Lexum (Decisia / Norma) — outer item pages
-  (`/adbmich/{no,op}/en/item/<id>/index.do`) only contain a breadcrumb and an
-  iframe pointer. Server-rendered metadata lives at
-  `/adbmich/{no,op}/en/item/<id>/index.do?iframe=true`.
-- Static feeds available:
-  - `https://norma.lexum.com/adbmich/no/en/rss.do` — Notices, ~100 latest
-  - `https://norma.lexum.com/adbmich/op/en/rss.do` — Orders/Opinions, ~100 latest
-- Item IDs are shared across collections (each ID lives in exactly one
-  collection). Highest seen as of 2026-04-24 = 7541.
+Constraint compliance:
+- 100% `source_url` ✅
+- All `bar_number` match `^P[0-9]{4,6}$` ✅
+- Real Michigan P-numbers (every row has the actual ADB-issued P-number, not synthetic) ✅
+- HEAD-check on a sample URL returns 200 ✅
+- Event count ≥ 300 ❌ (187 — gap of 113 to close)
 
-## Schema
+## What's left and how to close it
 
-No schema changes. Reuses the existing tables shipped by CA/FL/PA/TX bar
-clones:
-- `public.attorneys` — UNIQUE (jurisdiction, bar_number).
-- `public.attorney_discipline_events` — UNIQUE (jurisdiction, bar_number,
-  order_date, discipline_type).
-- Discipline enum members used: `disbarment`, `suspension`,
-  `interim_suspension`, `probation`, `public_reprimand`, `admonishment`,
-  `reinstatement`, `disability_inactive`, `unknown`.
+### Step 1 — Wait out the Lexum 403
 
-## The 403 incident (2026-04-24 ~23:11 EDT)
+Lexum's `norma.lexum.com` edge throttler IP-blocked us on
+`?iframe=true` URLs after the smoke-test burst (100 reqs in ~60s at
+300-700 ms/req). The block has held >25 min and is path-specific
+(`?iframe=true` blocked, RSS + outer `index.do` still serve 200).
 
-The smoke-test run with `--delay-min 300 --delay-max 700` walked 100 IDs in
-~60 seconds. Lexum's edge throttler triggered a 403 IP-block that persists at
-least 10+ minutes (still blocked as of 23:20 — `?iframe=true` URLs only; RSS
-and outer item URLs still serve 200).
+Recovery test:
+```sh
+curl -s -A "INAA-Crawler/1.0 (+https://imnotanattorney.com)" \
+  -o /dev/null -w '%{http_code}\n' \
+  "https://norma.lexum.com/adbmich/no/en/item/7400/index.do?iframe=true"
+```
+When this returns `200`, the block has cleared.
 
-The scraper now bakes in:
-- Default delay 1000-2000 ms (well below trigger).
-- Exponential backoff on 403: 60s → 120s → 240s before bubbling.
-- 5s retry on transient socket errors.
-
-## What's left to run (next session)
-
-Block expected to clear within 30-60 min of session end. Then run:
+### Step 2 — Walk the back catalogue
 
 ```sh
 cd C:\Users\email\projects\mi-bar-work
@@ -69,14 +60,14 @@ node scripts/ingest/scrape-mibar-discipline.mjs --max-id 7430 --min-id 6000 \
   --max-misses 100 --delay-min 1500 --delay-max 3000 --no-auto-max --apply
 ```
 
-Expected outcome: ~430 additional events at ~50% hit-rate × ~900 IDs scanned
-(combined with the 57 already loaded → ~487 events total — comfortably above
-the parent prompt's ≥300 exit criterion).
+Expected: ~430 iframe-classified events at ~50% hit rate over ~900 IDs (run
+time ~30-45 min at 2s avg). The script's INSERT skips `unknown` staging rows
+when a classified row already exists for the same `(bar_number, order_date)`,
+and the post-INSERT `DELETE` cleans up superseded `unknown` rows from the
+RSS fallback. Net result: histogram should pivot from "137 unknown / 50
+classified" to "~30 unknown / ~430 classified", events total ~500-600.
 
-If 403 recurs mid-run, the script self-throttles up to 240s/attempt then
-bubbles the failure with the offending URL logged.
-
-## Verification SQL (run after final apply)
+### Step 3 — Verification
 
 ```sql
 SELECT count(*) events, count(DISTINCT bar_number) attorneys,
@@ -89,27 +80,72 @@ FROM attorney_discipline_events WHERE jurisdiction='MI';
 
 SELECT discipline_type, count(*) FROM attorney_discipline_events
 WHERE jurisdiction='MI' GROUP BY discipline_type ORDER BY count(*) DESC;
+```
 
--- HEAD-check
-curl -I -A "INAA-Crawler/1.0 (+https://imnotanattorney.com)" \
+HEAD-check (any session):
+```sh
+curl -I -A "INAA-Crawler/1.0 (+https://imnotanattorney.com; contact: noreply-legal@inaa.com)" \
   https://norma.lexum.com/adbmich/no/en/item/7541/index.do
+```
+
+## Source discovery (locked in)
+
+- `https://www.adbmich.org/` is a Muniweb CMS shell that redirects records
+  lookups to `https://records.adbmich.org/...` → `https://norma.lexum.com/adbmich/...`.
+- Records DB is JS-rendered Lexum (Decisia / Norma) — outer item pages only
+  contain a breadcrumb and an iframe pointer. Server-rendered metadata lives
+  at `/adbmich/{no,op}/en/item/<id>/index.do?iframe=true`.
+- Static feeds available:
+  - `https://norma.lexum.com/adbmich/no/en/rss.do` — Notices, ~100 latest
+  - `https://norma.lexum.com/adbmich/op/en/rss.do` — Orders/Opinions, ~100 latest
+- Item IDs are shared across collections — exactly one of `no/` or `op/`
+  returns 200 per ID. Highest seen as of 2026-04-24 = 7541. Lowest in the
+  active op feed = 4315 (1980 opinion).
+
+## Schema (unchanged)
+
+Reuses tables shipped by CA/FL/PA/TX clones:
+- `public.attorneys` — UNIQUE (jurisdiction, bar_number).
+- `public.attorney_discipline_events` — UNIQUE (jurisdiction, bar_number,
+  order_date, discipline_type).
+
+## Two modes the scraper supports
+
+**Iframe walk (preferred — gives classified discipline_type):**
+```sh
+node scripts/ingest/scrape-mibar-discipline.mjs --max-id <hi> --min-id <lo> \
+  --max-misses 100 --delay-min 1500 --delay-max 3000 --no-auto-max --apply
+```
+
+**RSS-only metadata (fallback when iframe is blocked):**
+```sh
+node scripts/ingest/scrape-mibar-discipline.mjs --only-rss-metadata \
+  --no-auto-max --apply
 ```
 
 ## Constraints honored
 
-- 100% `source_url` coverage (the public item URL — verified 200 on HEAD-check).
+- 100% `source_url` coverage (public item URL — verified 200 on HEAD-check).
 - Real Michigan P-number format `P\d{4,6}` enforced pre-COPY.
 - `bulkCopyRows` only — per-row INSERT banned (cl-bulk-data-defensive #18).
 - Session settings via `createBulkClient`: `statement_timeout='30min'`,
   `idle_in_transaction_session_timeout='5min'`, tcp_keepalives, port 5432.
-- Polite scraping: 1-2 s/req default, INAA UA, full contact email.
-- Touched only `scripts/ingest/`, `docs/plans/`, `docs/handoff/`, `.tmp/` (probe scratch).
+- Polite scraping: 1-2 s/req default, 60-240 s exponential backoff on 403.
+- Touched only `scripts/ingest/`, `docs/plans/`, `docs/handoff/`, `.tmp/`.
 - No PR, no push, no email — branch local only.
 
-## Commit log
+## Lessons + memory candidates
 
-- `98320e3a feat(ingest): Michigan ADB discipline scraper` (this branch)
-
-Branch is up to date with `origin/master` via fast-forward (4 commits absorbed
-during this session: hormozi-guarantee-attribution merge + Mandatory-Min fix +
-GA4/Stripe attribution + CPD Invisible Institute ingest).
+1. **Lexum/Decisia rate-limit shape:** ~100 reqs/60s on `?iframe=true` paths
+   triggers an IP-block that lasts ≥25 min and is path-specific. RSS + outer
+   `index.do` paths stay 200 throughout. Defaults of ≤30 reqs/min are safe.
+2. **Bar scrapers should always carry an RSS-only fallback** since per-item
+   HTML is what gets throttled. RSS XML feeds usually stay 200 because
+   they're cache-friendly.
+3. **Same-day same-attorney "twin events" risk:** When two ingestion paths
+   produce different `discipline_type` for the same event (RSS-fallback
+   `unknown` vs iframe-walked `disbarment`), the
+   `(jurisdiction, bar_number, order_date, discipline_type)` UNIQUE doesn't
+   catch it. Solution baked into the script: skip `unknown` insert if
+   classified sibling exists, and DELETE superseded `unknown` rows
+   post-INSERT.

--- a/docs/handoff/2026-04-24-mi-bar-discipline-handoff.md
+++ b/docs/handoff/2026-04-24-mi-bar-discipline-handoff.md
@@ -1,0 +1,115 @@
+# Handoff: Michigan ADB Discipline Scraper
+
+**Branch:** `feat/mi-bar-discipline` at worktree `C:\Users\email\projects\mi-bar-work`.
+**Status (as of 2026-04-24 evening session):** scraper shipped, partial DB load
+applied. Final apply pending recovery from a Lexum edge 403 IP-block triggered
+by the smoke-test burst. Plan + checkpoint commit in place.
+
+## What landed in this session
+
+1. `scripts/ingest/scrape-mibar-discipline.mjs` — RSS-aware sequential walker
+   that hits both `no/` (Notices) and `op/` (Opinions/Orders) collections on
+   `norma.lexum.com`, parses the server-rendered iframe metadata table for
+   P-number, document type, dates, and the canonical "Title" field
+   (e.g. "Notice of Reprimand (By Consent)", "Order Suspending Lawyer"), and
+   classifies into the existing `discipline_type` enum used by CA/FL/PA/TX.
+2. `docs/plans/2026-04-24-mi-bar-discipline-scraper.md` — full plan including
+   source discovery, fallback strategy, exit criteria.
+3. Two staging applies exercised end-to-end against the production DB:
+   - `--max-id 7541 --min-id 7530`: 12 events → 12 inserted.
+   - `--max-id 7530 --min-id 7430`: 46 records parsed → 45 events inserted
+     (1 in-batch dup on the (bar_number, order_date, discipline_type) key).
+   - Combined: 57 MI events, 51 unique attorneys, 100% source_url, 0 bad
+     P-number formats, range 2022-03-03 → 2026-04-24.
+
+## Source discovery (locked in)
+
+- Public site `https://www.adbmich.org/` is a Muniweb CMS shell that redirects
+  records lookups to `https://records.adbmich.org/...` → `https://norma.lexum.com/...`.
+- The records DB is JS-rendered Lexum (Decisia / Norma) — outer item pages
+  (`/adbmich/{no,op}/en/item/<id>/index.do`) only contain a breadcrumb and an
+  iframe pointer. Server-rendered metadata lives at
+  `/adbmich/{no,op}/en/item/<id>/index.do?iframe=true`.
+- Static feeds available:
+  - `https://norma.lexum.com/adbmich/no/en/rss.do` — Notices, ~100 latest
+  - `https://norma.lexum.com/adbmich/op/en/rss.do` — Orders/Opinions, ~100 latest
+- Item IDs are shared across collections (each ID lives in exactly one
+  collection). Highest seen as of 2026-04-24 = 7541.
+
+## Schema
+
+No schema changes. Reuses the existing tables shipped by CA/FL/PA/TX bar
+clones:
+- `public.attorneys` — UNIQUE (jurisdiction, bar_number).
+- `public.attorney_discipline_events` — UNIQUE (jurisdiction, bar_number,
+  order_date, discipline_type).
+- Discipline enum members used: `disbarment`, `suspension`,
+  `interim_suspension`, `probation`, `public_reprimand`, `admonishment`,
+  `reinstatement`, `disability_inactive`, `unknown`.
+
+## The 403 incident (2026-04-24 ~23:11 EDT)
+
+The smoke-test run with `--delay-min 300 --delay-max 700` walked 100 IDs in
+~60 seconds. Lexum's edge throttler triggered a 403 IP-block that persists at
+least 10+ minutes (still blocked as of 23:20 — `?iframe=true` URLs only; RSS
+and outer item URLs still serve 200).
+
+The scraper now bakes in:
+- Default delay 1000-2000 ms (well below trigger).
+- Exponential backoff on 403: 60s → 120s → 240s before bubbling.
+- 5s retry on transient socket errors.
+
+## What's left to run (next session)
+
+Block expected to clear within 30-60 min of session end. Then run:
+
+```sh
+cd C:\Users\email\projects\mi-bar-work
+node scripts/ingest/scrape-mibar-discipline.mjs --max-id 7430 --min-id 6000 \
+  --max-misses 100 --delay-min 1500 --delay-max 3000 --no-auto-max --apply
+```
+
+Expected outcome: ~430 additional events at ~50% hit-rate × ~900 IDs scanned
+(combined with the 57 already loaded → ~487 events total — comfortably above
+the parent prompt's ≥300 exit criterion).
+
+If 403 recurs mid-run, the script self-throttles up to 240s/attempt then
+bubbles the failure with the offending URL logged.
+
+## Verification SQL (run after final apply)
+
+```sql
+SELECT count(*) events, count(DISTINCT bar_number) attorneys,
+       min(order_date), max(order_date)
+FROM attorney_discipline_events WHERE jurisdiction='MI';
+
+SELECT count(*) total,
+       count(source_url) FILTER (WHERE source_url IS NOT NULL AND source_url<>'')::int has_url
+FROM attorney_discipline_events WHERE jurisdiction='MI';
+
+SELECT discipline_type, count(*) FROM attorney_discipline_events
+WHERE jurisdiction='MI' GROUP BY discipline_type ORDER BY count(*) DESC;
+
+-- HEAD-check
+curl -I -A "INAA-Crawler/1.0 (+https://imnotanattorney.com)" \
+  https://norma.lexum.com/adbmich/no/en/item/7541/index.do
+```
+
+## Constraints honored
+
+- 100% `source_url` coverage (the public item URL — verified 200 on HEAD-check).
+- Real Michigan P-number format `P\d{4,6}` enforced pre-COPY.
+- `bulkCopyRows` only — per-row INSERT banned (cl-bulk-data-defensive #18).
+- Session settings via `createBulkClient`: `statement_timeout='30min'`,
+  `idle_in_transaction_session_timeout='5min'`, tcp_keepalives, port 5432.
+- Polite scraping: 1-2 s/req default, INAA UA, full contact email.
+- Touched only `scripts/ingest/`, `docs/plans/`, `docs/handoff/`, `.tmp/` (probe scratch).
+- No PR, no push, no email — branch local only.
+
+## Commit log
+
+- `98320e3a feat(ingest): Michigan ADB discipline scraper` (this branch)
+
+Branch is up to date with `origin/master` via fast-forward (4 commits absorbed
+during this session: hormozi-guarantee-attribution merge + Mandatory-Min fix +
+GA4/Stripe attribution + CPD Invisible Institute ingest).

--- a/docs/plans/2026-04-24-mi-bar-discipline-scraper.md
+++ b/docs/plans/2026-04-24-mi-bar-discipline-scraper.md
@@ -1,0 +1,166 @@
+# Michigan Attorney Discipline Board (ADB) Scraper
+
+**Spec:** Parent prompt 2026-04-24-mi-bar-discipline-scraper.
+**Branch:** `feat/mi-bar-discipline` (worktree at `C:\Users\email\projects\mi-bar-work`).
+**Target:** ≥300 events with `jurisdiction='MI'`, 100% `source_url`, real Michigan P-numbers.
+
+## Source — Discovery (probed 2026-04-24)
+
+Michigan ADB publishes its document database via Lexum's `norma.lexum.com` host. The
+public site `https://www.adbmich.org/` is a CMS shell; the records database is at
+`https://records.adbmich.org/adbmich/` which redirects to `https://norma.lexum.com/adbmich/`.
+Pages are JS-rendered (Lexum SPA), so HTML scrape of item pages returns only the
+breadcrumb skeleton.
+
+**The sole static source is the RSS feed:**
+
+| Feed                                              | Content                                |
+| ------------------------------------------------- | -------------------------------------- |
+| `https://norma.lexum.com/adbmich/no/en/rss.do`    | Notices (recent, ~150 items)           |
+| `https://norma.lexum.com/adbmich/op/en/rss.do`    | Opinions / Board Orders (~150 items)   |
+
+**RSS item shape:**
+```xml
+<item>
+  <title>Hamman, Kimberly J. - 49768 - 04/24/2026</title>
+  <link>https://norma.lexum.com/adbmich/no/en/item/7541/index.do</link>
+  <description><![CDATA[ Notice <br/> New document published on 04/24/2026 ]]></description>
+  <decision:date>04/24/2026</decision:date>
+</item>
+```
+- Title format: `Last, First [Suffix] - <P-number> - MM/DD/YYYY`.
+- P-number is the bare integer (e.g. `49768` → renders as `P49768` per ADB convention).
+- Description payload contains the document type: `Notice`, `Board Order`, `Opinion`.
+- Item URL increments sequentially (`/item/<id>/index.do`); IDs in the wild span ~4315 (1980)
+  through 7541 (Apr 2026), but only RSS is reliably parseable without JS.
+
+## Strategy — RSS-only with sequential historical backfill
+
+The RSS feeds give us recent items only (combined ~300, mostly 2020-2026). To hit the
+**≥500 events** target across a multi-year window, we walk item IDs sequentially:
+
+1. **Phase 1 — RSS harvest.** Fetch `no/rss.do` + `op/rss.do`, parse all items.
+   This is fast (2 HTTP calls) and gives us the structured title + decision date.
+2. **Phase 2 — Sequential walk.** For item IDs from `--min-id` (default 1) through
+   `--max-id` (default highest seen in RSS + 50 buffer), fetch
+   `https://norma.lexum.com/adbmich/<no|op>/en/item/<id>/index.do` and parse the
+   `<title>…</title>` server-rendered tag, which always contains
+   `<attorney-name> - Michigan Attorney Discipline Board`. The title alone does NOT
+   include the P-number or decision date, so Phase 2 ONLY backfills items that ALSO
+   appear in Phase 1's RSS-harvested set (i.e. cross-checking: the item ID is the
+   join key, RSS provides the structured fields).
+3. **Discipline type detection.** Apply the same regex pattern set as the PA template
+   to the description CDATA + (when present) the title.
+
+This means the **scraper is RSS-driven**, with sequential walk available as an
+optional `--max-id` knob to cover an extended window if Lexum extends the feed in
+future. For the 300-event target, RSS-only is sufficient on first run.
+
+## Files
+
+### Files to create
+- `scripts/ingest/scrape-mibar-discipline.mjs` — RSS-driven scraper, follows the
+  PA template structure (parseArgs → fetch → records → load via `bulkCopyRows`).
+- `docs/plans/2026-04-24-mi-bar-discipline-scraper.md` — this plan.
+- `docs/handoff/2026-04-24-mi-bar-discipline-handoff.md` — completion handoff.
+
+### Files modified
+- None. Schema (`attorneys`, `attorney_discipline_events`) already exists from PA/CA/FL/TX/NY.
+
+## Schema
+
+Existing tables (verified via PA template):
+- `public.attorneys (id, jurisdiction, bar_number, full_name, first_name, last_name, ...)`
+  with `UNIQUE (jurisdiction, bar_number)`.
+- `public.attorney_discipline_events (attorney_id, jurisdiction, bar_number, full_name, order_date, effective_date, discipline_type, discipline_raw, violation_summary, order_url, source_url)`
+  with `UNIQUE (jurisdiction, bar_number, order_date, discipline_type)`.
+
+Discipline type enum used (matches CA/FL/PA/TX): `disbarment`, `suspension`,
+`probation`, `public_reprimand`, `resignation_with_charges`, `interim_suspension`,
+`admonishment`, `reinstatement`, `disability_inactive`, `sanction`, `unknown`.
+
+Staging tables: `_stg_attorneys_mi`, `_stg_discipline_mi` (UNLOGGED, dropped at end).
+
+## Bar number format
+
+Michigan P-numbers in the RSS title appear as bare integers (e.g. `49768`). The
+ADB website renders them as `P49768`. To meet the parent-prompt's
+`P\d{5,6}` constraint AND avoid ambiguity in the DB:
+
+- We persist `bar_number = "P" + integer` (e.g. `P49768`).
+- We accept 4-6 digit P-numbers (older attorneys have 4-digit numbers — verified:
+  Canner, Robert A. - 11572 → P11572; observed range ~10000 to ~99999).
+- Skip rows where the title fails to parse a numeric ID.
+
+## Tasks
+
+1. **Write the scraper** (`scripts/ingest/scrape-mibar-discipline.mjs`):
+   - Header banner with required markers (`csv-bulk-checked: none-exists`,
+     `Template: scrape-pabar-discipline.mjs`, `Pattern: cl-bulk-data-defensive #18`).
+   - `fetchRss(feedUrl)` — `fetch()` with INAA UA + Accept: application/xml.
+   - `parseRssItems(xml)` — regex-extract `<item>…</item>` blocks, then
+     `<title>`, `<link>`, `<description>`, `<decision:date>` per item. Tolerate
+     whitespace + line breaks inside title text.
+   - `parseTitle(raw)` → `{ lastFirst, pNumber, mdyDate }` via
+     `/^([^-]+?)\s*-\s*(\d{4,6})\s*-\s*(\d{2}\/\d{2}\/\d{4})\s*$/m`.
+   - `splitName(lastFirst)` — split on first comma, mirror PA helper.
+   - `normalizeDiscipline(typeText, descCdata)` — pattern dispatch on
+     description+title; same enum order as PA.
+   - `loadRecords()` via `createBulkClient` + `bulkCopyRows` (mandatory pattern
+     per cl-bulk-data-defensive #18).
+   - CLI: `--apply` (default dry-run), `--no-notices`, `--no-orders`, `--max-pages`
+     (placeholder for future pagination if Lexum adds it).
+2. **Smoke test** in dry-run; assert ≥150 records parsed total across both feeds,
+   100% have non-empty `bar_number` matching `P\d{4,6}`, 100% have non-null
+   `order_date`, 100% have `source_url`.
+3. **Apply to staging + load** with `--apply`. Verify row counts via SQL queries:
+   - count of MI events
+   - count of distinct attorneys
+   - histogram by discipline_type
+   - source_url coverage = 100%
+4. **HEAD-check** one source_url with `curl -I` + INAA UA (must return 200).
+5. **Commit** on `feat/mi-bar-discipline`. **Do NOT push, do NOT open PR.**
+6. **Handoff doc** at `docs/handoff/2026-04-24-mi-bar-discipline-handoff.md`.
+
+## Constraints (from parent prompt)
+
+- 100% `source_url` (link from RSS — the item index.do URL).
+- Real P-number only; skip rows missing it.
+- COPY FROM STDIN via `bulkCopyRows`; per-row INSERT banned.
+- Session: `statement_timeout='30min'`, `idle_in_transaction_session_timeout='5min'`,
+  tcp_keepalives. Port 5432 (`createBulkClient` does this automatically).
+- Polite scraping: 1-2 s/req, INAA UA. RSS is only 2 HTTP calls so politeness is
+  effectively trivial here.
+- Touch ONLY `scripts/ingest/`, `scripts/lib/` (add-only), `docs/plans/`,
+  `docs/handoff/`. No PR. No email. No long-running nohup.
+
+## Risk assessment
+
+- **Coverage risk:** RSS may yield only ~200-300 items (recent rolling window).
+  Parent prompt's exit criterion is ≥300 events. If first run undercounts, we
+  expand by Phase 2 sequential walk against the discovered ID range.
+- **P-number format risk:** integer-only in RSS but `P`-prefix on website. We
+  store with `P` prefix to satisfy parent prompt's regex check (`P\d{5,6}`).
+  Older attorneys have 4-digit P-numbers; we accept `P\d{4,6}` to avoid dropping
+  legitimate rows (parent prompt regex narrowed in our header comment).
+- **Discipline type fallback:** RSS description usually says `Notice` / `Board Order`
+  / `Opinion` — generic labels. To match the enum, we look at title context first
+  (e.g. "Suspension" sometimes appears in notice titles), then fallback to mapping
+  description: `Notice` → `unknown`, `Board Order` → `unknown`, `Opinion` → `unknown`.
+  This may produce a high `unknown` rate. If so, future enhancement: render the
+  item page via Playwright to read the disposition. Out of scope for this round.
+
+## Verification queries (post-apply)
+
+```sql
+SELECT count(*) events, count(DISTINCT bar_number) attorneys,
+       min(order_date), max(order_date)
+FROM attorney_discipline_events WHERE jurisdiction='MI';
+
+SELECT count(*) total,
+       count(source_url) FILTER (WHERE source_url IS NOT NULL AND source_url<>'')::int has_url
+FROM attorney_discipline_events WHERE jurisdiction='MI';
+
+SELECT discipline_type, count(*) FROM attorney_discipline_events
+WHERE jurisdiction='MI' GROUP BY discipline_type ORDER BY count(*) DESC;
+```

--- a/scripts/ingest/scrape-mibar-discipline.mjs
+++ b/scripts/ingest/scrape-mibar-discipline.mjs
@@ -1,0 +1,653 @@
+// csv-bulk-checked: none-exists — Michigan ADB publishes no discipline bulk CSV; only RSS (recent ~100/feed) + per-item HTML pages on Lexum's norma platform.
+// Template: scripts/ingest/scrape-pabar-discipline.mjs (PA JSON API win — same staging + bulkCopyRows pattern)
+// Pattern: cl-bulk-data-defensive #18 (COPY FROM STDIN via bulkCopyRows — per-row INSERT banned)
+//
+// Michigan Attorney Discipline Board scraper.
+//
+// Source (probed 2026-04-24):
+//   Public site:    https://www.adbmich.org/         (CMS shell, JS-rendered)
+//   Records DB:     https://records.adbmich.org/     (redirects to norma.lexum.com)
+//   RSS feeds:
+//     Notices:      https://norma.lexum.com/adbmich/no/en/rss.do  (~100 items)
+//     Op/Orders:    https://norma.lexum.com/adbmich/op/en/rss.do  (~100 items)
+//   Item iframe:    https://norma.lexum.com/adbmich/{no|op}/en/item/<id>/index.do?iframe=true
+//
+// Strategy:
+//   The RSS feeds are limited to ~100 items each (recent rolling window). To
+//   reach the ≥300-event target across a multi-year window, we walk item IDs
+//   sequentially from --max-id down to --min-id. Item IDs are shared across
+//   the no/ and op/ collections — each ID lives in exactly one collection.
+//   We try /no/ first; on 404 fall back to /op/. Records found in either
+//   collection produce one event row each.
+//
+//   The per-item iframe page contains a server-rendered metadata table:
+//     Collection, Issued Date, Pnumber, Case number, Document Type, County,
+//     Title, Effective Date, City, State.
+//   The "Title" cell is the disposition (e.g. "Notice of Reprimand (By
+//   Consent)", "Order of Suspension", "Notice of Automatic Interim
+//   Suspension") — that's our discipline_type signal.
+//
+// Hard constraints (parent prompt):
+//   - 100% source_url coverage (the iframe item URL).
+//   - Real Michigan P-number (digits only in DB, prefixed "P" → P-number stored
+//     as "P<digits>" so it matches the P\d{4,6} regex check).
+//   - bulkCopyRows only; per-row INSERT banned (cl-bulk-data-defensive #18).
+//   - Session settings: statement_timeout='30min', idle_in_transaction_session_timeout='5min',
+//     tcp_keepalives. Port 5432. (createBulkClient handles this.)
+//   - Polite: 1-2 s/req randomized; INAA UA.
+//
+// Usage:
+//   node scripts/ingest/scrape-mibar-discipline.mjs                       # dry-run, walk 1..7541
+//   node scripts/ingest/scrape-mibar-discipline.mjs --apply               # write to DB
+//   node scripts/ingest/scrape-mibar-discipline.mjs --max-id 7541 --min-id 6500 --apply
+//   node scripts/ingest/scrape-mibar-discipline.mjs --max-id 7541 --max-misses 50  # smoke
+//
+// Output: staging tables _stg_attorneys_mi + _stg_discipline_mi populated via
+// bulkCopyRows, merged into public.attorneys + public.attorney_discipline_events.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { setTimeout as sleep } from 'node:timers/promises';
+
+import { createBulkClient, bulkCopyRows } from '../lib/pg-bulk-defaults.mjs';
+
+// ── Env loader (line-by-line, indexOf — no regex on file contents) ─────────
+// Mirrors seed-statutes-fl.mjs and the post-SEC-W1 single-source convention:
+// only the web repo's .env.local. Skips comments + blank lines, strips
+// balanced surrounding quotes, validates key shape.
+const _ENV_PATHS = [
+  'C:/Users/email/projects/ImNotAnAttorney-web/.env.local',
+  // worktree-local symlink fallback (kept second so primary path wins)
+  path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../.env.local'),
+];
+const _VALID_KEY_RX = /^[A-Z_][A-Z0-9_]*$/;
+for (const p of _ENV_PATHS) {
+  try {
+    if (!fs.existsSync(p)) continue;
+    const txt = fs.readFileSync(p, 'utf-8');
+    const lines = txt.split('\n');
+    for (const rawLine of lines) {
+      let line = rawLine.endsWith('\r') ? rawLine.slice(0, -1) : rawLine;
+      line = line.trim();
+      if (!line || line[0] === '#') continue;
+      const eq = line.indexOf('=');
+      if (eq <= 0) continue;
+      const key = line.slice(0, eq).trim();
+      let val = line.slice(eq + 1).trim();
+      if (
+        val.length >= 2 &&
+        ((val[0] === '"' && val[val.length - 1] === '"') ||
+          (val[0] === "'" && val[val.length - 1] === "'"))
+      ) {
+        val = val.slice(1, -1);
+      }
+      if (!_VALID_KEY_RX.test(key)) continue;
+      if (!process.env[key]) process.env[key] = val;
+    }
+    break; // first existing path wins
+  } catch {
+    // ignore — env may simply be missing in detached test contexts
+  }
+}
+
+// ── Config ──────────────────────────────────────────────────────────────────
+
+const __filename = fileURLToPath(import.meta.url);
+
+const HOST = 'https://norma.lexum.com';
+const COLLECTIONS = ['no', 'op']; // Notices first, then Orders/Opinions
+const ITEM_URL = (col, id) => `${HOST}/adbmich/${col}/en/item/${id}/index.do?iframe=true`;
+const ITEM_PUBLIC_URL = (col, id) => `${HOST}/adbmich/${col}/en/item/${id}/index.do`;
+const RSS_URL = (col) => `${HOST}/adbmich/${col}/en/rss.do`;
+
+const USER_AGENT =
+  'INAA-Crawler/1.0 (+https://imnotanattorney.com; contact: noreply-legal@inaa.com)';
+
+const JURISDICTION = 'MI';
+
+// Discipline type detection — order matters (disbarment before suspension;
+// "interim" / "automatic" / "temporary" before plain "suspension"; reciprocal
+// disbarment-then-suspension still classifies as disbarment).
+const DISCIPLINE_PATTERNS = [
+  [/\brevocation\s+of\s+(license|admission)/i, 'disbarment'],
+  [/\bdisbar/i, 'disbarment'],
+  [/\bresign(ation|ed)?\s+(with\s+(charges|disciplinary)|in\s+lieu)/i, 'resignation_with_charges'],
+  [/\bautomatic\s+interim\s+suspen/i, 'interim_suspension'],
+  [/\bautomatic\s+suspen/i, 'interim_suspension'],
+  [/\binterim\s+suspen/i, 'interim_suspension'],
+  [/\btemporary\s+suspen/i, 'interim_suspension'],
+  [/\bemergency\s+suspen/i, 'interim_suspension'],
+  [/\bsuspen/i, 'suspension'],
+  [/\bprobation/i, 'probation'],
+  [/\bpublic\s+repri(mand|of)/i, 'public_reprimand'],
+  [/\b(notice\s+of\s+)?reprimand/i, 'public_reprimand'],
+  [/\bpublic\s+censure/i, 'public_reprimand'],
+  [/\badmonish/i, 'admonishment'],
+  [/\breinstate/i, 'reinstatement'],
+  [/\bdisability\s+inactive|transfer(red)?\s+to\s+inactive/i, 'disability_inactive'],
+  [/\bdisabled?\b/i, 'disability_inactive'],
+];
+
+function normalizeDiscipline(titleField, documentType) {
+  const blob = `${titleField || ''} ${documentType || ''}`.trim();
+  if (!blob) return { type: 'unknown', raw: null };
+  for (const [re, type] of DISCIPLINE_PATTERNS) {
+    if (re.test(blob)) return { type, raw: blob.slice(0, 500) };
+  }
+  return { type: 'unknown', raw: blob.slice(0, 500) };
+}
+
+// ── CLI ─────────────────────────────────────────────────────────────────────
+
+function parseArgs(argv) {
+  const args = argv.slice(2);
+  const out = {
+    apply: false,
+    minId: 1,
+    maxId: 7541, // highest seen in RSS as of 2026-04-24; --max-id auto-bumps from RSS if --auto-max
+    autoMax: true, // bump maxId from RSS feeds before walking
+    maxMisses: 80, // give up after this many consecutive 404s (a margin around historical ID gaps)
+    delayMin: 1000,
+    delayMax: 2000,
+    onlyRss: false, // smoke: skip sequential walk, RSS only
+    skipRss: false,
+  };
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === '--apply') out.apply = true;
+    else if (a === '--min-id') out.minId = parseInt(args[++i], 10);
+    else if (a === '--max-id') { out.maxId = parseInt(args[++i], 10); out.autoMax = false; }
+    else if (a === '--max-misses') out.maxMisses = parseInt(args[++i], 10);
+    else if (a === '--delay-min') out.delayMin = parseInt(args[++i], 10);
+    else if (a === '--delay-max') out.delayMax = parseInt(args[++i], 10);
+    else if (a === '--only-rss') out.onlyRss = true;
+    else if (a === '--skip-rss') out.skipRss = true;
+    else if (a === '--no-auto-max') out.autoMax = false;
+    else if (a === '--help' || a === '-h') {
+      console.log(fs.readFileSync(__filename, 'utf8').split('\n').slice(0, 50).join('\n'));
+      process.exit(0);
+    } else {
+      throw new Error(`unknown arg: ${a}`);
+    }
+  }
+  if (!Number.isFinite(out.minId) || out.minId < 1) {
+    throw new Error('--min-id must be >= 1');
+  }
+  if (!Number.isFinite(out.maxId) || out.maxId < out.minId) {
+    throw new Error('--max-id must be >= --min-id');
+  }
+  return out;
+}
+
+const OPTS = parseArgs(process.argv);
+
+// ── HTTP ────────────────────────────────────────────────────────────────────
+
+function politeDelay() {
+  const range = Math.max(1, OPTS.delayMax - OPTS.delayMin);
+  const ms = OPTS.delayMin + Math.floor(Math.random() * range);
+  return sleep(ms);
+}
+
+// Lexum's edge returns 403 on bursts (observed 2026-04-24: ~100 requests in
+// 60s triggered IP-block). Retry on 403 with exponential backoff (60s, 120s,
+// 240s). 404 = real "not in this collection" → no retry. 5xx → one short
+// retry then bubble.
+async function httpGet(url, attempt = 0) {
+  let resp;
+  try {
+    resp = await fetch(url, {
+      headers: {
+        'User-Agent': USER_AGENT,
+        'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+        'Accept-Language': 'en-US,en;q=0.9',
+        'Referer': 'https://www.adbmich.org/',
+      },
+    });
+  } catch (err) {
+    if (attempt >= 2) throw err;
+    console.error(`[net] ${url}: ${err.message} — retrying in 5s`);
+    await sleep(5000);
+    return httpGet(url, attempt + 1);
+  }
+  if (resp.status === 403 && attempt < 3) {
+    const wait = 60_000 * Math.pow(2, attempt);
+    console.error(`[net] 403 on ${url} — backing off ${wait / 1000}s (attempt ${attempt + 1}/3)`);
+    await sleep(wait);
+    return httpGet(url, attempt + 1);
+  }
+  if (resp.status >= 500 && attempt < 1) {
+    console.error(`[net] ${resp.status} on ${url} — short retry in 10s`);
+    await sleep(10_000);
+    return httpGet(url, attempt + 1);
+  }
+  return { status: resp.status, ok: resp.ok, text: resp.ok ? await resp.text() : null };
+}
+
+// ── Parse helpers ───────────────────────────────────────────────────────────
+
+function decodeEntities(s) {
+  if (!s) return s;
+  return s
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&apos;/g, "'")
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>');
+}
+
+function stripTags(s) {
+  if (!s) return s;
+  return decodeEntities(s.replace(/<[^>]+>/g, '')).replace(/\s+/g, ' ').trim();
+}
+
+function splitName(full) {
+  if (!full) return { first: null, last: null, full };
+  // Michigan ADB uses "Last, First M. [Suffix]" — sometimes "Last, Jr., First M."
+  const ix = full.indexOf(',');
+  if (ix < 0) {
+    const parts = full.replace(/\s+/g, ' ').trim().split(' ');
+    if (parts.length === 1) return { first: null, last: parts[0], full };
+    return { first: parts.slice(0, -1).join(' '), last: parts[parts.length - 1], full };
+  }
+  const last = full.slice(0, ix).trim();
+  const rest = full.slice(ix + 1).trim();
+  // If rest contains another comma like "Jr., Luther W." treat token before
+  // the second comma as suffix; combine into last.
+  const ix2 = rest.indexOf(',');
+  if (ix2 >= 0 && /\b(jr|sr|ii|iii|iv|v)\b\.?/i.test(rest.slice(0, ix2))) {
+    const suffix = rest.slice(0, ix2).trim();
+    const first = rest.slice(ix2 + 1).trim() || null;
+    return { first, last: `${last}, ${suffix}`, full };
+  }
+  return { first: rest || null, last, full };
+}
+
+function parseMdy(s) {
+  if (!s) return null;
+  const m = String(s).trim().match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})$/);
+  if (!m) return null;
+  const [, mm, dd, yyyy] = m;
+  return `${yyyy.padStart(4, '0')}-${mm.padStart(2, '0')}-${dd.padStart(2, '0')}`;
+}
+
+// Pull a metadata-table cell value by label. Robust to whitespace and to the
+// site's stray-newline indentation. The <td class="metadata"> cell may be
+// followed directly by another <tr> (no closing </td>), so we accept either
+// </td> OR a <tr/<td start as terminator.
+//   <td class="label">Pnumber</td>
+//   <td class="metadata">
+//                                49768
+//                    </tr>
+function escapeRegex(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+function extractMetaCell(html, label) {
+  const pattern =
+    '<td[^>]*class="label"[^>]*>\\s*' +
+    escapeRegex(label) +
+    '\\s*</td>\\s*<td[^>]*class="metadata"[^>]*>([\\s\\S]*?)(?:</td>|<\\s*/?\\s*tr\\b|<td\\b)';
+  const re = new RegExp(pattern, 'i');
+  const m = html.match(re);
+  if (!m) return null;
+  const v = stripTags(m[1]);
+  return v || null;
+}
+
+// Pull <h3 class="title">…</h3>
+function extractH3Title(html) {
+  const m = html.match(/<h3[^>]*class="title"[^>]*>([\s\S]*?)<\/h3>/i);
+  return m ? stripTags(m[1]) : null;
+}
+
+// Parse one item iframe HTML into a record. Returns null on missing required
+// fields (P-number or order date or attorney name).
+function parseItem(html, collection, id) {
+  const fullName = extractH3Title(html);
+  const pnumberRaw = extractMetaCell(html, 'Pnumber');
+  const issuedDate = extractMetaCell(html, 'Issued Date');
+  const effectiveDate = extractMetaCell(html, 'Effective Date');
+  const docType = extractMetaCell(html, 'Document Type');
+  const titleField = extractMetaCell(html, 'Title');
+  const county = extractMetaCell(html, 'County');
+  const city = extractMetaCell(html, 'City');
+  const caseNumber = extractMetaCell(html, 'Case number') || extractMetaCell(html, 'Case Number');
+
+  if (!fullName || !pnumberRaw) return null;
+  const pnumDigits = (pnumberRaw.match(/\d{4,6}/) || [])[0];
+  if (!pnumDigits) return null;
+
+  const orderDate = parseMdy(issuedDate);
+  const effDate = parseMdy(effectiveDate) || orderDate;
+  if (!orderDate) return null;
+
+  const { type, raw } = normalizeDiscipline(titleField, docType);
+
+  return {
+    bar_number: `P${pnumDigits}`,
+    full_name: fullName,
+    order_date: orderDate,
+    effective_date: effDate,
+    discipline_type: type,
+    discipline_raw: raw,
+    title_field: titleField,
+    document_type: docType,
+    case_number: caseNumber,
+    county: county || null,
+    city: city || null,
+    source_url: ITEM_PUBLIC_URL(collection, id),
+    api_url: ITEM_URL(collection, id),
+    collection,
+  };
+}
+
+// Parse RSS feed into {id, link} pairs (used to discover the latest live ID).
+function parseRssLinkIds(xml) {
+  const out = [];
+  if (!xml) return out;
+  const itemBlocks = xml.split(/<item>/).slice(1);
+  for (const blk of itemBlocks) {
+    const inner = blk.split('</item>')[0];
+    const linkMatch = inner.match(/<link>([\s\S]*?)<\/link>/i);
+    if (!linkMatch) continue;
+    const link = linkMatch[1].trim();
+    const idMatch = link.match(/\/item\/(\d+)\/index\.do/);
+    const colMatch = link.match(/\/adbmich\/(no|op)\/en\/item\//);
+    if (!idMatch || !colMatch) continue;
+    out.push({ id: parseInt(idMatch[1], 10), collection: colMatch[1], link });
+  }
+  return out;
+}
+
+// ── Scrape phases ───────────────────────────────────────────────────────────
+
+async function discoverMaxIdFromRss() {
+  let maxId = 0;
+  for (const col of COLLECTIONS) {
+    const url = RSS_URL(col);
+    try {
+      const { ok, status, text } = await httpGet(url);
+      if (!ok) {
+        console.error(`[rss] ${col}: HTTP ${status}`);
+        continue;
+      }
+      const ids = parseRssLinkIds(text);
+      for (const it of ids) if (it.id > maxId) maxId = it.id;
+      console.error(`[rss] ${col}: ${ids.length} items, top id=${ids.length ? Math.max(...ids.map(x => x.id)) : 'n/a'}`);
+    } catch (err) {
+      console.error(`[rss] ${col}: ${err.message}`);
+    }
+    await politeDelay();
+  }
+  return maxId;
+}
+
+async function fetchItemAcrossCollections(id) {
+  // Try notices first, then orders. Either-or — never both.
+  for (const col of COLLECTIONS) {
+    const url = ITEM_URL(col, id);
+    let resp;
+    try {
+      resp = await httpGet(url);
+    } catch (err) {
+      console.error(`[fetch] id=${id} col=${col}: ${err.message}`);
+      continue;
+    }
+    if (!resp.ok) continue;
+    const rec = parseItem(resp.text, col, id);
+    if (rec) return rec;
+    // 200 but unparseable — log and keep trying alternate collection.
+    console.error(`[parse] id=${id} col=${col}: 200 but no metadata extracted`);
+  }
+  return null;
+}
+
+async function walkSequential() {
+  const records = [];
+  let consecutive404 = 0;
+  let scanned = 0;
+  for (let id = OPTS.maxId; id >= OPTS.minId; id--) {
+    scanned++;
+    const rec = await fetchItemAcrossCollections(id);
+    if (rec) {
+      consecutive404 = 0;
+      records.push(rec);
+      if (records.length % 25 === 0) {
+        console.error(`[walk] id=${id} found=${records.length} scanned=${scanned} (latest: ${rec.full_name} [${rec.bar_number}] ${rec.discipline_type} ${rec.order_date})`);
+      }
+    } else {
+      consecutive404++;
+      if (consecutive404 >= OPTS.maxMisses) {
+        console.error(`[walk] hit ${consecutive404} consecutive misses at id=${id} — stopping`);
+        break;
+      }
+    }
+    await politeDelay();
+  }
+  console.error(`[walk] scanned ${scanned} ids → ${records.length} records`);
+  return records;
+}
+
+async function harvestRss() {
+  const records = [];
+  for (const col of COLLECTIONS) {
+    const url = RSS_URL(col);
+    try {
+      const { ok, status, text } = await httpGet(url);
+      if (!ok) {
+        console.error(`[rss] ${col}: HTTP ${status}`);
+        continue;
+      }
+      const ids = parseRssLinkIds(text);
+      console.error(`[rss-harvest] ${col}: ${ids.length} ids to fetch`);
+      for (const it of ids) {
+        const rec = await fetchItemAcrossCollections(it.id);
+        if (rec) records.push(rec);
+        await politeDelay();
+      }
+    } catch (err) {
+      console.error(`[rss-harvest] ${col}: ${err.message}`);
+    }
+  }
+  return records;
+}
+
+// ── Load ────────────────────────────────────────────────────────────────────
+
+async function load(records) {
+  const { client, cleanup } = await createBulkClient();
+  try {
+    await client.query(`DROP TABLE IF EXISTS public._stg_attorneys_mi`);
+    await client.query(`DROP TABLE IF EXISTS public._stg_discipline_mi`);
+    await client.query(`
+      CREATE UNLOGGED TABLE public._stg_attorneys_mi (
+        jurisdiction    char(2),
+        bar_number      text,
+        full_name       text,
+        first_name      text,
+        last_name       text,
+        admission_date  date,
+        current_status  text,
+        city            text,
+        source_url      text
+      );
+      CREATE UNLOGGED TABLE public._stg_discipline_mi (
+        jurisdiction      char(2),
+        bar_number        text,
+        full_name         text,
+        order_date        date,
+        effective_date    date,
+        discipline_type   text,
+        discipline_raw    text,
+        violation_summary text,
+        order_url         text,
+        source_url        text
+      );
+    `);
+
+    // De-dupe attorneys by bar_number.
+    const byBar = new Map();
+    for (const r of records) {
+      const { first, last } = splitName(r.full_name);
+      const cur = byBar.get(r.bar_number);
+      if (!cur) {
+        byBar.set(r.bar_number, {
+          jurisdiction: JURISDICTION,
+          bar_number: r.bar_number,
+          full_name: r.full_name,
+          first_name: first,
+          last_name: last,
+          admission_date: null,
+          current_status: null,
+          city: r.city || r.county || null,
+          source_url: r.source_url,
+        });
+      } else {
+        if (!cur.city && (r.city || r.county)) cur.city = r.city || r.county;
+      }
+    }
+
+    const attorneyRows = [...byBar.values()].map((a) => [
+      a.jurisdiction, a.bar_number, a.full_name, a.first_name, a.last_name,
+      a.admission_date, a.current_status, a.city, a.source_url,
+    ]);
+    await bulkCopyRows(
+      client,
+      '_stg_attorneys_mi',
+      ['jurisdiction','bar_number','full_name','first_name','last_name','admission_date','current_status','city','source_url'],
+      attorneyRows,
+    );
+
+    // De-dupe events on (bar_number, order_date, discipline_type) before COPY,
+    // mirroring the unique constraint so re-runs don't COPY collisions before
+    // ON CONFLICT runs.
+    const seen = new Set();
+    const eventRows = [];
+    for (const r of records) {
+      const key = `${r.bar_number}|${r.order_date}|${r.discipline_type}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      const summary = (r.title_field || r.document_type || '').slice(0, 500) || null;
+      eventRows.push([
+        JURISDICTION,
+        r.bar_number,
+        r.full_name,
+        r.order_date,
+        r.effective_date,
+        r.discipline_type,
+        r.discipline_raw,
+        summary,
+        null,           // order_url — no PDF link extracted in this round
+        r.source_url,   // source_url — required, 100% populated
+      ]);
+    }
+
+    await bulkCopyRows(
+      client,
+      '_stg_discipline_mi',
+      ['jurisdiction','bar_number','full_name','order_date','effective_date','discipline_type','discipline_raw','violation_summary','order_url','source_url'],
+      eventRows,
+    );
+
+    const upsertAttorneys = await client.query(`
+      INSERT INTO public.attorneys
+        (jurisdiction, bar_number, full_name, first_name, last_name,
+         admission_date, current_status, city, source_url, last_seen_at)
+      SELECT jurisdiction, bar_number, full_name, first_name, last_name,
+             admission_date, current_status, city, source_url, NOW()
+      FROM _stg_attorneys_mi
+      ON CONFLICT (jurisdiction, bar_number) DO UPDATE SET
+        full_name      = EXCLUDED.full_name,
+        first_name     = COALESCE(EXCLUDED.first_name, public.attorneys.first_name),
+        last_name      = COALESCE(EXCLUDED.last_name, public.attorneys.last_name),
+        city           = COALESCE(EXCLUDED.city, public.attorneys.city),
+        source_url     = COALESCE(EXCLUDED.source_url, public.attorneys.source_url),
+        last_seen_at   = NOW()
+      RETURNING id, bar_number;
+    `);
+    console.error(`[db] attorneys upserted: ${upsertAttorneys.rowCount}`);
+
+    const insertEvents = await client.query(`
+      INSERT INTO public.attorney_discipline_events
+        (attorney_id, jurisdiction, bar_number, full_name, order_date, effective_date,
+         discipline_type, discipline_raw, violation_summary, order_url, source_url)
+      SELECT a.id, s.jurisdiction, s.bar_number, s.full_name, s.order_date, s.effective_date,
+             s.discipline_type, s.discipline_raw, s.violation_summary, s.order_url, s.source_url
+      FROM _stg_discipline_mi s
+      JOIN public.attorneys a
+        ON a.jurisdiction = s.jurisdiction AND a.bar_number = s.bar_number
+      WHERE s.order_date IS NOT NULL
+      ON CONFLICT (jurisdiction, bar_number, order_date, discipline_type) DO NOTHING;
+    `);
+    console.error(`[db] discipline events inserted: ${insertEvents.rowCount}`);
+
+    await client.query(`DROP TABLE IF EXISTS public._stg_attorneys_mi, public._stg_discipline_mi`);
+  } finally {
+    await cleanup();
+  }
+}
+
+// ── Main ────────────────────────────────────────────────────────────────────
+
+async function main() {
+  console.error(
+    `[mibar] start — apply=${OPTS.apply} min=${OPTS.minId} max=${OPTS.maxId} maxMisses=${OPTS.maxMisses} onlyRss=${OPTS.onlyRss} skipRss=${OPTS.skipRss}`,
+  );
+
+  if (OPTS.autoMax) {
+    const rssMax = await discoverMaxIdFromRss();
+    if (rssMax > OPTS.maxId) {
+      console.error(`[mibar] auto-bumping max-id ${OPTS.maxId} → ${rssMax} (from RSS)`);
+      OPTS.maxId = rssMax;
+    }
+  }
+
+  let records;
+  if (OPTS.onlyRss) {
+    records = await harvestRss();
+  } else {
+    records = await walkSequential();
+  }
+
+  console.error(`[mibar] collected ${records.length} discipline rows`);
+
+  // Sanity: 100% must have source_url and bar_number P\d{4,6}.
+  const missingUrl = records.filter((r) => !r.source_url).length;
+  const badBar = records.filter((r) => !/^P\d{4,6}$/.test(r.bar_number)).length;
+  console.error(`[mibar] sanity: missing_source_url=${missingUrl} bad_bar_number=${badBar}`);
+  if (missingUrl > 0 || badBar > 0) {
+    throw new Error('sanity check failed — abort before DB write');
+  }
+
+  // Histogram preview.
+  const hist = new Map();
+  for (const r of records) hist.set(r.discipline_type, (hist.get(r.discipline_type) || 0) + 1);
+  for (const [k, v] of [...hist.entries()].sort((a, b) => b[1] - a[1])) {
+    console.error(`  ${k}: ${v}`);
+  }
+  for (const r of records.slice(0, 5)) {
+    console.error(
+      `  · ${r.full_name} [${r.bar_number}] — ${r.discipline_type} (${r.order_date}) — ${r.city || r.county || '?'} — ${r.source_url}`,
+    );
+  }
+
+  if (!OPTS.apply) {
+    console.error(`[mibar] dry-run — pass --apply to write to DB`);
+    return;
+  }
+  if (records.length === 0) {
+    console.error(`[mibar] no records — nothing to load`);
+    return;
+  }
+
+  await load(records);
+  console.error(`[mibar] done`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/ingest/scrape-mibar-discipline.mjs
+++ b/scripts/ingest/scrape-mibar-discipline.mjs
@@ -150,7 +150,8 @@ function parseArgs(argv) {
     maxMisses: 80, // give up after this many consecutive 404s (a margin around historical ID gaps)
     delayMin: 1000,
     delayMax: 2000,
-    onlyRss: false, // smoke: skip sequential walk, RSS only
+    onlyRss: false, // smoke: skip sequential walk, fetch each RSS item iframe
+    onlyRssMetadata: false, // RSS-only metadata path — no per-item iframe fetch (used when blocked)
     skipRss: false,
   };
   for (let i = 0; i < args.length; i++) {
@@ -162,6 +163,7 @@ function parseArgs(argv) {
     else if (a === '--delay-min') out.delayMin = parseInt(args[++i], 10);
     else if (a === '--delay-max') out.delayMax = parseInt(args[++i], 10);
     else if (a === '--only-rss') out.onlyRss = true;
+    else if (a === '--only-rss-metadata') out.onlyRssMetadata = true;
     else if (a === '--skip-rss') out.skipRss = true;
     else if (a === '--no-auto-max') out.autoMax = false;
     else if (a === '--help' || a === '-h') {
@@ -358,6 +360,75 @@ function parseRssLinkIds(xml) {
     const colMatch = link.match(/\/adbmich\/(no|op)\/en\/item\//);
     if (!idMatch || !colMatch) continue;
     out.push({ id: parseInt(idMatch[1], 10), collection: colMatch[1], link });
+  }
+  return out;
+}
+
+// RSS-only fallback parser. Each <item> gives us:
+//   <title>Last, First - <P-num> - MM/DD/YYYY</title>
+//   <link>https://norma.lexum.com/adbmich/{no|op}/en/item/<id>/index.do</link>
+//   <description><![CDATA[ Notice|Board Order|Opinion <br/> ... ]]></description>
+//   <decision:date>MM/DD/YYYY</decision:date>
+// This populates everything except discipline_type (which we fall back to
+// 'unknown' since RSS doesn't expose the disposition title field). Used when
+// iframe URLs are temporarily blocked by Lexum's edge throttler.
+function parseRssItemsAsRecords(xml, fallbackCollection) {
+  const out = [];
+  if (!xml) return out;
+  const blocks = xml.split(/<item>/).slice(1);
+  for (const blk of blocks) {
+    const inner = blk.split('</item>')[0];
+    const titleM = inner.match(/<title>([\s\S]*?)<\/title>/i);
+    const linkM = inner.match(/<link>([\s\S]*?)<\/link>/i);
+    const descM = inner.match(/<description>[\s\S]*?<!\[CDATA\[([\s\S]*?)\]\]>[\s\S]*?<\/description>/i);
+    const decisionM = inner.match(/<decision:date>([\s\S]*?)<\/decision:date>/i);
+    if (!titleM || !linkM) continue;
+
+    const titleRaw = titleM[1].replace(/\s+/g, ' ').trim();
+    // "Last, First [Suffix] - <P-num> - MM/DD/YYYY"
+    const tm = titleRaw.match(/^(.*?)\s*-\s*(\d{4,6})\s*-\s*(\d{1,2}\/\d{1,2}\/\d{4})\s*$/);
+    if (!tm) continue;
+    const fullName = tm[1].trim();
+    const pnumDigits = tm[2];
+    const titleDate = parseMdy(tm[3]);
+
+    const link = linkM[1].trim();
+    const idMatch = link.match(/\/item\/(\d+)\/index\.do/);
+    const colMatch = link.match(/\/adbmich\/(no|op)\/en\/item\//);
+    if (!idMatch) continue;
+    const id = parseInt(idMatch[1], 10);
+    const collection = colMatch ? colMatch[1] : fallbackCollection;
+
+    const descText = descM ? decodeEntities(descM[1].replace(/<[^>]+>/g, ' ')).replace(/\s+/g, ' ').trim() : '';
+    const decisionDate = decisionM ? parseMdy(decisionM[1].trim()) : null;
+    const orderDate = decisionDate || titleDate;
+    if (!orderDate) continue;
+
+    // Document type derived from the "Notice|Board Order|Opinion" prefix
+    // present in the CDATA. Discipline_type tries to glean from
+    // descText (rarely informative) — defaults to 'unknown'.
+    const docType =
+      /\bnotice\b/i.test(descText) ? 'Notice' :
+      /\bboard\s+order\b/i.test(descText) ? 'Board Order' :
+      /\bopinion\b/i.test(descText) ? 'Opinion' : null;
+    const { type, raw } = normalizeDiscipline(descText, docType);
+
+    out.push({
+      bar_number: `P${pnumDigits}`,
+      full_name: fullName,
+      order_date: orderDate,
+      effective_date: orderDate,
+      discipline_type: type,
+      discipline_raw: raw,
+      title_field: docType, // best signal we have from RSS
+      document_type: docType,
+      case_number: null,
+      county: null,
+      city: null,
+      source_url: ITEM_PUBLIC_URL(collection, id),
+      api_url: link,
+      collection,
+    });
   }
   return out;
 }
@@ -570,6 +641,10 @@ async function load(records) {
     `);
     console.error(`[db] attorneys upserted: ${upsertAttorneys.rowCount}`);
 
+    // Skip 'unknown' rows when a classified row already exists for the same
+    // (bar_number, order_date) — RSS-only metadata path produces 'unknown'
+    // rows that overlap with iframe-walked classified rows. Inserting both
+    // would create same-day twins.
     const insertEvents = await client.query(`
       INSERT INTO public.attorney_discipline_events
         (attorney_id, jurisdiction, bar_number, full_name, order_date, effective_date,
@@ -580,9 +655,37 @@ async function load(records) {
       JOIN public.attorneys a
         ON a.jurisdiction = s.jurisdiction AND a.bar_number = s.bar_number
       WHERE s.order_date IS NOT NULL
+        AND NOT (
+          s.discipline_type = 'unknown'
+          AND EXISTS (
+            SELECT 1 FROM public.attorney_discipline_events e
+            WHERE e.jurisdiction = s.jurisdiction
+              AND e.bar_number = s.bar_number
+              AND e.order_date = s.order_date
+              AND e.discipline_type <> 'unknown'
+          )
+        )
       ON CONFLICT (jurisdiction, bar_number, order_date, discipline_type) DO NOTHING;
     `);
     console.error(`[db] discipline events inserted: ${insertEvents.rowCount}`);
+
+    // Post-INSERT cleanup: existing 'unknown' rows that now have a classified
+    // sibling (because this run added the classified version) get deleted.
+    const cleanupUnknown = await client.query(`
+      DELETE FROM public.attorney_discipline_events e
+      WHERE e.jurisdiction = '${JURISDICTION}'
+        AND e.discipline_type = 'unknown'
+        AND EXISTS (
+          SELECT 1 FROM public.attorney_discipline_events e2
+          WHERE e2.jurisdiction = e.jurisdiction
+            AND e2.bar_number = e.bar_number
+            AND e2.order_date = e.order_date
+            AND e2.discipline_type <> 'unknown'
+        );
+    `);
+    if (cleanupUnknown.rowCount > 0) {
+      console.error(`[db] cleaned up ${cleanupUnknown.rowCount} duplicate 'unknown' rows superseded by classified events`);
+    }
 
     await client.query(`DROP TABLE IF EXISTS public._stg_attorneys_mi, public._stg_discipline_mi`);
   } finally {
@@ -606,7 +709,24 @@ async function main() {
   }
 
   let records;
-  if (OPTS.onlyRss) {
+  if (OPTS.onlyRssMetadata) {
+    // RSS-only metadata path: no per-item iframe fetches. Used when Lexum's
+    // edge throttler is blocking ?iframe=true URLs. discipline_type will be
+    // 'unknown' for most rows since RSS doesn't expose the disposition title.
+    records = [];
+    for (const col of COLLECTIONS) {
+      const url = RSS_URL(col);
+      const { ok, status, text } = await httpGet(url);
+      if (!ok) {
+        console.error(`[rss-meta] ${col}: HTTP ${status}`);
+        continue;
+      }
+      const items = parseRssItemsAsRecords(text, col);
+      console.error(`[rss-meta] ${col}: ${items.length} records`);
+      records.push(...items);
+      await politeDelay();
+    }
+  } else if (OPTS.onlyRss) {
     records = await harvestRss();
   } else {
     records = await walkSequential();


### PR DESCRIPTION
## Summary
- New scraper `scripts/ingest/scrape-mibar-discipline.mjs` for Michigan Attorney Discipline Board (ADB).
- 187 events / 125 attorneys loaded into `attorney_discipline_events` (jurisdiction='MI').
- Date range: 1978-12-07 → 2026-04-24. 100% source_url coverage. 100% real Michigan P-numbers.

## Source strategy
Michigan ADB publishes through Lexum's `norma.lexum.com` (Decisia):
- **RSS feeds** at `/adbmich/{no,op}/en/rss.do` give recent ~100 items each
- **Per-item server-rendered metadata** at `/adbmich/{no,op}/en/item/<id>/index.do?iframe=true`
- Item IDs shared across collections — exactly one of `no/op` returns 200 per ID

## Histogram
| discipline_type | count |
|---|---:|
| unknown | 137 |
| suspension | 13 |
| public_reprimand | 13 |
| disbarment | 9 |
| reinstatement | 8 |
| interim_suspension | 6 |
| disability_inactive | 1 |

NOTE: 137 "unknown" rows are RSS-fallback only; will be reclassified when iframe walk runs after Lexum 403 throttle clears (handoff doc has reproduction command). Target was ≥300 — landed 187, gap-closure command in `docs/handoff/2026-04-24-mi-bar-discipline-handoff.md`.

## Throttle gotcha (memory-saved)
Lexum edge IP-blocks `?iframe=true` paths after ~100 requests/min. RSS path stays open throughout. RSS-only fallback added for resilience.

## Test plan
- [x] DB rows loaded (187 events / 125 attorneys)
- [x] 100% source_url populated
- [x] 100% real Michigan P-numbers (`P\d{4,6}`)
- [x] Per-jurisdiction staging (`_stg_attorneys_mi` / `_stg_discipline_mi`)
- [x] `bulkCopyRows` (cl-bulk-data-defensive #18)
- [x] Polite scraping: 1-2s default + 60-240s exponential backoff on 403

## Follow-up
Iframe walk after Lexum recovery: `node scripts/ingest/scrape-mibar-discipline.mjs --max-id 7430 --min-id 6000 --max-misses 100 --delay-min 1500 --delay-max 3000 --no-auto-max --apply` — expected ~430 iframe-classified events, push total to ~500-600.

🤖 Generated with [Claude Code](https://claude.com/claude-code)