### PR TITLE
fix(ib): tier-gate 7 orphan IBVariables slots (Hormozi az-2 ladder-collapse fix)

### DIFF
--- a/src/lib/intelligence-brief/prompts.ts
+++ b/src/lib/intelligence-brief/prompts.ts
@@ -165,11 +165,6 @@ SELF-VERIFICATION before output:
 - [ ] Bottom Line with 1 sentence + 1 action
 - [ ] Zero banned phrases
 
-${v.bench_jury_divergence_summary ? `<tier9_data context="War Room+ only, bench vs jury divergence for roadmap timing">
-BENCH VS JURY DIVERGENCE DATA (verified, with source URLs):
-${v.bench_jury_divergence_summary}
-INSTRUCTION: Incorporate into Section 1c (The Two Paths), use this data to inform the bench vs jury election discussion. Present the divergence as verified data, cite source URLs. Do NOT recommend bench or jury, present the data and generate an attorney question.
-</tier9_data>` : ""}
 ${v.sentencing_range_context ? `<sentencing_context>\n${v.sentencing_range_context}\n</sentencing_context>` : ""}
 ${v.outcome_benchmarks_summary ? `<outcome_benchmarks>\n${v.outcome_benchmarks_summary}\n</outcome_benchmarks>` : ""}`,
   };
@@ -260,11 +255,6 @@ SELF-VERIFICATION:
 - [ ] Communication options guide present
 - [ ] Zero banned phrases
 
-${v.similar_case_matches ? `<tier9_data context="War Room+ only, similar case matches for outcome grounding">
-SIMILAR CASE MATCHES (k-NN verified, with source URLs):
-${v.similar_case_matches}
-INSTRUCTION: Weave into Section 2a, "Cases like yours that resulted in acquittal/dismissal" as grounding data. Present as verified case matches with source URLs. Frame as hope-grounding: "Among cases with similar facts, here's what happened." Do NOT present as predictions.
-</tier9_data>` : ""}
 ${v.sentencing_range_context ? `<sentencing_context>\n${v.sentencing_range_context}\n</sentencing_context>` : ""}
 ${v.outcome_benchmarks_summary ? `<outcome_benchmarks>\n${v.outcome_benchmarks_summary}\n</outcome_benchmarks>` : ""}`,
   };
@@ -374,11 +364,7 @@ SELF-VERIFICATION:
 - [ ] Zero specific percentages from training data
 - [ ] Zero banned phrases
 
-${v.pairing_matrix_summary ? `<tier9_data context="War Room+ only, judge×prosecutor motion grant rates">
-JUDGE-PROSECUTOR PAIRING DATA (verified, with source URLs):
-${v.pairing_matrix_summary}
-INSTRUCTION: Integrate into Section 4a (Motion Landscape), for each motion category, note this judge's grant rate on this prosecutor's motions. This is verified court data, not training data. Cite source URLs. Frame as intelligence for the attorney meeting: "Ask your attorney how this pairing data changes the motion strategy."
-</tier9_data>` : ""}`,
+`,
   };
 }
 
@@ -485,11 +471,7 @@ SELF-VERIFICATION:
 - [ ] Family & Custody: ALWAYS present
 - [ ] Zero banned phrases
 
-${v.sentencing_outlier_flags ? `<tier9_data context="X-Ray+ only, sentencing outlier flags for risk assessment">
-SENTENCING OUTLIER DATA (verified, with source URLs):
-${v.sentencing_outlier_flags}
-INSTRUCTION: Integrate into Section 5b (Life Impact Map), in the sentencing/penalty domain, present this judge's sentencing deviation as verified data. Frame as: "Based on verified court records, this judge sentences [above/below] median for this charge type." Always pair with protective action and attorney question. Cite source URLs.
-</tier9_data>` : ""}`,
+`,
   };
 }
 
@@ -1087,33 +1069,23 @@ export function buildTier9DataAppendix(v: IBVariables): PromptConfig {
   // Collect which Tier 9 data blocks are available
   const blocks: string[] = [];
 
+  // Tier-9 baseline reads (IB+ only — kept per ARCHITECTURE.md spec).
+  // RESERVED: producers not yet wired. When wired, must populate at IB tier
+  // floor only. See variables.ts and worry-product-tier-data-audit-findings.md.
   if (v.judge_quote_library) {
     blocks.push(`<judge_quotes>\n${v.judge_quote_library}\n</judge_quotes>`);
   }
   if (v.appellate_trends_summary) {
     blocks.push(`<appellate_trends>\n${v.appellate_trends_summary}\n</appellate_trends>`);
   }
-  if (v.sentencing_outlier_flags) {
-    blocks.push(`<sentencing_outliers>\n${v.sentencing_outlier_flags}\n</sentencing_outliers>`);
-  }
-  if (v.officer_reliability_crosscase) {
-    blocks.push(`<officer_reliability>\n${v.officer_reliability_crosscase}\n</officer_reliability>`);
-  }
-  if (v.pairing_matrix_summary) {
-    blocks.push(`<judge_prosecutor_pairing>\n${v.pairing_matrix_summary}\n</judge_prosecutor_pairing>`);
-  }
-  if (v.bench_jury_divergence_summary) {
-    blocks.push(`<bench_jury_divergence>\n${v.bench_jury_divergence_summary}\n</bench_jury_divergence>`);
-  }
-  if (v.similar_case_matches) {
-    blocks.push(`<similar_cases>\n${v.similar_case_matches}\n</similar_cases>`);
-  }
-  if (v.codefendant_divergence_summary) {
-    blocks.push(`<codefendant_divergence>\n${v.codefendant_divergence_summary}\n</codefendant_divergence>`);
-  }
-  if (v.plea_discount_curve_summary) {
-    blocks.push(`<plea_discount_curve>\n${v.plea_discount_curve_summary}\n</plea_discount_curve>`);
-  }
+  // ─── DELETED 2026-04-25 (Hormozi az-2 tier-gating) ────────────────────
+  // Removed dead reads for sentencing_outlier_flags, officer_reliability_
+  // crosscase, pairing_matrix_summary, bench_jury_divergence_summary,
+  // similar_case_matches, codefendant_divergence_summary, plea_discount_
+  // curve_summary. All 7 had ZERO producers in the codebase AND would have
+  // collapsed the tier ladder if a producer was ever wired at IB level.
+  // These slots belong on X-Ray/WR/SR operator session-brief manifests
+  // (T13-T15 in worry-product-tier-data-audit plan), NOT on IB auto-render.
 
   // If no Tier 9 data at all, return empty section
   if (blocks.length === 0) {

--- a/src/lib/intelligence-brief/variables.ts
+++ b/src/lib/intelligence-brief/variables.ts
@@ -154,22 +154,40 @@ export interface IBVariables {
   protection_output: string;
   your_plan_output: string;
 
-  // Tier 9, Judge Intel (IB and above)
+  // Tier 9, Judge Intel (IB and above) — KEEP, ARCHITECTURE.md baseline promise
+  // RESERVED: producers not yet wired. When wired, must be at IB tier or higher
+  // only. Do NOT add producers that fire on Case Decoder ($197) — IB ($997) is
+  // the floor for these per the spec.
+  // TODO(tier-data-audit-2026-04-25): wire IB Phase A/B fetcher to populate
+  //   from judges/judge_quotes tables. See docs/plans/2026-04-25-worry-product-tier-data-audit-findings.md.
   judge_quote_library?: string;
   appellate_trends_summary?: string;
 
-  // Tier 9, X-Ray and above
-  sentencing_outlier_flags?: string;
-  officer_reliability_crosscase?: string;
-
-  // Tier 9, War Room and above
-  pairing_matrix_summary?: string;
-  bench_jury_divergence_summary?: string;
-  similar_case_matches?: string;
-
-  // Tier 9, Situation Room
-  codefendant_divergence_summary?: string;
-  plea_discount_curve_summary?: string;
+  // ─── DELETED 2026-04-25 (Hormozi az-2 ladder-collapse fix) ──────────────
+  // The following slots were typed + guarded-read in prompts.ts but had ZERO
+  // producers anywhere in the codebase. Worse: they appeared inside the IB
+  // ($997) prompt template, so any future producer wiring them at IB level
+  // would have detonated the strict-monotonic value ladder by leaking SR-only
+  // ($9,997) and WR/X-Ray-only data into the IB tier.
+  //
+  // Per Hormozi value-equation audit: codefendant_divergence + plea_discount
+  // are SR-ONLY differentiators. pairing_matrix + bench_jury + similar_case
+  // are WR-ONLY. sentencing_outlier_flags + officer_reliability_crosscase are
+  // X-Ray ONLY. These belong on the SR/WR/X-Ray operator session-brief
+  // manifest (when built — see worry-product-tier-data-audit plan T13-T15),
+  // NOT on the auto-rendered IB report.
+  //
+  // Removed:
+  //   sentencing_outlier_flags        → X-Ray operator session brief
+  //   officer_reliability_crosscase   → X-Ray operator session brief
+  //   pairing_matrix_summary          → War Room operator session brief
+  //   bench_jury_divergence_summary   → War Room operator session brief
+  //   similar_case_matches            → War Room operator session brief
+  //   codefendant_divergence_summary  → Situation Room operator session brief
+  //   plea_discount_curve_summary     → Situation Room operator session brief
+  //
+  // The corresponding `if (v.X) {...}` reads in prompts.ts are also removed
+  // in this commit (PR2 of 3 in Hormozi Path C remediation).
 
   // External Intelligence Layer, Phase 1
   outcome_benchmarks_summary?: string;


### PR DESCRIPTION
## Summary

PR2 of 3 in the Hormozi Path C remediation (worry-to-pristine 2026-04-25). Pairs with PR #145 (upsellTier cannibalization fix).

Deletes 7 dead Tier-9 slot definitions from `IBVariables` and the corresponding 7 dead read-guards from `prompts.ts`. Per Hormozi az-2: these slots were a ladder-detonation timebomb — typed + read-guarded inside the IB ($997) prompt template, but with ZERO producers anywhere in the codebase. If a producer was ever wired naively at the IB level, the IB report would have rendered SR-only ($9,997) and WR-only ($4,997) data inside the IB tier — collapsing the strict-monotonic value ladder by 10x.

## What's Deleted

| Slot | Should belong to (operator session brief) |
|---|---|
| sentencing_outlier_flags | X-Ray operator session brief |
| officer_reliability_crosscase | X-Ray operator session brief |
| pairing_matrix_summary | War Room operator session brief |
| bench_jury_divergence_summary | War Room operator session brief |
| similar_case_matches | War Room operator session brief |
| codefendant_divergence_summary | Situation Room operator session brief |
| plea_discount_curve_summary | Situation Room operator session brief |

## What's Kept (with explicit RESERVED + TODO comments)

| Slot | Why |
|---|---|
| judge_quote_library | ARCHITECTURE.md spec line 255 marks it IB+ baseline ("baseline upgrades, all tiers"). Reserved for future producer wiring at IB tier floor. |
| appellate_trends_summary | Same ARCHITECTURE.md spec basis. |

These remain typed as optional and read-guarded so they're harmless when undefined (current state). Producers MUST respect the IB tier floor when wired — engineer comments now make this explicit.

## Hormozi Framework

Per `~/.claude/experts/alex-hormozi.md` value equation: each tier's perceived value (Dream Outcome × Likelihood ÷ Time × Effort) must monotonically increase AND each higher tier MUST include everything lower tiers offer + meaningful new value. The pre-fix state had a hidden trap: any future contractor wiring "the obvious place" (the IB Phase A/B fetcher) would have broken every higher tier's value differentiation overnight.

## Behavioral Change

**Zero customer-facing change today.** All 7 deleted slots had `undefined` value in production (no producers existed), so the read-guards always fell through. This PR removes dead code that was a future hazard — pure interface-debt cleanup.

## Test plan
- [x] `tsc --noEmit -p tsconfig.json`: EXIT=0
- [x] Verified zero references for the 7 deleted slot names anywhere in `prompts.ts`
- [x] IB report rendering trace: removed lines were inside `${v.X ? ... : ""}` ternaries that always evaluated to ""
- [ ] Future: when SR/WR/X-Ray operator session briefs are built (T13-T15 in audit plan), the deleted slots must be re-introduced THERE with proper tier guards — not at the IB level

## Path C Roadmap

- ✅ PR1 (#145 merged): Fix upsellTier pointers (cannibalization stop)
- ✅ PR2 (this): Tier-gate orphan IBVariables slots (ladder-detonation fix)
- ⏭️ PR3 (next): Ship 1 buyer-visible deliverable per tier (per Hormozi az-3)

Full audit: `docs/plans/2026-04-25-worry-product-tier-data-audit-findings.md` (40 findings total).

🤖 Generated with [Claude Code](https://claude.com/claude-code)