### PR TITLE
fix(products): correct 6 standalone upsellTier pointers (Hormozi cannibalization fix)

### DIFF
--- a/src/lib/products.ts
+++ b/src/lib/products.ts
@@ -374,9 +374,13 @@ export const STANDALONE_PRODUCTS: Record<string, StandaloneProduct> = {
       "knownFacts",
     ],
     stripePriceId: "price_motion_opportunity_scan_live",
-    upsellTier: "case-decoder",
+    // Upsell to IB ($997, 2x step). Motion opportunities are IB's defense-
+    // strategy layer — the 10-20 motion shortlist feeds IB's prosecution
+    // pattern analysis. Downgrade to Case Decoder ($197) lost $497 buyers
+    // to a less expensive product — Hormozi cannibalization violation.
+    upsellTier: "intelligence-brief",
     upsellText:
-      "Knowing which motions apply is the first step. The Case Decoder maps the full defense landscape including evidentiary support.",
+      "Knowing which motions apply is the first step. The Intelligence Brief inherits this motion shortlist AND adds full prosecution pattern analysis with 15-25 questions calibrated to your case. $997.",
     dripSequenceKey: "research_motion_opportunity",
     isActive: true,
   },
@@ -1192,9 +1196,14 @@ export const STANDALONE_PRODUCTS: Record<string, StandaloneProduct> = {
       "Sentencing patterns, prosecutor pairing data, bench vs jury divergence, and quote library for your assigned judge.",
     intakeFields: ["judgeName", "state", "chargeType"],
     stripePriceId: null,
-    upsellTier: "case-decoder",
+    // Upsell to IB ($997, 5x step). The Judge Report Card covers ONE judge in
+    // depth; the Intelligence Brief inherits that layer AND adds full
+    // jurisdiction prosecution intel + accountability research. Lateral upsell
+    // to Case Decoder ($197) was a Hormozi value-step violation — same price
+    // tier means buyer perceives no Dream Outcome lift.
+    upsellTier: "intelligence-brief",
     upsellText:
-      "Your judge is one piece. The Case Decoder analyzes your full defense landscape.",
+      "Your judge is one piece. The Intelligence Brief inherits your judge data and adds full jurisdiction prosecution patterns, accountability research, and 15-25 questions calibrated to your case. $997.",
     dripSequenceKey: "research_judge_report_card",
     isActive: true,
   },
@@ -1210,9 +1219,13 @@ export const STANDALONE_PRODUCTS: Record<string, StandaloneProduct> = {
       "Cross-case officer reliability, credibility challenges, and discreditation history from verified court records.",
     intakeFields: ["officerName", "state", "agency", "badgeNumber"],
     stripePriceId: null,
-    upsellTier: "case-decoder",
+    // Upsell to X-Ray ($2,497, 25x step). Officer reliability is the X-Ray
+    // arrest-stage layer — cross-case officer history feeds the X-Ray
+    // discovery analysis directly. Case Decoder ($197) does not use officer
+    // intel; lateral upsell was a Hormozi value-step violation.
+    upsellTier: "x-ray",
     upsellText:
-      "Officer reliability is one angle. The Case Decoder maps your full defense position.",
+      "Officer reliability is one angle. The X-Ray inherits this cross-case officer history AND adds full discovery analysis with 35-50 calibrated questions. $2,497.",
     dripSequenceKey: "research_officer_background",
     isActive: true,
   },
@@ -1231,9 +1244,13 @@ export const STANDALONE_PRODUCTS: Record<string, StandaloneProduct> = {
     // citizenship, ageBucket.
     intakeFields: ["chargeType", "state", "priorConvictions", "citizenship", "ageBucket", "district"],
     stripePriceId: null,
-    upsellTier: "case-decoder",
+    // Upsell to X-Ray ($2,497, 8x step). Similar-cases data is X-Ray's
+    // sentencing-outlier-flag layer — the cohort comparison feeds the X-Ray
+    // discovery analysis. Downgrading $297 buyers to a $197 product was a
+    // Hormozi cannibalization violation (negative value step).
+    upsellTier: "x-ray",
     upsellText:
-      "Similar cases set expectations. The Case Decoder builds your specific defense strategy.",
+      "Similar cases set expectations. The X-Ray inherits this cohort intelligence AND adds full discovery analysis showing where YOU fit in the distribution. $2,497.",
     dripSequenceKey: "research_similar_cases",
     isActive: true,
   },
@@ -1255,9 +1272,13 @@ export const STANDALONE_PRODUCTS: Record<string, StandaloneProduct> = {
       "criminalHistoryCategory",
     ],
     stripePriceId: null,
-    upsellTier: "case-decoder",
+    // Upsell to X-Ray ($2,497, 8x step). FSD's distribution feeds X-Ray's
+    // sentencing-outlier flagging directly. Downgrade to Case Decoder
+    // ($197) silently lost $297 buyers to a less expensive product —
+    // a Hormozi cannibalization violation.
+    upsellTier: "x-ray",
     upsellText:
-      "A distribution tells you the range. The Case Decoder tells you where YOU fit inside it.",
+      "A distribution tells you the range. The X-Ray inherits this district sentencing intelligence AND tells you where YOU fit inside it via full discovery analysis. $2,497.",
     dripSequenceKey: "research_fsd",
     isActive: true,
   },
@@ -1274,9 +1295,12 @@ export const STANDALONE_PRODUCTS: Record<string, StandaloneProduct> = {
       "Top-10 motion filings + grant rates for your charge type and federal circuit, optional judge-specific patterns, and top-10 granted-motion case citations every defendant should know.",
     intakeFields: ["chargeType", "state", "circuit", "judgeName"],
     stripePriceId: null,
-    upsellTier: "case-decoder",
+    // Upsell to IB ($997, 5x step). Motion grant rates feed IB's defense
+    // strategy layer alongside motion-opportunity-scan. Lateral upsell to
+    // Case Decoder ($197 — same price tier) failed Hormozi value-step rule.
+    upsellTier: "intelligence-brief",
     upsellText:
-      "A motion map shows what gets granted. The Case Decoder tells you which ones apply to YOUR case.",
+      "A motion map shows what gets granted. The Intelligence Brief inherits this circuit grant-rate data AND tells you which motions apply to YOUR case via full prosecution pattern analysis. $997.",
     dripSequenceKey: "research_motion_success",
     isActive: true,
   },


### PR DESCRIPTION
## Summary

PR1 of 3 in the Hormozi Path C remediation (worry-to-pristine 2026-04-25).

Fixes 6 standalone SKU `upsellTier` pointers that violated Hormozi's strict-monotonic value-step rule: the upsell target was either same-price (lateral, useless) or lower-price (downgrade — actively cannibalizes the standalone's own buyer).

## The Cannibalization Math (pre-fix)

A defendant could buy:
- Judge Report Card $197
- Officer Background Check $97
- Similar Cases Analyzer $297

**Total: $591 — strictly outperforms IB ($997) on judge + officer + cohort dimensions.** Smart buyer skips IB. $406 of revenue per intent-buyer evaporates.

Worse: 3 of these standalones (similar-cases $297, FSD $297, motion-opportunity $497) had upsellTier pointing to a CHEAPER product (case-decoder $197) — net DOWNGRADE upsell.

## Fix Table

| SKU | Price | Was → Now | Step |
|---|---|---|---|
| judge-report-card | $197 | case-decoder $197 → **intelligence-brief $997** | 5x |
| officer-background-check | $97 | case-decoder $197 → **x-ray $2,497** | 25x |
| similar-cases-analyzer | $297 | case-decoder $197 → **x-ray $2,497** | 8x |
| federal-sentencing-distribution | $297 | case-decoder $197 → **x-ray $2,497** | 8x |
| motion-opportunity-scan | $497 | case-decoder $197 → **intelligence-brief $997** | 2x |
| motion-success-report | $197 | case-decoder $197 → **intelligence-brief $997** | 5x |

Each upsellText was rewritten to (a) name the inheritance ("inherits this data layer AND adds X") and (b) cite the price step explicitly so the buyer's value-step calculation is anchored.

## Hormozi Framework

Per `~/.claude/experts/alex-hormozi.md`: Value Equation is Dream Outcome × Likelihood ÷ (Time × Effort). Each tier in a ladder MUST monotonically increase value AND the higher tier MUST include everything lower tiers offer + meaningful new value, or the buyer perceives the higher tier as a tax. The pre-fix pointers failed this test on 6 SKUs.

## Path C Roadmap

- **PR1 (this):** Fix upsellTier pointers (cannibalization stop)
- **PR2 (next):** Tier-gate the 4 orphan IBVariables slots — DELETE codefendant_divergence + plea_discount from IB ($997), reserve for SR ($9,997). Prevents T10-style ladder detonation. (Per Hormozi finding az-2.)
- **PR3 (after):** Ship 1 buyer-visible deliverable per tier (rendered sections, not just test infra). Per Hormozi finding az-3.

Full audit: `docs/plans/2026-04-25-worry-product-tier-data-audit-findings.md` (40 findings total).

## Test plan
- [x] tsc --noEmit on products.ts: clean
- [x] price-check pre-commit hook: 49 anchors valid, 0 mismatches
- [ ] Future: end-to-end checkout flow test (out of scope this PR — pure data-config change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)