### PR TITLE
feat(tt-checkpoint): TikTok 2026-07-23 gate-tracking infra (P3)

### DIFF
--- a/scripts/log-content-removal.mjs
+++ b/scripts/log-content-removal.mjs
@@ -1,0 +1,197 @@
+#!/usr/bin/env node
+/**
+ * scripts/log-content-removal.mjs — Operator CLI for content_removal_incidents.
+ *
+ * Logs a content-removal strike (Gate B input for the TT 2026-07-23
+ * checkpoint cron). Use this whenever a YT/X/IG/FB/TT post is taken
+ * down or restricted — the row feeds /api/cron/tt-checkpoint and shows
+ * up in the next weekly Telegram digest if it crosses unresolved.
+ *
+ * Usage:
+ *   node scripts/log-content-removal.mjs \
+ *     --platform youtube \
+ *     --reason community_guidelines \
+ *     --url "https://youtube.com/watch?v=..." \
+ *     --occurred 2026-04-25T14:00:00Z \
+ *     --notes "DUI defense overview clip — flagged by automated review" \
+ *     [--platform-post-id 42] \
+ *     [--resolve --resolution-note "appeal granted, post restored"]
+ *
+ * Env: SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY (loaded from .env.local).
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { createClient } from '@supabase/supabase-js';
+
+const ALLOWED_PLATFORMS = new Set([
+  'youtube', 'x', 'twitter_x', 'tiktok', 'instagram', 'facebook', 'other',
+]);
+const ALLOWED_REASONS = new Set([
+  'community_guidelines', 'copyright', 'spam', 'misinformation',
+  'harassment', 'privacy', 'minor_safety', 'sensitive', 'manual', 'other',
+]);
+
+function parseArgs(argv) {
+  const args = argv.slice(2);
+  const opts = {
+    platform: null,
+    reason: null,
+    url: null,
+    occurred: null,
+    notes: null,
+    platformPostId: null,
+    resolve: false,
+    resolutionNote: null,
+    resolvedBy: process.env.USER || process.env.USERNAME || 'operator',
+    incidentId: null,
+    list: false,
+    listLimit: 20,
+    dryRun: false,
+  };
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === '--platform' && args[i + 1]) opts.platform = args[++i];
+    else if (a === '--reason' && args[i + 1]) opts.reason = args[++i];
+    else if (a === '--url' && args[i + 1]) opts.url = args[++i];
+    else if (a === '--occurred' && args[i + 1]) opts.occurred = args[++i];
+    else if (a === '--notes' && args[i + 1]) opts.notes = args[++i];
+    else if (a === '--platform-post-id' && args[i + 1]) opts.platformPostId = parseInt(args[++i], 10);
+    else if (a === '--resolve') opts.resolve = true;
+    else if (a === '--resolution-note' && args[i + 1]) opts.resolutionNote = args[++i];
+    else if (a === '--resolved-by' && args[i + 1]) opts.resolvedBy = args[++i];
+    else if (a === '--id' && args[i + 1]) opts.incidentId = parseInt(args[++i], 10);
+    else if (a === '--list') opts.list = true;
+    else if (a === '--list-limit' && args[i + 1]) opts.listLimit = parseInt(args[++i], 10);
+    else if (a === '--dry-run') opts.dryRun = true;
+    else if (a === '--help' || a === '-h') {
+      console.log(fs.readFileSync(new URL(import.meta.url), 'utf8').split('\n').slice(0, 30).join('\n'));
+      process.exit(0);
+    }
+  }
+  return opts;
+}
+
+function loadEnvLocal() {
+  const candidates = [
+    path.resolve(process.cwd(), '.env.local'),
+    path.resolve(process.cwd(), '../ImNotAnAttorney-web/.env.local'),
+    path.resolve(process.cwd(), '../../ImNotAnAttorney-web/.env.local'),
+  ];
+  for (const p of candidates) {
+    if (!fs.existsSync(p)) continue;
+    const lines = fs.readFileSync(p, 'utf8').split('\n');
+    for (const line of lines) {
+      const m = line.match(/^([A-Z0-9_]+)=(.*)$/);
+      if (!m) continue;
+      const key = m[1];
+      const val = m[2].replace(/^"|"$/g, '');
+      if (!(key in process.env)) process.env[key] = val;
+    }
+    return p;
+  }
+  return null;
+}
+
+async function main() {
+  const opts = parseArgs(process.argv);
+  loadEnvLocal();
+  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) {
+    console.error('FATAL: SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY required.');
+    process.exit(2);
+  }
+  const supabase = createClient(url, key, { db: { schema: 'public' } });
+
+  if (opts.list) {
+    const { data, error } = await supabase
+      .from('content_removal_incidents')
+      .select('id, platform, reason_code, occurred_at, resolved_at, source_url, notes')
+      .order('occurred_at', { ascending: false })
+      .limit(opts.listLimit);
+    if (error) {
+      console.error('list failed:', error.message);
+      process.exit(2);
+    }
+    for (const row of data || []) {
+      const status = row.resolved_at ? 'RESOLVED' : 'OPEN';
+      console.log(`#${row.id} [${status}] ${row.platform} ${row.reason_code} occurred=${row.occurred_at} url=${row.source_url || '(none)'}`);
+      if (row.notes) console.log(`     notes: ${row.notes.slice(0, 200)}`);
+    }
+    return;
+  }
+
+  if (opts.resolve) {
+    if (!opts.incidentId) {
+      console.error('FATAL: --resolve requires --id <incident_id>');
+      process.exit(2);
+    }
+    const updateRow = {
+      resolved_at: new Date().toISOString(),
+      resolved_by: opts.resolvedBy.slice(0, 64),
+      resolution_note: opts.resolutionNote ? opts.resolutionNote.slice(0, 4000) : null,
+    };
+    if (opts.dryRun) {
+      console.log('DRY-RUN — would update:', JSON.stringify(updateRow, null, 2));
+      return;
+    }
+    const { error } = await supabase
+      .from('content_removal_incidents')
+      .update(updateRow)
+      .eq('id', opts.incidentId);
+    if (error) {
+      console.error('resolve failed:', error.message);
+      process.exit(2);
+    }
+    console.log(`RESOLVED #${opts.incidentId}`);
+    return;
+  }
+
+  // Insert path: validate required fields
+  if (!opts.platform || !ALLOWED_PLATFORMS.has(opts.platform)) {
+    console.error(`FATAL: --platform must be one of ${[...ALLOWED_PLATFORMS].join(', ')}`);
+    process.exit(2);
+  }
+  if (!opts.reason || !ALLOWED_REASONS.has(opts.reason)) {
+    console.error(`FATAL: --reason must be one of ${[...ALLOWED_REASONS].join(', ')}`);
+    process.exit(2);
+  }
+  if (!opts.occurred) {
+    console.error('FATAL: --occurred <ISO-8601 timestamp> is required');
+    process.exit(2);
+  }
+  const occurredDate = new Date(opts.occurred);
+  if (isNaN(occurredDate.getTime())) {
+    console.error(`FATAL: --occurred "${opts.occurred}" is not a valid ISO-8601 timestamp`);
+    process.exit(2);
+  }
+  const insertRow = {
+    occurred_at: occurredDate.toISOString(),
+    platform: opts.platform,
+    platform_post_id: opts.platformPostId,
+    source_url: opts.url ? opts.url.slice(0, 2048) : null,
+    reason_code: opts.reason,
+    notes: opts.notes ? opts.notes.slice(0, 4000) : null,
+  };
+  if (opts.dryRun) {
+    console.log('DRY-RUN — would insert:', JSON.stringify(insertRow, null, 2));
+    return;
+  }
+  const { data, error } = await supabase
+    .from('content_removal_incidents')
+    .insert(insertRow)
+    .select('id')
+    .single();
+  if (error) {
+    console.error('insert failed:', error.message);
+    process.exit(2);
+  }
+  console.log(`LOGGED incident id=${data.id} platform=${opts.platform} reason=${opts.reason}`);
+  console.log(`Resolve later: node scripts/log-content-removal.mjs --resolve --id ${data.id} --resolution-note "..."`);
+}
+
+main().catch((err) => {
+  console.error('FATAL:', err);
+  process.exit(2);
+});

--- a/scripts/register-tt-checkpoint-cron.mjs
+++ b/scripts/register-tt-checkpoint-cron.mjs
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+// Register the /api/cron/tt-checkpoint endpoint on cron-job.org.
+// Weekly Monday 17:00 UTC — runs after source-health (14:00) so platform_posts
+// + content_removal_incidents are stable when the gate-state evaluator queries.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+function loadEnv() {
+  const envPath = path.join(__dirname, '..', '.env.local');
+  if (!fs.existsSync(envPath)) {
+    console.error('ERROR: .env.local not found');
+    process.exit(1);
+  }
+  const env = {};
+  for (const line of fs.readFileSync(envPath, 'utf8').split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const idx = trimmed.indexOf('=');
+    if (idx === -1) continue;
+    const key = trimmed.slice(0, idx).trim();
+    let val = trimmed.slice(idx + 1).trim();
+    if ((val.startsWith('"') && val.endsWith('"')) || (val.startsWith("'") && val.endsWith("'"))) {
+      val = val.slice(1, -1);
+    }
+    env[key] = val;
+  }
+  return env;
+}
+
+const env = loadEnv();
+const CRONJOB_API_KEY = env.CRONJOB_API_KEY;
+const CRON_AUTH_TOKEN = env.CRON_AUTH_TOKEN;
+if (!CRONJOB_API_KEY || !CRON_AUTH_TOKEN) {
+  console.error('ERROR: CRONJOB_API_KEY and CRON_AUTH_TOKEN required in .env.local');
+  process.exit(1);
+}
+
+const BASE_URL = env.NEXT_PUBLIC_SITE_URL || 'https://imnotanattorney.com';
+const URL = `${BASE_URL}/api/cron/tt-checkpoint`;
+
+const listResp = await fetch('https://api.cron-job.org/jobs', {
+  headers: { Authorization: `Bearer ${CRONJOB_API_KEY}` },
+});
+const listData = await listResp.json();
+const existing = (listData.jobs || []).find((j) => j.url === URL);
+if (existing) {
+  console.log('Already registered:');
+  console.log('  jobId:', existing.jobId);
+  console.log('  url:', existing.url);
+  console.log('  enabled:', existing.enabled);
+  console.log('  wdays:', JSON.stringify(existing.schedule?.wdays));
+  console.log('  hours:', JSON.stringify(existing.schedule?.hours));
+  console.log('  timezone:', existing.schedule?.timezone);
+  process.exit(0);
+}
+
+const payload = {
+  job: {
+    url: URL,
+    title: 'ImNotAnAttorney: tt-checkpoint',
+    enabled: true,
+    saveResponses: true,
+    schedule: {
+      timezone: 'UTC',
+      mdays: [-1],
+      wdays: [1],         // Monday
+      months: [-1],
+      hours: [17],        // 17:00 UTC — 3 hrs after source-health
+      minutes: [0],
+    },
+    extendedData: {
+      headers: {
+        Authorization: `Bearer ${CRON_AUTH_TOKEN}`,
+        'Content-Type': 'application/json',
+      },
+    },
+    requestMethod: 0,
+    requestTimeout: 60,
+  },
+};
+
+const resp = await fetch('https://api.cron-job.org/jobs', {
+  method: 'PUT',
+  headers: {
+    Authorization: `Bearer ${CRONJOB_API_KEY}`,
+    'Content-Type': 'application/json',
+  },
+  body: JSON.stringify(payload),
+});
+const text = await resp.text();
+let data;
+try {
+  data = JSON.parse(text);
+} catch {
+  console.error('Invalid JSON response:', text.slice(0, 300));
+  process.exit(1);
+}
+if (resp.ok && data.jobId) {
+  console.log('OK created:');
+  console.log('  jobId:', data.jobId);
+  console.log('  url:', URL);
+  console.log('  schedule: weekly Mon 17:00 UTC');
+} else {
+  console.error('FAILED:', JSON.stringify(data));
+  process.exit(1);
+}

--- a/src/app/api/cron/tt-checkpoint/route.ts
+++ b/src/app/api/cron/tt-checkpoint/route.ts
@@ -1,0 +1,217 @@
+/**
+ * @file /api/cron/tt-checkpoint — Weekly TikTok 2026-07-23 gate check.
+ *
+ * Computes the three APEX-W2 hard gates and Telegram-alerts on
+ * threshold crossings:
+ *   Gate A: >=50 /score completions attributable to YT or X within last
+ *           90d AND >=1 paid conversion within same window.
+ *   Gate B: zero unresolved content-removal strikes on YT or X in 90d.
+ *   Gate C: cached .01% expert for tt-legal triangulated within last 90d
+ *           (refreshed by a separate quarterly cron — this route only
+ *           reads gate_c_last_triangulated_at).
+ *
+ * Updates tt_checkpoint_state singleton + sends a single Gate-A alert
+ * the first time the threshold is crossed (gate_a_alert_sent_at gates
+ * repeat alerts).
+ *
+ * Auth: requireCron (Bearer CRON_AUTH_TOKEN).
+ * Schedule: weekly Mon 17:00 UTC via cron-job.org (registered by
+ * scripts/register-tt-checkpoint-cron.mjs).
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { requireCron } from "@/lib/auth/guards";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+export const runtime = "nodejs";
+export const maxDuration = 60;
+
+const NINETY_DAYS_MS = 90 * 24 * 60 * 60 * 1000;
+const GATE_A_THRESHOLD = 50;
+// Gate A YT/X attribution buckets — matches the score_completions
+// CHECK constraint values. Keep "twitter_x" alongside "x" until the
+// schema settles on one of them across the codebase.
+const GATE_A_PLATFORMS = ["youtube", "x", "twitter_x"] as const;
+
+async function sendTelegram(message: string): Promise<void> {
+  const token = process.env.TELEGRAM_ATLAS_BOT_TOKEN;
+  const chat = process.env.TELEGRAM_RAHIM_CHAT_ID;
+  if (!token || !chat) return;
+  try {
+    await fetch(`https://api.telegram.org/bot${token}/sendMessage`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ chat_id: chat, text: message, parse_mode: "Markdown" }),
+    });
+  } catch {
+    /* swallow — Telegram failure must not break the cron itself */
+  }
+}
+
+interface GateState {
+  gate_a_first_passed_at: string | null;
+  gate_a_alert_sent_at: string | null;
+  gate_b_last_strike_at: string | null;
+  gate_c_last_triangulated_at: string | null;
+  last_run_count_youtube: number;
+  last_run_count_x: number;
+  last_run_paid_conversions: number;
+  last_run_strikes_unresolved: number;
+}
+
+export async function GET(req: NextRequest) {
+  const authed = requireCron(req);
+  if (!authed.authorized) return authed.error;
+
+  const started = Date.now();
+  const supabase = createAdminClient();
+  const since = new Date(Date.now() - NINETY_DAYS_MS).toISOString();
+
+  // --- Gate A counts -----------------------------------------------------
+  const countAttribution = async (sources: string[]): Promise<number> => {
+    const { count, error } = await supabase
+      .from("score_completions")
+      .select("id", { count: "exact", head: true })
+      .in("attribution_source", sources)
+      .gte("created_at", since);
+    if (error) throw new Error(`score_completions count failed: ${error.message}`);
+    return count ?? 0;
+  };
+
+  let countYoutube = 0;
+  let countX = 0;
+  let strikesUnresolved = 0;
+  try {
+    countYoutube = await countAttribution(["youtube"]);
+    countX = await countAttribution(["x", "twitter_x"]);
+  } catch (e) {
+    return NextResponse.json(
+      { error: e instanceof Error ? e.message : String(e) },
+      { status: 500 },
+    );
+  }
+  const totalAttributed = countYoutube + countX;
+
+  // --- Paid conversions (v1: 0 placeholder until orders.attribution_source
+  // is wired in a follow-up). Documented in the handoff. ------------------
+  const paidConversions = 0;
+
+  // --- Gate B: unresolved strikes on YT or X in window -------------------
+  try {
+    const { count, error } = await supabase
+      .from("content_removal_incidents")
+      .select("id", { count: "exact", head: true })
+      .in("platform", ["youtube", "x", "twitter_x"])
+      .gte("occurred_at", since)
+      .is("resolved_at", null);
+    if (error) throw new Error(`content_removal_incidents count failed: ${error.message}`);
+    strikesUnresolved = count ?? 0;
+  } catch (e) {
+    return NextResponse.json(
+      { error: e instanceof Error ? e.message : String(e) },
+      { status: 500 },
+    );
+  }
+
+  // --- Read prior state to detect transitions ----------------------------
+  const { data: priorRaw, error: priorErr } = await supabase
+    .from("tt_checkpoint_state")
+    .select(
+      "gate_a_first_passed_at, gate_a_alert_sent_at, gate_b_last_strike_at, gate_c_last_triangulated_at, last_run_count_youtube, last_run_count_x, last_run_paid_conversions, last_run_strikes_unresolved",
+    )
+    .eq("id", 1)
+    .maybeSingle();
+  if (priorErr) {
+    return NextResponse.json({ error: `tt_checkpoint_state read: ${priorErr.message}` }, { status: 500 });
+  }
+  const prior: GateState = priorRaw ?? {
+    gate_a_first_passed_at: null,
+    gate_a_alert_sent_at: null,
+    gate_b_last_strike_at: null,
+    gate_c_last_triangulated_at: null,
+    last_run_count_youtube: 0,
+    last_run_count_x: 0,
+    last_run_paid_conversions: 0,
+    last_run_strikes_unresolved: 0,
+  };
+
+  const now = new Date().toISOString();
+  const gateAThresholdMet = totalAttributed >= GATE_A_THRESHOLD;
+  const gateAFullyPassed = gateAThresholdMet && paidConversions >= 1;
+  const newGateAFirstPass = gateAFullyPassed && prior.gate_a_first_passed_at == null;
+  const shouldAlertGateA = gateAThresholdMet && prior.gate_a_alert_sent_at == null;
+  const gateBNewStrike = strikesUnresolved > prior.last_run_strikes_unresolved;
+
+  // --- Telegram on threshold cross ---------------------------------------
+  const alerts: string[] = [];
+  if (shouldAlertGateA) {
+    alerts.push(
+      [
+        `*TT-checkpoint Gate A:* threshold crossed`,
+        `90-day completions: youtube=${countYoutube}, x=${countX} (total=${totalAttributed} >= ${GATE_A_THRESHOLD})`,
+        `Paid conversions in window: ${paidConversions} (need >=1 for full pass)`,
+        `2026-07-23 deadline: ${Math.max(0, Math.ceil((Date.parse("2026-07-23") - Date.now()) / 86400000))} days`,
+      ].join("\n"),
+    );
+  }
+  if (gateBNewStrike) {
+    alerts.push(
+      [
+        `*TT-checkpoint Gate B:* new strike(s)`,
+        `Unresolved strikes (YT/X, 90d): ${strikesUnresolved} (was ${prior.last_run_strikes_unresolved})`,
+        `Run: SELECT * FROM content_removal_incidents WHERE platform IN ('youtube','x','twitter_x') AND occurred_at >= now() - interval '90 days' AND resolved_at IS NULL ORDER BY occurred_at DESC;`,
+      ].join("\n"),
+    );
+  }
+  if (alerts.length > 0) {
+    await sendTelegram(alerts.join("\n\n"));
+  }
+
+  // --- Persist new state -------------------------------------------------
+  const update: Record<string, unknown> = {
+    last_run_at: now,
+    last_run_count_youtube: countYoutube,
+    last_run_count_x: countX,
+    last_run_paid_conversions: paidConversions,
+    last_run_strikes_unresolved: strikesUnresolved,
+  };
+  if (newGateAFirstPass) update.gate_a_first_passed_at = now;
+  if (shouldAlertGateA) update.gate_a_alert_sent_at = now;
+  if (gateBNewStrike) update.gate_b_last_strike_at = now;
+
+  const { error: updErr } = await supabase
+    .from("tt_checkpoint_state")
+    .update(update)
+    .eq("id", 1);
+  if (updErr) {
+    return NextResponse.json({ error: `tt_checkpoint_state update: ${updErr.message}` }, { status: 500 });
+  }
+
+  return NextResponse.json({
+    ok: true,
+    checked_at: now,
+    window_start: since,
+    gate_a: {
+      threshold: GATE_A_THRESHOLD,
+      youtube_completions_90d: countYoutube,
+      x_completions_90d: countX,
+      total_attributed: totalAttributed,
+      paid_conversions_90d: paidConversions,
+      threshold_met: gateAThresholdMet,
+      fully_passed: gateAFullyPassed,
+      first_passed_at: newGateAFirstPass ? now : prior.gate_a_first_passed_at,
+      alerted: shouldAlertGateA,
+    },
+    gate_b: {
+      strikes_unresolved_90d: strikesUnresolved,
+      new_strike_since_last_run: gateBNewStrike,
+      last_strike_at: gateBNewStrike ? now : prior.gate_b_last_strike_at,
+    },
+    gate_c: {
+      last_triangulated_at: prior.gate_c_last_triangulated_at,
+      stale: prior.gate_c_last_triangulated_at == null
+        || Date.parse(prior.gate_c_last_triangulated_at) < Date.now() - NINETY_DAYS_MS,
+    },
+    deadline: "2026-07-23",
+    elapsed_ms: Date.now() - started,
+  });
+}

--- a/src/app/api/score/route.ts
+++ b/src/app/api/score/route.ts
@@ -7,6 +7,10 @@
  * Privacy-first design:
  * - Anonymous aggregate counters are incremented (total completions and
  *   charge-type breakdowns). No individual answers, scores, or PII are stored.
+ * - score_completions records {charge_type, score_value, score_band,
+ *   attribution_source, referrer_host, matched_blog_slug} per completion
+ *   for the TT 2026-07-23 checkpoint Gate A computation. NO answers,
+ *   NO email, NO IP, NO full URL.
  * - No email is collected (email capture is handled by the frontend separately)
  * - No cookies or session tracking
  */
@@ -16,6 +20,7 @@ import { checkRateLimit } from "@/lib/rate-limit";
 import { getClientIp } from "@/lib/request";
 import { calculateScore, ALLOWED_VALUES } from "@/lib/score";
 import type { ScoreInput } from "@/lib/score";
+import { classifyAttributionSource, parseReferrerHost } from "@/lib/score-attribution";
 
 /**
  * Validates all 10 required inputs against the allowlist, then computes and
@@ -85,6 +90,35 @@ export async function POST(req: NextRequest) {
     const ct = input.chargeType;
     const rpcLog = (label: string) => (err: unknown) =>
       console.error(`[Score] RPC ${label} failed:`, err);
+
+    // TT 2026-07-23 checkpoint Gate A: log anonymous completion with
+    // attribution source. Body fields are advisory; final classification
+    // happens server-side in classifyAttributionSource (allowlist-only).
+    const referrerHeader = req.headers.get("referer") || req.headers.get("referrer") || null;
+    const referrerHost = parseReferrerHost(referrerHeader);
+    const attributionSource = classifyAttributionSource({
+      bodyAttributionSource: typeof body.attributionSource === "string" ? body.attributionSource : null,
+      bodyUtmSource: typeof body.utmSource === "string" ? body.utmSource : null,
+      referrerHost,
+    });
+    const matchedBlogSlug = typeof body.matchedBlogSlug === "string"
+      && /^[a-z0-9-]{1,120}$/.test(body.matchedBlogSlug)
+        ? body.matchedBlogSlug
+        : null;
+
+    supabase
+      .from("score_completions")
+      .insert({
+        charge_type: ct,
+        score_value: result.score,
+        score_band: result.band,
+        attribution_source: attributionSource,
+        referrer_host: referrerHost,
+        matched_blog_slug: matchedBlogSlug,
+      })
+      .then(({ error }) => {
+        if (error) console.error("[Score] score_completions insert failed:", error.message);
+      });
 
     supabase.rpc("increment_counter", { p_id: "score_completions" }).then(null, rpcLog("increment_counter"));
 

--- a/src/lib/__tests__/score-attribution.test.ts
+++ b/src/lib/__tests__/score-attribution.test.ts
@@ -1,0 +1,208 @@
+/**
+ * @fileoverview Unit tests for score-attribution.ts.
+ *
+ * Pure function coverage: classifyReferrerHost, classifyUtmSource,
+ * classifyAttributionSource, parseReferrerHost. No DB. No network.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  classifyAttributionSource,
+  classifyReferrerHost,
+  classifyUtmSource,
+  parseReferrerHost,
+  ALLOWED_ATTRIBUTION_SOURCES,
+} from "@/lib/score-attribution";
+
+describe("classifyReferrerHost", () => {
+  it.each([
+    ["www.youtube.com", "youtube"],
+    ["youtube.com", "youtube"],
+    ["m.youtube.com", "youtube"],
+    ["youtu.be", "youtube"],
+    ["twitter.com", "x"],
+    ["x.com", "x"],
+    ["t.co", "x"],
+    ["www.tiktok.com", "tiktok"],
+    ["tiktok.com", "tiktok"],
+    ["instagram.com", "instagram"],
+    ["www.facebook.com", "facebook"],
+    ["fb.me", "facebook"],
+    ["www.reddit.com", "reddit"],
+    ["redd.it", "reddit"],
+    ["www.quora.com", "quora"],
+    ["www.google.com", "google"],
+    ["google.co.uk", "google"],
+    ["bing.com", "bing"],
+  ])("classifies %s as %s", (host, expected) => {
+    expect(classifyReferrerHost(host)).toBe(expected);
+  });
+
+  it("returns 'other' for unrecognized hosts", () => {
+    expect(classifyReferrerHost("example.com")).toBe("other");
+    expect(classifyReferrerHost("randomsite.io")).toBe("other");
+  });
+
+  it("returns null for null/empty", () => {
+    expect(classifyReferrerHost(null)).toBeNull();
+    expect(classifyReferrerHost("")).toBeNull();
+  });
+
+  it("is case-insensitive", () => {
+    expect(classifyReferrerHost("WWW.YouTube.COM")).toBe("youtube");
+    expect(classifyReferrerHost("X.COM")).toBe("x");
+  });
+
+  it("does not classify lookalike hosts as legitimate platforms", () => {
+    // Defense against domain-takeover spoofing: youtubefake.example.com
+    // must NOT classify as youtube.
+    expect(classifyReferrerHost("youtubefake.example.com")).toBe("other");
+    expect(classifyReferrerHost("notyoutube.com")).toBe("other");
+    expect(classifyReferrerHost("evilreddit.com")).toBe("other");
+  });
+});
+
+describe("classifyUtmSource", () => {
+  it.each([
+    ["youtube", "youtube"],
+    ["yt", "youtube"],
+    ["youtube_shorts", "youtube"],
+    ["shorts", "youtube"],
+    ["x", "x"],
+    ["twitter", "x"],
+    ["twit", "x"],
+    ["tt", "tiktok"],
+    ["tiktok", "tiktok"],
+    ["ig", "instagram"],
+    ["instagram", "instagram"],
+    ["fb", "facebook"],
+    ["meta", "facebook"],
+    ["reddit", "reddit"],
+    ["quora", "quora"],
+    ["google", "google"],
+    ["bing", "bing"],
+    ["organic", "organic"],
+    ["direct", "direct"],
+  ])("normalizes %s to %s", (utm, expected) => {
+    expect(classifyUtmSource(utm)).toBe(expected);
+  });
+
+  it("normalizes hyphens to underscores before matching", () => {
+    expect(classifyUtmSource("twitter-x")).toBe("x");
+  });
+
+  it("returns 'other' for unrecognized values", () => {
+    expect(classifyUtmSource("snapchat")).toBe("other");
+    expect(classifyUtmSource("randomstring")).toBe("other");
+  });
+
+  it("returns null for null/empty/whitespace-only", () => {
+    expect(classifyUtmSource(null)).toBeNull();
+    expect(classifyUtmSource("")).toBeNull();
+  });
+
+  it("trims whitespace", () => {
+    expect(classifyUtmSource("  youtube  ")).toBe("youtube");
+  });
+});
+
+describe("classifyAttributionSource", () => {
+  it("prefers explicit body.attributionSource over utm + referrer", () => {
+    expect(
+      classifyAttributionSource({
+        bodyAttributionSource: "youtube",
+        bodyUtmSource: "x",
+        referrerHost: "instagram.com",
+      }),
+    ).toBe("youtube");
+  });
+
+  it("falls back to utm when explicit attribution missing", () => {
+    expect(
+      classifyAttributionSource({
+        bodyAttributionSource: null,
+        bodyUtmSource: "tiktok",
+        referrerHost: "google.com",
+      }),
+    ).toBe("tiktok");
+  });
+
+  it("falls back to referrer when utm + explicit missing", () => {
+    expect(
+      classifyAttributionSource({
+        bodyAttributionSource: null,
+        bodyUtmSource: null,
+        referrerHost: "youtube.com",
+      }),
+    ).toBe("youtube");
+  });
+
+  it("returns null when all signals missing", () => {
+    expect(
+      classifyAttributionSource({
+        bodyAttributionSource: null,
+        bodyUtmSource: null,
+        referrerHost: null,
+      }),
+    ).toBeNull();
+  });
+
+  it("does NOT preempt fallback when explicit body string is unknown ('other')", () => {
+    // "other" is a real classification — caller treats it as known. utm
+    // fallback must not override.
+    expect(
+      classifyAttributionSource({
+        bodyAttributionSource: "snapchat",
+        bodyUtmSource: "youtube",
+        referrerHost: null,
+      }),
+    ).toBe("other");
+  });
+});
+
+describe("parseReferrerHost", () => {
+  it("extracts hostname from full URL", () => {
+    expect(parseReferrerHost("https://www.youtube.com/watch?v=abc")).toBe("www.youtube.com");
+  });
+
+  it("strips ports + userinfo + path", () => {
+    expect(parseReferrerHost("https://user@host.example.com:8443/foo/bar?baz=1")).toBe("host.example.com");
+  });
+
+  it("returns null for malformed input", () => {
+    expect(parseReferrerHost("not a url")).toBeNull();
+    expect(parseReferrerHost(null)).toBeNull();
+    expect(parseReferrerHost("")).toBeNull();
+  });
+
+  it("rejects oversized hostnames", () => {
+    const huge = "a".repeat(254) + ".com";
+    expect(parseReferrerHost(`https://${huge}/`)).toBeNull();
+  });
+
+  it("lowercases hostname", () => {
+    expect(parseReferrerHost("https://WWW.X.COM/profile")).toBe("www.x.com");
+  });
+});
+
+describe("ALLOWED_ATTRIBUTION_SOURCES", () => {
+  it("matches the DB CHECK constraint shape", () => {
+    // Migration 20260426a_tt_checkpoint_tracking.sql defines this exact set.
+    // If migration changes, this test must be updated in the same PR.
+    expect(ALLOWED_ATTRIBUTION_SOURCES).toEqual([
+      "youtube",
+      "x",
+      "twitter_x",
+      "tiktok",
+      "instagram",
+      "facebook",
+      "reddit",
+      "quora",
+      "google",
+      "bing",
+      "organic",
+      "direct",
+      "other",
+    ]);
+  });
+});

--- a/src/lib/score-attribution.ts
+++ b/src/lib/score-attribution.ts
@@ -1,0 +1,131 @@
+/**
+ * @fileoverview /score attribution classification.
+ *
+ * Maps incoming utm_source values + referrer hosts onto the bounded
+ * `attribution_source` enum used by score_completions. Pure functions
+ * for unit-test friendliness.
+ *
+ * The CHECK constraint in supabase/migrations/20260426a_tt_checkpoint_tracking.sql
+ * enforces the same allowlist at the DB boundary; this lib short-circuits
+ * insert errors by returning a known-good value or NULL.
+ */
+
+export type AttributionSource =
+  | "youtube"
+  | "x"
+  | "twitter_x"
+  | "tiktok"
+  | "instagram"
+  | "facebook"
+  | "reddit"
+  | "quora"
+  | "google"
+  | "bing"
+  | "organic"
+  | "direct"
+  | "other";
+
+export const ALLOWED_ATTRIBUTION_SOURCES: ReadonlyArray<AttributionSource> = [
+  "youtube",
+  "x",
+  "twitter_x",
+  "tiktok",
+  "instagram",
+  "facebook",
+  "reddit",
+  "quora",
+  "google",
+  "bing",
+  "organic",
+  "direct",
+  "other",
+] as const;
+
+const ALLOWED_SET: ReadonlySet<string> = new Set(ALLOWED_ATTRIBUTION_SOURCES);
+
+/**
+ * Map a referrer hostname onto an attribution_source bucket.
+ *
+ * Hostname-only mapping; full URL would leak path PII. Uses suffix
+ * matching so subdomains (m.youtube.com, www.tiktok.com) classify
+ * correctly. Unknown hosts return "other"; missing host returns NULL.
+ */
+export function classifyReferrerHost(host: string | null): AttributionSource | null {
+  if (!host) return null;
+  const h = host.toLowerCase();
+  if (/(?:^|\.)youtube\.com$/.test(h) || h === "youtu.be") return "youtube";
+  if (/(?:^|\.)twitter\.com$/.test(h) || h === "t.co" || /(?:^|\.)x\.com$/.test(h)) return "x";
+  if (/(?:^|\.)tiktok\.com$/.test(h)) return "tiktok";
+  if (/(?:^|\.)instagram\.com$/.test(h)) return "instagram";
+  if (/(?:^|\.)facebook\.com$/.test(h) || /(?:^|\.)fb\.com$/.test(h) || /(?:^|\.)fb\.me$/.test(h)) return "facebook";
+  if (/(?:^|\.)reddit\.com$/.test(h) || /(?:^|\.)redd\.it$/.test(h)) return "reddit";
+  if (/(?:^|\.)quora\.com$/.test(h)) return "quora";
+  if (/(?:^|\.)google\.[a-z.]+$/.test(h)) return "google";
+  if (/(?:^|\.)bing\.com$/.test(h)) return "bing";
+  return "other";
+}
+
+/**
+ * Normalize a `utm_source` query-param value onto our enum.
+ *
+ * `youtube` / `yt` / `youtube_shorts` all map to "youtube"; `x` / `twitter`
+ * map to "x". Defensive: only return values inside the allowed set.
+ */
+export function classifyUtmSource(utmSource: string | null): AttributionSource | null {
+  if (!utmSource) return null;
+  const v = utmSource.trim().toLowerCase().replace(/-/g, "_");
+  if (v === "yt" || v === "youtube" || v === "youtube_shorts" || v === "shorts") return "youtube";
+  if (v === "x" || v === "twitter" || v === "twitter_x" || v === "twit") return "x";
+  if (v === "tt" || v === "tiktok") return "tiktok";
+  if (v === "ig" || v === "instagram") return "instagram";
+  if (v === "fb" || v === "facebook" || v === "meta") return "facebook";
+  if (v === "reddit") return "reddit";
+  if (v === "quora") return "quora";
+  if (v === "google") return "google";
+  if (v === "bing") return "bing";
+  if (v === "organic") return "organic";
+  if (v === "direct") return "direct";
+  if (ALLOWED_SET.has(v)) return v as AttributionSource;
+  return "other";
+}
+
+/**
+ * Pick the most authoritative attribution source.
+ *
+ * Priority: explicit body.attributionSource (frontend-provided,
+ * post-validation) > utm_source > referrer host. Returns NULL only when
+ * none of the three carry a usable signal — caller stores NULL in
+ * score_completions.attribution_source which is allowed by the schema.
+ */
+export function classifyAttributionSource(opts: {
+  bodyAttributionSource: string | null;
+  bodyUtmSource: string | null;
+  referrerHost: string | null;
+}): AttributionSource | null {
+  const explicit = opts.bodyAttributionSource
+    ? classifyUtmSource(opts.bodyAttributionSource)
+    : null;
+  if (explicit) return explicit;
+  const utm = opts.bodyUtmSource ? classifyUtmSource(opts.bodyUtmSource) : null;
+  if (utm) return utm;
+  return classifyReferrerHost(opts.referrerHost);
+}
+
+/**
+ * Extract the bare host from a Referer header value. Strips port,
+ * userinfo, and path. Returns NULL if header is empty or malformed.
+ *
+ * `URL` parsing is wrapped in try/catch because Referer can include
+ * any string the browser feels like sending.
+ */
+export function parseReferrerHost(referrer: string | null): string | null {
+  if (!referrer) return null;
+  try {
+    const u = new URL(referrer);
+    if (!u.hostname) return null;
+    if (u.hostname.length > 253) return null;
+    return u.hostname.toLowerCase();
+  } catch {
+    return null;
+  }
+}

--- a/supabase/migrations/20260426a_tt_checkpoint_tracking.sql
+++ b/supabase/migrations/20260426a_tt_checkpoint_tracking.sql
@@ -1,0 +1,128 @@
+-- TikTok 2026-07-23 checkpoint tracking infra (P3 from work order).
+--
+-- Per APEX-W2 in 20b3606, three hard gates must clear by 2026-07-23 before
+-- the TT defer is lifted:
+--   Gate A: >=50 /score completions attributable to YT or X within last
+--           90d AND >=1 paid conversion
+--   Gate B: zero content-removal strikes on YT or X
+--   Gate C: cached .01% expert for TT-legal passes 3-angle triangulation
+--
+-- This migration ships:
+--   1. score_completions (privacy-first, no PII; tracks attribution_source
+--      so Gate A can be computed from a single SQL count)
+--   2. content_removal_incidents (Gate B incident log; written by the
+--      log-content-removal.mjs CLI)
+--   3. tt_checkpoint_state (cron singleton; tracks last alert time so
+--      we don't spam Telegram every 24h once the gate trips)
+--
+-- Privacy posture: score_completions stores ZERO answers, ZERO email,
+-- ZERO IP. Only charge_type (already public-aggregate-grade), the score
+-- band, and the attribution_source string. Same threat model as the
+-- existing counters / score_aggregates RPCs.
+
+-- 1. score_completions ------------------------------------------------------
+-- One row per /api/score POST. Anonymous, no PII.
+CREATE TABLE IF NOT EXISTS score_completions (
+  id          bigserial PRIMARY KEY,
+  created_at  timestamptz NOT NULL DEFAULT now(),
+  charge_type text        NOT NULL,
+  score_value integer     NOT NULL CHECK (score_value >= 0 AND score_value <= 100),
+  score_band  text        NOT NULL CHECK (score_band IN ('Critical','Concerning','Average','Adequate','Excellent')),
+  -- attribution_source: classification bucket
+  attribution_source text  CHECK (
+    attribution_source IS NULL
+    OR attribution_source IN (
+      'youtube','x','twitter_x','tiktok','instagram','facebook',
+      'reddit','quora','google','bing','organic','direct','other'
+    )
+  ),
+  -- referrer_host: parsed hostname only (path would be PII).
+  referrer_host text       CHECK (referrer_host IS NULL OR length(referrer_host) <= 253),
+  -- matched_blog_slug: optional source post; lets us join to platform_posts.
+  matched_blog_slug text   CHECK (matched_blog_slug IS NULL OR matched_blog_slug ~ '^[a-z0-9-]{1,120}$')
+);
+
+CREATE INDEX IF NOT EXISTS idx_score_completions_attribution_recent
+  ON score_completions (attribution_source, created_at DESC)
+  WHERE attribution_source IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_score_completions_created_at
+  ON score_completions (created_at DESC);
+
+ALTER TABLE score_completions ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY score_completions_service_all ON score_completions
+  AS PERMISSIVE FOR ALL
+  TO service_role
+  USING (true) WITH CHECK (true);
+
+COMMENT ON TABLE score_completions IS
+  'Anonymous /api/score completion log. NO PII. Powers Gate A of the TikTok 2026-07-23 checkpoint (>=50 YT/X-attributed completions in 90d).';
+
+-- 2. content_removal_incidents ----------------------------------------------
+-- Manual log written by scripts/log-content-removal.mjs.
+CREATE TABLE IF NOT EXISTS content_removal_incidents (
+  id              bigserial PRIMARY KEY,
+  reported_at     timestamptz NOT NULL DEFAULT now(),
+  occurred_at     timestamptz NOT NULL,
+  platform        text        NOT NULL CHECK (platform IN (
+    'youtube','x','twitter_x','tiktok','instagram','facebook','other'
+  )),
+  -- platform_post_id links to platform_posts.id when known; NULL otherwise.
+  platform_post_id integer REFERENCES platform_posts(id) ON DELETE SET NULL,
+  source_url      text        CHECK (source_url IS NULL OR length(source_url) <= 2048),
+  reason_code     text        NOT NULL CHECK (reason_code IN (
+    'community_guidelines','copyright','spam','misinformation',
+    'harassment','privacy','minor_safety','sensitive','manual','other'
+  )),
+  notes           text        CHECK (notes IS NULL OR length(notes) <= 4000),
+  resolved_at     timestamptz,
+  resolved_by     text        CHECK (resolved_by IS NULL OR length(resolved_by) <= 64),
+  resolution_note text        CHECK (resolution_note IS NULL OR length(resolution_note) <= 4000)
+);
+
+CREATE INDEX IF NOT EXISTS idx_content_removal_platform_recent
+  ON content_removal_incidents (platform, occurred_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_content_removal_unresolved
+  ON content_removal_incidents (platform, occurred_at DESC)
+  WHERE resolved_at IS NULL;
+
+ALTER TABLE content_removal_incidents ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY content_removal_service_all ON content_removal_incidents
+  AS PERMISSIVE FOR ALL
+  TO service_role
+  USING (true) WITH CHECK (true);
+
+COMMENT ON TABLE content_removal_incidents IS
+  'Operator-logged content strikes on social platforms. Powers Gate B of the TikTok 2026-07-23 checkpoint (zero unresolved strikes on YT/X in the 90-day window).';
+
+-- 3. tt_checkpoint_state ----------------------------------------------------
+-- Cron singleton. Tracks last-run + last-alert so the cron does not
+-- re-Telegram the same threshold cross every 24h.
+CREATE TABLE IF NOT EXISTS tt_checkpoint_state (
+  id                            smallint PRIMARY KEY DEFAULT 1 CHECK (id = 1),
+  last_run_at                   timestamptz,
+  last_run_count_youtube        integer NOT NULL DEFAULT 0,
+  last_run_count_x              integer NOT NULL DEFAULT 0,
+  last_run_paid_conversions     integer NOT NULL DEFAULT 0,
+  last_run_strikes_unresolved   integer NOT NULL DEFAULT 0,
+  gate_a_first_passed_at        timestamptz,
+  gate_a_alert_sent_at          timestamptz,
+  gate_b_last_strike_at         timestamptz,
+  gate_c_last_triangulated_at   timestamptz,
+  notes                         text     CHECK (notes IS NULL OR length(notes) <= 4000)
+);
+
+INSERT INTO tt_checkpoint_state (id) VALUES (1) ON CONFLICT (id) DO NOTHING;
+
+ALTER TABLE tt_checkpoint_state ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY tt_checkpoint_state_service_all ON tt_checkpoint_state
+  AS PERMISSIVE FOR ALL
+  TO service_role
+  USING (true) WITH CHECK (true);
+
+COMMENT ON TABLE tt_checkpoint_state IS
+  'Singleton state row for /api/cron/tt-checkpoint. Tracks last computed Gate A/B/C state so re-runs do not duplicate Telegram alerts.';


### PR DESCRIPTION
## Summary
Mechanical observability for the three APEX-W2 hard gates that must clear by 2026-07-23 to lift the TikTok defer.

- **Gate A** (>=50 YT/X-attributed /score completions in 90d AND >=1 paid conversion): score_completions table + attribution lib + cron compute
- **Gate B** (zero unresolved YT/X strikes in 90d): content_removal_incidents table + log CLI + cron alert
- **Gate C** (cached .01% TT-legal expert <=90d old): gate_c_last_triangulated_at column ready for the quarterly triangulation cron (next session)

## Files
- supabase/migrations/20260426a_tt_checkpoint_tracking.sql — 3 tables (score_completions, content_removal_incidents, tt_checkpoint_state)
- src/lib/score-attribution.ts — pure attribution classification (allowlist of 13)
- src/lib/__tests__/score-attribution.test.ts — 56 tests
- src/app/api/score/route.ts — server-side classify + score_completions insert; NO PII added
- src/app/api/cron/tt-checkpoint/route.ts — weekly gate evaluator + Telegram alerts
- scripts/log-content-removal.mjs — operator CLI for Gate B
- scripts/register-tt-checkpoint-cron.mjs — cron-job.org registration

## Test plan
- [x] vitest src/lib/__tests__/score-attribution.test.ts — 56/56 pass
- [x] tsc --noEmit — clean
- [x] next build (pre-push hook) — successful, /api/cron/tt-checkpoint registered
- [ ] Apply migration to prod via supabase db push
- [ ] node scripts/register-tt-checkpoint-cron.mjs — register weekly Mon 17:00 UTC cron
- [ ] Manual smoke: POST /api/score with referer=https://www.youtube.com/x — verify score_completions row + attribution_source='youtube'
- [ ] Manual smoke: GET /api/cron/tt-checkpoint with CRON_AUTH_TOKEN — verify gate-state JSON shape

## Privacy posture
score_completions stores ZERO answers, ZERO email, ZERO IP, ZERO full URL. Only:
- charge_type (already public-aggregate)
- score_value + score_band
- attribution_source (allowlist enum)
- referrer_host (hostname only — path is PII)
- matched_blog_slug (optional)

Same threat model as the existing counters / score_aggregates RPCs.

## Outstanding (next sessions)
- Frontend `/score` page not yet sending `utm_source` / `attributionSource` in body — relies on Referer header alone until UTM parsing ships.
- `orders.attribution_source` not yet wired — `tt-checkpoint` cron's `paid_conversions` is hard-zero until that ships. Threshold-cross alert fires correctly today; full Gate-A pass requires that PR.
- Gate C quarterly triangulation cron (re-trigger expert-triangulation skill for tt-legal-content) not yet registered. `gate_c_last_triangulated_at` column is in place.

## CASCADE
- us: 89-day runway with mechanical gate evaluation; no eyeballing
- operator (Rahim): single Telegram alert when threshold first crosses; CLI for logging strikes
- ecosystem (sibling brands): score_completions + attribution lib reusable for sibling brand checkpoints
- defendants: privacy-first design (no PII added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)