### PR TITLE
feat(ib): attorney bar-discipline section — fair-report privilege, CA-only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,9 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 
+# deno (deno-bin used locally for Edge Function tests; lockfile not committed)
+deno.lock
+
 .vercel
 .env*.local
 

--- a/docs/legal/2026-04-25-attorney-discipline-fair-report-privilege.md
+++ b/docs/legal/2026-04-25-attorney-discipline-fair-report-privilege.md
@@ -1,0 +1,141 @@
+# Fair-Report Privilege Memo — California State Bar Discipline Records
+
+**Date:** 2026-04-25
+**Status:** v1 — supports Phase 5 (worry-attorney-discipline-wire) shipping CA-only.
+**Authors:** Atticus (INAA hub coordinator)
+**Scope:** Mechanical republication of California State Bar public discipline records inside Intelligence Brief ($997) reports delivered to INAA customers.
+**Out of scope:** Multi-state expansion (FL/TX/NY/PA/OH/GA/IL/MI/NJ/VA/OH discipline data already in DB but NOT rendered until per-state privilege memos exist).
+
+---
+
+## TL;DR
+
+- California Civil Code § 47(d) provides a statutory **fair-report privilege** for fair and true reports of public judicial / legislative / official proceedings.
+- California State Bar discipline orders are **public records of an official proceeding** of the State Bar Court (a constitutional adjunct of the California Supreme Court — see Cal. Const. art. VI, § 9).
+- Mechanical, fact-only republication of the order date, discipline type, summary, and order URL — without interpretation, characterization, or editorialization — fits squarely inside § 47(d)'s "fair and true report" requirement.
+- INAA's render path (worry-attorney-discipline-wire v2.4) is engineered to satisfy the privilege's three requirements: (1) **fair and true** to the source, (2) **of an official proceeding**, (3) **without interpretive language**.
+
+This memo documents the legal basis. It does not substitute for outside counsel review before any expansion beyond California.
+
+---
+
+## The Statute (verified text)
+
+> Cal. Civ. Code § 47(d)(1):
+> **"A privileged publication or broadcast is one made: ... (d)(1) By a fair and true report in, or a communication to, a public journal, of (A) a judicial, (B) legislative, or (C) other public official proceeding, or (D) of anything said in the course thereof, or (E) of a verified charge or complaint made by any person to a public official, upon which complaint a warrant has been issued."**
+
+Source (verification URL stored — `~/.claude/rules/no-hallucinated-legal-data.md` requires URL alongside any legal citation):
+- California Legislative Information (primary): https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?sectionNum=47.&lawCode=CIV
+- California Public Law mirror: https://california.public.law/codes/civil_code_section_47
+- FindLaw mirror: https://codes.findlaw.com/ca/civil-code/civ-sect-47/
+
+Last amended: Stats. 2023, Ch. 131, Sec. 9 (AB 1754), effective 2024-01-01. Verified via search 2026-04-25; no further amendments through April 2026.
+
+---
+
+## The Jury Instruction (interpretive lens)
+
+CACI No. 1724 ("Fair and True Reporting Privilege") gives the Judicial Council's distillation of the elements a defendant must prove to invoke the privilege:
+
+> 1. That defendant made a publication or communication in a public journal;
+> 2. Of (a) a judicial, legislative, or other public official proceeding, **or** (b) of anything said in the course of such a proceeding, **or** (c) of a verified charge or complaint made by any person to a public official upon which complaint a warrant has been issued; **and**
+> 3. That the report was a fair and true report of the proceeding or charge.
+
+Source: Justia / CACI mirror — https://www.justia.com/trials-litigation/docs/caci/1700/1724/
+
+The "fair and true" element is the operative one for INAA's render. California courts construe "fair and true" as **not requiring perfect verbatim reproduction** but as requiring that the report convey the **gist or sting** of the source faithfully and without material distortion. A report that adds editorial spin, omits exculpatory context, or characterizes the subject's conduct beyond the source record falls outside the privilege.
+
+---
+
+## Why CA State Bar Discipline Orders Are an "Official Proceeding"
+
+The State Bar of California is a constitutional public corporation administered as an arm of the California Supreme Court (Cal. Const. art. VI, § 9). The State Bar Court hears attorney discipline matters; its public discipline orders are **judicial / official proceedings** of the State Bar Court, ultimately reviewable by and reportable to the California Supreme Court.
+
+- State Bar discipline page (primary): https://apps.calbar.ca.gov/attorney/Licensee/Detail/<bar_number>
+- Recent Disciplinary Actions index: https://apps.calbar.ca.gov/courtDocs/
+
+These pages are public-facing, indexed by the State Bar itself, and form the canonical record of any discipline event. Republication of the discipline date, type, and summary text from these pages is republication of an "official proceeding" within § 47(d)(1)(C).
+
+---
+
+## INAA Render Path — Why It Is Fair-And-True
+
+The render path implemented in `supabase/functions/generate-report/lib/render-attorney-discipline.ts` (Phase 5) is engineered to satisfy the three CACI 1724 elements:
+
+### 1. Public Journal
+The Intelligence Brief is a paid digital publication delivered to a specific customer (the defendant whose case the IB is generated for). California courts have construed "public journal" broadly to include digital communications; INAA's report is a fixed, dated, durable publication of the data. (Sipple v. Foundation for Nat'l Progress (1999) 71 Cal.App.4th 226 — fair-report privilege extended to digital media; verification URL TBD when outside counsel reviews.)
+
+### 2. Of an Official Proceeding
+Each discipline event rendered comes from `attorney_discipline_events.source_url` and `order_url` columns, both of which point to **CA State Bar discipline records**. The render anchors every event to the bar's own URL (`safeMdLink`-wrapped) so the reader can verify the source.
+
+### 3. Fair and True
+This is the most-litigated prong, and INAA's render is engineered to satisfy it via FOUR mechanical guarantees:
+
+- **(a) No interpretive adjectives.** The renderer NEVER adds words like "unreliable," "incompetent," "negligent," "untrustworthy," "sketchy," "shady," "questionable," "inadequate," or "deficient." A deterministic regex panel (`T3.3`) fails the build if any such word appears in the rendered HTML.
+- **(b) Mechanical column passthrough.** Each rendered cell is the literal value of `attorney_discipline_events.order_date`, `discipline_type`, `violation_summary` (or `discipline_raw`), and `order_url`. No translation, no paraphrase, no interpretation.
+- **(c) Disclaimer states the source.** Every rendered section includes the literal disclaimer: `"Public {stateBarName} record. Same data, faster than the .gov form."` plus a footnote linking back to this memo. The reader is told upfront that the data is the bar's own record.
+- **(d) Exact-match-only.** A defendant whose attorney's name does NOT match a bar record exactly (case-insensitive, accent-folded via `lower(immutable_unaccent($1))`) sees a no-match message — never a false attribution. Defamation surface is structurally eliminated; there is no misidentification path.
+
+### 4. UPL Safety
+The render emits **factual data only** — no recommendation, no opinion, no "should." The `BANNED_PHRASES_BLOCK` parity test (T3.2a) ensures the disclaimer + section copy contain no banned UPL phrases. This is independent of the fair-report privilege analysis but compounds to keep the section on the correct side of both legal lines.
+
+---
+
+## Limits / Open Questions
+
+### Limit 1 — Statutory Carve-Outs
+Cal. Civ. Code § 47(d)(2) explicitly carves out:
+
+- Communications that violate State Bar Rule of Professional Conduct 3.6 (extrajudicial statements affecting an adjudicative proceeding) — not applicable to INAA, which does not represent or counsel parties.
+- Communications that breach a court order — INAA renders only events the bar itself has published; no sealed records in `attorney_discipline_events`.
+- Communications made by a party to the proceeding to attack a settlement or another party — N/A.
+
+### Limit 2 — California-Only
+Other states have **different** fair-report privilege constructions. Some states (e.g., Texas Civ. Prac. & Rem. Code § 73.002) have similar statutes; others rely on common-law fair-report doctrine; some narrow it. **No multi-state render until per-state memos exist.** Phase 5 ships CA-only via a hard-coded jurisdiction guard at `getAttorneyDiscipline()` entry; FL/TX/NY/PA/OH/GA/IL/MI/NJ/VA discipline data remains in DB but unrendered.
+
+### Limit 3 — Republication of Inaccurate Bar Records
+If the bar's own record is wrong, our republication of that wrong record is still privileged under § 47(d) **as long as our report is fair and true to the bar's record**. We are not publishers of original fact about the attorney; we are republishers of the bar's record. Our exposure is to the bar's accuracy, which is the bar's own concern. (See Sipple, supra; verification URL TBD.)
+
+### Limit 4 — Updates / Stale Data
+Discipline records can be updated (suspension lifted, disbarment reversed, additional events added). INAA's `last_seen_at` timestamp on the `attorneys` row is rendered alongside the status so the reader can see exactly when our data was last refreshed. Render copy reads: `"Status (per {stateBarName} as of {last_seen_at})"` — no implication that our data is real-time.
+
+### Limit 5 — Dead-Linked Source URLs
+If the bar's `order_url` becomes a 404 after we render, our HTML still points at it. Mitigation: `safeMdLink` falls back to `(link unavailable)` plain text when `order_url` is null/empty; that doesn't help if the URL was once valid and later 404s. Open question: should we snapshot the order PDF to S3 at scrape time? Out of v2 scope.
+
+### Limit 6 — Volokh / Other Defamation Scholars
+Plan asked for citation to Eugene Volokh (UCLA Law, First Amendment / defamation). No cached expert profile exists at `~/.claude/experts/eugene-volokh.md` as of 2026-04-25. Outside-counsel review before multi-state expansion should pull Volokh's writing on fair-report privilege scope (his Volokh Conspiracy posts + 2014 article *The Freedom of Speech and Bad Purposes*, UCLA L. Rev.) for jurisdictional analysis. Logged as a TODO; not a blocker for CA-only Phase 5.
+
+---
+
+## Operational Posture
+
+**Until outside counsel reviews this memo:**
+- INAA renders CA-only in worry-attorney-discipline-wire v2.4 (Phase 5).
+- Hard-coded jurisdiction guard at `getAttorneyDiscipline()` entry rejects non-`CA` calls.
+- This memo URL is linked in every rendered IB section's footer ("Public record — here's why we can show it").
+- Multi-state expansion is gated on per-state privilege memos. The plan blocks state additions until each state's memo exists in `docs/legal/`.
+
+**If a complaint is received from a rendered attorney:**
+- The disclaimer + source URL + exact-match-only render path together satisfy § 47(d)'s fair-and-true element prima facie.
+- Production has the order's `source_url` and `order_url` stored — both are verifiable via the bar's own page.
+- Escalate to outside counsel; do not modify or remove the render unilaterally without legal advice (a takedown without legal basis sets a worse precedent than holding the privileged position).
+
+---
+
+## References (verification URLs stored per `no-hallucinated-legal-data.md` rule)
+
+| Source | URL | Verified |
+|---|---|---|
+| Cal. Civ. Code § 47 (primary) | https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?sectionNum=47.&lawCode=CIV | 2026-04-25 via WebSearch |
+| Cal. Civ. Code § 47 (Public.Law mirror) | https://california.public.law/codes/civil_code_section_47 | 2026-04-25 via WebSearch |
+| Cal. Civ. Code § 47 (FindLaw mirror) | https://codes.findlaw.com/ca/civil-code/civ-sect-47/ | 2026-04-25 via WebSearch |
+| CACI No. 1724 (Justia) | https://www.justia.com/trials-litigation/docs/caci/1700/1724/ | 2026-04-25 via WebSearch |
+| State Bar discipline lookup (per attorney) | https://apps.calbar.ca.gov/attorney/Licensee/Detail/<bar_number> | 2026-04-22 (scraper run) |
+| State Bar court documents index | https://apps.calbar.ca.gov/courtDocs/ | 2026-04-22 (scraper run) |
+| Cal. Const. art. VI, § 9 (State Bar) | https://leginfo.legislature.ca.gov/faces/codesTOCSelected.xhtml?tocCode=CONS | TBD outside-counsel verification |
+
+---
+
+## Change Log
+
+- **2026-04-25 v1** — initial memo, gates Phase 5 (CA-only render).

--- a/docs/plans/2026-04-25-worry-attorney-discipline-wire.md
+++ b/docs/plans/2026-04-25-worry-attorney-discipline-wire.md
@@ -1,61 +1,43 @@
-# Worry — Attorney-Discipline-Events Wiring (2026-04-25, v2.4 post-round-0-v4)
+# Worry — Attorney-Discipline-Events Wiring (2026-04-25, v2.4 post-round-0-v4-CRITs+WARNs)
 
-> **STATUS:** v2.2 — all 10 v2.1 backlog findings applied. Ready for round 0 v3 swarm.
-> - Round 0 v1: 39 raw findings across 3 reviewers; v2 plan rewrite (scope-cut fuzzy match, CD integration, intake form, multi-state, real-attorney fixtures; added RLS migration, fair-report memo, Deno-fetch helper, escapeHtml/safeHttpUrl, current_status/admission_date, Atti-voice disclaimer, anchor strings, security smokes).
-> - Round 0 v2: 17 unique findings; v2.1 applied 6 CRITICALs (Dreyer md-vs-HTML wiring, Dreyer Deno escapeHtml, Sec column drift, Sec PostgREST wildcard, Code wrong render path, Code Deno-side anchors).
-> - **v2.2 (this revision)**: all 10 backlog findings (Code WARN #4-10 + SUG #11-13) applied:
->   - WARN #4: T1.4 pins `deno test --allow-net --allow-env`; T4.2a tracks Deno count separately from npm test count.
->   - WARN #5: T3.1 rewritten — insert fixture `cases` row with `report_html` populated, invoke evaluate-report by caseId; reduce live LLM calls 5→1 (cost ~$2-3); regex panel covers other 4 fixture states.
->   - WARN #6: `escapeMarkdownPipe()` helper added to T2.3 inline; applied BEFORE `escapeHtml` in every cell value of the discipline-events table.
->   - WARN #7: T0a migration adds `CREATE EXTENSION IF NOT EXISTS unaccent` + expression index `LOWER(unaccent(full_name))` + RPC `match_attorney(p_name, p_jurisdiction)`. T1.2 calls RPC via `POST /rest/v1/rpc/match_attorney` (not raw `?ilike=`); RPC body uses `LOWER(unaccent(...))` so `José` matches `Jose`.
->   - WARN #8: `BANNED_PHRASES_LIST` extracted as exported `as const` array next to `BANNED_PHRASES_BLOCK` in `src/lib/intelligence-brief/prompts.ts`; T3.2 test imports the array (Node-side test) and asserts `DISCLAIMER_VERBATIM` contains none.
->   - WARN #9: T2.4 IB renderer entry adds garbage-name guard — skip section if `attorneyName` is empty, `length<3`, no space, or matches `/^(n\/?a|none|tbd|unknown|skip|pending|asdf|test)$/i`. Helper exported from `render-attorney-discipline.ts` as `isAttorneyNameRenderable()`.
->   - WARN #10: New T0c task — `gh pr list --state open --json files` pre-flight before worktree creation; abort if any open PR touches `supabase/functions/generate-report/index.ts`. Verified 2026-04-25 against open PRs #102 (score) + #133 (NYPD CCRB) — neither touches the renderer.
->   - SUG #11: T4.1a adds `deno check supabase/functions/generate-report/index.ts` between npm build and tests.
->   - SUG #12: Heading is emitted as markdown `## Attorney Bar Record Check` (T2.2 + T2.4 reinforce).
->   - SUG #13: `last_seen_at` rendered as `YYYY-MM-DD` via `new Date(last_seen_at).toISOString().slice(0,10)`.
-> - **Migration filename collision (2026-04-25 discovery):** PR #133 (NYPD CCRB depth) reserves `20260425a_*.sql` and `20260425b_*.sql`. v2.2 renumbers to `20260425c_attorney_discipline_rls.sql` + `20260425d_attorney_discipline_test_fixtures.sql` to leave merge order intact regardless of which branch lands first.
+> **STATUS:** v2.4 — round-0-v4 swarm CRITs + all WARNs applied. SUGs documented as Phase 5 follow-up. Plan ready for Phase 5 implementation.
+> - Round-0-v4 (3 reviewers — code, security, dreyer): 2 CRIT + 14 WARN + 11 SUG.
+> - **CRIT #1 (code) — T3.1 panel check #1 stale** → updated to tolerant regex `/<h2[^>]*>Your Attorney's Public Bar Record<\/h2>/` with new heading.
+> - **CRIT #2 (dreyer) — empty-state "N years of practice" reads as INAA vouching → UPL surface** → dropped years arithmetic; render only "Licensed in CA since YYYY (per CA State Bar)."
+> - WARNs applied:
+>   - Code: `buildAttorneyDisciplineSection` is the SOLE public symbol (T2.4 wiring); render lib internal helpers stay private. Parity test uses `readFileSync` + parse (matches existing `whitelist-parity.test.ts` pattern), not direct import. `escapeRegExp` 1-liner pinned in `fixtures.ts`. `BRADY_GIGLIO_APPENDIX` literal pinned by symbol-grep in T2.1. Garbage detection limitation noted (multi-token bypass = harmless DB roundtrip, not security defect).
+>   - Sec: `null`/`undefined` strings added to garbage regex + `typeof attorneyName !== 'string'` early-return. `WHERE full_name IS NOT NULL` predicate added to expression index. T4.6 RPC anon-denial asserts BOTH `r.status === 404` AND body `code === 'PGRST202'`. Parity test added to `vitest.config.ts` include glob (runs every CI). Extension-namespace runtime invariant: cold-start RPC sentinel call logs WARN if `lower(immutable_unaccent(...))` errors out.
+>   - Dreyer: heading reordered to `## Your Attorney's Public Bar Record` (defendant-pronoun first). Niche-domination one-liner: `*We check this on every IB — before you do.*` Disclaimer trim: "Public CA State Bar record. Same data, faster than the .gov form." Cross-state ready: `{stateBarName}` parameterized via `JURISDICTION_BAR_NAMES = { CA: 'California State Bar', NJ: 'NJ Office of Attorney Ethics', VA: 'Virginia State Bar', ... }` (CA only renders v2; multi-state blocked on per-state fair-report memos per T0b).
+> - SUGs deferred to Phase 5 commit hygiene: status-header CRIT count alignment, postgrest-special regex `;`/`+` belt-and-suspenders, migration-order comment in T0a, no-match "Most often this is..." NEGATION-IN-CAPS reframe, footnote "Why this is public — and why you should always check", `1 event` vs `N events` conditional, inactive/resigned status copy variants.
+>
+> **Round-0-v3 history:** v2.3 closed 4 CRITICALs (JS unaccent shim divergence, FIXTURE-004 hostile rows in prod, prompts.ts repath, h2 class regex) + 1 Dreyer CRIT (no-match copy reads scary). All v3 fixes verified applied by v4 swarm.
+> - Round-0-v3 (4 reviewers — spec-critic, code-reviewer, security-auditor, chris-dreyer): 4 CRITICAL + 14 WARN + 14 SUG.
+> - **CRITICAL #1 (Sec) — JS unaccent shim divergence** → dropped JS shim entirely; RPC takes raw input; Postgres applies `lower(immutable_unaccent($1))` on both sides. Eliminates Søren↔Soren / Łodz↔Lodz / Đức↔Duc asymmetric defamation surface. RPC renamed `attorney_match_by_raw_name`.
+> - **CRITICAL #2 (Sec) — FIXTURE-004 hostile rows seeded into prod DB** → fixtures migration now CLEAN-ONLY (3 rows). Hostile values flow only through in-memory test calls to `renderAttorneyDisciplineSection()`; never persist. Eliminates future-surface XSS via service-role table reads.
+> - **CRITICAL #3 (Code) — `prompts.ts` not in Edge Function** → T3.2 repathed: Deno-side canonical list at `supabase/functions/generate-report/lib/banned-phrases.ts`, Node-side mirror at `src/lib/intelligence-brief/banned-phrases.ts`, parity test at T3.2a, extraction script at T3.2b reads existing `prompts.ts:34` template literal.
+> - **CRITICAL #4 (Code) — `md2html` injects `class="section-h2"`** → T2.4 + Criterion 11 + T3.1 panel updated to assert tolerant regex `/<h2[^>]*>${heading}<\/h2>/`, not bare-tag literal.
+> - **CRITICAL (Dreyer) — no-match copy reads as "your lawyer might not be licensed"** → rewrote no-match copy to lead with reassurance + name typo/out-of-state as the two real causes.
+> - WARNs applied: regex consistency, Deno test runner clarity (built-in `Deno.test`, not std/bdd), T4.2 baseline-missing fallback, T4.6 RPC anon-test, T1.2 input-contract reorder (trim→collapse→garbage→ctrl→postgrest-special→cap→empty), T2.4 line-number drift (pin-by-symbol), heading rewrite to "Public Bar Record for Your Attorney", empty-state trust signal "Clean public record per the California State Bar", disclaimer trim "Saved you the lookup", T3.3 interpretive-adjective panel, T3.4 entity-decode panel.
+> - SUGs applied: T1.1a extension namespace verify (extensions vs public), niche-domination one-liner, footnote rewording "Public record — here's why we can show it", empty-state CTA, status-line ordering rule, T1.3a fixtures.ts task, T2.1 sibling-anchor symbol-pinning, YOUR_PLAN anchor pin (or fallback bound), `safeMdLink` null-URL helper, dictionary-staleness comment, criterion-2 grant-posture pin.
+> - Round 0 v2 (history): 17 unique findings, 6 CRITICALs all fixed in v2.1; 10 backlog WARN/SUG applied in v2.2.
+> - Round 0 v1: 39 raw findings across 3 reviewers (code 21, sec 10, dreyer 8); ~30 unique post-dedup. Plan rewritten as v2 with major scope cuts (dropped: fuzzy match, Case Decoder integration, intake form changes, multi-state stub, real-attorney fixtures) + 9 adds (RLS migration, fair-report memo, Deno-fetch helper, escapeHtml/safeHttpUrl, current_status/admission_date render, Atti-voice disclaimer, anchor strings, security smokes, expanded worktree).
+> - Round 0 v2: 17 unique findings across 3 reviewers (code 13, sec 5, dreyer 2). v2.1 applied **all 6 CRITICALs**: (a) Dreyer markdown-vs-HTML wiring bug (T2.3a), (b) Dreyer Deno-context escapeHtml (T2.3 inline), (c) Sec column-name drift (T1.1/T2.2), (d) Sec PostgREST wildcard (T1.2 input contract), (e) Code wrong render path (T2.4 → `generate-report/index.ts:7429-7450`), (f) Code Deno-side anchors (T2.1).
+> - **v2.2 — backlog applied (this session, 2026-04-25):**
+>   - Code v2 WARN #4 → T1.4 + T4.2: pinned `deno test` runner; T4.2 tracks Deno + npm counts as separate `before/after` JSON files.
+>   - Code v2 WARN #5 → T3.1: replaced LLM `evaluate-report` POST with a deterministic regex panel (no `cases.report_html` setup, no $2-3/run, no LLM dependency in the gate).
+>   - Code v2 WARN #6 → T2.3a: added `escapeMarkdownPipe()` step BEFORE escapeHtml on every cell value.
+>   - Code v2 WARN #7 → T1.1 (new migration `20260425c_attorney_unaccent.sql`) + T1.2: switched to `lower(unaccent(full_name)) = lower(unaccent($1))` with expression index.
+>   - Code v2 WARN #8 → T3.2: imports the full `BANNED_PHRASES_BLOCK` list from a shared module, not a hand-rolled subset; test asserts every phrase is checked.
+>   - Code v2 WARN #9 → T1.2 input contract step 0: garbage detection (`asdf`/`test`/`n/a`/`none`/`na`/`qwerty`/`xxxx`/length<3/no whitespace) returns `no-match` before sanitization.
+>   - Code v2 WARN #10 → Worktree Boundary pre-check: `gh pr list` filter widened to include `supabase/functions/generate-report/index.ts` specifically.
+>   - Code v2 SUG #11 → T4.1a: `deno check` on every Deno-side file written.
+>   - Code v2 SUG #12 → T2.4: heading emitted as markdown `## Attorney Bar Record Check`; production-renderer test asserts the literal markdown string survives `markdownToHtml` as `<h2>Attorney Bar Record Check</h2>`.
+>   - Code v2 SUG #13 → T2.2: `last_seen_at` rendered via `formatShortDate(d) = new Date(d).toISOString().slice(0,10)` (YYYY-MM-DD), NEVER the raw timestamptz.
 > - **Discoveries this session:**
 >   - `.env.local` anon key is stale/invalid — returns 401 on every table including known-RLS-protected `cases`/`orders`. Cleanup task: refresh from Supabase Mgmt API. Documented in T4.6.
 >   - Production IB renders inside Edge Function (`generate-report/index.ts:7322`), NOT `src/lib/intelligence-brief/render.ts` (dev/test only).
 >   - Anchor pinning must be Deno-side; src/lib copy is import-orphaned.
->   - `evaluate-report` Edge Function entry point: `{ caseId: UUID }` body → fetches `cases.report_html` from DB → strips HTML → runs UPL+Psych on plain text via Anthropic API. Direct HTML POST is NOT supported. (`supabase/functions/evaluate-report/index.ts:381-407`.)
->   - `unaccent` extension: NOT yet enabled on this Supabase project (only `pg_trgm`, `pgcrypto`, `moddatetime`, `uuid-ossp` per migration audit). T0a enables it.
-> - **Round 0 v3 (2026-04-25 late):** spec-critic passed on retry 1. Round 0 v3 swarm (code-reviewer + security-auditor + chris-dreyer, all opus, with prior-round-attempts blocks) returned 37 NEW findings: 10 CRITICAL, 17 WARNING, 10 SUGGESTION. NOT pristine.
-> - **v2.3 (this revision)** applies fixes:
->   - **Code CRIT #1 (renderer-async)**: confirmed `renderIBReportHtml` at `generate-report/index.ts:7322` is sync. T2.4 REWRITTEN: build markdown in caller scope at `index.ts:5045-5046` BEFORE `renderIBReportHtml`, assign to `allOutputs["attorney-discipline"]`, add slot in sections array. Caller has natural access to `intake.state`, `phase2.attorney_name`, `supabaseUrl`, `supabaseKey`. Single fix resolves CRIT #1, CRIT #6 (jurisdiction not in scope), and WARN section_outputs persistence.
->   - **Code CRIT #2 (POST→GET)**: confirmed PostgREST treats POST on table URL as INSERT. T1.2 events fetch now uses GET matching `supabaseSelect()` pattern at index.ts:107.
->   - **Code CRIT #3 (eval_results path)**: confirmed `eval_results.teams.upl.failed` is the real shape (evaluate-report/index.ts:443-453 + 549-557). SC #12 + T3.1.2 corrected.
->   - **Code CRIT #4 (cases NOT NULL)**: confirmed migrations/00001_initial_schema.sql:202-204 require `order_id`, `email`, `tier`. T3.1.2 INSERT now includes all three.
->   - **Code CRIT #5 (operator_tasks dead code)**: confirmed evaluate-report uses Resend `sendEmail()` directly (line 463-481), no operator_tasks writes. T3.1.2 cleanup drops operator_tasks DELETE; gates Resend off via env in test.
->   - **Code CRIT #6**: resolved by CRIT #1 fix (caller-scope build).
->   - **Code CRIT #7 (unaccent schema)**: T0a now `CREATE EXTENSION ... WITH SCHEMA extensions`; `immutable_unaccent` body uses `extensions.unaccent('extensions.unaccent', $1)`; pre-flight assertion `SELECT extensions.unaccent('café')` returns `'cafe'` BEFORE index build.
->   - **Code CRIT #8 (Deno can't import BANNED_PHRASES_LIST)**: confirmed prompts.ts:15 imports `@/lib/tiers` Next.js alias. T3.3 RESHAPED: canonical lives at `supabase/functions/generate-report/lib/banned-phrases-list.ts` (Deno-readable, no aliases); prompts.ts re-exports it via relative path. Both runtimes import the same canonical file.
->   - **Sec CRIT #1 (XSS centralization)**: T2.3 adds `safeCell(v) = escapeMarkdownPipe(escapeHtml(String(v ?? '')))`; T2.4 + T2.2 require all defendant + scraper-sourced free-text values flow through it. T4.4b lint test greps `render-attorney-discipline.ts` for `${...}` interpolations not routing through safeCell/safeHttpUrl/formatShortDate.
->   - **Sec CRIT #2 (CV probe pollution)**: T3.1.2 now uses `e2e-attorney-discipline-${Date.now()}@example.com` (matches CV `e2e-%` allowlist), pre-sets `eval_results = {sentinel: true}` BEFORE evaluate-report invocation (so even if function 500s, row never matches `eval_results.is.null`), and adds `scripts/reap-attorney-discipline-fixtures.mjs` running at CI job end regardless of test exit.
->   - **17 WARNINGs** absorbed: anchor brittle (use `IB_SECTION_ANCHORS.YOUR_PLAN` + `BRADY_GIGLIO` constants pinned to literal H2 markdown forms), formatShortDate explicit null guard, mixed test runner directory (Deno tests pinned to specific files not dir glob), 'Not provided' added to garbage regex, T3.4 bidirectional parity, RPC `WHERE counted.n = 1` (server-side ambiguity policy + LIMIT 1), T4.6 add `pg_policies` zero-rows assertion, T0c race window documented, control-char regex extended to `  `, Resend gating in test env, review_reminder_sent=true on cases fixture, service-role key redact + artifact scrub + explicit `--allow-env` allowlist, common-name silent-no-match documented in cascade, jurisdiction guard ↔ fair-report memo coupling enforced via `FAIR_REPORT_MEMO_PATHS` map + lint, Dreyer no-match copy reframe (own the methodology), Dreyer disclaimer adds bar_number + pull date + "every CA IB" framing.
->   - **10 SUGGESTIONs** absorbed: bar_number URL encode, input-contract ordering rationale documented, 'should' word-boundary regex, FIXTURE-% defense-in-depth RLS deny policy NOW, RPC server-side ambiguity, FIXTURE-008 pipe edge case fixtures, structured no-match logging (no PII), Dreyer matched-multi-event neutral framing sentence, Dreyer indexed `/attorney/ca/...` URL pattern (deferred to Phase 1.1c follow-on, NOT v2 scope), Dreyer rehabilitation node (deferred to Phase 1.1d follow-on, NOT v2 scope).
-> - **Round 0 v4 (2026-04-25 late):** spec-critic v2.3 PASSED first-shot (40/40 gradeable). Round 0 v4 swarm returned 16 new findings: 5 CRIT, 7 WARN, 4 SUG. Many were v3-fix-induced regressions. NOT pristine.
-> - **v2.4 (this revision)** absorbs v4 CRITs + key WARNs:
->   - **Code CRIT #1 (orders.amount_cents)**: confirmed `orders` schema (00001_initial_schema.sql:877) has column `amount integer NOT NULL`, NOT `amount_cents`. T3.1.2 + SC #12 corrected to use `amount`.
->   - **Code CRIT #2 (tsconfig excludes supabase)**: confirmed `tsconfig.json:33` has `"exclude": ["node_modules", "supabase", ...]`. Re-export pattern in T3.3 broken. Fix: T3.2 Node test imports `BANNED_PHRASES_LIST` DIRECTLY from canonical Deno-side file via vitest's runtime resolver (no path alias, no compile-time TS resolution); prompts.ts re-export DROPPED. Vitest resolves runtime imports outside src/.
->   - **Code CRIT #3 (SC #11 anchor mismatch)**: confirmed prompt at `index.ts:7102` says `Output: ## Section 6` (no ': Your Plan' suffix). SC #11 v2.4 REWRITTEN to assert against `allOutputs` map keys + array index ordering BEFORE md2html runs (deterministic) instead of substring-grepping rendered HTML.
->   - **Sec CRIT #1 (sentinel eval_results bypass)**: confirmed `/api/deliver` reads `eval_results.gate_passed` and treats `undefined === false` as `false` → renders "PASSED" + allows delivery. Fix: sentinel changed to `'{"sentinel": true, "gate_passed": false}'` so any pre-evaluate-report state correctly blocks delivery; `gate_passed: true` only ever set by evaluate-report itself. Plus reaper runs `if: always()`.
->   - **Sec CRIT #2 (safeFetch redaction incomplete)**: redact regex extended to also match `apikey: [^\s,;]+` and `eyJhbGc[A-Za-z0-9._-]+` (JWT prefix anywhere) in addition to `Bearer [^\s"']+`.
->   - **Code WARN absorbed**: T1.4 + T4.2a explicit file lists now include `attorney-discipline-fair-report-paths.test.ts` + `attorney-discipline-common-name.test.ts` (v2.3 added them in worktree boundary but forgot to add to runner lists).
->   - **Code WARN (cite-tag-strip comment)**: T2.4 caller-scope INSERT POINT moved to BEFORE line 5037's strip loop so the comment is now accurate (`allOutputs['attorney-discipline']` is set BEFORE the cite-strip loop iterates `Object.keys(allOutputs)`).
->   - **Code WARN (U+0085 regex gap)**: T1.2 input contract regex extended to `/[\x00-\x1f  ]/`.
->   - **Code WARN (RPC permission status)**: SC #26 accepts `r.status === 401 || r.status === 403 || r.status === 404` (PostgREST returns 404 for missing-EXECUTE on RPC).
->   - **Dreyer WARN #1 (bar-lookup-url ambiguous)**: T2.2 matched-state copy now interpolates `BAR_LOOKUP_URLS.CA.detail(bar_number)` (deep link); T2.2 no-match uses `BAR_LOOKUP_URLS.CA.base` (generic search). SC #41 NEW asserts both URL patterns appear in the right states.
->   - **Dreyer WARN #2 (fair-report-memo no public route)**: NEW T2.6 — create public-facing route at `src/app/legal/fair-report-privilege/page.tsx` that renders the T0b memo body (sanitized for public). T2.2 disclaimer uses absolute URL `https://imnotanattorney.com/legal/fair-report-privilege`. SC #42 NEW asserts the route file exists + renders.
->   - **Code WARN (test_run_id rule compliance)**: per `~/.claude/rules/drafts/test-isolation.md`, T3.1.2 fixture writes are exempt via marker `// test-isolation-justified: e2e fixture uses CV-allowlisted email pattern + sentinel eval_results + reaper safety net; test_run_id column not present in cases/orders schema in this branch yet (test-isolation infra is on a separate worktree)`. Marker added to test files; hook accepts.
-> - **Deferred to Phase 5 acceptance criteria** (documented in Out of Scope as known follow-ons, NOT silent drops):
->   - Code SUG (cleanup transactional): wrap DELETE-cases + DELETE-orders in single BEGIN/COMMIT block at execution time.
->   - Code SUG (SC #38 runtime verify): execution agent confirms migration apply success in addition to file-text grep.
->   - Code WARN (report_html construction): execution agent uses hand-crafted fixture HTML for the e2e UPL smoke (cheaper, isolates test scope to UPL gate, NOT producer fidelity); T2.4 caller-scope wiring is verified separately by SC #11 + #28 lint.
->   - Dreyer SUG (visual count callout): bold "{N} public discipline event(s) on file" prepended to attribution sentence at execution time.
->   - Dreyer SUG (DISCLAIMER 'CA' lint coupling): T4.5e adds at execution — Deno test asserts DISCLAIMER_VERBATIM hardcoded jurisdiction matches the SINGLE key in FAIR_REPORT_MEMO_PATHS.
-> - **Phase 5 begins now.** Plan converged enough; remaining items are execution-time polish, not architectural.
+> - **Next entry point:** re-spec-critic v2.2 → swarm round-0-v3 → if pristine, Phase 5 in worktree at `C:\Users\email\projects\_worktrees\worry-attorney-discipline`.
 
 ## Worry
 We loaded 1,842 California Bar attorneys and 3,417 attorney-discipline events into Supabase (PR shipped 2026-04-22 to 2026-04-24). The `attorneys` table is **populated but unread by product code** — the 91 occurrences of "attorney" in `playbook-configs.ts` and 280 in `generate-report` are all copy/labels referring to "your attorney," not table queries. Zero `from('attorneys')` or `from('attorney_discipline_events')` calls exist in `src/`. The IB Phase-2 intake (`src/app/intake/intelligence-brief/page.tsx:84`) collects `attorneyName` (required), but no surface JOINs that name against the bar tables.
@@ -106,509 +88,255 @@ No node loses (under exact-match-only rendering). Cascade-positive.
 ## Numbered Tasks (v2)
 
 ### T0 — Pre-implementation gates
-- **T0a (RLS + unaccent + match RPC migration)** — Create `supabase/migrations/20260425c_attorney_discipline_rls.sql` (renumbered from `20260425a` to dodge collision with PR #133):
+- **T0a (RLS migration)** — Create `supabase/migrations/20260425a_attorney_discipline_rls.sql`:
   ```sql
-  -- 1. Enable RLS deny-by-default. service_role bypasses RLS; no SELECT policy = no anon access.
   ALTER TABLE public.attorneys ENABLE ROW LEVEL SECURITY;
   ALTER TABLE public.attorney_discipline_events ENABLE ROW LEVEL SECURITY;
-
-  -- 2. Enable unaccent for Unicode-folded matching (José ↔ Jose ↔ JOSÉ).
-  --    Pin schema to `extensions` per Supabase convention (existing extensions
-  --    pg_trgm / pgcrypto / moddatetime / uuid-ossp all live there per
-  --    migrations/00001_initial_schema.sql:14-16). Without WITH SCHEMA, install
-  --    location varies across Supabase versions and the immutable_unaccent
-  --    wrapper below would fail with `dictionary "..." does not exist` at
-  --    index-build time.
-  CREATE EXTENSION IF NOT EXISTS unaccent WITH SCHEMA extensions;
-
-  -- 2a. Pre-flight smoke (Code CRIT #7 + Sec WARN). MUST succeed BEFORE the
-  --     index in step 3 fires the wrapper for the first time. If this fails,
-  --     the migration aborts and step 3 never runs.
-  DO $$
-  DECLARE folded text;
-  BEGIN
-    SELECT extensions.unaccent('extensions.unaccent', 'café') INTO folded;
-    IF folded <> 'cafe' THEN
-      RAISE EXCEPTION 'unaccent dictionary lookup failed: got % (expected ''cafe'')', folded;
-    END IF;
-  END $$;
-
-  -- 3. Functional index supports the case-folded + accent-folded equality lookup.
-  --    IMMUTABLE wrapper required because unaccent() is STABLE not IMMUTABLE by default,
-  --    and CREATE INDEX rejects non-IMMUTABLE expressions.
-  --    Body references the dictionary as `'extensions.unaccent'` (regdictionary
-  --    is schema-resolved at parse time; pinning the FQN is required because
-  --    SET search_path inside the function body cannot retroactively rebind a
-  --    regdictionary literal).
-  CREATE OR REPLACE FUNCTION public.immutable_unaccent(text) RETURNS text
-    LANGUAGE sql IMMUTABLE PARALLEL SAFE STRICT AS
-    $$ SELECT extensions.unaccent('extensions.unaccent', $1) $$;
-
-  CREATE INDEX IF NOT EXISTS idx_attorneys_jurisdiction_lower_unaccent_full_name
-    ON public.attorneys (jurisdiction, LOWER(public.immutable_unaccent(full_name)));
-
-  -- 3a. Future-proof RLS deny policies for FIXTURE-* rows (Sec SUG defense-in-depth).
-  --     These are no-ops today (RLS is already deny-by-default with no SELECT
-  --     policy) but stay in place if a future migration accidentally adds a
-  --     permissive `FOR SELECT TO anon USING (true)` policy. Postgres ANDs
-  --     policies, so this overlay survives accidentally-permissive additions.
-  CREATE POLICY deny_anon_test_fixtures_attorneys
-    ON public.attorneys FOR SELECT TO anon
-    USING (bar_number NOT LIKE 'FIXTURE-%');
-  CREATE POLICY deny_anon_test_fixtures_events
-    ON public.attorney_discipline_events FOR SELECT TO anon
-    USING (NOT EXISTS (
-      SELECT 1 FROM public.attorneys a
-      WHERE a.id = attorney_discipline_events.attorney_id
-        AND a.bar_number LIKE 'FIXTURE-%'
-    ));
-
-  -- 4. RPC for the match path. Returns the matched attorney row + their discipline events.
-  --    SECURITY DEFINER so the RPC runs as table owner (bypasses caller's RLS posture
-  --    consistently); explicit grant restricts who can CALL it.
-  CREATE OR REPLACE FUNCTION public.match_attorney(p_name text, p_jurisdiction text)
-  RETURNS TABLE (
-    attorney_id BIGINT,
-    bar_number TEXT,
-    full_name TEXT,
-    admission_date DATE,
-    current_status TEXT,
-    last_seen_at TIMESTAMPTZ,
-    match_count INTEGER
-  )
-  LANGUAGE sql
-  STABLE
-  SECURITY DEFINER
-  SET search_path = public, extensions
-  AS $$
-    WITH candidates AS (
-      SELECT id, bar_number, full_name, admission_date, current_status, last_seen_at
-      FROM public.attorneys
-      WHERE jurisdiction = p_jurisdiction
-        AND LOWER(public.immutable_unaccent(full_name))
-            = LOWER(public.immutable_unaccent(p_name))
-    ),
-    counted AS (SELECT COUNT(*)::int AS n FROM candidates)
-    -- Server-side ambiguity policy (Code SUG + Sec): when match_count > 1,
-    -- return ZERO rows. Caller now treats zero-rows uniformly as no-match
-    -- regardless of cause (no candidate vs ambiguous), eliminating the
-    -- comment-only "policy" that future callers would skip.
-    SELECT c.id, c.bar_number, c.full_name, c.admission_date,
-           c.current_status, c.last_seen_at, counted.n
-    FROM candidates c CROSS JOIN counted
-    WHERE counted.n = 1
-    LIMIT 1;
-  $$;
-
-  REVOKE ALL ON FUNCTION public.match_attorney(text, text) FROM PUBLIC;
-  GRANT EXECUTE ON FUNCTION public.match_attorney(text, text) TO service_role;
+  -- service_role bypasses RLS by default; no SELECT policy = no anon access.
+  -- Explicit deny-by-default is the posture.
   ```
-  Apply via Supabase Management API. Verify post-apply: (a) `relrowsecurity=t` on both tables, (b) anon SELECT returns `200 + []` (NOT 401 — RLS-blocked-anon = empty), (c) service-role `POST /rest/v1/rpc/match_attorney` with body `{"p_name":"José Smith","p_jurisdiction":"CA"}` returns rows when accent variant exists.
+  Apply via Management API. Verify anon-key SELECT returns 401 (not `[]`) post-apply.
 - **T0b (fair-report memo)** — Write `docs/legal/2026-04-25-attorney-discipline-fair-report-privilege.md` documenting CA Civ. Code § 47 coverage of accurate republication of CA State Bar discipline records inside our reports. Cite source: triangulated .01% media/defamation expert OR cached `~/.claude/experts/eugene-volokh.md` (TBD-triangulate if uncached). Reference memo path in section footer disclaimer (T2.3).
-- **T0c (sibling-PR pre-flight)** — Run `gh pr list --repo rahim0kapadia/ImNotAnAttorney-web --state open --json number,headRefName,files --limit 50` immediately BEFORE creating the worktree. Parse `files[].path` for any open PR. Abort with named conflict if ANY open PR's `files[]` contains:
-  - `supabase/functions/generate-report/index.ts` (the production renderer wired by T2.4 — sibling edits would silent-merge-conflict)
-  - `src/lib/intelligence-brief/prompts.ts` (re-exporting `BANNED_PHRASES_LIST` per T3.3)
-  - `src/lib/intelligence-brief/render.ts` (parallel dev mirror per T2.4 optional)
-  - `supabase/functions/generate-report/lib/banned-phrases-list.ts` (canonical T3.3 file, NEW v2.3)
-  - `supabase/migrations/20260425c_*.sql` or `supabase/migrations/20260425d_*.sql` (rename higher if taken)
-  Verified 2026-04-25 baseline: PR #102 (score) and PR #133 (NYPD CCRB depth) — neither touches the five blocking paths above. Re-run this check immediately before `git worktree add` to catch new sibling PRs opened between plan ship and execution.
-
-  **Race window (Code WARN #18)**: between `gh pr list` returning clean and `git worktree add` running, another session may open a PR. Mitigation: (a) wrap pre-flight + worktree-add in a single shell block running `gh pr list` → save JSON → `git worktree add` immediately (one operator action), (b) AFTER `git worktree add` completes, re-run pre-flight; if a new sibling PR appeared touching any blocking path, abort the worktree (`git worktree remove`) and surface to user. The artifact required by SC #25 is the BEFORE-worktree pre-flight JSON; SC #25b (NEW v2.3) requires an AFTER-worktree pre-flight JSON proving the post-creation race window held clean.
 
 ### T1 — DB layer (CA-only, exact match)
 - **T1.1** — Schema confirmed (per `supabase/migrations/20260422e_attorney_discipline.sql`):
   - `attorneys`: `(id BIGSERIAL, jurisdiction CHAR(2), bar_number TEXT, full_name TEXT, first_name TEXT, last_name TEXT, admission_date DATE, current_status TEXT, last_seen_at TIMESTAMPTZ, ...)`. UNIQUE `(jurisdiction, bar_number)`.
   - `attorney_discipline_events`: `(id BIGSERIAL, attorney_id BIGINT FK→attorneys, jurisdiction CHAR(2), bar_number TEXT, full_name TEXT, order_date DATE, effective_date DATE, discipline_type TEXT, discipline_raw TEXT, violation_summary TEXT, order_url TEXT, source_url TEXT, scraped_at TIMESTAMPTZ)`. UNIQUE `(jurisdiction, bar_number, order_date, discipline_type)`.
   - Note: there is NO column called `date`/`type`/`outcome`. Render template (T2.2) MUST use the literal column names: `order_date`, `discipline_type`, `violation_summary` (or `discipline_raw` as fallback for human-readable type), `order_url` (preferred for the bar-document link) with fallback to `source_url`. (Sec v2 CRIT #2.)
-- **T1.2** — Write Deno-compatible query helper at `supabase/functions/generate-report/lib/attorney-discipline.ts` (Deno-side, not src/lib) using raw `fetch` to PostgREST matching the `supabaseSelect()` pattern at `generate-report/index.ts:107`. Signature: `getAttorneyDiscipline(attorneyName: string, jurisdiction: string): Promise<{ attorney: AttorneyRow | null, events: DisciplineEvent[], status: 'matched' | 'no-match' }>`.
-  - **Jurisdiction guard via FAIR_REPORT_MEMO_PATHS map** (v2.3 — supersedes hard-coded `=== 'CA'`): see Match strategy below.
-  - **Input contract** (v2.3: ordering rationale documented + Unicode line separators + 'Not provided' added):
-    1. `trim()` whitespace.
-    2. **Reject all control chars + Unicode line/paragraph separators** (one regex, no redundant step): `/[\x00-\x1f  ]/` → return `no-match`. Single regex replaces the prior split. Regex content (v2.4 explicit codepoints): control chars `\x00-\x1f` AND `` (NEXT LINE — codepoint 0x85, OUTSIDE the `\x00-\x1f` range) AND ` ` (LINE SEPARATOR) AND ` ` (PARAGRAPH SEPARATOR). Code WARN v4: prior v2.3 regex had U+2028+U+2029 as literals but missed U+0085; v2.4 explicit codepoint enumeration closes the audit-log injection class fully.
-    3. Cap 200 chars (BEFORE garbage-name guard — see ordering note below).
-    4. Empty after sanitization → `no-match`.
-    5. Garbage-name guard via `isAttorneyNameRenderable()` (T2.3 helper, exported, single source of truth for both T1.2 entry and T2.4 renderer): predicate returns false (caller returns `no-match`) for empty / whitespace-only / `length<3` / no internal space (single-token like `'Smith'`) / matches `/^(n\/?a|none|tbd|unknown|skip|pending|asdf|test|not[ -]?provided)$/i` (note: `not[ -]?provided` catches the renderer's `'Not provided'` fallback at index.ts:5174 — Code WARN #14).
-  - **Ordering rationale (Code SUG)**: cap (step 3) deliberately runs BEFORE garbage-regex (step 5) because the regex is `^...$`-anchored and a 300-char `'A'.repeat(300)` is still single-token after trim (no spaces) so it falls into the no-space branch and returns `no-match` regardless of cap-vs-regex order. The cap is purely a defense-in-depth bound on payload size for downstream JSON serialization. SC #20 covers `'A'.repeat(300)` to verify ordering invariance.
-  - **Match strategy** (v2.3 corrected verbs + jurisdiction-memo coupling):
-    - Step A: `POST ${SUPABASE_URL}/rest/v1/rpc/match_attorney` (POST is correct for RPC) with `Authorization: Bearer ${service_role_key}` + `apikey: ${service_role_key}` headers and JSON body `{"p_name": <sanitized name>, "p_jurisdiction": "CA"}`. Response: array of rows. 0 rows = no candidate OR ambiguous (RPC enforces n=1 server-side); branch identical: `{ attorney: null, events: [], status: 'no-match' }`.
-    - Step B: 1 row returned → fetch discipline events via **GET** (not POST — POST against a table URL is INSERT, not SELECT, per Code CRIT #2): `GET ${SUPABASE_URL}/rest/v1/attorney_discipline_events?attorney_id=eq.${row.attorney_id}&order=order_date.desc.nullslast` matching the `supabaseSelect()` pattern at `generate-report/index.ts:107`. Return `{ attorney: row, events, status: 'matched' }`.
-  - **Why RPC, not raw `?ilike=`**: PostgREST cannot apply `LOWER(unaccent(...))` in a query-string `WHERE`. RPC moves the predicate into SQL where the functional index is usable. Side benefit: removes the wildcard-injection class entirely (`p_name` is a parameterized text arg, not a URL substring).
-  - **Jurisdiction–fair-report-memo coupling (Sec WARN)**: helper imports a `FAIR_REPORT_MEMO_PATHS` map from `attorney-discipline.ts`:
-    ```ts
-    export const FAIR_REPORT_MEMO_PATHS: Record<string, string> = {
-      CA: 'docs/legal/2026-04-25-attorney-discipline-fair-report-privilege.md',
-    };
-    ```
-    The jurisdiction guard is replaced with `if (!FAIR_REPORT_MEMO_PATHS[jurisdiction]) return { attorney: null, events: [], status: 'no-match' };`. Adding a new state to the allowlist requires creating its memo path entry in the SAME edit. Lint test (T4.5c) parses the file and asserts every key in `BAR_LOOKUP_URLS` (T2.3) has a matching key in `FAIR_REPORT_MEMO_PATHS`.
-  - **Structured no-match logging (Sec SUG)**: every silent no-match decision logs one structured JSON line to console (no PII):
-    ```ts
-    console.log(JSON.stringify({
-      component: 'attorney-discipline',
-      reason: 'jurisdiction-guard' | 'control-chars' | 'garbage-name'
-            | 'rpc-status-non-200' | 'rpc-error' | 'no-rows',
-      jurisdiction, name_length: name?.length ?? 0,
-    }));
-    ```
-    Edge Function logs are queryable in Supabase dashboard. Closes the silent-product-regression visibility gap.
-- **T1.3** — Synthetic test fixtures: create `supabase/migrations/20260425d_attorney_discipline_test_fixtures.sql` (renumbered from `20260425b` to dodge PR #133 collision) inserting all 7 fixture attorneys + their events using actual schema column names (`order_date`, `discipline_type`, `violation_summary`, `discipline_raw`, `order_url`, `source_url`):
+- **T1.1a (unaccent + expression index)** — Code v2 WARN #7. Create `supabase/migrations/20260425c_attorney_unaccent.sql`:
   ```sql
-  INSERT INTO public.attorneys
-    (jurisdiction, bar_number, full_name, first_name, last_name, admission_date, current_status, last_seen_at)
+  CREATE EXTENSION IF NOT EXISTS unaccent;
+  -- IMMUTABLE wrapper required because unaccent() is STABLE and indexes need IMMUTABLE.
+  -- The wrapper pins to the default 'unaccent' dictionary so behavior matches the index.
+  -- NOTE: the two-arg unaccent() form is unaccent(regdictionary, text) — the dictionary
+  -- name MUST be cast to regdictionary explicitly (otherwise overload resolution picks the
+  -- single-arg form OR errors out on apply).
+  CREATE OR REPLACE FUNCTION public.immutable_unaccent(text)
+    RETURNS text LANGUAGE sql IMMUTABLE PARALLEL SAFE STRICT AS
+    $$ SELECT public.unaccent('public.unaccent'::regdictionary, $1) $$;
+  CREATE INDEX IF NOT EXISTS idx_attorneys_full_name_norm
+    ON public.attorneys (jurisdiction, lower(public.immutable_unaccent(full_name)))
+    WHERE full_name IS NOT NULL;
+  ```
+  (Sec v4 WARN: `WHERE full_name IS NOT NULL` predicate keeps the index lean — NULL `full_name` rows aren't matchable anyway, no point indexing them.)
+  Apply via Supabase Management API (`POST /v1/projects/<ref>/database/query`). **Migration role posture (spec-critic CRITICAL):** all migrations apply as the `postgres` superuser role via the Management API, which BYPASSES RLS. T0a's RLS enable + T1.3 fixture INSERT + T1.1a index build all succeed for this reason. Document explicitly so reviewers don't flag the T0a→T1.3 ordering. Verify post-apply: `EXPLAIN SELECT * FROM attorneys WHERE jurisdiction='CA' AND lower(immutable_unaccent(full_name)) = 'jose garcia'` shows index usage. citext was rejected because case-fold is unrelated to diacritic-fold (`José` vs `Jose` is a unaccent problem, not a casefold problem).
+- **T1.2** — Write Deno-compatible query helper at `supabase/functions/generate-report/lib/attorney-discipline.ts` (Deno-side, not src/lib) using raw `fetch` to PostgREST matching the `supabaseSelect()` pattern at `generate-report/index.ts:107`. Signature: `getAttorneyDiscipline(attorneyName: string, jurisdiction: string): Promise<{ attorney: AttorneyRow | null, events: DisciplineEvent[], status: 'matched' | 'no-match' }>`.
+  - **Jurisdiction guard** (Sec v2 SUG #5): hard-code `if (jurisdiction !== 'CA') return { attorney: null, events: [], status: 'no-match' };` at function entry. Defense-in-depth so v2's CA-only fair-report scope is enforced in code, not only in plan prose. TODO comment names the per-state-memo gate (T0b extension) for future state additions.
+  - **Input contract** (Sec v1 CRIT #2 + Sec v2 WARN #3 + Code v2 WARN #9 + Sec v3 WARN reorder + Code v3 + Sec v3 CRITICAL — drop JS shim + Sec v4 WARN null-bypass): apply IN ORDER:
+    0. **Type gate (Sec v4 WARN)** — `if (typeof attorneyName !== 'string') return no-match;`. Closes the JS-coercion path where `String(null)` produces `"null"` (4 chars, no whitespace) and bypasses the empty-after-sanitize gate.
+    1. `trim()` whitespace
+    2. Collapse interior whitespace via `replace(/\s+/g, ' ')` (catches `"n a"`, `"t b d"` bypasses identified by Sec v3).
+    3. **Garbage-input gate (Code v2 WARN #9 + Sec v3 WARN ordering + Sec v4 WARN null-literal)** — return `no-match` (don't even reach the DB) if input matches any of:
+       - Length < 3
+       - No whitespace character (single-token "FirstLast" → most placeholder inputs are tokens)
+       - Matches case-insensitive regex `/^(asdf|qwerty|test|n\s*\/?\s*a|none|na|null|undefined|tbd|tbc|x{2,}|z{2,})$/i`
+       Limitation note (Code v4 WARN): multi-token garbage like `"asdf foo"` passes this gate and reaches the DB. That is a harmless DB roundtrip (returns no-match), not a security defect. T1.4 garbage-input assertion is scoped to single-token inputs only; the test expectation states "fetch is invoked at most 0 times for single-token inputs, at most 1 time and returns 0 rows for multi-token garbage."
+    4. Reject (return `no-match`) on control characters: `/[\r\n\x00]/`.
+    5. Reject (return `no-match`) on PostgREST-special chars: `/[*%_,():.]/` — `*` and `%` are wildcards in PostgREST `ilike` (`"Smith*"` would silently match all Smith-prefixed names → defamation surface). `,()` are PostgREST filter separators. `:` is PostgREST operator delimiter. `_` is SQL LIKE single-char wildcard. `.` is reserved in PostgREST identifiers.
+    6. Cap 200 chars after sanitization.
+    7. Empty after sanitization → return `no-match`.
+    > **NO JS-side normalization** (Code v3 CRITICAL + Sec v3 CRITICAL). Earlier v2.2 draft had `s.normalize('NFD').replace(/\p{M}/gu, '').toLowerCase()` as a "JS unaccent shim." That shim diverges from Postgres `unaccent()` for precomposed-only Latin extensions: `Ł→L`, `Ø→O`, `Æ→AE`, `Ð→D`, `Þ→Th`, `ß→ss`, `đ→d` — JS leaves them intact, Postgres folds them. Asymmetric divergence creates a defamation surface (defendant input `Søren` matches stored `Soren` one direction but not the other). Fix: **drop the JS shim entirely**; pass the trimmed/sanitized RAW input to the RPC; let Postgres apply `lower(immutable_unaccent($1))` on BOTH sides of the equality. Single source of truth, zero divergence.
+  - **Match strategy** (Code v2 WARN #7 + revised v3): use a **PostgREST stored RPC**: define `public.attorney_match_by_raw_name(jur text, raw_name text)` returning `setof attorneys`. Helper calls `POST /rest/v1/rpc/attorney_match_by_raw_name` with body `{ "jur": "CA", "raw_name": "<sanitized raw input>" }`. NEVER string-concat into URL or body; use `JSON.stringify` for body and `URLSearchParams` for any query args. RPC + expression-index match yields O(log n), case- and accent-insensitive via Postgres `unaccent`, with `ilike` entirely avoided (no wildcard surface).
+  - **RPC migration (T1.1a addendum)**: append the function definition to `20260425c_attorney_unaccent.sql`:
+    ```sql
+    CREATE OR REPLACE FUNCTION public.attorney_match_by_raw_name(jur text, raw_name text)
+      RETURNS SETOF public.attorneys LANGUAGE sql STABLE SECURITY INVOKER AS
+      $$ SELECT * FROM public.attorneys
+         WHERE jurisdiction = jur
+           AND lower(public.immutable_unaccent(full_name))
+             = lower(public.immutable_unaccent(raw_name)) $$;
+    REVOKE ALL ON FUNCTION public.attorney_match_by_raw_name(text, text) FROM PUBLIC, anon, authenticated;
+    GRANT EXECUTE ON FUNCTION public.attorney_match_by_raw_name(text, text) TO service_role;
+    ```
+    `SECURITY INVOKER` + `service_role`-only `EXECUTE` keeps RLS posture: anon cannot call the RPC (PostgREST returns 404 for un-EXECUTE-able functions), only the Edge Function (running as service_role) can. **Extension namespace verify (Code v3 SUG):** Supabase typically installs `unaccent` into the `extensions` schema, NOT `public`. Run `SELECT n.nspname FROM pg_extension e JOIN pg_namespace n ON e.extnamespace=n.oid WHERE e.extname='unaccent'` post-CREATE; if `extensions`, change all `public.unaccent` references in `immutable_unaccent` body and the regdictionary cast to `extensions.unaccent` / `'extensions.unaccent'::regdictionary`. Index/RPC signatures unchanged.
+  - **Ambiguous match handling** (Code v1 WARN #15): if >1 row returned, return `status: 'no-match'` (treat as ambiguous → no render). Disambiguation is out of v2 scope.
+- **T1.3 (CLEAN fixtures only — Sec v3 CRITICAL #2 — NEVER seed live exploit strings into prod tables)** — Synthetic test fixtures stay STRICTLY non-hostile when seeded via the migration system. Hostile-input testing (XSS, pipe-shred) is done at TEST TIME by the test inserting/restoring rows in a transaction it rolls back, OR by passing hostile values directly to the render builder (in-memory) without DB round-trip.
+  Create `supabase/migrations/20260425b_attorney_discipline_test_fixtures.sql` inserting ONLY clean rows:
+  ```sql
+  INSERT INTO public.attorneys (jurisdiction, bar_number, full_name, first_name, last_name, admission_date, current_status, last_seen_at)
   VALUES
-    ('CA', 'FIXTURE-001', 'Fixture Cleanrecord',  'Fixture', 'Cleanrecord',  '2010-01-15', 'active',     '2026-04-25 00:00:00+00'),
-    ('CA', 'FIXTURE-002', 'Fixture Disciplined',  'Fixture', 'Disciplined',  '2005-06-20', 'suspended',  '2026-04-25 00:00:00+00'),
-    ('CA', 'FIXTURE-003', 'Fixture Cleanrecord',  'Fixture', 'Cleanrecord',  '2012-08-10', 'active',     '2026-04-25 00:00:00+00'),  -- ambiguous duplicate of -001 (same full_name)
-    ('CA', 'FIXTURE-004', 'Fixture Hostile',      'Fixture', 'Hostile',      '2008-04-01', 'suspended',  '2026-04-25 00:00:00+00'),
-    ('CA', 'FIXTURE-005', 'Fixture Pipechar',     'Fixture', 'Pipechar',     '2008-04-01', 'suspended',  '2026-04-25 00:00:00+00'),
-    ('CA', 'FIXTURE-006', 'José García',          'José',    'García',       '2014-09-01', 'active',     '2026-04-25 00:00:00+00'),  -- accented (T4.5a forward direction)
-    ('CA', 'FIXTURE-007', 'Jose Garcia',          'Jose',    'Garcia',       '2014-09-01', 'active',     '2026-04-25 00:00:00+00'),  -- ASCII (T4.5a reverse direction)
-    ('CA', 'FIXTURE-008', 'Fixture Pipeedge',     'Fixture', 'Pipeedge',     '2008-04-01', 'suspended',  '2026-04-25 00:00:00+00');  -- pipe-edge case fixture (Sec SUG)
-
-  -- DISCIPLINED multi-event (FIXTURE-002, count = 2)
-  INSERT INTO public.attorney_discipline_events
-    (attorney_id, jurisdiction, bar_number, full_name, order_date, discipline_type, violation_summary, discipline_raw, order_url, source_url)
-  SELECT id, 'CA', bar_number, full_name, '2018-03-12'::date, 'Suspension', '90-day suspension stayed pending probation', '90-day suspension stayed', 'https://example.com/fixture-002-order-1', 'https://example.com/fixture-002-source-1'
-    FROM public.attorneys WHERE bar_number = 'FIXTURE-002';
-  INSERT INTO public.attorney_discipline_events
-    (attorney_id, jurisdiction, bar_number, full_name, order_date, discipline_type, violation_summary, discipline_raw, order_url, source_url)
-  SELECT id, 'CA', bar_number, full_name, '2020-11-04'::date, 'Reproval', 'Failure to communicate with client', 'public reproval', 'https://example.com/fixture-002-order-2', 'https://example.com/fixture-002-source-2'
-    FROM public.attorneys WHERE bar_number = 'FIXTURE-002';
-
-  -- HOSTILE-INPUT (FIXTURE-004, single event, XSS payloads embedded so render-time escaping is testable end-to-end)
-  INSERT INTO public.attorney_discipline_events
-    (attorney_id, jurisdiction, bar_number, full_name, order_date, discipline_type, violation_summary, discipline_raw, order_url, source_url)
-  SELECT id, 'CA', bar_number, full_name, '2019-07-22'::date, '<script>alert(1)</script>', 'Failure & misappropriation <evil>', 'misappropriation', 'javascript:alert(1)', 'https://example.com/fixture-004-source'
-    FROM public.attorneys WHERE bar_number = 'FIXTURE-004';
-
-  -- PIPE-CHAR (FIXTURE-005, raw markdown-pipe in cell values — covers escapeMarkdownPipe path)
-  INSERT INTO public.attorney_discipline_events
-    (attorney_id, jurisdiction, bar_number, full_name, order_date, discipline_type, violation_summary, discipline_raw, order_url, source_url)
-  SELECT id, 'CA', bar_number, full_name, '2017-02-08'::date, 'Suspension | 90 days', 'Failure to file | client funds | trust account', '90-day suspension', 'https://example.com/fixture-005-order', 'https://example.com/fixture-005-source'
-    FROM public.attorneys WHERE bar_number = 'FIXTURE-005';
-
-  -- PIPE-EDGE (FIXTURE-008, multiple consecutive pipes + literal backslash-pipe — Sec SUG)
-  INSERT INTO public.attorney_discipline_events
-    (attorney_id, jurisdiction, bar_number, full_name, order_date, discipline_type, violation_summary, discipline_raw, order_url, source_url)
-  SELECT id, 'CA', bar_number, full_name, '2016-05-15'::date, '\|', '|||', 'edge case', 'https://example.com/fixture-008-order', 'https://example.com/fixture-008-source'
-    FROM public.attorneys WHERE bar_number = 'FIXTURE-008';
+    ('CA', 'FIXTURE-001', 'Fixture Cleanrecord', 'Fixture', 'Cleanrecord', '2010-01-15', 'active',    '2026-04-25T00:00:00Z'),
+    ('CA', 'FIXTURE-002', 'Fixture Disciplined', 'Fixture', 'Disciplined', '2005-06-20', 'suspended', '2026-04-25T00:00:00Z'),
+    ('CA', 'FIXTURE-003', 'Fixture Cleanrecord', 'Fixture', 'Cleanrecord', '2012-09-10', 'active',    '2026-04-25T00:00:00Z'); -- duplicate full_name → ambiguous-match probe
+  INSERT INTO public.attorney_discipline_events (attorney_id, jurisdiction, bar_number, full_name, order_date, discipline_type, discipline_raw, violation_summary, order_url, source_url, scraped_at)
+  SELECT a.id, 'CA', a.bar_number, a.full_name, e.order_date, e.discipline_type, e.discipline_raw, e.violation_summary, e.order_url, e.source_url, '2026-04-25T00:00:00Z'
+  FROM public.attorneys a
+  CROSS JOIN LATERAL (VALUES
+    ('FIXTURE-002', DATE '2018-03-12', 'Suspension', 'SUSPENSION 90D STAYED', '90-day suspension stayed', 'https://example.com/fixture-002-evt-1', 'https://example.com/fixture-002-source'),
+    ('FIXTURE-002', DATE '2020-07-01', 'Probation',  'PROBATION 1Y',          '1-year probation imposed', 'https://example.com/fixture-002-evt-2', 'https://example.com/fixture-002-source')
+  ) AS e(bar, order_date, discipline_type, discipline_raw, violation_summary, order_url, source_url)
+  WHERE a.bar_number = e.bar AND a.jurisdiction='CA';
   ```
-  Test-only marker: bar_numbers all start with `FIXTURE-`. T0a's `deny_anon_test_fixtures_*` policies (added v2.3) keep them invisible to anon SELECT even if a future migration adds a permissive policy.
-- **T1.4** — Deno unit tests at `supabase/functions/generate-report/__tests__/attorney-discipline.test.ts`. **Pinned runner + explicit file list** (Code WARN #4 + WARN #13):
-  ```
-  deno test \
-    --allow-env=SUPABASE_URL,SUPABASE_SERVICE_ROLE_KEY,SUPABASE_ANON_KEY,ANTHROPIC_API_KEY,RESEND_API_KEY \
-    --allow-net=jxjbjmgdukwkoclydqdr.supabase.co,api.anthropic.com \
-    supabase/functions/generate-report/__tests__/attorney-discipline.test.ts \
-    supabase/functions/generate-report/__tests__/upl-regex-panel.test.ts \
-    supabase/functions/generate-report/__tests__/attorney-discipline-guard.test.ts \
-    supabase/functions/generate-report/__tests__/render-attorney-discipline-lint.test.ts \
-    supabase/functions/generate-report/__tests__/attorney-discipline-fair-report-paths.test.ts \
-    supabase/functions/generate-report/__tests__/attorney-discipline-common-name.test.ts \
-    supabase/functions/__tests__/rls-attorney-discipline.test.ts
-  ```
-  Specific file list (NOT directory glob) avoids collision with the existing vitest test at `supabase/functions/generate-report/__tests__/no-mandatory-min-fallback.test.ts` which `import { describe, it, expect } from 'vitest'` and would fail under Deno. Explicit `--allow-env` allowlist (Sec WARN service-role key leak) makes the secret surface auditable; `--allow-net` allowlist pins the only two outbound hosts the tests need. The Node-side `BANNED_PHRASES_LIST` parity test in T3.2 is a SEPARATE Node-side vitest under `src/lib/intelligence-brief/__tests__/`.
+  Mark fixtures as test-only via comment + RLS policy `WHERE bar_number NOT LIKE 'FIXTURE-%'` for any future anon-readable view (future-proof). `FIXTURE_DISCIPLINED_EVENT_COUNT = 2`.
 
-  **Test coverage** (each as own `Deno.test()` block):
-  - matched-clean (`FIXTURE_CLEAN_BAR_NUMBER`)
-  - matched-disciplined-multi-event (`FIXTURE_DISCIPLINED_BAR_NUMBER`)
-  - no-match (`'Zzzzz Nonexistent'`)
-  - ambiguous (RPC server-side now returns 0 rows when n>1 per T0a `WHERE counted.n = 1`; test verifies behavior matches `no-match` shape; no fetch to events endpoint occurs)
-  - garbage-name skip 8-input matrix (per SC #20)
-  - control-character input (`"\r\nSmith"`, `" John"`, `"Doe"`)
-  - 300-char input (`'A'.repeat(300)` — SC #20 cap-vs-regex ordering invariance)
-  - unaccent forward (`'Jose Garcia'` returns FIXTURE-006 with `full_name='José García'`)
-  - unaccent reverse (`'José García'` returns FIXTURE-007 with `full_name='Jose Garcia'`)
-  - jurisdiction guard (`getAttorneyDiscipline('Anyone', 'NY')` returns no-match without ANY fetch)
-  - injection input (`"' OR 1=1 --"` returns no-match without error)
-
-  Mock `fetch` via test-scoped `globalThis.fetch` override; assert exact request URL (HTTP verb included — GET vs POST per Code CRIT #2), body shape, and that no fetch is made when garbage-name guard or jurisdiction guard fires (`fetch.mock.calls.length === 0`).
-
-  **Failure-message redaction (Sec WARN service-role key leak)**: the test file's top-level `safeFetch` wrapper redacts `Bearer [^\s"']+` patterns from any thrown error. Pattern:
+  **In-memory hostile fixture (T4.4 / criterion 10)** — hostile values (`<script>`, `javascript:`, pipe-shred) are passed DIRECTLY to `buildAttorneyDisciplineSection()` in the test as in-memory `DisciplineEvent` objects. NO DB write required:
   ```ts
-  const REDACT_PATTERNS: Array<[RegExp, string]> = [
-    [/Bearer [^\s"',;]+/g, 'Bearer [REDACTED]'],
-    [/apikey[:=][\s]*[^\s,;}\)"']+/gi, 'apikey: [REDACTED]'],
-    [/eyJhbGc[A-Za-z0-9._-]+/g, '[REDACTED-JWT]'],
-  ];
-  const redact = (s: string): string =>
-    REDACT_PATTERNS.reduce((acc, [re, sub]) => acc.replace(re, sub), s);
-  const safeFetch = async (url: string, init?: RequestInit) => {
-    try { return await fetch(url, init); }
-    catch (e) {
-      if (e instanceof Error) e.message = redact(e.message);
-      throw e;
-    }
+  const hostileEvent: DisciplineEvent = {
+    order_date: '2024-01-15',
+    discipline_type: '<script>alert(1)</script>',
+    discipline_raw: 'XSS RAW',
+    violation_summary: 'alert | <script>',
+    order_url: 'javascript:alert(1)',
+    source_url: 'javascript:alert(2)',
   };
+  const html = renderAttorneyDisciplineSection({ status: 'matched', attorney: hostileAttorney, events: [hostileEvent] });
+  // panel + per-fixture assertions on `html` — never persists.
   ```
-  v2.4 fix per Sec CRIT #2: redact extended beyond just `Bearer` to also catch `apikey:` header form (PostgREST sends both `Authorization: Bearer ...` AND `apikey: ...` with the service-role key — only redacting one was insufficient) AND any JWT-prefix substring (`eyJhbGc`) wherever it appears. Used for all real-network calls.
+  This eliminates the round-0-v3 attack surface where future surfaces (Slack notifier, admin email, CSV export, ops dashboard) could fetch the live FIXTURE-004 row over the service-role key and emit raw `<script>` without going through `cell()`.
+- **T1.3a (fixtures.ts module — spec-critic CRITICAL)** — Create `supabase/functions/generate-report/__tests__/fixtures.ts` exporting all constants the test suite + Success-Criteria assertions reference:
+  ```ts
+  export const FIXTURE_CLEAN_BAR_NUMBER = 'FIXTURE-001';
+  export const FIXTURE_CLEAN_ATTORNEY_NAME = 'Fixture Cleanrecord';
+  export const FIXTURE_DISCIPLINED_BAR_NUMBER = 'FIXTURE-002';
+  export const FIXTURE_DISCIPLINED_ATTORNEY_NAME = 'Fixture Disciplined';
+  export const FIXTURE_DISCIPLINED_EVENT_COUNT = 2;
+  export const FIXTURE_AMBIGUOUS_BAR_NUMBER = 'FIXTURE-003';
+  export const FIXTURE_HOSTILE_BAR_NUMBER = 'FIXTURE-004';
+  export const FIXTURE_HOSTILE_ATTORNEY_NAME = 'Fixture Hostile';
+  // Re-export from render-attorney-discipline.ts so tests don't import twice:
+  export { NO_MATCH_MESSAGE, DISCLAIMER_VERBATIM } from '../lib/render-attorney-discipline.ts';
+  // CA Bar lookup base URL — used in success criterion #6 (panel check).
+  export const CA_BAR_LOOKUP_BASE = 'https://apps.calbar.ca.gov/attorney/Licensee/Detail/';
+  ```
+  No logic, just constants + re-exports. Single source of truth for every fixture identifier referenced in T1.4, T3.1, T3.2, T4.4, and Success Criteria 4-13.
+- **T1.4** — Unit test in `supabase/functions/generate-report/__tests__/attorney-discipline.test.ts`. **Runner pinned (Code v2 WARN #4 + Code v3 WARN clarity):** `deno test --allow-net --allow-env --no-check=remote supabase/functions/generate-report/__tests__/attorney-discipline.test.ts`. Use Deno's BUILT-IN `Deno.test(name, fn)` global API directly — zero std imports needed. (Earlier v2.2 wording mixed `Deno.test` with `std/testing/bdd.ts` describe/it — incoherent. Pick one. We pick the built-in.) NOT vitest, NOT node:test — those break in Deno's runtime. Cover: matched-clean, matched-disciplined, no-match, ambiguous (`FIXTURE-003` shares full_name with `FIXTURE-001`), injection input (`"' OR 1=1 --"` returns no-match, no error), control-character input, **garbage input (`asdf`, `n/a`, `n a`, `xx`, single-token `Bob`, length<3) returns no-match without DB call** (mock fetch and assert it's never invoked), **diacritic-input (`José García` matches stored `Jose Garcia` via Postgres unaccent — and Postgres-only because we dropped the JS shim per Code v3 CRITICAL; this test exercises the live RPC, NOT a JS-side normalization)**, **non-NFD-decomposable diacritic-input (`Søren Larsen` matches stored `Soren Larsen`; `Nguyễn Đức` matches `Nguyen Duc`) — proves the JS-shim divergence Sec v3 CRITICAL flagged is closed**.
 
 ### T2 — IB section (mechanical render only)
 - **T2.1** — New file: `supabase/functions/generate-report/lib/section-anchors.ts` (Deno-side, NOT `src/lib/...` — Code v2 CRIT #2: src/lib is import-orphaned in Deno runtime). Export `IB_SECTION_ANCHORS = { ... }` with literal H2 heading strings used by the production IB renderer at `supabase/functions/generate-report/index.ts:7322` (`renderIBReportHtml`, sections array at lines 7429-7450). Read existing strings from `index.ts:7429-7450` and from each `buildXxx()` static appendix builder, pin them here. The Edge Function renderer + Deno-side tests both import from this file. Optional parallel mirror at `src/lib/intelligence-brief/section-anchors.ts` for Node-side dev tools (`scripts/test-ib-pipeline.ts`, `render-ib-test.mjs`) with a parity test (mirror pattern from `src/lib/report/__tests__/whitelist-parity.test.ts`).
-- **T2.2** — New section builder in `supabase/functions/generate-report/lib/render-attorney-discipline.ts` (Deno-side, factual mechanical render). Inputs: result of T1.2. Outputs: markdown string (NOT raw HTML — see T2.3a). Heading is always `## Attorney Bar Record Check` (markdown, SUG #12).
-
-  **`last_seen_at` format (SUG #13):** render as short date `YYYY-MM-DD`, never raw timestamptz. Helper: `formatShortDate(ts: string | null): string` returning `new Date(ts).toISOString().slice(0,10)` or `'unknown'` for null. Applied wherever the spec below says `{last_seen_at}`.
-
-  **`admission_date` years-of-practice:** compute via `Math.floor((Date.now() - admission_date) / (365.25 * 24 * 60 * 60 * 1000))` and display as integer.
-
-  **Disclaimer (Atti voice + UPL-safe + methodology proof, Dreyer WARN #2 v3 + WARN #1 v4 disambiguation):**
-  `DISCLAIMER_VERBATIM` is built per-call (NOT a single constant) because it interpolates `bar_number` + pull date. The disclaimer template lives at `attorney-discipline-disclaimer.ts`:
-  ```ts
-  export const buildDisclaimer = (barNumber: string, pullDate: string): string =>
-    `CA State Bar #${barNumber} — pulled from the official State Bar discipline registry on ${pullDate}. Public record. You can pull it yourself at ${BAR_LOOKUP_URLS.CA.detail(barNumber)}; we pulled it as part of every CA Intelligence Brief.`;
-  export const DISCLAIMER_TEMPLATE_VERBATIM = `CA State Bar #{bar_number} — pulled from the official State Bar discipline registry on {pull_date}. Public record. You can pull it yourself at {bar_lookup_detail_url}; we pulled it as part of every CA Intelligence Brief.`;
-  ```
-  v2.4 fix per Dreyer WARN #1: matched-state interpolations explicitly use `BAR_LOOKUP_URLS.CA.detail(bar_number)` (deep link to that licensee — preserves "we pulled it" methodology proof). The DISCLAIMER_TEMPLATE_VERBATIM string with placeholders is what T3.2 + T3.4 BANNED_PHRASES tests assert against (substituted-out form would have variable bar numbers, breaking deterministic comparison).
-
-  States:
-  - **`matched` + `current_status='active'` + `events.length === 0`:**
+- **T2.2** — New section builder in `supabase/functions/generate-report/lib/render-attorney-discipline.ts` (Deno-side, factual mechanical render). Inputs: result of T1.2. Outputs: markdown string (NOT HTML; flows through `markdownToHtml` per T2.3a). Helper `formatShortDate(d) = new Date(d).toISOString().slice(0,10)` returns `YYYY-MM-DD` or `'unknown'` on `NaN` (Code v2 SUG #13 — never render raw timestamptz). **Render-order rule (Dreyer v3 SUG):** trust-signal headline FIRST, status second, admission year third, detail last. Crisis-buyer hierarchy = answer-first, evidence-second.
+  - **`matched` + `current_status='active'` + `events.length === 0` (Dreyer v3 WARN + Dreyer v4 CRIT — drop years-of-practice INAA-vouching):**
     ```
-    ## Attorney Bar Record Check
-
-    **Status (per CA State Bar as of {safeCell(last_seen_at-date)}):** Active
-    **Licensed in CA since {safeCell(YYYY)}** — {N} years of practice
-    **Public discipline record:** none on file.
-
-    {DISCLAIMER_VERBATIM}
-
-    [Why we can show this](https://imnotanattorney.com/legal/fair-report-privilege)
+    **Clean public record per the {stateBarName} — no discipline events on file.**
+    Status (per {stateBarName} as of {formatShortDate(last_seen_at)}): Active
+    Licensed in {jurisdiction} since {YYYY of admission_date} (per {stateBarName}).
+    Verify yourself: {bar-lookup-url-with-bar-number}
     ```
-  - **`matched` + `events.length >= 1`:**
+    Dreyer v4 CRIT: drop "— N years of practice" (INAA editorializing the credential = vouching for the attorney = UPL surface). Years arithmetic stays out of the render. The defendant came suspicious; we don't editorialize.
+  - **`matched` + `events.length >= 1` (Dreyer v4 SUG — singular/plural conditional):**
     ```
-    ## Attorney Bar Record Check
-
-    **Status (per CA State Bar as of {safeCell(last_seen_at-date)}):** {safeCell(current_status)}
-    **Licensed in CA since {safeCell(YYYY)}** — {N} years of practice
-
-    The CA State Bar's public registry lists {events.length} discipline event(s) on this licensee's record:
-
+    **Public discipline record on file with the {stateBarName} ({events.length === 1 ? '1 event' : `${events.length} events`}).**
+    Status (per {stateBarName} as of {formatShortDate(last_seen_at)}): {current_status}
+    Licensed in {jurisdiction} since {YYYY of admission_date} (per {stateBarName}).
     | Date | Type | Summary | Source |
     |------|------|---------|--------|
-    | {safeCell(formatShortDate(order_date))} | {safeCell(discipline_type)} | {safeCell(violation_summary \|\| discipline_raw)} | [CA Bar order]({safeHttpUrl(order_url \|\| source_url)}) |
-
-    {DISCLAIMER_VERBATIM}
-
-    [Why we can show this](https://imnotanattorney.com/legal/fair-report-privilege)
+    | {cell(formatShortDate(order_date))} | {cell(discipline_type)} | {cell(violation_summary || discipline_raw)} | [CA Bar order]({safeHttpUrl(order_url || source_url)}) |
     ```
-    Column-name source per T1.1: `order_date`, `discipline_type`, `violation_summary` (fallback to `discipline_raw`), `order_url` (fallback to `source_url`). EVERY interpolation MUST flow through one of: `safeCell()` (free text), `safeHttpUrl()` (URLs), `formatShortDate()` (dates), or be a literal/structural template piece. The neutral framing sentence "The CA State Bar's public registry lists..." (Dreyer SUG) attributes the data to the State Bar's registry rather than INAA's editorial choice — keeps the section pro-defendant-not-anti-attorney.
-  - **`no-match` (RPC returned 0 rows: includes ambiguous-match collapsed server-side):**
+    `cell(s)` is the composition `escapeHtml(escapeMarkdownPipe(s))` — pipe-escape FIRST (so the cell stays one cell), HTML-escape SECOND (defangs `<` `>` `&` `"` `'`). See T2.3 + T2.3a. Column-name source per T1.1: `order_date`, `discipline_type`, `violation_summary` (fallback to `discipline_raw`), `order_url` (fallback to `source_url`). All four free-text columns (`discipline_type`, `discipline_raw`, `violation_summary`, plus `formatShortDate(order_date)` for safety even though it's a DATE) flow through `cell()`. (Sec v2 CRIT #2 + Code v2 WARN #6.)
+    Footer disclaimer (Atti voice — UPL-safe — Dreyer v4 WARN rewrite): "Public {stateBarName} record. Same data, faster than the .gov form: {bar-lookup-url}." Drops "Saved you the lookup" (read cute/dismissive on a discipline section); replaces with insider-Atti speed-of-access framing.
+
+    Footnote (separate paragraph, smaller font / muted color in CSS): "[Public record — here's why we can show it]({fair-report-memo-url})" (Dreyer v3 SUG). Link target is the deployed URL of `docs/legal/2026-04-25-attorney-discipline-fair-report-privilege.md`.
+  - **`no-match` (includes ambiguous-match) — Dreyer v3 CRITICAL rewrite (lead with reassurance, not negative):**
     ```
-    ## Attorney Bar Record Check
-
-    No exact match for "{safeCell(attorney_name)}" in the California State Bar's public roster.
-
-    We only render bar records on exact name match — fuzzy matching against an attorney's identity is how false accusations happen, and we don't ship that. If the spelling on the State Bar's roster differs from what was entered (initials, hyphenation, married name), the lookup link below resolves it in one click.
-
-    [California State Bar attorney lookup →]({BAR_LOOKUP_URLS.CA.base})
+    We couldn't match "{cell(attorney_name)}" to a {stateBarName} record. Most often this is a spelling difference, or your attorney is barred in another state. It does NOT mean they're unlicensed. Try the official lookup yourself: {bar-lookup-url}
     ```
-    No-match copy (Dreyer WARN #1 v3) reframes the limitation as INAA's deliberate methodology, NOT a user error. Removes "verify spelling and bar admission state" (burden-shifting per brand-voice.md DO-NOT list). Uses `bar-lookup-base-url` (no bar_number — defendant doesn't know it).
-- **T2.3** — Helpers in the Deno-side `render-attorney-discipline.ts` file (Deno cannot import from `src/lib/intelligence-brief/render.ts` which imports from `../email`):
-  - `escapeHtml(s: string): string` — 5-line, covers `& < > " '`
-  - `safeHttpUrl(u: string | null | undefined): string` — explicit null guard FIRST: `if (!u) return '#'`; then return `u` if matches `/^https?:\/\//i` else `'#'`
-  - `escapeMarkdownPipe(s: string): string` — `s.replace(/\|/g, '\\|')` (Code WARN #6)
-  - `formatShortDate(ts: string | null | undefined): string` — **explicit null/undefined guard FIRST** (Code WARN #11): `if (!ts) return 'unknown'; const d = new Date(ts); if (isNaN(d.getTime())) return 'unknown'; return d.toISOString().slice(0,10);`. Closes the silent `1970-01-01` leak from `new Date(null) || ...`.
-  - `safeCell(v: string | null | undefined): string` — **canonical interpolation gate (Sec CRIT #1)**: `escapeMarkdownPipe(escapeHtml(String(v ?? '')))`. EVERY defendant-supplied AND scraper-fed free-text value in the rendered output flows through this single helper. Lint test (T4.4b) regex-greps `render-attorney-discipline.ts` for any `${...}` inside a markdown table cell or copy block that does NOT route through `safeCell` / `safeHttpUrl` / `formatShortDate` and fails the build.
-  - `isAttorneyNameRenderable(name: string | null | undefined): boolean` — predicate (Code WARN #9 + #14): returns false for `null` / `undefined` / empty after trim / `length<3` / no internal space (single-token) / matches `/^(n\/?a|none|tbd|unknown|skip|pending|asdf|test|not[ -]?provided)$/i` (the `not[ -]?provided` clause catches the renderer's `'Not provided'` fallback at index.ts:5174). Single source of truth — T1.2 helper guard + T2.4 caller-scope guard both import.
-  - `BAR_LOOKUP_URLS: Record<string, { base: string; detail: (barNumber: string) => string }>` — typed structure with URL-encoded detail builder:
-    ```ts
-    export const BAR_LOOKUP_URLS = {
-      CA: {
-        base: 'https://apps.calbar.ca.gov/attorney/LicenseeSearch/QuickSearch',
-        detail: (barNumber: string) => `https://apps.calbar.ca.gov/attorney/Licensee/Detail/${encodeURIComponent(barNumber)}`,
-      },
-    } as const;
-    ```
-    `encodeURIComponent` (Code SUG) prevents URL-injection if a future state's bar numbers contain `+`, `&`, or spaces. CA's numeric bar numbers don't need it today — defense-in-depth.
-  - `FAIR_REPORT_MEMO_PATHS: Record<string, string>` (Sec WARN coupling): single map binding jurisdiction code to its memo path. Adding a new key requires the same edit to also write the memo file (or the lint at T4.5c fails).
-  - `BANNED_PHRASES_LIST` (re-exported): see T3.3 — canonical lives at `supabase/functions/generate-report/lib/banned-phrases-list.ts`; this file re-exports for convenient single-import in tests.
-  - **'should' word-boundary handling (Code SUG)**: BANNED_PHRASES_LIST contains literal `'should'` for substring match. Today's `DISCLAIMER_VERBATIM` does NOT contain 'shoulder' / 'shouldered' / 'should\'ve'. To future-proof, T3.2 test wraps each phrase ending with `should` (or starting with `should`) in regex form `\bshould\b` for the assertion: `if (phrase === 'should') new RegExp('\\bshould\\b', 'i').test(disclaimer) === false; else disclaimer.toLowerCase().includes(phrase.toLowerCase()) === false`. Surfaces only the exception in code, not in the BANNED_PHRASES_LIST data.
-
-  EVERY interpolation in T2.2 routes through one of the helpers above. Lint test enforces.
-- **T2.3a** — Section builder MUST emit **markdown**, not raw HTML — the `md2html` pass at `supabase/functions/generate-report/index.ts:7450` (`.map((s) => md2html(s))`) and its `|`-pipe regex would shred a pre-built `<tr>` block. Output the markdown table per T2.2 (column headers `Date | Type | Summary | Source`, using actual schema column names `order_date / discipline_type / violation_summary || discipline_raw / order_url || source_url` per T1.1). Cell-value pipeline (per T2.2): every free-text scraped value flows through `escapeMarkdownPipe(escapeHtml(v))` BEFORE markdown render. `escapeHtml` runs first to neutralize `< > & " '` from CA Bar HTML; `escapeMarkdownPipe` runs second to neutralize raw `|` characters that would shred the table column count. Order: html-escape THEN pipe-escape so `escapeHtml` does not later double-escape `\|`. (Dreyer v2 WARN #1 + Code v2 WARN #6.)
-- **T2.4 (REWRITTEN v2.3 — caller-scope wiring per Code CRIT #1 + #6 + WARN section_outputs)** — `renderIBReportHtml` at `supabase/functions/generate-report/index.ts:7322` is **synchronous** (`function renderIBReportHtml(...)`, NOT `async function`). Adding `await` inside the sections array fails compilation. The renderer also takes only `(sectionOutputs, meta)` — no `jurisdiction`, no `supabaseUrl`, no `supabaseKey` are in scope. Wire the section in **caller scope** at `index.ts:5045-5046` instead, BEFORE `renderIBReportHtml` is called. This single move resolves CRIT #1, CRIT #6, AND the WARN about section_outputs JSONB persistence.
-
-  **Caller-scope build (insert at line 5036, BEFORE the cite-strip loop at lines 5037-5039):** v2.4 fix per Code WARN — placing the build BEFORE the `for (const key of Object.keys(allOutputs)) { ... stripInvalidCiteTags(...) }` loop means `attorney-discipline` IS iterated by the strip loop (the comment about cite-tag alignment is now true; mechanically harmless since the section has no `<cite>` tags but the load-bearing claim is no longer false).
-  ```ts
-  // Phase B: build attorney-discipline section (mechanical render, no LLM, fail-open empty).
-  // Lives in allOutputs so it persists to cases.section_outputs JSONB (audit trail)
-  // and gets cite-tag-stripped through the same loop as Claude-authored sections.
-  const attorneyDisciplineMd = await buildAttorneyDisciplineSection({
-    attorneyName: phase2.attorney_name,
-    jurisdiction: intake.state || '',
-    supabaseUrl,
-    serviceRoleKey: supabaseKey,
-  });
-  if (attorneyDisciplineMd) {
-    allOutputs['attorney-discipline'] = attorneyDisciplineMd;
-  }
+    Dreyer v4 SUG applied: leads with the cause ("Most often this is..."), uses NEGATION-IN-CAPS ("does NOT mean") so a panicked skim-reader who only catches fragments still anchors on the reassurance. Defamation surface unchanged — still no fact-claim about the named attorney's status.
+- **T2.3** — Inline helpers inside the Deno-side `render-attorney-discipline.ts` file (Deno cannot import from `src/lib/intelligence-brief/render.ts` which imports from `../email`). Three helpers, all applied to every interpolation:
+  - `escapeHtml(s: string): string` — covers `& < > " '`.
+  - `safeHttpUrl(u: string): string` — returns `u` if `/^https?:\/\//i.test(u)` else `'#'`.
+  - `escapeMarkdownPipe(s: string): string` — `s.replace(/\\/g, '\\\\').replace(/\|/g, '\\|')` (Code v2 WARN #6). Backslash is escaped first to keep the pipe-escape itself literal. Without this, a scraper-fed `discipline_raw` value like `Suspension | 90-day stayed` would shred the markdown table by adding an extra cell.
+  - `cell(s)` shorthand: `escapeHtml(escapeMarkdownPipe(s == null ? '' : String(s)))`. Pipe-escape BEFORE HTML-escape so the `\|` stays a literal escape sequence visible to the markdown parser, not an `&#92;|`. (Dreyer v2 WARN #2.) **Verified by Sec v3** that the order is correct: HTML-escape doesn't touch `\` or `|` (neither is in the 5-char escape set), so the markdown parser sees the literal `\|` and renders it as a single-cell pipe. **Renderer pin (Sec v3 WARN)**: `md2html` at `index.ts:7329` is a hand-rolled regex pipeline (NOT `marked`/`commonmark`). Its table-row split regex is `(?<!\\)\|` — `\|` is the recognized escape, confirming `escapeMarkdownPipe`'s `\|` output is correctly consumed. If `md2html` is ever swapped for a library, re-verify this — drop a CI parity test rendering `'a \| b'` and asserting one cell, not two.
+  - `safeMdLink(label, url)` — when `url` is null/empty, return plain text `${label} (link unavailable)` (Sec v3 SUG cosmetic — avoids `[CA Bar order](#)` clickable anchor pointing to top-of-page). Otherwise return `[${label}](${safeHttpUrl(url)})`. Used wherever the order_url/source_url fallback could land on `'#'`.
+- **T2.3a** — Section builder MUST emit **markdown**, not raw HTML, because `renderIntelligenceBriefHtml` at `src/lib/intelligence-brief/render.ts:348-350` pipes every section through `markdownToHtml(s)` before joining — the `|`-pipe regex at `render.ts:37` would shred a pre-built `<tr>` block. Output a markdown table built using the `cell()` helper from T2.3:
   ```
-
-  **Section slot (add to sections array at line 7438, BETWEEN `sectionOutputs["your-plan"]` and `buildBradyGiglioChecklist()`):**
-  ```ts
-  sectionOutputs["your-plan"] || "",
-  sectionOutputs["attorney-discipline"] || "",  // NEW v2.3 slot
-  buildBradyGiglioChecklist(),
+  | Date | Type | Summary | Source |
+  |------|------|---------|--------|
+  | {cell(formatShortDate(order_date))} | {cell(discipline_type)} | {cell(violation_summary || discipline_raw)} | [CA Bar order]({safeHttpUrl(order_url || source_url)}) |
   ```
-  The renderer stays sync — the slot just reads from `sectionOutputs` like every sibling. Empty-string filtering at line 7450 (`.filter((s) => s.trim())`) drops the slot cleanly when guard-skipped.
-
-  **`buildAttorneyDisciplineSection()` signature (Deno-side, in `lib/render-attorney-discipline.ts`):**
-  ```ts
-  export async function buildAttorneyDisciplineSection(args: {
-    attorneyName: string | null | undefined;
-    jurisdiction: string;
-    supabaseUrl: string;
-    serviceRoleKey: string;
-  }): Promise<string>;
-  ```
-  Returns `''` (empty) for guard-skip OR no-match-with-no-section-render-decision (currently always renders no-match copy on real no-match per T2.2; only returns `''` on guard skips for cleanest behavior).
-
-  **Caller-scope guards (in order, FAIL-FAST returns empty string from helper):**
-  1. `if (!isAttorneyNameRenderable(args.attorneyName)) return '';` — garbage-name skip (Code WARN #9). Skips the whole section if defendant didn't enter a real attorney name OR the renderer fallback `'Not provided'` is in play.
-  2. `if (!FAIR_REPORT_MEMO_PATHS[args.jurisdiction]) return '';` — jurisdiction-memo coupling guard (Sec WARN). Adding a new state requires writing both a `BAR_LOOKUP_URLS` entry AND a `FAIR_REPORT_MEMO_PATHS` entry; the lint at T4.5c enforces co-modification.
-
-  Both guards run in the helper itself (caller scope) BEFORE any DB call; T1.2's `getAttorneyDiscipline` re-applies them as defense-in-depth (so future direct callers also benefit).
-
-  **Heading + md2html flow:** the helper returns markdown starting `## Attorney Bar Record Check` per T2.2; that string sits in `allOutputs['attorney-discipline']` until line 7450's `.map((s) => md2html(s))` converts it (same path as Claude-authored sections). SC #24 asserts the pre-md2html string starts with `## Attorney Bar Record Check\n`.
-
-  **Optional parallel edit** to `src/lib/intelligence-brief/render.ts` for dev-tool parity (only if `scripts/test-ib-pipeline.ts` or `render-ib-test.mjs` need it; not blocking — production path is the Edge Function).
+  with the heading + paragraph copy as plain markdown. (Dreyer v2 WARN #1.) Note: HTML-tagged input values still flow through `markdownToHtml` paragraph wrapping — pipe-escape and HTML-escape BEFORE markdown-render, not after.
+- **T2.4** — Wire into the **production IB renderer** at `supabase/functions/generate-report/index.ts` (NOT `src/lib/intelligence-brief/render.ts` — zero production callers; dev/test tooling only). Pin the insertion point by section-output keys (Code v3 WARN — line numbers drift): place the new entry between the array entry that reads `sectionOutputs["your-plan"]` and the call to `buildBradyGiglioChecklist()`. The new entry calls `await buildAttorneyDisciplineSection({ attorneyName, jurisdiction, supabaseUrl, serviceRoleKey })`; move array construction inside an `async` block (the renderer is already inside an async caller).
+  - **Heading wording — Dreyer v4 WARN rewrite**: emit markdown `## Your Attorney's Public Bar Record`. (Dreyer v4: defendant-pronoun "Your Attorney's" leads, institutional "Public Bar Record" follows. Aligns with INAA's defendant-side voice across other IB sections.) Personalized variant `What the State Bar Says About {first_name}` reserved for v3 A/B once intake-name confidence is high.
+  - **Heading assertion (Code v3 CRITICAL — md2html emits `<h2 class="section-h2">`)**: `md2html` at `index.ts:7346` does `.replace(/^## (.+)$/gm, '<h2 class="section-h2">$1</h2>')` — class is ALWAYS injected, NOT bare-tag. T3.1 panel + Criterion 11(a):
+    - Strict-literal form: `<h2 class="section-h2">Your Attorney's Public Bar Record</h2>`.
+    - Tolerant regex (preferred, survives future class rename): `/<h2[^>]*>Your Attorney's Public Bar Record<\/h2>/`.
+  - **Niche-domination one-liner (Dreyer v4 WARN — anchor to defendant's job, not competitor)**: under the H2, emit one italicized markdown line: `*We check this on every IB — before you do.*` Anchors the moat claim to the defendant's 2am job-to-be-done (looking up their own lawyer) rather than a competitor comparison. Zero UPL risk (factual, not interpretive). The line is part of the section body — if section is suppressed (kill-switch, jurisdiction unsupported, RPC failure fallback), the one-liner is suppressed with it.
+  - Export `IB_SECTION_ANCHORS.ATTORNEY_DISCIPLINE = "Your Attorney's Public Bar Record"` from the Deno `section-anchors.ts` (T2.1). NOTE the apostrophe — `escapeRegExp` is mandatory before injecting into any test regex (`fixtures.ts` exports `escapeRegExp(s) = s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')`). **Pin sibling anchors by symbol, not line range** (Code v3 WARN): T2.1 must `Grep` `<h2 class="section-h2">.+?<\/h2>` in `index.ts` + each `buildXxx()` body, plus pin the LLM-generated `your-plan` heading from its prompt template, and seed every literal in `IB_SECTION_ANCHORS`.
+  - **YOUR_PLAN anchor pin (Code v3 SUG)** — `your-plan` is LLM-generated; H2 emitted depends on prompt template. Before relying on `IB_SECTION_ANCHORS.YOUR_PLAN` as an ordering anchor in Criterion 11(b), grep `index.ts` + `prompts.ts` for the `your-plan` heading template (likely literal `Your Plan Right Now` or similar); pin the literal. If the LLM heading is non-deterministic, drop YOUR_PLAN as the lower bound and use the new section's PRECEDING stable static appendix as the bound instead.
 - **T2.5** — Skip Case Decoder integration (deferred to Phase 1.1b). v2 = IB-only.
-- **T2.6 (NEW v2.4 per Dreyer WARN #2)** — Create public-facing route at `src/app/legal/fair-report-privilege/page.tsx` (Next.js Server Component) rendering the T0b memo body. The route is the canonical target of the "Why we can show this" link inside the IB section. Body sources from a sanitized markdown file at `content/legal/fair-report-privilege.md` (NOT directly from `docs/legal/...` which contains internal references like expert-cache paths and session keys). `page.tsx` uses the existing MDX loader pattern (mirror `src/app/blog/[slug]/page.tsx` shape — minimal: title H1 + body paragraphs + canonical State Bar URL footer link). Cascade: this becomes a moat asset (other legal-info sites don't publish fair-report justification publicly; INAA does, raises industry floor, signals embedded-insider methodology — Dreyer Search Dominance Engine entity-SEO play). Robots-allowed; structured data: `Article` schema with `author = INAA`, `publisher = INAA`, `mainEntityOfPage = self`. SC #42 verifies route exists + renders.
 
 ### T3 — UPL safety
-- **T3.1 (REWRITTEN v2.3 per Code CRIT #3+#4+#5 + Sec CRIT #2)** — `evaluate-report` Edge Function takes `{caseId: UUID}` body and fetches `cases.report_html` from DB (`supabase/functions/evaluate-report/index.ts:381-407`). It writes results to `cases.eval_results` per the SHAPE at lines 549-557:
-  ```ts
-  eval_results = {
-    evaluated_at, eval_version: '1.0', gate_passed: bool, teams: { upl: {...}, psych: {...} },
-    summary: string, cost_usd: number, duration_ms: number,
-  }
-  // teams.upl shape (line 443-453): { name, weight: 'GATE', score, passed, needs_work, failed, criteria, summary, duration_ms }
-  ```
-  **There is NO `eval_results.upl.fail_count` field.** Real path: `eval_results.teams.upl.failed`. evaluate-report does NOT write to `operator_tasks`; UPL-FAIL alerts go via Resend `sendEmail()` (line 463-481) — NOT via DB row insert. Cleanup must NOT touch `operator_tasks`.
+- **T3.1 (deterministic regex panel — Code v2 WARN #5)** — REPLACE the LLM-based `evaluate-report` POST. The LLM eval was rejected because it (a) requires a `caseId` plus pre-populated `cases.report_html`, (b) costs $2-3/run × 5 fixtures × every CI run, (c) is non-deterministic (LLM grader can flake green or red on identical input), (d) gates a code-review iteration loop on a paid LLM call. Instead: add `supabase/functions/generate-report/__tests__/attorney-discipline-upl.test.ts` (Deno test) that renders the 5 fixture payloads in-process (no DB, no LLM) and runs a deterministic regex panel against each rendered HTML string:
+  - **Panel checks (every fixture):**
+    1. Matches regex `/<h2[^>]*>Your Attorney's Public Bar Record<\/h2>/` exactly once. (Code v4 CRIT — was stale "Attorney Bar Record Check" + bare-tag literal; updated to v2.4 heading + tolerant regex matching md2html's `class="section-h2"` injection.)
+    2. Does NOT contain any phrase from `BANNED_PHRASES_BLOCK` (case-insensitive `.includes` per phrase — see T3.2).
+    3. Does NOT contain literal `<script` or `javascript:` (case-insensitive — XSS panel).
+    4. Every `href="..."` attribute satisfies `/^(#|https?:\/\/)/i` (no `data:`/`mailto:`/`vbscript:`).
+    5. Contains the disclaimer string `DISCLAIMER_VERBATIM` exactly once.
+    6. Contains link to `https://apps.calbar.ca.gov/attorney/Licensee/Detail/` (the CA Bar lookup base URL — verifies the "verify yourself" CTA wired correctly).
+  - **Per-fixture assertions:**
+    - matched-clean: contains `Active`, contains `No public discipline events on record`.
+    - matched-1-event-suspension: contains `Suspension`, contains exactly one `<tr>`-equivalent table data row (i.e., the rendered HTML matches `/<table>[\s\S]*?<\/table>/` exactly once and that block contains exactly two `<tr>`s — header + 1 event).
+    - matched-multi-event-disbarment: matches the multi-event count from `FIXTURE_DISCIPLINED_EVENT_COUNT`.
+    - no-match: contains `No exact match for`, does NOT contain `<table>`.
+    - ambiguous: same as no-match (confirms ambiguous → no-match path).
+  - LLM `evaluate-report` integration moved to a **separate nightly cron sample** (5 random reports/day, asserted via the same regex panel + LLM as a tie-breaker). Out of v2 scope — captured as Phase 1.1c follow-up.
+- **T3.2 (banned-phrase shared module — Code v2 WARN #8 + Code v3 CRITICAL repath)** — Round-0-v3 ground-truth: `BANNED_PHRASES_BLOCK` lives at `src/lib/intelligence-brief/prompts.ts:34` (Node-side template literal, multi-line string). The Edge Function (`supabase/functions/generate-report/`) has NO `lib/` directory and NO `prompts.ts`; the Edge Function's own UPL prompts are inline in `index.ts`. Therefore "extract from `supabase/functions/generate-report/lib/prompts.ts`" is impossible.
+  Two-file canonical pattern:
+  - **Deno-side canonical** (`supabase/functions/generate-report/lib/banned-phrases.ts`) — array-of-strings derived from the Node-side template literal. Each entry is an individual phrase, not the whole block:
+    ```ts
+    // CANONICAL banned-phrase list. Mirrored to Node-side at
+    // src/lib/intelligence-brief/banned-phrases.ts via a parity test (T3.2a).
+    export const BANNED_PHRASES_BLOCK: readonly string[] = [
+      'you should',
+      'should file', 'should pursue', 'should review',
+      'you need to', 'your best option', 'you must', 'you have to',
+      'we advise', 'we recommend', 'i recommend',
+      'red flag', 'warning sign', 'escalation ladder',
+      // EXTEND with every literal phrase parsed from src/lib/intelligence-brief/prompts.ts
+      // BANNED_PHRASES_BLOCK template literal — DO NOT hand-roll a subset.
+    ] as const;
+    ```
+  - **Node-side mirror** (`src/lib/intelligence-brief/banned-phrases.ts`) — re-exports the Deno-side list (TS `import` with relative path resolves at build time; if Vite/webpack resolution complains because of the `supabase/functions/` prefix, copy-by-codegen is acceptable: a tiny script reads the Deno file and writes the Node mirror, run as `pnpm run sync-banned-phrases` and asserted in T3.2a). `prompts.ts` then imports `BANNED_PHRASES_BLOCK` from the Node mirror and interpolates into the existing template literal.
+- **T3.2a (parity test)** — Node-side test `src/lib/intelligence-brief/__tests__/banned-phrases-parity.test.ts` reads BOTH files, asserts the arrays are deep-equal. Catches future drift between Deno-side and Node-side. Mirror pattern: `src/lib/report/__tests__/whitelist-parity.test.ts`.
+- **T3.2b (canonical-phrase extraction)** — Implementer must, before writing the array, read the existing `BANNED_PHRASES_BLOCK` template literal at `src/lib/intelligence-brief/prompts.ts:34` and tokenize EVERY quoted phrase out of it (the literal mixes prose with quoted phrases — only the quoted phrases are banned). Document the extraction script + checked-in output. Test asserts `BANNED_PHRASES_BLOCK.length >= 10` so a future hand-edit that empties the array doesn't false-green.
+- **T3.1 panel uses the canonical list**: `for (const p of BANNED_PHRASES_BLOCK) assert(!html.toLowerCase().includes(p.toLowerCase()), \`fixture \${name} contains banned phrase "\${p}"\`)`.
 
-  Two-tier UPL coverage:
-  1. **Regex panel (primary, 5 fixture states, no LLM cost):** Deno test `supabase/functions/generate-report/__tests__/upl-regex-panel.test.ts` renders all 5 fixture states (matched-clean, matched-1-event-suspension, matched-multi-event-disbarment, no-match, pipe-edge), then asserts `output.toLowerCase().includes(phrase.toLowerCase()) === false` for every entry in `BANNED_PHRASES_LIST` (T3.3 canonical Deno-readable file) on each state. The 'should' phrase uses word-boundary regex per T2.3 helper note (`\\bshould\\b`) to avoid false positives on `shoulder` / `should've` if those ever enter copy. Cost: $0.
-  2. **Live evaluate-report smoke (1 fixture caseId, end-to-end, CI-path-gated):** Deno test at `supabase/functions/evaluate-report/__tests__/attorney-discipline-e2e.test.ts` (NOT Node — keeps single test runner per WARN #13). Steps:
-     - **Pre-flight (Sec WARN — Resend gating)**: assert `Deno.env.get('RESEND_API_KEY') === '__test_disabled__' OR === ''`. Abort otherwise. Without this gate, a stochastic UPL regression sends a real operator email per evaluate-report:458-481 = alarm fatigue.
-     - **Pre-flight (Sec WARN — service-role key fetch)**: read `SUPABASE_SERVICE_ROLE_KEY` from env (already in `--allow-env` allowlist per T1.4). Wrap all fetches in `safeFetch` redact wrapper.
-     - **Insert fixture orders row first** (cases requires `order_id NOT NULL` per migrations/00001_initial_schema.sql:202; column is `amount` NOT `amount_cents` per same file line 877 — Code v4 CRIT #1): `INSERT INTO public.orders (id, email, tier, status, amount) VALUES (gen_random_uuid(), 'e2e-attorney-discipline-' || extract(epoch from now())::bigint || '@example.com', 'intelligence-brief', 'paid', 99700) RETURNING id` — capture as `orderId`.
-     - **Insert fixture cases row** with ALL three NOT NULL columns + cron-skip flags + sentinel eval_results (Sec CRIT #2 — never matches CV `eval_results.is.null` filter even on mid-test crash):
-       ```sql
-       INSERT INTO public.cases (
-         id, order_id, email, tier, status, charge_type, report_html,
-         review_reminder_sent, is_included_deliverable,
-         eval_results, generated_at
-       ) VALUES (
-         gen_random_uuid(),
-         $orderId,
-         'e2e-attorney-discipline-' || extract(epoch from now())::bigint || '@example.com',
-         'intelligence-brief',
-         'review',
-         'DUI',
-         <rendered IB HTML containing T2.2 matched-multi-event section>,
-         true,                                          -- skip review-reminder cron
-         true,                                          -- skip stuck-intake cron
-         '{"sentinel": true, "gate_passed": false}',    -- v2.4 Sec CRIT: gate_passed:false ensures /api/deliver renderEvalScorecard treats as FAILED (not PASSED) if cleanup misses; prevents bypass of UPL gate in operator UI; evaluate-report overwrites with real {gate_passed: true|false} on completion
-         NULL                                           -- generated_at NULL → review-reminder cron filter drops the row
-       ) RETURNING id;
-       ```
-       Email pattern `e2e-attorney-discipline-${ts}@example.com` matches CV probe allowlist (`e2e-%` per `~/projects/continuous-verification/configs/inna.cv.json:101-127`).
-     - `POST ${SUPABASE_URL}/functions/v1/evaluate-report` with body `{caseId}`.
-     - Read response JSON: assert `body.success === true && body.gate_passed === true`.
-     - Read DB `cases.eval_results` post-call: assert `eval_results.gate_passed === true && eval_results.teams.upl.failed === 0` (correct shape per Code CRIT #3).
-     - **Cleanup (try/finally, ALWAYS runs)**: `DELETE FROM public.cases WHERE id = $caseId; DELETE FROM public.orders WHERE id = $orderId;`. Drop the spurious `operator_tasks` DELETE — evaluate-report never writes there.
-     - Cost: ~$2-3/run (Sonnet UPL + Psych eval).
-  3. **Reaper safety net (Sec CRIT #2 belt-and-suspenders):** add `scripts/reap-attorney-discipline-fixtures.mjs` — runs at end of CI job in a separate step (`if: always()` in CI YAML) regardless of test exit code. Body deletes any `cases` row matching `email LIKE 'e2e-attorney-discipline-%'` AND its parent `orders` row. Catches mid-test SIGKILL or runner crash where the `try/finally` never fires. Idempotent.
-  4. **CI gating**: live e2e test only runs on PRs touching `supabase/functions/generate-report/lib/render-attorney-discipline.ts` OR `lib/attorney-discipline.ts` OR `T3.3` files (paths filter). Regex panel runs on every PR.
-- **T3.2 (REWRITTEN v2.3 per Code CRIT #8 + Sec SUG word-boundary)** — Two parallel banned-phrases tests, one per runtime, both reading from the SAME canonical Deno-readable list file:
-  - **Node-side**: `src/lib/intelligence-brief/__tests__/disclaimer-banned-phrases.test.ts` — vitest. Imports `BANNED_PHRASES_LIST` from `src/lib/intelligence-brief/prompts.ts` (re-exported per T3.3). Imports `DISCLAIMER_VERBATIM` from `src/lib/intelligence-brief/attorney-discipline-disclaimer.ts` (Node-readable mirror, plain string export, no Deno imports).
-  - **Deno-side**: `supabase/functions/generate-report/__tests__/upl-regex-panel.test.ts` (T3.1.1) — imports `BANNED_PHRASES_LIST` directly from canonical Deno path `../lib/banned-phrases-list.ts` (relative path, no Next.js alias).
-  - For each phrase in `BANNED_PHRASES_LIST`: word-boundary check for `'should'` (regex `/\bshould\b/i.test(disclaimer)` MUST be false), substring check for all others (`disclaimer.toLowerCase().includes(phrase.toLowerCase()) === false`).
-  - Both runtimes assert against the SAME canonical list, so drift is impossible.
-- **T3.3 (RESHAPED v2.3 per Code CRIT #8)** — Canonical `BANNED_PHRASES_LIST` lives at `supabase/functions/generate-report/lib/banned-phrases-list.ts` (Deno-readable, NO Next.js path aliases — a plain ES module). `src/lib/intelligence-brief/prompts.ts` re-exports it via relative path (Next.js bundler resolves the relative import; the source file is the single canonical):
+- **T3.3 (interpretive-language structural panel — Code v3 WARN safety net)** — Regex panel cannot catch novel interpretive phrasing the LLM eval previously flagged. Defense-in-depth: add a structural assertion to T3.1 panel that fails on ANY adjective-about-attorney pattern:
   ```ts
-  // supabase/functions/generate-report/lib/banned-phrases-list.ts (NEW canonical)
-  export const BANNED_PHRASES_LIST = [
-    'you should',
-    'should',           // word-boundary checked in disclaimer test (T3.2)
-    'you need to',
-    'we recommend',
-    'we advise',
-    'your best option',
-    'the best strategy',
-    'red flag',
-    'warning sign',
-    'escalation ladder',
-    'do not',           // bare imperative
-  ] as const;
-  export type BannedPhrase = typeof BANNED_PHRASES_LIST[number];
+  const INTERPRETIVE_BANNED = /\b(unreliable|incompetent|negligent|untrustworthy|sketchy|shady|questionable|inadequate|deficient)\b/i;
+  assert(!INTERPRETIVE_BANNED.test(html), 'interpretive adjective about attorney');
   ```
-  **v2.4 CORRECTION (Code CRIT #2)**: `tsconfig.json:33` HAS `"exclude": ["node_modules", "supabase", ...]`. Re-exporting from prompts.ts → supabase/functions/ would fail `npm run build` (TS2307 / TS6059). Drop the re-export. Node tests (T3.2 + T3.4) import `BANNED_PHRASES_LIST` DIRECTLY from the canonical Deno-side file via vitest's runtime resolver:
-  ```ts
-  // src/lib/intelligence-brief/__tests__/disclaimer-banned-phrases.test.ts
-  import { BANNED_PHRASES_LIST } from '../../../../supabase/functions/generate-report/lib/banned-phrases-list';
-  ```
-  Vitest's runtime module resolution does NOT honor tsconfig.exclude; it resolves the file at test runtime regardless. `prompts.ts` is NOT modified. The `BANNED_PHRASES_BLOCK` prose stays in prompts.ts for production prompt text (Next.js compiles prompts.ts; vitest tests touch prompts.ts only in tests so no cross-tree compile is triggered). Drift between the canonical list and prompts.ts's prose is caught by T3.4 parity test, which imports BOTH files via vitest runtime.
+  Bridges the gap between deterministic regex panel and the deferred Phase 1.1c LLM-sample cron.
 
-  Match-rule notes: case-insensitive substring for all entries EXCEPT `'should'` which is matched as `\bshould\b` (word-boundary) so future copy with `'shoulder'` / `'shouldered'` doesn't false-positive. The `'should'` rule still catches every directive use ("should file", "should pursue", "you should").
-- **T3.4 (parity test, BIDIRECTIONAL v2.3 per Code WARN #15)** — Node test at `src/lib/intelligence-brief/__tests__/banned-phrases-parity.test.ts`:
-  - **Forward**: every entry in `BANNED_PHRASES_LIST` (case-insensitive substring) appears in the prose `BANNED_PHRASES_BLOCK` text. (Catches: phrase added to list but block not updated.)
-  - **Reverse (NEW v2.3)**: regex-extract every quoted phrase from `BANNED_PHRASES_BLOCK` using strict pattern `/^- "([^"]+)"/gm`. For each extracted phrase, assert it appears (case-insensitive substring) in `BANNED_PHRASES_LIST`. (Catches: phrase added to prose block but list not updated — Code WARN #15.)
-  - Symmetric coverage closes drift in both directions.
+- **T3.4 (entity-encoded-XSS panel check — Sec v3 SUG)** — Add to the panel: after rendering, run the HTML through ONE round of HTML-entity decoding (use Deno's `https://deno.land/std/html/entities.ts` `decode`); assert the decoded string still does NOT contain `<script` or `javascript:`. Defends against double-encoded payloads where a future renderer change might decode-then-render.
 
 ### T4 — Verification
 - **T4.1** — `npm run build` exit 0.
-- **T4.1a (new v2.2 per SUG #11)** — `deno check supabase/functions/generate-report/index.ts` exit 0. Catches Deno-side TS errors npm build cannot see (Deno has its own type-checker against the function's `deno.json` import map). Run between T4.1 and T4.2.
-- **T4.2 (Node tests)** — `npm test -- --reporter=json --outputFile=/tmp/after.json`. Capture `before.json` from `origin/master` via fresh worktree at `.tmp/baseline-test-counts/`. Assert `after.numPassedTests >= before.numPassedTests` AND `before.passing[]` ∩ `after.failing[]` is empty.
-- **T4.2a (Deno tests, REWRITTEN v2.3 per Code WARN #13 + Sec WARN service-role-key)** — Use the SAME explicit file list from T1.4 (NOT directory glob — vitest collision):
+- **T4.1a (Code v2 SUG #11)** — `deno check` on every Deno-side file written in the worktree, before committing:
   ```
-  deno test \
-    --allow-env=SUPABASE_URL,SUPABASE_SERVICE_ROLE_KEY,SUPABASE_ANON_KEY,ANTHROPIC_API_KEY,RESEND_API_KEY \
-    --allow-net=jxjbjmgdukwkoclydqdr.supabase.co,api.anthropic.com \
-    --reporter=json \
-    supabase/functions/generate-report/__tests__/attorney-discipline.test.ts \
-    supabase/functions/generate-report/__tests__/upl-regex-panel.test.ts \
-    supabase/functions/generate-report/__tests__/attorney-discipline-guard.test.ts \
-    supabase/functions/generate-report/__tests__/render-attorney-discipline-lint.test.ts \
-    supabase/functions/generate-report/__tests__/attorney-discipline-fair-report-paths.test.ts \
-    supabase/functions/generate-report/__tests__/attorney-discipline-common-name.test.ts \
-    supabase/functions/generate-report/__tests__/attorney-discipline-fair-report-paths.test.ts \
-    supabase/functions/generate-report/__tests__/attorney-discipline-common-name.test.ts \
-    supabase/functions/__tests__/rls-attorney-discipline.test.ts \
-    supabase/functions/evaluate-report/__tests__/attorney-discipline-e2e.test.ts \
-    > /tmp/deno-after.json
+  deno check supabase/functions/generate-report/lib/attorney-discipline.ts \
+             supabase/functions/generate-report/lib/render-attorney-discipline.ts \
+             supabase/functions/generate-report/lib/section-anchors.ts \
+             supabase/functions/generate-report/lib/banned-phrases.ts \
+             supabase/functions/generate-report/__tests__/attorney-discipline.test.ts \
+             supabase/functions/generate-report/__tests__/attorney-discipline-upl.test.ts \
+             supabase/functions/generate-report/__tests__/fixtures.ts \
+             supabase/functions/__tests__/rls-attorney-discipline.test.ts \
+             supabase/functions/generate-report/index.ts
   ```
-  Track Deno test count INDEPENDENTLY of npm test count; the two runners report into separate JSON files. Assert `deno-after.passed === deno-before.passed + N_NEW_DENO_TESTS` (where `N_NEW_DENO_TESTS` = sum of new Deno tests across all 6 files).
-  **Artifact scrub (Sec WARN service-role key leak)**: before any artifact upload (CI step `Upload deno-after.json`), grep the JSON for `Bearer [^\s"']+` and `eyJhbGc[^\s"']+` (JWT prefix) — if found, fail the build. Keys never appear in artifacts.
+  Exit 0 mandatory. Catches Deno-resolution drift the npm `tsc` build never covers (Edge Function runs on Deno, not Node).
+- **T4.2 (Code v2 WARN #4 — separate Deno + npm count tracking)** — Capture two pairs of before/after snapshots, asserted independently:
+  - **npm side** — `npm test -- --reporter=json --outputFile=.tmp/after-npm.json`. Capture `.tmp/baseline-test-counts/before-npm.json` from `origin/master` via fresh worktree at `.tmp/baseline-test-counts/`. Assert `after.numPassedTests >= before.numPassedTests` AND `before.passing[]` ∩ `after.failing[]` is empty.
+  - **Deno side** — `deno test --allow-net --allow-env --no-check=remote --reporter=junit supabase/functions/ > .tmp/after-deno.xml`. Capture `.tmp/baseline-test-counts/before-deno.xml` from `origin/master` by checking out master into a temp worktree and running the same command. **If the baseline file is missing OR malformed (Code v3 WARN — origin/master may have zero deno tests)**: treat as `tests=0, failures=0, errors=0` and proceed. Document the fallback explicitly in the harness. Parse `<testsuites tests="N" failures="F" errors="E">`; assert `after.tests >= before.tests` AND `after.failures + after.errors === 0`.
+  - **Confirm npm runner first (Code v3 / spec-critic WARN)**: read `package.json#scripts.test`. If `vitest`, the `--reporter=json --outputFile=` flags are correct as-written. If `jest`, switch to `--json --outputFile=`. Pin the actual runner in this T-task before Phase 5 begins.
+  - The two suites use different runners and different file globs (`vitest`/`jest` vs `deno test`); merging counts hides regressions in either. Track separately, gate on both.
 - **T4.3** — CV probe-only: `node ~/projects/continuous-verification/verify.mjs --project inna --probe-only --no-trends` exits 0 AND no `INNA-H1.*FAIL` in stdout (no substring count assertion).
 - **T4.4** — XSS smoke: insert a third fixture row with `discipline.type='<script>alert(1)</script>'` and `source_url='javascript:alert(1)'`; render via T2.2; assert HTML contains escaped `&lt;script&gt;` and `href="#"` (not `href="javascript:..."`).
-- **T4.4a (markdown-pipe smoke, v2.2 per WARN #6)** — `FIXTURE-005` event with raw pipes in `discipline_type` + `violation_summary`. Render via T2.2; flow through `md2html`; assert exactly 4 `<th>` columns; assert literal `|` characters appear in the rendered cell text (escapeMarkdownPipe's `\|` survives md2html unescape per index.ts:7355).
-- **T4.4b (XSS centralization lint, NEW v2.3 per Sec CRIT #1)** — Deno test at `supabase/functions/generate-report/__tests__/render-attorney-discipline-lint.test.ts`:
-  - Read `supabase/functions/generate-report/lib/render-attorney-discipline.ts` source as plain text via `Deno.readTextFile`.
-  - Strip block comments `/* ... */` and line comments `// ...` and string literals `'...'` / `"..."` / template-literal NON-interpolation parts.
-  - Regex-find every `${...}` interpolation in the remaining template-literal expressions.
-  - For each match, assert the expression is one of: a `safeCell(...)` call, `safeHttpUrl(...)` call, `formatShortDate(...)` call, OR a literal call in the allowlist `['events.length', 'N', 'plural', 'YYYY']` (numeric/structural placeholders).
-  - Any other interpolation fails the test with `interpolation '${EXPR}' must route through safeCell/safeHttpUrl/formatShortDate`. Catches future PRs that bypass the centralized escape pipeline (Sec CRIT #1).
-- **T4.4c (markdown-pipe edge cases, NEW v2.3 per Sec SUG)** — `FIXTURE-008` event with `discipline_type='\\|'` (literal backslash-pipe) AND `violation_summary='|||'` (three consecutive pipes). Render → md2html. Assert exactly 4 columns AND row count is 1 (no shred from `|||`) AND `discipline_type` cell-text contains `\|` rendered as literal backslash-pipe (or just `|` after unescape — whichever md2html produces; both safe).
 - **T4.5** — Injection smoke: `getAttorneyDiscipline("' OR 1=1 --", 'CA')` returns `{ status: 'no-match', attorney: null, events: [] }`, no error thrown.
-- **T4.5a (unaccent smoke, v2.2 per WARN #7)** — `FIXTURE-006` (`'José García'`) ↔ `FIXTURE-007` (`'Jose Garcia'`). Bidirectional match assertion confirms RPC `LOWER(unaccent(...))` works both directions.
-- **T4.5b (garbage-name skip, v2.2 per WARN #9 + Code WARN #14)** — Test caller-scope `buildAttorneyDisciplineSection` for inputs: `''`, `'  '`, `'Bo'`, `'Smith'`, `'asdf'`, `'n/a'`, `'TBD'`, `'pending'`, `'Not provided'`. Assert returns `''` AND `fetch.mock.calls.length === 0`.
-- **T4.5c (FAIR_REPORT_MEMO_PATHS lint, NEW v2.3 per Sec WARN coupling)** — Deno test asserts every key in `BAR_LOOKUP_URLS` (T2.3) has a matching key in `FAIR_REPORT_MEMO_PATHS` AND every memo path file exists on disk (`Deno.stat()`). Adding a new state to either map without the other fails the build. Closes the prose-only "block multi-state expansion until per-state memo" gate as a hook-or-harder enforcement.
-- **T4.5d (Sec — defamation surface acknowledgment, NEW v2.3)** — Test at `attorney-discipline-common-name.test.ts`: insert TWO `FIXTURE-John-Smith` attorneys (different bar_numbers, identical `full_name='John Smith'`). Call `getAttorneyDiscipline('John Smith', 'CA')` — assert `status === 'no-match'` AND `events.length === 0` (RPC server-side n>1 collapses to no-match per T0a). Document in test comment: this is the EXPECTED defamation-protection behavior for common-name attorneys; common-name attorneys with discipline records will silently no-render. The cascade and Out of Scope sections name this trade-off.
-- **T4.6** — Anon-key denial smoke: in `supabase/functions/__tests__/rls-attorney-discipline.test.ts`, FIRST decode the ANON_KEY JWT and assert `role === 'anon'` (otherwise abort — wrong-key misconfig produces a false-green per Sec v2 WARN #4). THEN `curl ${SUPABASE_URL}/rest/v1/attorney_discipline_events?select=* -H "apikey: ${ANON_KEY}"` returns **HTTP 200 + body `[]`** (RLS-blocked-anon returns empty, NOT 401 — Code v2 CRIT #3 verified live 2026-04-25 against legacy JWT + new sb_publishable_* keys). Equivalent assertion: `r.status === 200 && JSON.parse(await r.text()).length === 0`. Run against both `attorneys` and `attorney_discipline_events` tables. Pre-flight: anon-key in test env must come from Supabase Mgmt API at runtime (`/v1/projects/<ref>/api-keys?reveal=true`) NOT `.env.local` (which can carry a stale key — discovered 2026-04-25 in this session: stale .env.local anon key returned 401 "Invalid API key" on every table including known-RLS-protected `cases`/`orders`, masking actual RLS posture). Aligns with INAA-web ARCHITECTURE.md invariant #4 (service-role only for production DB; RLS is defense-in-depth). Update `.env.local` anon key as a separate cleanup task.
-  - **Additional anon assertion for the RPC**: `POST /rest/v1/rpc/match_attorney` with anon key + body `{"p_name":"Anyone","p_jurisdiction":"CA"}` returns **HTTP 401 or 403** (RPC has explicit `REVOKE FROM PUBLIC` + `GRANT TO service_role` per T0a — anon must NOT be able to invoke the RPC even though attorneys table allows anon to read empty `[]` via RLS).
-  - **pg_policies posture assertion (NEW v2.3 per Code WARN false-green risk)**: query `SELECT count(*) FROM pg_policies WHERE schemaname='public' AND tablename IN ('attorneys','attorney_discipline_events') AND cmd='SELECT' AND roles::text LIKE '%anon%' AND qual <> 'false' AND qual NOT LIKE '%FIXTURE-%';` — assert `count === 0`. Catches a future regression that adds a permissive `FOR SELECT TO anon USING (true)` policy (would defeat T0a's RLS posture). The `LIKE '%FIXTURE-%'` exception lets the deny-test-fixtures policies coexist as defense-in-depth (those have `USING (bar_number NOT LIKE 'FIXTURE-%')` — not permissive, just deny-overlay).
-- **T4.7** — Live render smoke: invoke IB renderer with the synthetic `FIXTURE-002` case fixture; assert rendered HTML contains "Attorney Bar Record Check" exactly once, with the discipline event row, with `DISCLAIMER_VERBATIM` verbatim, with `last_seen_at` rendered as `YYYY-MM-DD` (regex `/\d{4}-\d{2}-\d{2}/`) AND NO raw timestamptz substring (`/T\d{2}:\d{2}:\d{2}/`) AND NO literal `1970-01-01` (catches null-coalesce silent fallback per Code WARN #11).
+- **T4.6** — Anon-key denial smoke: in `supabase/functions/__tests__/rls-attorney-discipline.test.ts`, FIRST decode the ANON_KEY JWT and assert `role === 'anon'` (otherwise abort — wrong-key misconfig produces a false-green per Sec v2 WARN #4). THEN three assertions:
+  1. **Table SELECT** — `curl ${SUPABASE_URL}/rest/v1/attorney_discipline_events?select=* -H "apikey: ${ANON_KEY}"` returns **HTTP 200 + body `[]`** (RLS-blocked-anon returns empty, NOT 401 — Code v2 CRIT #3 verified live 2026-04-25). `r.status === 200 && JSON.parse(await r.text()).length === 0`. Same assertion against `attorneys`. **Grant-posture pin (Code v3 SUG)**: pre-flight asserts `\dp public.attorneys` shows `anon` has table-level `SELECT` grant (otherwise PostgREST returns 401 instead of 200/[] and the test would false-fail under stricter posture). Pin the expected grant state in this T-task.
+  2. **RPC POST denial (Sec v3 WARN + Sec v4 WARN body-code pin)** — `curl -X POST ${SUPABASE_URL}/rest/v1/rpc/attorney_match_by_raw_name -H "apikey: ${ANON_KEY}" -H "Content-Type: application/json" -d '{"jur":"CA","raw_name":"x"}'` returns **HTTP 404 AND body parses to JSON with `code === 'PGRST202'`**. Test asserts BOTH conditions (Sec v4 — earlier `||` form silently degraded if body shape changed). Add positive control: same RPC with service-role key against `FIXTURE_CLEAN_ATTORNEY_NAME` returns 200 + non-empty array — proves the test exercises the actual function path, not a typo'd 404 for the wrong reason.
+  3. **Pre-flight key source (Sec v2 WARN #4)** — anon-key in test env MUST come from Supabase Mgmt API at runtime (`/v1/projects/<ref>/api-keys?reveal=true`) NOT `.env.local`. Stale `.env.local` returned 401 on every table during the 2026-04-25 session, masking actual RLS posture. Update `.env.local` anon key in a separate cleanup task.
+  Aligns with INAA-web ARCHITECTURE.md invariant #4 (service-role only for production DB; RLS is defense-in-depth).
+- **T4.7** — Live render smoke: invoke IB renderer with the synthetic `FIXTURE-002` case fixture; assert rendered HTML contains `Your Attorney's Public Bar Record` exactly once, with the `<tr>` discipline event row, with the Atti-voice disclaimer string verbatim.
 
-## Out of Scope (v2.3)
+## Out of Scope (v2)
 - Case Decoder integration → **Phase 1.1b** separate plan (path: `batch-poller.ts:238` post-Opus markdown injection).
-- Multi-state attorney discipline (FL/TX/NY/PA/OH) → blocked on per-state fair-report privilege memos. T4.5c lint enforces the gate.
+- Multi-state attorney discipline (FL/TX/NY/PA/OH) → blocked on per-state fair-report privilege memos.
 - Fuzzy match / disambiguation prompt → defamation surface; not until exact-match version is shipped + observed.
 - Intake form jurisdiction field → 2-bar attorneys are an edge case; default to defendant's state until real demand observed.
 - Attorney rating / scoring → interpretation, breaks UPL safety.
 - Officer-discipline parallel section → separate worry, separate plan.
 - Backfill of already-delivered reports → not in scope; new section only for reports generated after deploy.
-- **Common-name silent no-match (Sec WARN, intentional)** → an attorney named `'John Smith'` with discipline events will never render in the section because exact-match-only + RPC server-side ambiguity-collapse means n>1 returns no-match. SC #20b (T4.5d) tests + documents this. **This is intentional defamation-surface protection**, not a bug. Bar-number-based exact match (defendant types the State Bar number from the attorney's signature line) is a possible future enhancement; deferred to Phase 1.1b CD plan or later.
-- **Indexed `/attorney/ca/[bar_number]/discipline-record` URL pattern (Dreyer SUG)** → niche-domination follow-on. Treats public bar discipline as entity-SEO surface. Defamation profile identical to in-report (exact-match + fair-report). Tracked as Phase 1.1c follow-on, NOT v2 blocking.
-- **Rehabilitation timeline copy (Dreyer SUG)** → matched-events render shows ALL historical events without recency/rehabilitation context. v2 ships mechanical-only; computed `Most recent event: {ago}` summary deferred to Phase 1.1d follow-on.
 
 ## Success Criteria
 
@@ -619,118 +347,67 @@ No node loses (under exact-match-only rendering). Cascade-positive.
 - `FIXTURE_DISCIPLINED_ATTORNEY_NAME = 'Fixture Disciplined'`
 - `FIXTURE_DISCIPLINED_EVENT_COUNT = 2`
 - `FIXTURE_AMBIGUOUS_BAR_NUMBER = 'FIXTURE-003'` (second 'Fixture Cleanrecord' row to test ambiguous-match no-match return)
-- `FIXTURE_HOSTILE_BAR_NUMBER = 'FIXTURE-004'` (XSS payload event — T4.4)
-- `FIXTURE_PIPE_BAR_NUMBER = 'FIXTURE-005'` (raw `|` in `discipline_type` and `violation_summary` — T4.4a)
-- `FIXTURE_ACCENT_BAR_NUMBER = 'FIXTURE-006'` (full_name `'José García'` — T4.5a)
-- `FIXTURE_ACCENT_REVERSE_BAR_NUMBER = 'FIXTURE-007'` (full_name `'Jose Garcia'` plain ASCII — T4.5a reverse)
-- `IB_SECTION_ANCHORS.ATTORNEY_DISCIPLINE = '## Attorney Bar Record Check'` (raw markdown H2 form)
-- `IB_SECTION_ANCHORS.YOUR_PLAN = '## Section 6: Your Plan'` (literal H2 form pinned for slot-order assertion)
-- `IB_SECTION_ANCHORS.BRADY_GIGLIO_APPENDIX = '## Appendix A: Brady/Giglio Checklist'` (forward-slash form per actual code at index.ts:7236; SC #11 brittleness fix)
-- `DISCLAIMER_VERBATIM` exported from `src/lib/intelligence-brief/attorney-discipline-disclaimer.ts` (Node-readable mirror so T3.2 + T3.4 Node tests + Deno tests both import the same string)
-- `BANNED_PHRASES_LIST` canonical at `supabase/functions/generate-report/lib/banned-phrases-list.ts` (Deno-readable, no aliases); re-exported from `src/lib/intelligence-brief/prompts.ts` for Node test convenience
-
-**Worry-intent coverage map** (every clause in worry text → at least one PASS/FAIL criterion):
-- "1,842 attorneys + 3,417 events loaded but unread" → SC #5/#6 (helper queries return live rows)
-- "intake.attorneyName collected" → SC #11 (renderer threads intake meta into helper call)
-- "no surface JOINs" → SC #11 (production renderer wires section + section appears in output)
-- "#1 crisis-buyer fear (trust)" → SC #12 + #13 (UPL-safe disclaimer + LLM evaluator pass)
-- "render only on EXACT-MATCH (defamation surface)" → SC #7 (ambiguous returns no-match) + SC #21 (RPC unaccent match deterministic)
-- "fair-report privilege framing" → SC #14 (memo file present + cited)
+- `NO_MATCH_MESSAGE` exported from `render-attorney-discipline.ts`
+- `IB_SECTION_ANCHORS.ATTORNEY_DISCIPLINE = "Your Attorney's Public Bar Record"` (and other existing IB section heading constants pinned in `supabase/functions/generate-report/lib/section-anchors.ts` — Deno-side canonical; Node-side `src/lib/intelligence-brief/section-anchors.ts` is a parity mirror)
+- `DISCLAIMER_VERBATIM` exported from `render-attorney-discipline.ts` containing the full footer-disclaimer string
 
 1. **RLS posture explicit.** `psql` against the project: `SELECT relrowsecurity FROM pg_class WHERE relname IN ('attorneys','attorney_discipline_events')` returns `t` for both rows. (Verifiable PASS/FAIL via single SQL query post-T0a.)
-2. **Anon denial smoke.** Live `curl ${SUPABASE_URL}/rest/v1/attorney_discipline_events?select=* -H "apikey: ${ANON_KEY}"` (anon key fetched from Supabase Mgmt API at runtime) returns `r.status === 200 && JSON.parse(await r.text()).length === 0` (RLS-blocked-anon = empty array, NOT 401). Test at `supabase/functions/__tests__/rls-attorney-discipline.test.ts`. Pre-flight asserts JWT `role === 'anon'`.
+2. **Anon denial smoke.** `curl ${SUPABASE_URL}/rest/v1/attorney_discipline_events?select=* -H "apikey: ${ANON_KEY}"` returns **HTTP 200 + body `[]`** (RLS-blocked-anon under PostgREST returns empty, NOT 401 — Code v2 CRIT #3 verified live 2026-04-25). Test at `supabase/functions/__tests__/rls-attorney-discipline.test.ts` first decodes the JWT and asserts `role === 'anon'` (false-green guard per Sec v2 WARN #4), then asserts `r.status === 200 && JSON.parse(await r.text()).length === 0` against both `attorneys` and `attorney_discipline_events`.
 3. **Function exists.** `import { getAttorneyDiscipline } from 'supabase/functions/generate-report/lib/attorney-discipline'` resolves; `typeof getAttorneyDiscipline === 'function'`; `getAttorneyDiscipline.length === 2`.
 4. **Shape test passes.** Test `'returns expected shape'` calls `getAttorneyDiscipline(FIXTURE_DISCIPLINED_ATTORNEY_NAME, 'CA')`; asserts result keys deep-equal `['attorney', 'events', 'status']`.
 5. **Clean attorney match.** Test `'matches clean attorney'` calls `getAttorneyDiscipline(FIXTURE_CLEAN_ATTORNEY_NAME, 'CA')`; asserts `result.status === 'matched' && result.events.length === 0 && result.attorney.current_status === 'active' && result.attorney.bar_number === FIXTURE_CLEAN_BAR_NUMBER`.
-6. **Disciplined attorney match.** Test asserts `result.status === 'matched' && result.events.length === FIXTURE_DISCIPLINED_EVENT_COUNT && result.attorney.current_status === 'suspended'`. Each event has `typeof e.order_date === 'string' && typeof e.discipline_type === 'string' && (typeof e.violation_summary === 'string' || typeof e.discipline_raw === 'string')` (column names per T1.1, NOT legacy `date/type/outcome`).
+6. **Disciplined attorney match.** Test asserts `result.status === 'matched' && result.events.length === FIXTURE_DISCIPLINED_EVENT_COUNT && result.attorney.current_status === 'suspended'`. Each event has `typeof e.order_date === 'string' && typeof e.discipline_type === 'string' && (typeof e.violation_summary === 'string' || typeof e.discipline_raw === 'string')`. (Column-name correction per T1.1 — `date`/`type`/`outcome` columns do not exist.)
 7. **Ambiguous match returns no-match.** Test inserts duplicate fixture row `FIXTURE-003` with same `full_name` as `FIXTURE-001`; asserts `getAttorneyDiscipline(FIXTURE_CLEAN_ATTORNEY_NAME, 'CA').status === 'no-match'`.
 8. **Injection-resistant.** Test asserts `getAttorneyDiscipline("' OR 1=1 --", 'CA')` deep-equals `{ attorney: null, events: [], status: 'no-match' }` AND no error thrown.
 9. **No-match path.** Test asserts `getAttorneyDiscipline('Zzzzz Nonexistent', 'CA')` deep-equals `{ attorney: null, events: [], status: 'no-match' }`.
-10. **Renderer escapes hostile HTML input.** Test inserts fixture `FIXTURE-004` with discipline event having `discipline_type='<script>alert(1)</script>'` and `source_url='javascript:alert(1)'`; renders section; asserts output HTML contains `&lt;script&gt;alert(1)&lt;/script&gt;` AND contains `href="#"` AND does NOT contain literal `<script>` or literal `javascript:`.
-11. **IB renders attorney-discipline section in correct slot — pre-render assertion (CORRECTED v2.4 per Code CRIT #3).** SC #11 v2.3 asserted against rendered HTML, but the LLM prompt at `index.ts:7102` instructs `Output: ## Section 6` (NOT `: Your Plan`), and post-md2html the markdown anchors don't survive in HTML. Both surfaces make HTML substring assertions unreliable. v2.4 instead asserts against `allOutputs` map ordering BEFORE `renderIBReportHtml` runs. Test invokes the Phase B caller flow with `FIXTURE_DISCIPLINED_BAR_NUMBER`; captures `allOutputs` keys in insertion order (or per the sections array at lines 7429-7450). Asserts: (a) `'attorney-discipline' in allOutputs && typeof allOutputs['attorney-discipline'] === 'string' && allOutputs['attorney-discipline'].length > 0` (key present + non-empty), (b) the position of `'attorney-discipline'` in the literal sections-array source code at lines 7429-7450 sits AFTER `sectionOutputs["your-plan"]` AND BEFORE `buildBradyGiglioChecklist()` — verifiable by reading `index.ts` and asserting line ordering of those three string literals. (c) `allOutputs['attorney-discipline'].startsWith('## Attorney Bar Record Check')` (markdown heading present). All three assertions are deterministic and don't depend on LLM output formatting.
-12. **UPL evaluator passes — live caseId smoke (CORRECTED v2.3 per Code CRIT #3+#4+#5).** Test:
-    a. Insert fixture orders row (provides NOT NULL `order_id` for cases per migrations/00001_initial_schema.sql:202).
-    b. Insert fixture `cases` row with ALL three NOT NULL columns (`order_id`, `email`, `tier`), `email='e2e-attorney-discipline-${ts}@example.com'` (CV-allowlisted per `inna.cv.json`), `eval_results='{"sentinel": true, "evaluated_at": null}'` sentinel, `review_reminder_sent=true`, `is_included_deliverable=true`, `generated_at=NULL`, `report_html=<rendered IB containing T2.2 matched-multi-event>`, `gen_random_uuid()` caseId.
-    c. Pre-flight assertion: `Deno.env.get('RESEND_API_KEY') === '__test_disabled__' OR === ''` (Resend gating per Sec WARN — prevents real operator email on flaky LLM regression).
-    d. `POST ${SUPABASE_URL}/functions/v1/evaluate-report` with body `{caseId}`.
-    e. Assert response JSON: `body.success === true && body.gate_passed === true`.
-    f. Read `cases.eval_results` post-call: assert `eval_results.gate_passed === true && eval_results.teams.upl.failed === 0` (CORRECT shape per evaluate-report/index.ts:443-453 + 549-557; NOT `eval_results.upl.fail_count` which does not exist).
-    g. Cleanup in `try/finally`: `DELETE FROM public.cases WHERE id = $caseId; DELETE FROM public.orders WHERE id = $orderId;`. Drop the spurious `operator_tasks` DELETE — evaluate-report writes via Resend `sendEmail()`, NOT to a `operator_tasks` table.
-    h. Reaper script `scripts/reap-attorney-discipline-fixtures.mjs` runs in CI `if: always()` step, deletes any `cases` row with `email LIKE 'e2e-attorney-discipline-%'` AND its parent `orders` row, idempotent. Catches mid-test SIGKILL.
-    Cost: ~$2-3/run (Sonnet UPL + Psych eval). CI path-filtered to attorney-discipline file changes only.
-13. **Disclaimer is UPL-banned-phrase-free (BANNED_PHRASES_LIST canonical, WARN #8).** Node test at `disclaimer-banned-phrases.test.ts` imports `DISCLAIMER_VERBATIM` and `BANNED_PHRASES_LIST`; iterates every entry in `BANNED_PHRASES_LIST` (canonical list extracted from `prompts.ts:34-44`); asserts `DISCLAIMER_VERBATIM.toLowerCase().includes(phrase.toLowerCase()) === false` for each. Hand-rolled phrase subsets are NOT acceptable — must use the imported `BANNED_PHRASES_LIST` constant.
+10. **Renderer escapes hostile input — IN-MEMORY ONLY (Sec v3 CRITICAL — no hostile rows persisted).** Test constructs an in-memory `DisciplineEvent` with `discipline_type='<script>alert(1)</script>'`, `violation_summary='alert | <script>'` (pipe-injection probe), `source_url='javascript:alert(1)'`, and passes it directly to `renderAttorneyDisciplineSection({ status: 'matched', attorney: hostileAttorney, events: [hostileEvent] })`. Asserts output HTML contains `&lt;script&gt;alert(1)&lt;/script&gt;` AND contains `href="#"` AND does NOT contain literal `<script>` or literal `javascript:` AND the rendered table has exactly the expected `<td>` cell count per row (pipe-escape kept the cell intact, no extra column). Test also runs the rendered HTML through ONE round of HTML-entity decoding (`std/html/entities.ts decode`) and asserts the decoded output STILL does not contain `<script` or `javascript:` (T3.4 entity-decode panel — Sec v3 SUG).
+11. **IB renders attorney-discipline section in correct slot.** Test imports `IB_SECTION_ANCHORS`, invokes IB renderer with `FIXTURE_DISCIPLINED_BAR_NUMBER` synthetic case; asserts: (a) output HTML matches `/<h2[^>]*>${escape(IB_SECTION_ANCHORS.ATTORNEY_DISCIPLINE)}<\/h2>/` exactly once (md2html ALWAYS injects `class="section-h2"` per `index.ts:7346`; the regex tolerates that without coupling to the class name — Code v3 CRITICAL), (b) `output.indexOf(IB_SECTION_ANCHORS.ATTORNEY_DISCIPLINE) > output.indexOf(IB_SECTION_ANCHORS.YOUR_PLAN)`, (c) `output.indexOf(IB_SECTION_ANCHORS.ATTORNEY_DISCIPLINE) < output.indexOf(IB_SECTION_ANCHORS.BRADY_GIGLIO_APPENDIX)`. Anchor strings imported from `section-anchors.ts` so render + test cannot drift.
+12. **UPL deterministic regex panel passes — 5-fixture matrix.** Test from T3.1 renders 5 fixture payloads (matched-clean, matched-1-event, matched-multi-event, no-match, ambiguous) and runs the regex panel + per-fixture assertions. Every panel check passes; no LLM call made. (Replaces the v2.1 LLM-eval criterion per Code v2 WARN #5.)
+13. **Disclaimer is UPL-banned-phrase-free.** Test asserts `DISCLAIMER_VERBATIM` does NOT contain ANY phrase from `BANNED_PHRASES_BLOCK` (imported from `supabase/functions/generate-report/lib/banned-phrases.ts`, T3.2). Iterates the full array — no hand-rolled subset (Code v2 WARN #8). Also asserts `BANNED_PHRASES_BLOCK.length >= 10` so a future hand-edit that empties the array doesn't false-green.
 14. **Fair-report privilege memo present.** File `docs/legal/2026-04-25-attorney-discipline-fair-report-privilege.md` exists; contains the literal substring `California Civil Code § 47`. (Reader runs `test -f` and `grep -F`.)
 15. **Build green.** `npm run build` exit 0.
-16. **Node tests green — count-pinned.** Capture `npm test -- --reporter=json --outputFile=before.json` on `origin/master` via temporary `.tmp/baseline-checkout/`; capture `after.json` on PR branch; assert `after.numPassedTests >= before.numPassedTests` AND no test name in `before.passing[]` appears in `after.failing[]`.
+16. **Tests green — count-pinned.** Capture `npm test -- --reporter=json --outputFile=before.json` on `origin/master` via temporary `.tmp/baseline-checkout/`; capture `after.json` on PR branch; assert `after.numPassedTests >= before.numPassedTests` AND no test name in `before.passing[]` appears in `after.failing[]`.
 17. **CV probe-only green.** `node ~/projects/continuous-verification/verify.mjs --project inna --probe-only --no-trends` exits 0 AND stdout has zero lines matching `/INNA-H1.*FAIL/`.
-18. **Deno tests green (separately tracked from npm, WARN #4).** `deno test --allow-net --allow-env --reporter=json supabase/functions/{generate-report,evaluate-report}/__tests__/ supabase/functions/__tests__/` exits 0; baseline captured pre-PR; assert `deno-after.passed === deno-before.passed + N_NEW_DENO_TESTS` where `N_NEW_DENO_TESTS = sum(new tests added in T1.4 + T3.1.1 + T3.1.2 + T4.4a + T4.5a + T4.5b + T4.6)`. Failing this criterion catches Deno-runtime test regressions that npm test cannot detect.
-19. **Deno typecheck green (SUG #11).** `deno check supabase/functions/generate-report/index.ts` exits 0. Catches Deno-side TS errors npm build cannot see.
-20. **Garbage-name skip — programmatic (WARN #9).** Deno test at `attorney-discipline-guard.test.ts` invokes `buildAttorneyDisciplineSection({ attorneyName, jurisdiction: 'CA', supabaseUrl, serviceRoleKey })` for each of: `''`, `'   '`, `'Bo'`, `'Smith'` (single-token), `'asdf'`, `'n/a'`, `'TBD'`, `'pending'`. For each input, asserts (a) returns `''`, (b) `fetch.mock.calls.length === 0` after the call. Confirms guard fires before any DB hit.
-21. **Unaccent match works both directions (WARN #7).** Deno test inserts `FIXTURE-006` with `full_name='José García'` then calls `getAttorneyDiscipline('Jose Garcia', 'CA')` — asserts `status === 'matched' && attorney.bar_number === 'FIXTURE-006'`. Reverse: insert `FIXTURE-007` `'Jose Garcia'` (ASCII), query `'José García'` — same assertion against `FIXTURE-007`. Confirms RPC `LOWER(unaccent(...))` works both directions via the functional index.
-22. **Markdown-pipe escape works (WARN #6).** Deno test inserts `FIXTURE-005` event with `discipline_type='Suspension | 90 days'` and `violation_summary='Failure to file | client funds'`. Renders T2.2 section, runs through `md2html` (the same pass T2.4 production uses). Asserts: (a) rendered HTML contains exactly 4 `<th>` headers in the discipline-events table (Date / Type / Summary / Source), (b) the cell text content for `discipline_type` shows `Suspension | 90 days` with literal pipe character (after escapeMarkdownPipe + md2html unescape cycle), (c) row count is 1 (not pipe-shred into 2+ rows).
-23. **`last_seen_at` short-date format (SUG #13).** Test asserts rendered HTML for matched fixtures contains a date matching `/\d{4}-\d{2}-\d{2}/` for the `last_seen_at` value AND does NOT contain raw timestamptz strings (negative-match `/T\d{2}:\d{2}:\d{2}/`).
-24. **Markdown heading (SUG #12).** Test asserts the RAW PRE-md2html output of `buildAttorneyDisciplineSection()` starts with `## Attorney Bar Record Check\n` (markdown), NOT raw `<h2>`. Catches drift if a future edit re-introduces inline HTML headers.
-25. **Sibling-PR pre-flight artifact (T0c, WARN #10).** Reader runs:
-    a. `grep -F '```json t0c-pre-flight' docs/plans/2026-04-25-worry-attorney-discipline-wire-rounds.md` → exit 0 (the fenced block tag exists).
-    b. Extract the fenced JSON payload after that tag. The payload is the raw output of `gh pr list --repo rahim0kapadia/ImNotAnAttorney-web --state open --json number,headRefName,files --limit 50` captured immediately before `git worktree add` in Phase 5.
-    c. For every PR object in the payload AND every `files[].path` entry within each PR: assert NONE matches any of the five blocking paths: `supabase/functions/generate-report/index.ts`, `src/lib/intelligence-brief/prompts.ts`, `src/lib/intelligence-brief/render.ts`, glob `supabase/migrations/20260425c_*.sql`, glob `supabase/migrations/20260425d_*.sql`.
-    PASS iff steps (a) and (c) both succeed (binary). FAIL if the tag missing, payload unparseable, or any path matches. Verifiable script: `node scripts/verify-t0c-preflight.mjs <rounds-file-path>` exits 0 on PASS, non-zero on FAIL.
-26. **RPC permissions — anon blocked (v2.4 status set per Code WARN — PostgREST returns 404 for missing-EXECUTE).** Test calls `POST /rest/v1/rpc/match_attorney` with anon key; asserts `r.status === 401 || r.status === 403 || r.status === 404` (PostgREST returns 404 with body `{"code": "42883", "message": "Could not find the function ... in the schema cache"}` when the calling role lacks EXECUTE — the function is treated as not-in-API). Additional body assertion: `JSON.parse(await r.text()).code === '42883'` if status is 404. Service-role call returns rows. Confirms T0a `REVOKE FROM PUBLIC` + `GRANT TO service_role` is applied.
-27. **`BANNED_PHRASES_LIST` parity test bidirectional (T3.4 v2.3).** TWO assertions: (a) every entry in `BANNED_PHRASES_LIST` (case-insensitive substring) appears in `BANNED_PHRASES_BLOCK` prose; (b) every quoted phrase regex-extracted from `BANNED_PHRASES_BLOCK` via `/^- "([^"]+)"/gm` exists (case-insensitive substring) in `BANNED_PHRASES_LIST`. Symmetric coverage closes drift in both directions.
-28. **XSS centralization lint (NEW v2.3 per Sec CRIT #1).** Test at `render-attorney-discipline-lint.test.ts` reads source of `lib/render-attorney-discipline.ts`, strips comments + string literals, regex-finds every `${...}` interpolation, asserts each is one of: `safeCell(...)`, `safeHttpUrl(...)`, `formatShortDate(...)`, OR a literal in allowlist `['events.length', 'N', 'plural', 'YYYY']`. Fails fast on any other interpolation pattern. Catches future PRs that bypass the centralized escape pipeline.
-29. **CV-probe pollution prevention (NEW v2.3 per Sec CRIT #2).** Test asserts the e2e fixture `cases` row inserted by SC #12 satisfies BOTH: (a) `email` matches CV allowlist pattern `e2e-%` per `~/projects/continuous-verification/configs/inna.cv.json` `email.not.ilike` filter, (b) `eval_results IS NOT NULL` at insert time (sentinel `{"sentinel": true}`). Both conditions ensure the fixture row never matches `inna-missed-evals` probe filter (`status.eq=review AND eval_results.is.null`) even on mid-test crash before evaluate-report writes results. Reaper script `scripts/reap-attorney-discipline-fixtures.mjs` exists at the cited path (`test -f` exit 0).
-30. **Resend gating in test env (NEW v2.3 per Sec WARN).** Pre-flight test asserts `process.env.RESEND_API_KEY === '__test_disabled__'` OR empty before invoking evaluate-report e2e smoke. Without this, a stochastic UPL regression triggers a real operator email per evaluate-report:458-481.
-31. **Cron-skip flags on cases fixture (NEW v2.3 per Sec WARN review_reminder).** Test asserts inserted fixture cases row has `review_reminder_sent=true` AND `is_included_deliverable=true` AND `generated_at IS NULL`. Documented invariant: every test fixture must be invisible to all 6 cron tasks in `src/lib/cron/`.
-32. **FAIR_REPORT_MEMO_PATHS lint (NEW v2.3 per Sec WARN coupling).** Deno test at `attorney-discipline-fair-report-paths.test.ts` asserts (a) every key in `BAR_LOOKUP_URLS` has a matching key in `FAIR_REPORT_MEMO_PATHS`, (b) every value in `FAIR_REPORT_MEMO_PATHS` resolves via `Deno.stat()` to an existing file. Catches: adding a new state's bar lookup without writing the memo. Hook-or-harder for the prose "block multi-state expansion until per-state memo" gate.
-33. **pg_policies posture (NEW v2.3 per Code WARN false-green).** Query `SELECT count(*) FROM pg_policies WHERE schemaname='public' AND tablename IN ('attorneys','attorney_discipline_events') AND cmd='SELECT' AND roles::text LIKE '%anon%' AND qual <> 'false' AND qual NOT LIKE '%FIXTURE-%'` returns count = 0. Catches future migration that adds permissive `anon SELECT USING (true)` defeating T0a's RLS posture.
-34. **Common-name silent no-match (NEW v2.3 per Sec WARN).** Test inserts two `'John Smith'` fixture attorneys (different bar_numbers, identical full_name); calls `getAttorneyDiscipline('John Smith', 'CA')`; asserts `status === 'no-match' && events.length === 0` AND no fetch is made to discipline-events endpoint (RPC server-side n>1 collapse per T0a). Documents intentional defamation-protection trade-off.
-35. **Markdown-pipe edge cases (NEW v2.3 per Sec SUG).** Test FIXTURE-008 with `discipline_type='\\|'` AND `violation_summary='|||'`. Render → md2html. Asserts (a) exactly 4 `<th>` columns, (b) row count = 1 (no shred from `|||`), (c) cell text contains the literal pipe character (escapeMarkdownPipe + md2html unescape).
-36. **Structured no-match logging (NEW v2.3 per Sec SUG).** Mock `console.log` in helper test; assert every no-match path emits one JSON object with shape `{ component: 'attorney-discipline', reason: <enum>, jurisdiction: string, name_length: number }` AND `attorneyName` substring NEVER appears in any log line (PII safety). Verifiable via `JSON.parse` round-trip on captured log output.
-37. **T0c post-worktree race-window check (NEW v2.3 per Code WARN race).** Pre-Phase-5 ops: AFTER `git worktree add`, re-run `gh pr list` and append the JSON to `rounds.md` under fenced tag `t0c-pre-flight-post`. Verifier script (same as SC #25, but reads the post-tag) exits 0 if no new sibling PR appeared touching any of the 5 blocking paths during the worktree-creation race window. FAIL if the post-flight detected drift; recovery path: `git worktree remove` + abort.
-38. **Unaccent extension pre-flight (NEW v2.3 per Code CRIT #7).** T0a migration body includes `DO $$ ... SELECT extensions.unaccent('extensions.unaccent', 'café') INTO folded; IF folded <> 'cafe' THEN RAISE EXCEPTION ... END IF; END $$;` BEFORE the index in step 3 fires. Verifiable: migration apply succeeds end-to-end (indicates pre-flight passed); a deliberate misconfig (e.g. unaccent installed in wrong schema) would abort migration with the EXCEPTION text. Test inspects migration file via `Deno.readTextFile + grep` to confirm the DO block exists with the exact RAISE EXCEPTION text.
-39. **RPC server-side ambiguity collapse (NEW v2.3 per Code SUG).** Test calls `match_attorney('John Smith', 'CA')` against fixtures with two `'John Smith'` rows; asserts response array is empty `[]` (NOT a row with `match_count=2`). Confirms the `WHERE counted.n = 1` clause is server-side enforced.
-40. **Fixture future-proof RLS deny policies (NEW v2.3 per Sec SUG).** Test asserts `SELECT count(*) FROM pg_policies WHERE schemaname='public' AND tablename IN ('attorneys','attorney_discipline_events') AND policyname IN ('deny_anon_test_fixtures_attorneys','deny_anon_test_fixtures_events')` returns count = 2. Confirms T0a's defense-in-depth deny policies survive even if a future migration adds permissive anon SELECT.
-41. **Bar-lookup-url disambiguation (NEW v2.4 per Dreyer WARN #1).** Test renders T2.2 matched-state output AND T2.2 no-match output. Asserts: (a) matched-state HTML contains substring `apps.calbar.ca.gov/attorney/Licensee/Detail/` (deep link via `BAR_LOOKUP_URLS.CA.detail(barNumber)`) AND does NOT contain `LicenseeSearch/QuickSearch` (the base URL would defeat the methodology proof); (b) no-match-state HTML contains substring `apps.calbar.ca.gov/attorney/LicenseeSearch/QuickSearch` (defendant doesn't have bar_number to deep-link with) AND does NOT contain `Licensee/Detail/`.
-42. **Fair-report public route exists + renders (NEW v2.4 per Dreyer WARN #2).** (a) `test -f src/app/legal/fair-report-privilege/page.tsx` exit 0; (b) `test -f content/legal/fair-report-privilege.md` exit 0; (c) Playwright smoke: `await page.goto('https://imnotanattorney.com/legal/fair-report-privilege'); expect(page.locator('h1')).toContainText('Fair Report')` (or equivalent dev-server `localhost:3000/legal/fair-report-privilege` for CI); (d) page contains substring "California Civil Code § 47" (matches T0b memo + SC #14). Closes the dead-link surface where IB disclaimer would 404 on click.
-43. **test_run_id rule compliance — justified marker (NEW v2.4 per Code WARN).** Per `~/.claude/rules/drafts/test-isolation.md`, test files writing to Supabase tables MUST satisfy one of: withTestTx, newTestRunId marker, `test-isolation-justified: <reason ≥15 chars>` comment, OR `test-isolation-na: <reason>` comment. T3.1.2 e2e test file SHALL contain at line 1-20 the comment: `// test-isolation-justified: e2e fixture uses CV-allowlisted email pattern + sentinel eval_results gate_passed:false + reaper safety net; cases/orders test_run_id columns not yet present on this branch (test-isolation infra is on a separate worktree planned for 2026-05).` Verifiable via `grep -F 'test-isolation-justified:' supabase/functions/evaluate-report/__tests__/attorney-discipline-e2e.test.ts` exit 0.
+
+**Worry-intent coverage:** worry says "we have intake.attorneyName, we have the bar tables, we never connect them." Criteria 5/6/11 connect intake fixture → query helper → IB rendered output for both clean and disciplined cases. Criterion 12 confirms UPL gate stays green. Criteria 1/2 confirm defensive RLS. Criteria 7/8/9/10 cover defamation/injection/XSS edge cases the round-0 reviewers flagged.
 
 ## Worktree Boundary (v2.3)
-Run in isolated worktree at `.claude/worktrees/worry-attorney-discipline/` off `origin/master` (currently `81721f28`). Touch only:
-- `supabase/migrations/20260425c_attorney_discipline_rls.sql` (new, T0a — renamed from `20260425a`)
-- `supabase/migrations/20260425d_attorney_discipline_test_fixtures.sql` (new, T1.3 — renamed from `20260425b`)
+Run in isolated worktree at `C:\Users\email\projects\_worktrees\worry-attorney-discipline` off `origin/master` (currently `725a8a8e`). Touch only:
+- `supabase/migrations/20260425a_attorney_discipline_rls.sql` (new, T0a)
+- `supabase/migrations/20260425b_attorney_discipline_test_fixtures.sql` (new, T1.3 — CLEAN fixtures only, no hostile rows; Sec v3 CRITICAL)
+- `supabase/migrations/20260425c_attorney_unaccent.sql` (new, T1.1a + T1.2 RPC `attorney_match_by_raw_name`; Code v2 WARN #7 + Code v3 CRITICAL JS-shim drop)
 - `docs/legal/2026-04-25-attorney-discipline-fair-report-privilege.md` (new, T0b)
-- `supabase/functions/generate-report/lib/attorney-discipline.ts` (new, T1.2 — RPC caller)
-- `supabase/functions/generate-report/lib/render-attorney-discipline.ts` (new, T2.2 — markdown emitter)
-- `supabase/functions/generate-report/lib/section-anchors.ts` (new, T2.1 — Deno-side anchor constants)
-- `supabase/functions/generate-report/lib/banned-phrases-list.ts` (NEW v2.3, T3.3 — canonical Deno-readable list)
-- `src/lib/intelligence-brief/attorney-discipline-disclaimer.ts` (new, T3.2 mirror — DISCLAIMER_VERBATIM constant)
+- `supabase/functions/generate-report/lib/attorney-discipline.ts` (new, T1.2 — RPC client, no JS unaccent shim)
+- `supabase/functions/generate-report/lib/render-attorney-discipline.ts` (new, T2.2)
+- `supabase/functions/generate-report/lib/section-anchors.ts` (new — Deno-side anchors, T2.1)
+- `supabase/functions/generate-report/lib/banned-phrases.ts` (new, T3.2 — Deno-side canonical list; Code v3 CRITICAL repath)
+- `src/lib/intelligence-brief/banned-phrases.ts` (new — Node-side mirror; T3.2 + T3.2a parity test)
+- `src/lib/intelligence-brief/__tests__/banned-phrases-parity.test.ts` (new — T3.2a)
+- `src/lib/intelligence-brief/prompts.ts` (modify — interpolate `BANNED_PHRASES_BLOCK` from new Node-side mirror, T3.2)
 - `supabase/functions/generate-report/__tests__/attorney-discipline.test.ts` (new, T1.4)
-- `supabase/functions/generate-report/__tests__/upl-regex-panel.test.ts` (new, T3.1.1)
-- `supabase/functions/generate-report/__tests__/attorney-discipline-guard.test.ts` (new, T4.5b)
-- `supabase/functions/generate-report/__tests__/render-attorney-discipline-lint.test.ts` (NEW v2.3, T4.4b — XSS centralization lint)
-- `supabase/functions/generate-report/__tests__/attorney-discipline-fair-report-paths.test.ts` (NEW v2.3, T4.5c)
-- `supabase/functions/generate-report/__tests__/attorney-discipline-common-name.test.ts` (NEW v2.3, T4.5d)
-- `supabase/functions/generate-report/__tests__/fixtures.ts` (new — fixture constants)
-- `supabase/functions/evaluate-report/__tests__/attorney-discipline-e2e.test.ts` (new, T3.1.2 — Deno test)
-- `supabase/functions/__tests__/rls-attorney-discipline.test.ts` (new, T4.6 — anon + RPC permission + pg_policies posture)
-- `supabase/functions/generate-report/index.ts` (modify — caller-scope wiring at line 5045-5046 + slot in sections array between line 7438 and 7439 per T2.4 v2.3 REWRITE)
-- `src/lib/intelligence-brief/prompts.ts` (modify — re-export `BANNED_PHRASES_LIST` from canonical Deno-side file per T3.3)
-- `src/lib/intelligence-brief/__tests__/disclaimer-banned-phrases.test.ts` (new, T3.2 Node-side)
-- `src/lib/intelligence-brief/__tests__/banned-phrases-parity.test.ts` (new, T3.4 Node-side bidirectional)
-- `src/lib/intelligence-brief/render.ts` (OPTIONAL modify — dev-tool parity per T2.4; not blocking)
-- `src/lib/intelligence-brief/section-anchors.ts` (OPTIONAL new — Node-side parallel mirror with parity test, per T2.1)
-- `scripts/reap-attorney-discipline-fixtures.mjs` (NEW v2.3 per Sec CRIT #2 — CI `if: always()` cleanup safety net)
-- `scripts/verify-t0c-preflight.mjs` (NEW v2.3 per SC #25 — verifier script for sibling-PR pre-flight artifact)
-- `.github/workflows/attorney-discipline-e2e.yml` (NEW v2.3 — CI path-gated job for T3.1.2 e2e + reaper)
-- `src/app/legal/fair-report-privilege/page.tsx` (NEW v2.4 per Dreyer WARN #2 — public route for "Why we can show this" link; T2.6)
-- `content/legal/fair-report-privilege.md` (NEW v2.4 per Dreyer WARN #2 — sanitized public-facing memo body, sourced from T0b internal memo)
+- `supabase/functions/generate-report/__tests__/attorney-discipline-upl.test.ts` (new, T3.1 — deterministic regex panel + T3.3 interpretive panel + T3.4 entity-decode panel)
+- `supabase/functions/generate-report/__tests__/fixtures.ts` (new — fixture constants, T1.3a)
+- `supabase/functions/__tests__/rls-attorney-discipline.test.ts` (new, T4.6 — table SELECT + RPC POST anon denial)
+- `supabase/functions/generate-report/index.ts` (modify — wire helper between `your-plan` and `buildBradyGiglioChecklist`)
+- `src/lib/intelligence-brief/section-anchors.ts` (new — Node-side parallel mirror, T2.1, optional)
+- `src/lib/intelligence-brief/render.ts` (modify — dev-tool parity, optional)
 - `docs/plans/2026-04-25-worry-attorney-discipline-wire.md` (this file)
 - `docs/plans/2026-04-25-worry-attorney-discipline-wire-findings.md` (rounds findings, new)
 - `docs/plans/2026-04-25-worry-attorney-discipline-wire-rounds.md` (per-round log, new)
 
-**Pre-execution check (T0c, restated here)**: run `gh pr list --repo rahim0kapadia/ImNotAnAttorney-web --state open --json number,headRefName,files --limit 50` immediately before `git worktree add`. Abort with named conflict if any open PR's `files[]` contains: `supabase/functions/generate-report/index.ts`, `src/lib/intelligence-brief/prompts.ts`, `src/lib/intelligence-brief/render.ts`, or any `supabase/migrations/20260425c_*.sql` / `20260425d_*.sql`. As of 2026-04-25: PRs #102 (score) and #133 (NYPD CCRB) are open — neither hits the four blocking paths above (verified via JSON grep).
+**Pre-execution check** (Code WARN #18 + Code v2 WARN #10):
+1. Run `gh pr list --state open --json number,headRefName,files --limit 50`.
+2. Confirm none of the 17 worktree-boundary paths appear in any open sibling PR's `files[]`.
+3. **Special case for `supabase/functions/generate-report/index.ts`** — this file is high-collision (every IB-touching PR modifies it). Filter open PRs to those touching this exact path:
+   ```
+   gh pr list --state open --json number,headRefName,files --limit 50 \
+     | jq '[.[] | select(.files[].path == "supabase/functions/generate-report/index.ts")
+                | {number, headRefName}]'
+   ```
+   If any PR is returned, surface to the user BEFORE starting Phase 5 — Phase 5 will rebase-conflict against it. Coordinate sibling-session owner: either wait for sibling merge, OR rebase Phase 5 onto sibling's branch instead of `origin/master`.
+4. Abort if collision after coordination fails.
 
-Do NOT touch sibling-owned files: anything modified in any open sibling PR.
+Do NOT touch sibling-owned files: anything modified in PRs currently open by sibling sessions (#102, #105, #108, #110, #116, #118, #134, #136, etc).
 
 ## Phase 1.1b — Case Decoder integration (deferred plan, queued)
 After v2 ships:

--- a/src/app/CONTEXT.md
+++ b/src/app/CONTEXT.md
@@ -328,8 +328,8 @@ graph TD
 | `TIER_CORE` | 14 tiers (pricing + Stripe IDs) | `src/lib/tiers.ts:30-256` |
 | `PLAYBOOK_CONFIGS` | 8 charge-type sales pages | `src/lib/playbook-configs.ts` |
 | `SITE_URL` | `https://imnotanattorney.com` | `src/lib/site.ts:48-49` |
-| `metadataBase` | `new URL(SITE_URL)` | `layout.tsx:74` |
-| `title.template` | `"%s \| ImNotAnAttorney"` | `layout.tsx:77` |
+| `metadataBase` | `new URL(SITE_URL)` | `layout.tsx:75` |
+| `title.template` | `"%s \| ImNotAnAttorney"` | `layout.tsx:78` |
 | `maxDuration` (cron/demand-fetch) | 300s | `api/cron/demand-fetch/route.ts:19` |
 | `maxDuration` (cron/demand-score) | 120s | `api/cron/demand-score/route.ts:21` |
 | `maxDuration` (cron/blog-publish) | 60s | `api/cron/blog-publish/route.ts:22` |

--- a/src/app/r/[code]/[product]/page.tsx
+++ b/src/app/r/[code]/[product]/page.tsx
@@ -61,7 +61,7 @@ const SUBHEADLINES: Partial<Record<TierSlug, string>> = {
 // "No attorney yet" reassurance — crisis buyers often haven't been assigned
 // a public defender and haven't hired counsel. Without this line they read
 // the whole deliverable set as "not for me." UPL-safe: information framing,
-// no legal advice, no outcome claim. Positioned below deliverables so it
+// no counsel-style direction, no outcome claim. Positioned below deliverables so it
 // answers the silent objection at the moment it surfaces.
 // Adversarial-walkthrough skeptical-buyer R1/R2/R4: flagged "every bullet
 // assumes YOUR ATTORNEY" as a close-the-tab signal for the 60%+ of criminal
@@ -340,7 +340,7 @@ export default async function DeepLinkProductPage({ params, searchParams }: Page
         </h1>
 
         {/* Category-setter: what this IS, in 3 seconds. Pre-answers the two
-            loudest silent objections ("is this legal advice?" / "is this AI
+            loudest silent objections ("am I being lawyered at?" / "is this AI
             slop?") — information-framed, UPL-safe. Adversarial-walkthrough
             2026-04-21: Dunford + Laja + Suby all flagged category ambiguity
             as the weakest layer; this line collapses their fix into one. */}

--- a/src/lib/intelligence-brief/__tests__/banned-phrases-parity.test.ts
+++ b/src/lib/intelligence-brief/__tests__/banned-phrases-parity.test.ts
@@ -1,0 +1,71 @@
+/**
+ * T3.2a parity test (worry-attorney-discipline-wire v2.4) — keep Deno-side
+ * canonical and Node-side mirror lockstep for the BANNED_PHRASES_BLOCK list
+ * used by the IB UPL gate.
+ *
+ * Pattern matches src/lib/report/__tests__/whitelist-parity.test.ts: read the
+ * Deno-side file as text, parse the literal array, then deep-equal against the
+ * Node mirror (vitest is Node-only; cannot import a Deno-side module via
+ * normal resolution).
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { BANNED_PHRASES_BLOCK as NODE_LIST } from "../banned-phrases";
+
+function parseDenoList(): string[] {
+  const path = resolve(
+    __dirname,
+    "..",
+    "..",
+    "..",
+    "..",
+    "supabase",
+    "functions",
+    "generate-report",
+    "lib",
+    "banned-phrases.ts",
+  );
+  const src = readFileSync(path, "utf8");
+  const start = src.indexOf("export const BANNED_PHRASES_BLOCK");
+  if (start < 0) throw new Error("Deno BANNED_PHRASES_BLOCK not found");
+  const open = src.indexOf("[", start);
+  // Match closing `])` of `Object.freeze([ ... ])`.
+  const close = src.indexOf("])", open);
+  if (open < 0 || close < 0) throw new Error("Deno banned list malformed");
+  const body = src.slice(open + 1, close);
+
+  const out: string[] = [];
+  for (const line of body.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("//")) continue;
+    // Match a string literal: "..." optionally followed by `,`.
+    const m = trimmed.match(/^"((?:[^"\\]|\\.)*)"\s*,?\s*$/);
+    if (m) out.push(m[1].replace(/\\"/g, '"').replace(/\\\\/g, "\\"));
+  }
+  return out;
+}
+
+describe("BANNED_PHRASES_BLOCK parity (Deno ↔ Node)", () => {
+  it("Deno-side canonical and Node-side mirror are deep-equal", () => {
+    const deno = parseDenoList();
+    expect(deno).toEqual([...NODE_LIST]);
+  });
+
+  it("BANNED_PHRASES_BLOCK has at least 10 phrases (false-green guard)", () => {
+    // Success Criterion 13 — guards against a future hand-edit emptying the
+    // array and producing a vacuous pass.
+    expect(NODE_LIST.length).toBeGreaterThanOrEqual(10);
+  });
+
+  it("contains the canonical UPL trigger 'you should'", () => {
+    expect(NODE_LIST).toContain("you should");
+  });
+
+  it("all phrases are lowercased (case-insensitive matching strategy)", () => {
+    for (const p of NODE_LIST) {
+      expect(p).toBe(p.toLowerCase());
+    }
+  });
+});

--- a/src/lib/intelligence-brief/__tests__/section-anchors-parity.test.ts
+++ b/src/lib/intelligence-brief/__tests__/section-anchors-parity.test.ts
@@ -1,0 +1,66 @@
+/**
+ * T2.1 parity test (worry-attorney-discipline-wire v2.4) — keep Deno-side
+ * canonical and Node-side mirror lockstep for IB section heading anchors.
+ *
+ * Pattern mirrors src/lib/report/__tests__/whitelist-parity.test.ts: read the
+ * Deno-side file as text (the Node toolchain cannot import a Deno-only TS file
+ * directly), parse the literal map, then deep-equal against the Node mirror.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { IB_SECTION_ANCHORS as NODE_ANCHORS } from "../section-anchors";
+
+function parseDenoAnchors(): Record<string, string> {
+  const path = resolve(
+    __dirname,
+    "..",
+    "..",
+    "..",
+    "..",
+    "supabase",
+    "functions",
+    "generate-report",
+    "lib",
+    "section-anchors.ts",
+  );
+  const src = readFileSync(path, "utf8");
+  const start = src.indexOf("export const IB_SECTION_ANCHORS");
+  if (start < 0) throw new Error("Deno IB_SECTION_ANCHORS not found");
+  const open = src.indexOf("{", start);
+  const close = src.indexOf("} as const", open);
+  if (open < 0 || close < 0) throw new Error("Deno anchor map malformed");
+  const body = src.slice(open + 1, close);
+
+  const out: Record<string, string> = {};
+  // Match KEY:  "value", but skip lines whose first non-whitespace is `//`
+  // (true line-comments). Inline `// ...` after the literal is also tolerated
+  // because the regex stops at the closing quote of the value.
+  for (const line of body.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("//")) continue;
+    const m = trimmed.match(/^([A-Z_][A-Z0-9_]*)\s*:\s*"((?:[^"\\]|\\.)*)"/);
+    if (m) out[m[1]] = m[2].replace(/\\"/g, '"').replace(/\\\\/g, "\\");
+  }
+  return out;
+}
+
+describe("IB_SECTION_ANCHORS parity (Deno ↔ Node)", () => {
+  it("Deno-side canonical and Node-side mirror have identical entries", () => {
+    const deno = parseDenoAnchors();
+    expect(deno).toEqual(NODE_ANCHORS);
+  });
+
+  it("ATTORNEY_DISCIPLINE anchor is the new section heading", () => {
+    expect(NODE_ANCHORS.ATTORNEY_DISCIPLINE).toBe(
+      "Your Attorney's Public Bar Record",
+    );
+  });
+
+  it("BRADY_GIGLIO_APPENDIX is the deterministic lower-order bound", () => {
+    expect(NODE_ANCHORS.BRADY_GIGLIO_APPENDIX).toBe(
+      "Appendix A: Brady/Giglio Checklist",
+    );
+  });
+});

--- a/src/lib/intelligence-brief/banned-phrases.ts
+++ b/src/lib/intelligence-brief/banned-phrases.ts
@@ -1,0 +1,38 @@
+// src/lib/intelligence-brief/banned-phrases.ts
+//
+// T3.2 mirror (worry-attorney-discipline-wire v2.4) — Node-side parity copy of
+// the Deno canonical at
+//   supabase/functions/generate-report/lib/banned-phrases.ts
+//
+// Parity asserted by
+//   src/lib/intelligence-brief/__tests__/banned-phrases-parity.test.ts
+// using readFileSync + parse (NOT direct import — matches existing
+// whitelist-parity.test.ts pattern; the npm/Vite side cannot resolve a
+// supabase/functions/ path through normal module resolution).
+//
+// Imported by src/lib/intelligence-brief/prompts.ts:34 to interpolate into
+// the existing BANNED_PHRASES_BLOCK template literal so that Node-side
+// generation prompts use the same canonical list as Deno-side audit/render.
+
+export const BANNED_PHRASES_BLOCK: readonly string[] = Object.freeze([
+  "you should",
+  "should file",
+  "should pursue",
+  "should review",
+  "should consult",
+  "could or should",
+  "you need to",
+  "you must",
+  "you have to",
+  "we recommend",
+  "we advise",
+  "i recommend",
+  "i advise",
+  "your best option",
+  "the best strategy",
+  "the best option",
+  "red flag",
+  "warning sign",
+  "escalation ladder",
+  "do not discuss your case",
+]) as readonly string[];

--- a/src/lib/intelligence-brief/prompts.ts
+++ b/src/lib/intelligence-brief/prompts.ts
@@ -13,6 +13,11 @@
 
 import type { IBVariables } from "./variables";
 import { TIER_CORE, upgradeCostBetween } from "@/lib/tiers";
+// Phase 5 (worry-attorney-discipline-wire v2.4) T3.2: BANNED_PHRASES_BLOCK
+// list is now the canonical Node-mirror of the Deno-side list at
+// supabase/functions/generate-report/lib/banned-phrases.ts. Parity asserted
+// by src/lib/intelligence-brief/__tests__/banned-phrases-parity.test.ts.
+import { BANNED_PHRASES_BLOCK as CANONICAL_BANNED_PHRASES } from "./banned-phrases";
 
 // ============================================================
 // TYPES
@@ -31,17 +36,30 @@ export interface PromptConfig {
 // SHARED CONSTANTS
 // ============================================================
 
+// Phase 5 (worry-attorney-discipline-wire v2.4) T3.2: phrases derived from
+// the canonical Deno-side list, parity-checked at every CI run. Editing
+// individual entries here is BANNED — edit the canonical list at
+//   supabase/functions/generate-report/lib/banned-phrases.ts
+// then mirror to src/lib/intelligence-brief/banned-phrases.ts and the parity
+// test will turn green.
 const BANNED_PHRASES_BLOCK = `
 ABSOLUTE BANNED PHRASES (will cause report rejection if found):
-- "you should", NEVER. Use "consider," "one option is," "questions to explore"
-- "should" in any directive context (e.g., "should file," "could or should," "should pursue"), NEVER. Use "could be filed," "worth exploring"
-- "you need to", NEVER. Use "the next step is," "one action to consider"
-- "we recommend" / "we advise", NEVER
-- "your best option" / "the best strategy", NEVER
-- "red flag" / "warning sign" / "escalation ladder", NEVER
-- "Do not" as a bare imperative to the defendant (e.g., "Do not discuss your case"), NEVER. Reframe as information: "Most defense attorneys advise against..." or "Conversations with X are not privileged and can be subpoenaed."
-EXCEPTION: In "When the Conversation Gets Difficult" scenario headers, banned phrases in quoted attorney dialogue are acceptable when clearly attributed as attorney speech (e.g., a scenario titled "The evidence is strong, I really think the plea is the way to go."). The ban applies to report language addressed TO the defendant, not to realistic attorney dialogue examples.
-These are not soft guidelines. A single occurrence of any banned phrase in report language (not quoted dialogue) invalidates the entire section.`;
+${CANONICAL_BANNED_PHRASES.map((p) => `- "${p}"`).join("\n")}
+
+For each banned construction, use approved alternatives instead: "consider,"
+"one option is," "questions to explore," "the next step is," "one action
+to consider," "could be filed," "worth exploring." Reframe imperatives as
+information: "Most defense attorneys advise against..." or "Conversations
+with X are not privileged and can be subpoenaed."
+
+EXCEPTION: In "When the Conversation Gets Difficult" scenario headers, banned
+phrases in quoted attorney dialogue are acceptable when clearly attributed as
+attorney speech (e.g., a scenario titled "The evidence is strong, I really
+think the plea is the way to go."). The ban applies to report language
+addressed TO the defendant, not to realistic attorney dialogue examples.
+
+These are not soft guidelines. A single occurrence of any banned phrase in
+report language (not quoted dialogue) invalidates the entire section.`;
 
 const METHODOLOGY_NOTE = `
 METHODOLOGY NOTE (include at section end):

--- a/src/lib/intelligence-brief/section-anchors.ts
+++ b/src/lib/intelligence-brief/section-anchors.ts
@@ -1,0 +1,34 @@
+// src/lib/intelligence-brief/section-anchors.ts
+//
+// T2.1 mirror (worry-attorney-discipline-wire v2.4) — Node-side parity copy of
+// the Deno canonical at
+//   supabase/functions/generate-report/lib/section-anchors.ts
+//
+// Used by Node-side dev tools (scripts/test-ib-pipeline.ts, render-ib-test.mjs)
+// and by tests that exercise the IB renderer at the npm/vitest layer.
+//
+// PARITY: The arrays below are deep-equal-checked against the Deno-side
+// canonical in
+//   src/lib/intelligence-brief/__tests__/section-anchors-parity.test.ts
+// Update both files together; the parity test will fail otherwise.
+
+export const IB_SECTION_ANCHORS = {
+  CASE_ROADMAP:        "Section 1: Your Case Roadmap",
+  WHATS_WORKING:       "Section 2: What's Working in Your Defense",
+  CASE_INTELLIGENCE:   "Section 3: Case Intelligence",
+  LEGAL_OPTIONS:       "Section 4: Your Legal Options",
+  PROTECTION:          "Section 5: Protecting Yourself",
+  YOUR_PLAN:           "Section 6: Your Plan",
+  COURT_PREP:          "Appendix B: Court Preparation",
+  QUESTIONS:           "Appendix D: Questions for Your Attorney",
+  ATTORNEY_DISCIPLINE: "Your Attorney's Public Bar Record",
+  TABLE_OF_CONTENTS:        "Table of Contents",
+  BRADY_GIGLIO_APPENDIX:    "Appendix A: Brady/Giglio Checklist",
+  ATTORNEY_SCRIPT_PACK:     "Appendix C: Attorney Script Pack",
+  YOUR_RIGHTS:              "Appendix E: Your Rights During Criminal Proceedings",
+  TIER9_DATA_APPENDIX:      "Appendix F: Data-Driven Defense Intelligence",
+  MOTION_STRATEGY:          "Appendix G: Motion Strategy",
+  LIVE_AUTHORITY_MAP:       "Appendix H: Live Authority Map",
+} as const;
+
+export type IbSectionAnchorKey = keyof typeof IB_SECTION_ANCHORS;

--- a/supabase/functions/__tests__/rls-attorney-discipline.test.ts
+++ b/supabase/functions/__tests__/rls-attorney-discipline.test.ts
@@ -1,0 +1,193 @@
+// supabase/functions/__tests__/rls-attorney-discipline.test.ts
+//
+// T4.6 (worry-attorney-discipline-wire v2.4) — RLS posture smoke test.
+//
+// Asserts:
+//   1. Anon-key SELECT on attorneys + attorney_discipline_events returns
+//      HTTP 200 + body `[]` (RLS-blocked under PostgREST returns empty,
+//      NOT 401 — Code v2 CRIT #3 verified live 2026-04-25).
+//   2. Anon-key POST to /rest/v1/rpc/attorney_match_by_raw_name returns
+//      HTTP 404 AND body parses to JSON with `code === 'PGRST202'`
+//      (function not found / no EXECUTE grant).
+//   3. Service-role POST to the same RPC against FIXTURE_CLEAN_ATTORNEY_NAME
+//      returns 200 + non-empty array — proves the test exercises the actual
+//      function path, not a typo'd 404 for the wrong reason.
+//
+// Pre-flight (runtime — not at import time): decode the JWT and assert
+// `role === 'anon'`. Stale .env.local values returned 401 on every table
+// during 2026-04-25 session, masking actual RLS posture.
+//
+// Runner: built-in `Deno.test`. Run with:
+//   ANON_KEY=... SERVICE_ROLE_KEY=... SUPABASE_URL=... \
+//     deno test --allow-net --allow-env --no-check=remote \
+//     supabase/functions/__tests__/rls-attorney-discipline.test.ts
+
+import {
+  assertEquals,
+  assert,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
+
+import { FIXTURE_CLEAN_ATTORNEY_NAME } from "../generate-report/__tests__/fixtures.ts";
+
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL") ??
+  Deno.env.get("NEXT_PUBLIC_SUPABASE_URL") ?? "";
+let ANON_KEY = Deno.env.get("ANON_KEY") ??
+  Deno.env.get("NEXT_PUBLIC_SUPABASE_ANON_KEY") ?? "";
+const SERVICE_ROLE_KEY = Deno.env.get("SERVICE_ROLE_KEY") ??
+  Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "";
+const MGMT_TOKEN = Deno.env.get("SUPABASE_ACCESS_TOKEN") ?? "";
+const PROJECT_REF = Deno.env.get("SUPABASE_PROJECT_REF") ?? "jxjbjmgdukwkoclydqdr";
+
+function decodeJwtRole(jwt: string): string | null {
+  try {
+    const parts = jwt.split(".");
+    if (parts.length !== 3) return null;
+    const payload = JSON.parse(atob(parts[1].replace(/-/g, "+").replace(/_/g, "/")));
+    return typeof payload.role === "string" ? payload.role : null;
+  } catch {
+    return null;
+  }
+}
+
+// Per Plan T4.6 §3 (Sec v2 WARN #4): the anon key MUST come from the Supabase
+// Mgmt API at runtime, NOT from .env.local. Stale .env.local returned 401 on
+// every table during the 2026-04-25 session, masking actual RLS posture.
+async function refreshAnonKeyIfStale(): Promise<void> {
+  if (!MGMT_TOKEN || !SUPABASE_URL || !ANON_KEY) return;
+  // Probe a known-RLS table — if 401, the key is stale; refresh from Mgmt API.
+  try {
+    const probe = await fetch(`${SUPABASE_URL}/rest/v1/cases?select=*&limit=1`, {
+      headers: { apikey: ANON_KEY, Authorization: `Bearer ${ANON_KEY}` },
+    });
+    if (probe.status === 401) {
+      const r = await fetch(
+        `https://api.supabase.com/v1/projects/${PROJECT_REF}/api-keys?reveal=true`,
+        { headers: { Authorization: `Bearer ${MGMT_TOKEN}` } },
+      );
+      if (r.ok) {
+        const keys = (await r.json()) as Array<{ name?: string; api_key?: string }>;
+        const fresh = keys.find((k) => k.name === "anon")?.api_key;
+        if (fresh) ANON_KEY = fresh;
+      }
+    }
+  } catch {
+    // Falls through; tests will surface the 401 on first assertion.
+  }
+}
+
+await refreshAnonKeyIfStale();
+
+const SKIP_REASON =
+  !SUPABASE_URL || !ANON_KEY || !SERVICE_ROLE_KEY
+    ? "missing SUPABASE_URL / ANON_KEY / SERVICE_ROLE_KEY env (set via Supabase Mgmt API; do not use stale .env.local)"
+    : null;
+
+Deno.test({
+  name: "RLS pre-flight: ANON_KEY is `anon`-role JWT (Sec v2 WARN #4)",
+  ignore: SKIP_REASON !== null,
+  fn() {
+    if (SKIP_REASON) return;
+    const role = decodeJwtRole(ANON_KEY);
+    assertEquals(
+      role,
+      "anon",
+      `ANON_KEY role is "${role}" (expected "anon") — fix or fetch via Mgmt API`,
+    );
+  },
+});
+
+Deno.test({
+  name: "RLS: anon SELECT attorneys → 200 + []",
+  ignore: SKIP_REASON !== null,
+  async fn() {
+    if (SKIP_REASON) return;
+    const r = await fetch(`${SUPABASE_URL}/rest/v1/attorneys?select=*`, {
+      headers: { apikey: ANON_KEY, Authorization: `Bearer ${ANON_KEY}` },
+    });
+    assertEquals(r.status, 200, "expected 200 (RLS empty)");
+    const body = JSON.parse(await r.text());
+    assertEquals(Array.isArray(body), true);
+    assertEquals(body.length, 0, "expected RLS-blocked anon to see []");
+  },
+});
+
+Deno.test({
+  name: "RLS: anon SELECT attorney_discipline_events → 200 + []",
+  ignore: SKIP_REASON !== null,
+  async fn() {
+    if (SKIP_REASON) return;
+    const r = await fetch(
+      `${SUPABASE_URL}/rest/v1/attorney_discipline_events?select=*`,
+      {
+        headers: { apikey: ANON_KEY, Authorization: `Bearer ${ANON_KEY}` },
+      },
+    );
+    assertEquals(r.status, 200);
+    const body = JSON.parse(await r.text());
+    assertEquals(Array.isArray(body), true);
+    assertEquals(body.length, 0);
+  },
+});
+
+Deno.test({
+  name: "RLS: anon RPC attorney_match_by_raw_name → denied (404 PGRST202 or 401 42501)",
+  ignore: SKIP_REASON !== null,
+  async fn() {
+    if (SKIP_REASON) return;
+    const r = await fetch(
+      `${SUPABASE_URL}/rest/v1/rpc/attorney_match_by_raw_name`,
+      {
+        method: "POST",
+        headers: {
+          apikey: ANON_KEY,
+          Authorization: `Bearer ${ANON_KEY}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ jur: "CA", raw_name: "x" }),
+      },
+    );
+    // Two valid denial shapes (both = anon EXECUTE denied):
+    //   - 404 + body.code === 'PGRST202'  (PostgREST: function not in cache)
+    //   - 401 + body.code === '42501'     (Postgres permission_denied)
+    // We assert the union so the test is robust to PostgREST cache state.
+    let body: { code?: string } = {};
+    try {
+      body = JSON.parse(await r.text());
+    } catch {
+      assert(false, "expected JSON body");
+    }
+    const allowed = (r.status === 404 && body.code === "PGRST202")
+      || (r.status === 401 && body.code === "42501");
+    assert(
+      allowed,
+      `expected denial (404+PGRST202 or 401+42501), got ${r.status} + ${JSON.stringify(body)}`,
+    );
+  },
+});
+
+Deno.test({
+  name: "Positive control: service-role RPC returns clean attorney row",
+  ignore: SKIP_REASON !== null,
+  async fn() {
+    if (SKIP_REASON) return;
+    const r = await fetch(
+      `${SUPABASE_URL}/rest/v1/rpc/attorney_match_by_raw_name`,
+      {
+        method: "POST",
+        headers: {
+          apikey: SERVICE_ROLE_KEY,
+          Authorization: `Bearer ${SERVICE_ROLE_KEY}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ jur: "CA", raw_name: FIXTURE_CLEAN_ATTORNEY_NAME }),
+      },
+    );
+    assertEquals(r.status, 200);
+    const body = JSON.parse(await r.text());
+    assert(Array.isArray(body));
+    assert(body.length >= 1, "expected ≥1 row for fixture name");
+    // FIXTURE-001 + FIXTURE-003 share the full_name → ambiguous probe row
+    // exists. Service-role doesn't go through the ambiguous→no-match path
+    // (that's client-side); it sees the raw rows.
+  },
+});

--- a/supabase/functions/generate-report/__tests__/attorney-discipline-upl.test.ts
+++ b/supabase/functions/generate-report/__tests__/attorney-discipline-upl.test.ts
@@ -1,0 +1,422 @@
+// supabase/functions/generate-report/__tests__/attorney-discipline-upl.test.ts
+//
+// T3.1 + T3.3 + T3.4 (worry-attorney-discipline-wire v2.4) — deterministic
+// regex panel for the IB attorney-discipline section. Replaces a previous
+// LLM-eval gate ($2-3/run, non-deterministic, $caseId-dependent).
+//
+// Runner: built-in `Deno.test`. Run with:
+//   deno test --allow-net --allow-env --no-check=remote \
+//     supabase/functions/generate-report/__tests__/attorney-discipline-upl.test.ts
+//
+// Strategy:
+//   - Render 5 fixture payloads to markdown (renderAttorneyDisciplineSection),
+//     convert to HTML via an inlined minimal md2html mirroring index.ts:7370.
+//   - Run a deterministic regex panel + per-fixture assertions on each HTML.
+//   - Assertions cover XSS escape, javascript: defang, banned-phrase absence,
+//     interpretive-adjective absence (T3.3), entity-decode panel (T3.4).
+
+import {
+  assertEquals,
+  assert,
+  assertMatch,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
+
+import {
+  renderAttorneyDisciplineSection,
+  buildAttorneyDisciplineSection,
+  DISCLAIMER_VERBATIM,
+  type AttorneyRow,
+  type DisciplineEvent,
+} from "../lib/render-attorney-discipline.ts";
+import { BANNED_PHRASES_BLOCK } from "../lib/banned-phrases.ts";
+import { IB_SECTION_ANCHORS } from "../lib/section-anchors.ts";
+import {
+  FIXTURE_DISCIPLINED_ATTORNEY_NAME,
+  FIXTURE_CLEAN_ATTORNEY_NAME,
+  CA_BAR_LOOKUP_BASE,
+  escapeRegExp,
+} from "./fixtures.ts";
+
+// ─────────────────────────────────────────────────────────────────
+// Inline minimal md2html mirroring supabase/functions/generate-report/
+// index.ts:7370-7392. Test-only — kept narrow to what the panel asserts on.
+// ─────────────────────────────────────────────────────────────────
+
+function md2html(markdown: string): string {
+  const preservedTables: string[] = [];
+  let src = markdown.replace(
+    /<table\b[\s\S]*?<\/table>/gi,
+    (tbl) => {
+      const idx = preservedTables.length;
+      preservedTables.push(tbl);
+      return `@@PRESERVED_TABLE_${idx}@@`;
+    },
+  );
+  let h = src
+    .replace(/^#### (.+)$/gm, '<h4 class="section-h4">$1</h4>')
+    .replace(/^### (.+)$/gm, '<h3 class="section-h3">$1</h3>')
+    .replace(/^## (.+)$/gm, '<h2 class="section-h2">$1</h2>')
+    .replace(/\*\*(.+?)\*\*/g, '<strong class="bold-text">$1</strong>')
+    .replace(/\*(.+?)\*/g, "<em>$1</em>")
+    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2">$1</a>')
+    .replace(/\|(.+)\|/g, (match) => {
+      const rawCells = match.split(/(?<!\\)\|/).filter(Boolean).map((c) =>
+        c.trim()
+      );
+      const cells = rawCells.map((c) => c.replace(/\\\|/g, "|"));
+      if (cells.every((c) => /^[-:]+$/.test(c))) return "";
+      const tag = cells.some((c) => c.startsWith("**")) ? "th" : "td";
+      const cls = tag === "th" ? "table-header" : "table-cell";
+      return `<tr>${cells.map((c) => `<${tag} class="${cls}">${c}</${tag}>`).join("")}</tr>`;
+    })
+    .replace(
+      /(<tr>[\s\S]*?<\/tr>(\s*<tr>[\s\S]*?<\/tr>)*)/g,
+      (tableMatch) => `<table>${tableMatch}</table>`,
+    );
+  h = h.replace(
+    /@@PRESERVED_TABLE_(\d+)@@/g,
+    (_m, idx: string) => preservedTables[Number(idx)] || "",
+  );
+  return h;
+}
+
+function renderToHtml(
+  result:
+    | { status: "no-match"; attorney: null; events: [] }
+    | { status: "matched"; attorney: AttorneyRow; events: DisciplineEvent[] },
+  attorneyName?: string,
+): string {
+  const md = renderAttorneyDisciplineSection({
+    result,
+    jurisdiction: "CA",
+    attorneyName,
+  });
+  return md2html(md);
+}
+
+// ─────────────────────────────────────────────────────────────────
+// Fixture payloads
+// ─────────────────────────────────────────────────────────────────
+
+const cleanAttorney: AttorneyRow = {
+  id: 1,
+  jurisdiction: "CA",
+  bar_number: "FIXTURE-001",
+  full_name: FIXTURE_CLEAN_ATTORNEY_NAME,
+  first_name: "Fixture",
+  last_name: "Cleanrecord",
+  admission_date: "2010-01-15",
+  current_status: "active",
+  firm: null,
+  city: null,
+  source_url: null,
+  last_seen_at: "2026-04-25T00:00:00Z",
+  created_at: "2026-04-22T00:00:00Z",
+};
+const disciplinedAttorney: AttorneyRow = {
+  ...cleanAttorney,
+  id: 2,
+  bar_number: "FIXTURE-002",
+  full_name: FIXTURE_DISCIPLINED_ATTORNEY_NAME,
+  last_name: "Disciplined",
+  admission_date: "2005-06-20",
+  current_status: "suspended",
+};
+
+const oneSuspension: DisciplineEvent[] = [
+  {
+    order_date: "2018-03-12",
+    discipline_type: "Suspension",
+    discipline_raw: "SUSPENSION 90D STAYED",
+    violation_summary: "90-day suspension stayed",
+    order_url: "https://example.com/fixture-002-evt-1",
+    source_url: "https://example.com/fixture-002-source",
+  },
+];
+const twoEventDisbarment: DisciplineEvent[] = [
+  {
+    order_date: "2018-03-12",
+    discipline_type: "Suspension",
+    discipline_raw: "SUSPENSION 90D STAYED",
+    violation_summary: "90-day suspension stayed",
+    order_url: "https://example.com/fixture-002-evt-1",
+    source_url: "https://example.com/fixture-002-source",
+  },
+  {
+    order_date: "2020-07-01",
+    discipline_type: "Probation",
+    discipline_raw: "PROBATION 1Y",
+    violation_summary: "1-year probation imposed",
+    order_url: "https://example.com/fixture-002-evt-2",
+    source_url: "https://example.com/fixture-002-source",
+  },
+];
+
+// In-memory hostile fixture — never persisted.
+const hostileAttorney: AttorneyRow = {
+  ...cleanAttorney,
+  id: 99,
+  bar_number: "FIXTURE-004",
+  full_name: "Fixture Hostile",
+};
+const hostileEvent: DisciplineEvent = {
+  order_date: "2024-01-15",
+  discipline_type: '<script>alert(1)</script>',
+  discipline_raw: "XSS RAW",
+  violation_summary: "alert | <script>",
+  order_url: "javascript:alert(1)",
+  source_url: "javascript:alert(2)",
+};
+
+// ─────────────────────────────────────────────────────────────────
+// Panel — runs against every fixture's rendered HTML.
+// ─────────────────────────────────────────────────────────────────
+
+const HEADING_REGEX = new RegExp(
+  `<h2[^>]*>${escapeRegExp(IB_SECTION_ANCHORS.ATTORNEY_DISCIPLINE)}<\\/h2>`,
+);
+
+const HREF_REGEX = /href="([^"]*)"/g;
+
+const INTERPRETIVE_BANNED =
+  /\b(unreliable|incompetent|negligent|untrustworthy|sketchy|shady|questionable|inadequate|deficient)\b/i;
+
+function runPanel(html: string, name: string) {
+  // 1. heading present exactly once.
+  const headingMatches = html.match(new RegExp(HEADING_REGEX.source, "g")) ?? [];
+  assertEquals(
+    headingMatches.length,
+    1,
+    `${name}: expected exactly one heading, got ${headingMatches.length}`,
+  );
+
+  // 2. no banned phrases.
+  const lower = html.toLowerCase();
+  for (const phrase of BANNED_PHRASES_BLOCK) {
+    assert(
+      !lower.includes(phrase.toLowerCase()),
+      `${name}: contains banned phrase "${phrase}"`,
+    );
+  }
+
+  // 3. no literal <script or javascript:.
+  assert(
+    !lower.includes("<script"),
+    `${name}: contains literal <script`,
+  );
+  assert(
+    !lower.includes("javascript:"),
+    `${name}: contains literal javascript:`,
+  );
+
+  // 4. every href is # or http(s)://.
+  for (const m of html.matchAll(HREF_REGEX)) {
+    const href = m[1];
+    assertMatch(
+      href,
+      /^(#|https?:\/\/)/i,
+      `${name}: bad href "${href}"`,
+    );
+  }
+
+  // 6. CA Bar lookup link present (omitted for no-match — rendered as plain text).
+  // Asserted in per-fixture tests below where applicable.
+
+  // T3.3 interpretive-adjective panel.
+  assert(
+    !INTERPRETIVE_BANNED.test(html),
+    `${name}: contains interpretive adjective about attorney`,
+  );
+
+  // NB: T3.4 entity-decode panel runs as a separate test below; it only
+  // applies to inputs that don't already contain raw `<script>` (decoding
+  // safely-escaped raw `<script>` legitimately reverts to the raw string,
+  // which is not a security issue — the BROWSER never sees the decoded form).
+}
+
+function decodeHtmlEntitiesOnce(s: string): string {
+  return s
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&amp;/g, "&");
+}
+
+// ─────────────────────────────────────────────────────────────────
+// 5-fixture matrix (Success Criterion 12)
+// ─────────────────────────────────────────────────────────────────
+
+Deno.test("Panel: matched-clean fixture", () => {
+  const html = renderToHtml({
+    status: "matched",
+    attorney: cleanAttorney,
+    events: [],
+  });
+  runPanel(html, "matched-clean");
+  // Per-fixture: contains "Active" + "no discipline events".
+  assert(html.includes("active") || html.includes("Active"));
+  assert(html.includes("no discipline events on file"));
+  assert(html.includes(CA_BAR_LOOKUP_BASE));
+  assert(html.includes(DISCLAIMER_VERBATIM.split(".")[0]));
+});
+
+Deno.test("Panel: matched-1-event-suspension", () => {
+  const html = renderToHtml({
+    status: "matched",
+    attorney: disciplinedAttorney,
+    events: oneSuspension,
+  });
+  runPanel(html, "matched-1-event-suspension");
+  assert(html.includes("Suspension"));
+  assert(html.includes("1 event"));
+  // Exactly one table block, two <tr>s (header + 1 event).
+  const tableMatches = html.match(/<table>[\s\S]*?<\/table>/g) ?? [];
+  assertEquals(tableMatches.length, 1, "expected exactly one <table>");
+  const trCount = (tableMatches[0]!.match(/<tr>/g) ?? []).length;
+  assertEquals(trCount, 2, `expected 2 <tr>s (header + 1 event), got ${trCount}`);
+});
+
+Deno.test("Panel: matched-multi-event-disbarment (2 events)", () => {
+  const html = renderToHtml({
+    status: "matched",
+    attorney: disciplinedAttorney,
+    events: twoEventDisbarment,
+  });
+  runPanel(html, "matched-multi-event");
+  assert(html.includes("2 events"));
+  const tableMatches = html.match(/<table>[\s\S]*?<\/table>/g) ?? [];
+  assertEquals(tableMatches.length, 1);
+  const trCount = (tableMatches[0]!.match(/<tr>/g) ?? []).length;
+  assertEquals(trCount, 3, `expected 3 <tr>s (header + 2 events), got ${trCount}`);
+});
+
+Deno.test("Panel: no-match", () => {
+  const html = renderToHtml(
+    { status: "no-match", attorney: null, events: [] },
+    FIXTURE_CLEAN_ATTORNEY_NAME,
+  );
+  runPanel(html, "no-match");
+  assert(html.includes("couldn&#39;t match") || html.includes("couldn't match"));
+  assert(!/<table>/i.test(html), "no-match must not render a <table>");
+  // Rewrite verifies "does NOT mean they're unlicensed" reassurance is present.
+  assert(html.includes("does NOT mean"));
+});
+
+Deno.test("Panel: ambiguous (rendered as no-match)", () => {
+  // The RPC returns 2+ rows → getAttorneyDiscipline returns no-match. Renderer
+  // gets no-match status. Same shape as no-match.
+  const html = renderToHtml(
+    { status: "no-match", attorney: null, events: [] },
+    FIXTURE_CLEAN_ATTORNEY_NAME,
+  );
+  runPanel(html, "ambiguous");
+  assert(!/<table>/i.test(html));
+});
+
+// ─────────────────────────────────────────────────────────────────
+// In-memory hostile-input test (Success Criterion 10)
+// ─────────────────────────────────────────────────────────────────
+
+Deno.test("Hostile input: <script> escaped, javascript: defanged, pipe-cell preserved", () => {
+  const html = renderToHtml({
+    status: "matched",
+    attorney: hostileAttorney,
+    events: [hostileEvent],
+  });
+
+  // Rendered as escaped entities — never raw.
+  assert(html.includes("&lt;script&gt;alert(1)&lt;/script&gt;"));
+  // No literal <script in source.
+  assert(!html.includes("<script"));
+  // javascript: URLs defanged to "#" (via safeMdLink fallback).
+  assert(!html.toLowerCase().includes("javascript:"));
+  // Run the full panel (heading + banned + interpretive + entity-decode).
+  runPanel(html, "hostile-event");
+
+  // Pipe-escape preserved exactly one event row (no extra <td>).
+  const tableMatches = html.match(/<table>[\s\S]*?<\/table>/g) ?? [];
+  assertEquals(tableMatches.length, 1);
+  const trCount = (tableMatches[0]!.match(/<tr>/g) ?? []).length;
+  assertEquals(trCount, 2, "hostile event should render exactly header + 1 row");
+
+  // Entity-decode round still does NOT yield javascript: — defense-in-depth.
+  // (Decoded `&lt;script&gt;` legitimately becomes `<script>` for raw input;
+  // the security guarantee is that BROWSER-rendered output is escaped, not
+  // that decoding plaintext escapes is impossible.)
+  const decoded = decodeHtmlEntitiesOnce(html);
+  assert(!decoded.toLowerCase().includes("javascript:"));
+});
+
+Deno.test("T3.4: pre-encoded XSS payload survives ONE round of entity-decode", () => {
+  // Defends against an attacker who pre-encodes their payload, banking on
+  // a future renderer change adding a decode-then-render step.
+  const preEncodedAttorney: AttorneyRow = {
+    ...cleanAttorney,
+    id: 88,
+    bar_number: "FIXTURE-PRE",
+    full_name: "Pre Encoded",
+  };
+  const preEncodedEvent: DisciplineEvent = {
+    order_date: "2024-01-15",
+    discipline_type: "&lt;script&gt;alert(1)&lt;/script&gt;",
+    discipline_raw: "ENT RAW",
+    violation_summary: "&lt;img src=x onerror=alert(1)&gt;",
+    order_url: "https://example.com/fixture-pre",
+    source_url: "https://example.com/fixture-pre",
+  };
+  const html = renderToHtml({
+    status: "matched",
+    attorney: preEncodedAttorney,
+    events: [preEncodedEvent],
+  });
+  // Rendered HTML escapes the `&` of `&lt;` → `&amp;lt;` etc.
+  assert(html.includes("&amp;lt;script&amp;gt;"));
+  // After ONE round of decoding, it reverts to `&lt;script&gt;` — still safe.
+  const decoded = decodeHtmlEntitiesOnce(html);
+  assert(
+    !decoded.toLowerCase().includes("<script"),
+    "decoded once must NOT contain <script literal",
+  );
+  assert(
+    !decoded.toLowerCase().includes("javascript:"),
+    "decoded once must NOT contain javascript:",
+  );
+});
+
+Deno.test("DISCLAIMER_VERBATIM contains zero banned phrases (Success Criterion 13)", () => {
+  const lower = DISCLAIMER_VERBATIM.toLowerCase();
+  for (const phrase of BANNED_PHRASES_BLOCK) {
+    assert(
+      !lower.includes(phrase.toLowerCase()),
+      `DISCLAIMER_VERBATIM contains banned phrase "${phrase}"`,
+    );
+  }
+  assert(
+    BANNED_PHRASES_BLOCK.length >= 10,
+    `BANNED_PHRASES_BLOCK length ${BANNED_PHRASES_BLOCK.length} < 10 (false-green guard)`,
+  );
+});
+
+Deno.test("buildAttorneyDisciplineSection (production path): suppresses on missing inputs", async () => {
+  // Empty attorney → "" (suppressed).
+  assertEquals(
+    await buildAttorneyDisciplineSection({
+      attorneyName: "",
+      jurisdiction: "CA",
+      supabaseUrl: "https://x.supabase.co",
+      serviceRoleKey: "k",
+    }),
+    "",
+  );
+  // Missing supabaseUrl → "".
+  assertEquals(
+    await buildAttorneyDisciplineSection({
+      attorneyName: "Bob Smith",
+      jurisdiction: "CA",
+      supabaseUrl: "",
+      serviceRoleKey: "",
+    }),
+    "",
+  );
+});

--- a/supabase/functions/generate-report/__tests__/attorney-discipline.test.ts
+++ b/supabase/functions/generate-report/__tests__/attorney-discipline.test.ts
@@ -1,0 +1,355 @@
+// supabase/functions/generate-report/__tests__/attorney-discipline.test.ts
+//
+// T1.4 (worry-attorney-discipline-wire v2.4) — unit tests for the RPC client.
+//
+// Runner: built-in `Deno.test` (NOT std/bdd, NOT vitest). Run with:
+//   deno test --allow-net --allow-env --no-check=remote \
+//     supabase/functions/generate-report/__tests__/attorney-discipline.test.ts
+//
+// Strategy:
+//   - Mock fetch so tests run without network or DB.
+//   - Cover all 8 cases listed in plan T1.4:
+//       matched-clean, matched-disciplined, no-match, ambiguous, injection
+//       input, control-character input, garbage input, diacritic input.
+//   - Garbage / sanitize-fail inputs assert the mocked fetch is NEVER called
+//     (proves short-circuit before DB roundtrip).
+
+import {
+  assertEquals,
+  assert,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
+
+import {
+  getAttorneyDiscipline,
+  __INTERNALS,
+  type AttorneyRow,
+  type DisciplineEvent,
+} from "../lib/attorney-discipline.ts";
+
+import {
+  FIXTURE_CLEAN_ATTORNEY_NAME,
+  FIXTURE_CLEAN_BAR_NUMBER,
+  FIXTURE_DISCIPLINED_ATTORNEY_NAME,
+  FIXTURE_DISCIPLINED_BAR_NUMBER,
+  FIXTURE_DISCIPLINED_EVENT_COUNT,
+} from "./fixtures.ts";
+
+// ─────────────────────────────────────────────────────────────────────
+// Fetch-mock harness
+// ─────────────────────────────────────────────────────────────────────
+
+type Calls = Array<{ url: string; init: RequestInit }>;
+
+function mockFetch(
+  rpcRows: AttorneyRow[],
+  eventRows: DisciplineEvent[],
+  calls: Calls = [],
+): typeof fetch {
+  return ((input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    calls.push({ url, init: init ?? {} });
+    if (url.includes("/rpc/attorney_match_by_raw_name")) {
+      // Filter on raw_name so unrelated inputs (injection literals etc.)
+      // don't accidentally "match" the seeded fixture rows. The real RPC
+      // applies `lower(immutable_unaccent($1))` before comparing; we mimic
+      // by lowercasing both sides.
+      const body = init?.body
+        ? JSON.parse(String(init.body))
+        : { raw_name: "" };
+      const want = String(body.raw_name ?? "").trim().toLowerCase();
+      const matched = rpcRows.filter(
+        (r) => r.full_name.trim().toLowerCase() === want,
+      );
+      return Promise.resolve(
+        new Response(JSON.stringify(matched), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    }
+    if (url.includes("/rest/v1/attorney_discipline_events")) {
+      return Promise.resolve(
+        new Response(JSON.stringify(eventRows), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    }
+    return Promise.resolve(new Response("not mocked", { status: 500 }));
+  }) as typeof fetch;
+}
+
+const cleanAttorney: AttorneyRow = {
+  id: 1,
+  jurisdiction: "CA",
+  bar_number: FIXTURE_CLEAN_BAR_NUMBER,
+  full_name: FIXTURE_CLEAN_ATTORNEY_NAME,
+  first_name: "Fixture",
+  last_name: "Cleanrecord",
+  admission_date: "2010-01-15",
+  current_status: "active",
+  firm: null,
+  city: null,
+  source_url: null,
+  last_seen_at: "2026-04-25T00:00:00Z",
+  created_at: "2026-04-22T00:00:00Z",
+};
+const disciplinedAttorney: AttorneyRow = {
+  ...cleanAttorney,
+  id: 2,
+  bar_number: FIXTURE_DISCIPLINED_BAR_NUMBER,
+  full_name: FIXTURE_DISCIPLINED_ATTORNEY_NAME,
+  last_name: "Disciplined",
+  admission_date: "2005-06-20",
+  current_status: "suspended",
+};
+const ambiguousRow: AttorneyRow = {
+  ...cleanAttorney,
+  id: 3,
+  bar_number: "FIXTURE-003",
+};
+const disciplineEvents: DisciplineEvent[] = [
+  {
+    order_date: "2018-03-12",
+    discipline_type: "Suspension",
+    discipline_raw: "SUSPENSION 90D STAYED",
+    violation_summary: "90-day suspension stayed",
+    order_url: "https://example.com/fixture-002-evt-1",
+    source_url: "https://example.com/fixture-002-source",
+  },
+  {
+    order_date: "2020-07-01",
+    discipline_type: "Probation",
+    discipline_raw: "PROBATION 1Y",
+    violation_summary: "1-year probation imposed",
+    order_url: "https://example.com/fixture-002-evt-2",
+    source_url: "https://example.com/fixture-002-source",
+  },
+];
+
+const baseOpts = (fetchImpl?: typeof fetch) => ({
+  supabaseUrl: "https://example.test.supabase.co",
+  serviceRoleKey: "test-service-role-key",
+  fetchImpl,
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────
+
+Deno.test("matched-clean: returns matched + 0 events", async () => {
+  const calls: Calls = [];
+  const f = mockFetch([cleanAttorney], [], calls);
+  const r = await getAttorneyDiscipline(
+    FIXTURE_CLEAN_ATTORNEY_NAME,
+    "CA",
+    baseOpts(f),
+  );
+  assertEquals(r.status, "matched");
+  if (r.status === "matched") {
+    assertEquals(r.attorney.bar_number, FIXTURE_CLEAN_BAR_NUMBER);
+    assertEquals(r.events.length, 0);
+  }
+  // RPC + events fetch = 2 calls.
+  assertEquals(calls.length, 2);
+});
+
+Deno.test("matched-disciplined: returns matched + N events", async () => {
+  const calls: Calls = [];
+  const f = mockFetch([disciplinedAttorney], disciplineEvents, calls);
+  const r = await getAttorneyDiscipline(
+    FIXTURE_DISCIPLINED_ATTORNEY_NAME,
+    "CA",
+    baseOpts(f),
+  );
+  assertEquals(r.status, "matched");
+  if (r.status === "matched") {
+    assertEquals(r.attorney.bar_number, FIXTURE_DISCIPLINED_BAR_NUMBER);
+    assertEquals(r.events.length, FIXTURE_DISCIPLINED_EVENT_COUNT);
+  }
+});
+
+Deno.test("no-match: zero rows from RPC", async () => {
+  const calls: Calls = [];
+  const f = mockFetch([], [], calls);
+  const r = await getAttorneyDiscipline(
+    "Zzzzz Nonexistent",
+    "CA",
+    baseOpts(f),
+  );
+  assertEquals(r.status, "no-match");
+  assertEquals(r.attorney, null);
+  assertEquals(r.events.length, 0);
+  // RPC called, events skipped (zero match means no second fetch).
+  assertEquals(calls.length, 1);
+});
+
+Deno.test("ambiguous: 2 rows → no-match", async () => {
+  const calls: Calls = [];
+  const f = mockFetch([cleanAttorney, ambiguousRow], [], calls);
+  const r = await getAttorneyDiscipline(
+    FIXTURE_CLEAN_ATTORNEY_NAME,
+    "CA",
+    baseOpts(f),
+  );
+  assertEquals(r.status, "no-match");
+});
+
+Deno.test("injection input → no-match (RPC sees parameterized input, returns 0 rows)", async () => {
+  const calls: Calls = [];
+  const f = mockFetch([cleanAttorney], [], calls);
+  const r = await getAttorneyDiscipline(
+    "' OR 1=1 --",
+    "CA",
+    baseOpts(f),
+  );
+  // Single quote and `=` aren't postgrest-special; sanitizer passes the input
+  // through verbatim. The RPC then runs lower(immutable_unaccent($1)) = ...
+  // against the parameterized literal — zero rows match. Result: no-match.
+  assertEquals(r.status, "no-match");
+  assert(!Object.prototype.hasOwnProperty.call(r, "attorney") || r.attorney === null);
+});
+
+Deno.test("control-char input (\\x00) → no-match without DB call", async () => {
+  const calls: Calls = [];
+  const f = mockFetch([cleanAttorney], [], calls);
+  const r = await getAttorneyDiscipline(
+    "Bob\x00Hidden",
+    "CA",
+    baseOpts(f),
+  );
+  assertEquals(r.status, "no-match");
+  // CTRL_REGEX fires before any fetch — assert short-circuit.
+  assertEquals(calls.length, 0);
+});
+
+Deno.test("newline input collapses to whitespace and may pass sanitize", async () => {
+  // \n is whitespace — collapse turns "Bob\nSmith" into "Bob Smith". Two-token
+  // form survives sanitize and reaches the DB. RPC returns no-match because
+  // "Bob Smith" isn't in fixture data.
+  const calls: Calls = [];
+  const f = mockFetch([cleanAttorney], [], calls);
+  const r = await getAttorneyDiscipline(
+    "Bob\nSmith",
+    "CA",
+    baseOpts(f),
+  );
+  assertEquals(r.status, "no-match");
+});
+
+Deno.test("garbage single-token: no-match without DB call", async () => {
+  const calls: Calls = [];
+  const f = mockFetch([cleanAttorney], [], calls);
+  for (const garbage of ["asdf", "n/a", "n a", "test", "qwerty", "xx", "Bob"]) {
+    const r = await getAttorneyDiscipline(garbage, "CA", baseOpts(f));
+    assertEquals(r.status, "no-match", `garbage="${garbage}" should be no-match`);
+  }
+  // ZERO fetch invocations — every garbage input short-circuits.
+  assertEquals(calls.length, 0);
+});
+
+Deno.test("type-gate: non-string inputs return no-match", async () => {
+  const calls: Calls = [];
+  const f = mockFetch([cleanAttorney], [], calls);
+  for (const bad of [null, undefined, 42, {}, []]) {
+    // deno-lint-ignore no-explicit-any
+    const r = await getAttorneyDiscipline(bad as any, "CA", baseOpts(f));
+    assertEquals(r.status, "no-match");
+  }
+  assertEquals(calls.length, 0);
+});
+
+Deno.test("non-CA jurisdiction returns no-match without DB call", async () => {
+  const calls: Calls = [];
+  const f = mockFetch([cleanAttorney], [], calls);
+  const r = await getAttorneyDiscipline(
+    FIXTURE_CLEAN_ATTORNEY_NAME,
+    "FL",
+    baseOpts(f),
+  );
+  assertEquals(r.status, "no-match");
+  assertEquals(calls.length, 0);
+});
+
+Deno.test("diacritic input passes raw to RPC (no JS-side normalization)", async () => {
+  // The Postgres-side `lower(immutable_unaccent($1))` does the folding. The
+  // client must NOT normalize — that would diverge from Postgres for
+  // precomposed-only Latin extensions (Søren↔Soren, Ł↔L, Đ↔D, etc.). This
+  // test verifies the body arrives at the RPC verbatim (modulo whitespace
+  // normalization).
+  const calls: Calls = [];
+  const f = mockFetch([cleanAttorney], [], calls);
+  await getAttorneyDiscipline("José García", "CA", baseOpts(f));
+  // At least one fetch (the RPC) — events fetch only fires on match.
+  assert(calls.length >= 1);
+  const body = JSON.parse(String(calls[0].init.body));
+  assertEquals(body.raw_name, "José García");
+});
+
+Deno.test("non-NFD diacritic (Søren) — no JS-side fold; raw passes through", async () => {
+  // Sec v3 CRITICAL closed: JS shim used to normalize Søren → Soren which
+  // diverged from Postgres unaccent. Now: no normalization client-side.
+  const calls: Calls = [];
+  const f = mockFetch([cleanAttorney], [], calls);
+  await getAttorneyDiscipline("Søren Larsen", "CA", baseOpts(f));
+  const body = JSON.parse(String(calls[0].init.body));
+  assertEquals(body.raw_name, "Søren Larsen");
+});
+
+Deno.test("RPC HTTP error → no-match", async () => {
+  const calls: Calls = [];
+  const f = ((url: string) => {
+    calls.push({ url, init: {} });
+    return Promise.resolve(new Response("server fire", { status: 500 }));
+  }) as unknown as typeof fetch;
+  const r = await getAttorneyDiscipline(
+    FIXTURE_CLEAN_ATTORNEY_NAME,
+    "CA",
+    baseOpts(f),
+  );
+  assertEquals(r.status, "no-match");
+});
+
+Deno.test("RPC fetch throws → no-match (network error)", async () => {
+  const f = (() => Promise.reject(new Error("network down"))) as unknown as
+    typeof fetch;
+  const r = await getAttorneyDiscipline(
+    FIXTURE_CLEAN_ATTORNEY_NAME,
+    "CA",
+    baseOpts(f),
+  );
+  assertEquals(r.status, "no-match");
+});
+
+Deno.test("sanitize internal: postgrest-special chars rejected", () => {
+  const cases = ["Bob*", "Bob%", "Bob,Smith", "Bob(Smith)", "a:b", "a.b", "a_b"];
+  for (const s of cases) {
+    assertEquals(
+      __INTERNALS.sanitizeAttorneyName(s),
+      null,
+      `should reject: "${s}"`,
+    );
+  }
+});
+
+Deno.test("sanitize internal: trim + collapse whitespace", () => {
+  // Two-token input survives; whitespace collapsed.
+  assertEquals(
+    __INTERNALS.sanitizeAttorneyName("  Bob   Smith  "),
+    "Bob Smith",
+  );
+});
+
+Deno.test("sanitize internal: cap at 200 chars", () => {
+  const long = "a ".repeat(150); // 300 chars w/ spaces.
+  const r = __INTERNALS.sanitizeAttorneyName(long);
+  assert(r === null || (r as string).length <= 200);
+});
+
+Deno.test("Success Criterion 3: function arity is 3 (name, juris, opts)", () => {
+  // Fixed when migrating to the options-bag pattern. Plan SC #3 said arity 2;
+  // arity is now 3 because options is required for fetch+url+key. Document
+  // here so future drift surfaces visibly.
+  assertEquals(typeof getAttorneyDiscipline, "function");
+  assertEquals(getAttorneyDiscipline.length, 3);
+});

--- a/supabase/functions/generate-report/__tests__/fixtures.ts
+++ b/supabase/functions/generate-report/__tests__/fixtures.ts
@@ -1,0 +1,51 @@
+// Phase 5 (worry-attorney-discipline-wire v2.4) test fixtures + helpers.
+//
+// Single source of truth for every constant referenced in:
+//   - T1.4 attorney-discipline.test.ts
+//   - T3.1 attorney-discipline-upl.test.ts (regex panel + interpretive + entity-decode)
+//   - T4.6 rls-attorney-discipline.test.ts
+//   - Success Criteria 4-13 in
+//     docs/plans/2026-04-25-worry-attorney-discipline-wire.md
+//
+// MUST mirror the rows seeded by
+//   supabase/migrations/20260425b_attorney_discipline_test_fixtures.sql
+//
+// Hostile values are NOT seeded into the DB (Sec v3 CRITICAL #2). They are
+// passed in-memory to renderAttorneyDisciplineSection() in the UPL test.
+
+export const FIXTURE_CLEAN_BAR_NUMBER = "FIXTURE-001";
+export const FIXTURE_CLEAN_ATTORNEY_NAME = "Fixture Cleanrecord";
+
+export const FIXTURE_DISCIPLINED_BAR_NUMBER = "FIXTURE-002";
+export const FIXTURE_DISCIPLINED_ATTORNEY_NAME = "Fixture Disciplined";
+export const FIXTURE_DISCIPLINED_EVENT_COUNT = 2;
+
+// FIXTURE-003 shares full_name with FIXTURE-001 → ambiguous-match probe.
+export const FIXTURE_AMBIGUOUS_BAR_NUMBER = "FIXTURE-003";
+
+// In-memory only — never persisted (Sec v3 CRIT #2).
+export const FIXTURE_HOSTILE_BAR_NUMBER = "FIXTURE-004";
+export const FIXTURE_HOSTILE_ATTORNEY_NAME = "Fixture Hostile";
+
+// CA Bar lookup base URL — used in success criterion #6 (panel check) and
+// in the renderer's "Verify yourself" CTA.
+export const CA_BAR_LOOKUP_BASE =
+  "https://apps.calbar.ca.gov/attorney/Licensee/Detail/";
+
+// Re-export render-side public symbols so tests import once.
+export {
+  buildAttorneyDisciplineSection,
+  renderAttorneyDisciplineSection,
+  NO_MATCH_MESSAGE,
+  DISCLAIMER_VERBATIM,
+  JURISDICTION_BAR_NAMES,
+} from "../lib/render-attorney-discipline.ts";
+
+/**
+ * Escape a string for safe use inside a regex literal.
+ * Pinned here so every test that builds a regex around a fixture constant
+ * uses the same single implementation.
+ */
+export function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/supabase/functions/generate-report/index.ts
+++ b/supabase/functions/generate-report/index.ts
@@ -75,6 +75,15 @@
  */
 
 // ============================================================
+// LOCAL LIBRARY IMPORTS
+// Local-only — no npm/esm.sh, so the cold-start budget is preserved.
+// Phase 5 (worry-attorney-discipline-wire v2.4): split the attorney-discipline
+// renderer + RPC client into ./lib/ for unit testability.
+// ============================================================
+
+import { buildAttorneyDisciplineSection } from "./lib/render-attorney-discipline.ts";
+
+// ============================================================
 // SUPABASE REST HELPERS
 // Raw PostgREST fetch calls, no SDK import needed.
 // These replace @supabase/supabase-js to avoid esm.sh cold start.
@@ -5039,6 +5048,24 @@ async function handleIBPhaseB(
   }
   console.log(`[IB-Phase-B] Phase 2 whitelist: ${ibWhitelist.validIds.size} valid entity IDs, cite tags filtered`);
 
+  // Phase 5 (worry-attorney-discipline-wire v2.4): mechanical attorney
+  // bar-discipline section. Slotted into allOutputs["attorney-discipline"] so
+  // it sits between sectionOutputs["your-plan"] and buildBradyGiglioChecklist()
+  // in the renderer's sections array. Empty string suppresses the section
+  // (jurisdiction guard, missing keys, RPC error).
+  try {
+    const disciplineMd = await buildAttorneyDisciplineSection({
+      attorneyName: phase2.attorney_name,
+      jurisdiction: intake.state ?? "",
+      supabaseUrl,
+      serviceRoleKey: supabaseKey,
+    });
+    if (disciplineMd) allOutputs["attorney-discipline"] = disciplineMd;
+  } catch (err) {
+    console.error("[IB-Phase-B] attorney-discipline render failed", err);
+    // Suppress section on failure — invariant: renderer never blocks IB compile.
+  }
+
   // Compile HTML report
   console.log(`[IB-Phase-B] Compiling HTML report...`);
   const reportToken = crypto.randomUUID();
@@ -7436,6 +7463,11 @@ function renderIBReportHtml(sectionOutputs: Record<string, string>, meta: {
     sectionOutputs["legal-options"] || "",
     sectionOutputs["protection"] || "",
     sectionOutputs["your-plan"] || "",
+    // Phase 5 (worry-attorney-discipline-wire v2.4): mechanical attorney
+    // bar-discipline section. Suppressed (empty string) on jurisdiction
+    // mismatch / RPC error / no intake attorney name. Anchor:
+    // IB_SECTION_ANCHORS.ATTORNEY_DISCIPLINE.
+    sectionOutputs["attorney-discipline"] || "",
     buildBradyGiglioChecklist(),
     sectionOutputs["court-prep"] || "",
     buildAttorneyScriptPack(),

--- a/supabase/functions/generate-report/lib/attorney-discipline.ts
+++ b/supabase/functions/generate-report/lib/attorney-discipline.ts
@@ -1,0 +1,243 @@
+// supabase/functions/generate-report/lib/attorney-discipline.ts
+//
+// T1.2 (worry-attorney-discipline-wire v2.4) — RPC client for the attorney
+// directory + discipline-events lookup, used by the IB renderer.
+//
+// Hard rules baked in:
+//   - CA-only jurisdiction guard (defense-in-depth — multi-state expansion is
+//     blocked on per-state fair-report memos; see T0b memo).
+//   - Sanitization in fixed order; ANY garbage / wildcard / control-char input
+//     short-circuits to no-match WITHOUT a DB roundtrip.
+//   - NO JS-side unaccent shim. Postgres applies `lower(immutable_unaccent($1))`
+//     on both sides; raw input goes to the RPC.
+//   - Ambiguous match (>1 row) → return no-match. Disambiguation is out of v2.
+//
+// See also:
+//   - migrations/20260425a_attorney_discipline_rls.sql       (T0a — RLS)
+//   - migrations/20260425c_attorney_unaccent.sql              (T1.1a — RPC)
+//   - lib/render-attorney-discipline.ts                       (T2.2 — renderer)
+//   - __tests__/attorney-discipline.test.ts                   (T1.4 — unit tests)
+
+export type AttorneyRow = {
+  id: number;
+  jurisdiction: string;
+  bar_number: string;
+  full_name: string;
+  first_name: string | null;
+  last_name: string | null;
+  admission_date: string | null;        // ISO date YYYY-MM-DD
+  current_status: string | null;        // 'active' | 'inactive' | 'disbarred' | 'suspended' | 'resigned'
+  firm: string | null;
+  city: string | null;
+  source_url: string | null;
+  last_seen_at: string;                  // timestamptz
+  created_at: string;                    // timestamptz
+};
+
+export type DisciplineEvent = {
+  id?: number;
+  attorney_id?: number | null;
+  jurisdiction?: string;
+  bar_number?: string;
+  full_name?: string;
+  order_date: string | null;            // ISO date
+  effective_date?: string | null;
+  discipline_type: string;
+  discipline_raw: string | null;
+  violation_summary: string | null;
+  order_url: string | null;
+  source_url: string | null;
+  scraped_at?: string;
+};
+
+export type DisciplineLookupResult =
+  | {
+      status: "matched";
+      attorney: AttorneyRow;
+      events: DisciplineEvent[];
+    }
+  | {
+      status: "no-match";
+      attorney: null;
+      events: [];
+    };
+
+export type DisciplineLookupOptions = {
+  /** Supabase project URL (e.g., https://<ref>.supabase.co). */
+  supabaseUrl: string;
+  /** Service-role key. anon-key callers will hit a 404 PGRST202 on the RPC. */
+  serviceRoleKey: string;
+  /**
+   * Optional fetch override for tests. Production code passes `globalThis.fetch`
+   * implicitly. Tests inject a mock to verify garbage-input short-circuits skip
+   * the DB roundtrip entirely.
+   */
+  fetchImpl?: typeof fetch;
+};
+
+const NO_MATCH: DisciplineLookupResult = {
+  status: "no-match",
+  attorney: null,
+  events: [],
+};
+
+// Garbage-input regex — fires AFTER trim+collapse-whitespace+length-check+
+// no-whitespace check. Multi-token garbage like "asdf foo" passes this gate
+// and reaches the DB (harmless DB roundtrip — returns no-match).
+const GARBAGE_REGEX =
+  /^(asdf|qwerty|test|n\s*\/?\s*a|none|na|null|undefined|tbd|tbc|x{2,}|z{2,})$/i;
+
+// Control characters — \r, \n, \x00 — reject outright.
+const CTRL_REGEX = /[\r\n\x00]/;
+
+// PostgREST-special characters — wildcards and filter delimiters.
+//   * % → ilike wildcards (defamation surface — "Smith*" matches all Smith*)
+//   , ( ) → PostgREST filter separators
+//   : → PostgREST operator delimiter
+//   _ → SQL LIKE single-char wildcard
+//   . → reserved in PostgREST identifiers
+const POSTGREST_SPECIAL_REGEX = /[*%_,():.]/;
+
+/**
+ * Sanitize the raw attorney name input. Returns `null` on rejected inputs.
+ * Steps applied IN ORDER (changing the order opens new bypass paths):
+ *   0. type gate
+ *   1. trim
+ *   2. collapse interior whitespace
+ *   3. garbage-input gate (single-token only — multi-token reaches DB harmlessly)
+ *   4. control-char gate
+ *   5. postgrest-special gate
+ *   6. cap to 200 chars
+ *   7. empty-after-sanitize gate
+ */
+function sanitizeAttorneyName(input: unknown): string | null {
+  // Step 0 — type gate. Closes the JS-coercion path where `String(null)`
+  // returns "null" (4 chars, no whitespace) and bypasses the empty-check.
+  if (typeof input !== "string") return null;
+
+  // Step 1 — trim.
+  let s = input.trim();
+
+  // Step 2 — control-char gate (BEFORE whitespace collapse). \n, \r, \t are
+  // whitespace and would be eaten by the next step; \x00 is the only ctrl
+  // char left after collapse — but checking pre-collapse covers all of them
+  // and surfaces injection attempts that use non-printable separators.
+  if (CTRL_REGEX.test(s)) return null;
+
+  // Step 3 — collapse interior whitespace.
+  s = s.replace(/\s+/g, " ");
+
+  // Step 4 — length gate.
+  if (s.length < 3) return null;
+
+  // Step 5 — garbage-input gate. Runs on multi-token AND single-token forms
+  // so "n a" / "n / a" boilerplate is rejected before any DB call.
+  if (GARBAGE_REGEX.test(s)) return null;
+
+  // Step 6 — single-token rejection (real attorney names have first + last;
+  // exact-match-only requires whitespace separator).
+  if (!/\s/.test(s)) return null;
+
+  // Step 7 — postgrest-special gate.
+  if (POSTGREST_SPECIAL_REGEX.test(s)) return null;
+
+  // Step 8 — cap.
+  if (s.length > 200) s = s.slice(0, 200);
+
+  // Step 9 — empty after sanitize.
+  if (s.length === 0) return null;
+
+  return s;
+}
+
+/**
+ * Lookup attorney + their disciplinary history by raw intake name.
+ *
+ * Returns `{ status: "matched", attorney, events[] }` on EXACTLY-ONE match,
+ * `{ status: "no-match", attorney: null, events: [] }` on zero / 2+ /
+ * sanitize-fail / non-CA / network-error.
+ */
+export async function getAttorneyDiscipline(
+  attorneyName: unknown,
+  jurisdiction: unknown,
+  options: DisciplineLookupOptions
+): Promise<DisciplineLookupResult> {
+  // Jurisdiction guard — defense-in-depth for v2's CA-only fair-report scope.
+  // TODO(per-state-memo): when adding a state, write the per-state fair-report
+  // memo first (T0b extension), then add the state code here.
+  if (jurisdiction !== "CA") return NO_MATCH;
+
+  const sanitized = sanitizeAttorneyName(attorneyName);
+  if (sanitized === null) return NO_MATCH;
+
+  const fetchImpl = options.fetchImpl ?? globalThis.fetch;
+
+  let attorneys: AttorneyRow[];
+  try {
+    const r = await fetchImpl(
+      `${options.supabaseUrl}/rest/v1/rpc/attorney_match_by_raw_name`,
+      {
+        method: "POST",
+        headers: {
+          apikey: options.serviceRoleKey,
+          Authorization: `Bearer ${options.serviceRoleKey}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ jur: jurisdiction, raw_name: sanitized }),
+      }
+    );
+    if (!r.ok) {
+      console.error(
+        `attorney_match_by_raw_name HTTP ${r.status}: ${await r.text()}`
+      );
+      return NO_MATCH;
+    }
+    attorneys = (await r.json()) as AttorneyRow[];
+  } catch (err) {
+    console.error("attorney_match_by_raw_name fetch error", err);
+    return NO_MATCH;
+  }
+
+  if (!Array.isArray(attorneys) || attorneys.length !== 1) {
+    // 0 → no match. 2+ → ambiguous → no match (Code v1 WARN #15).
+    return NO_MATCH;
+  }
+  const attorney = attorneys[0];
+
+  // Pull discipline events for this attorney.
+  let events: DisciplineEvent[];
+  try {
+    const r2 = await fetchImpl(
+      `${options.supabaseUrl}/rest/v1/attorney_discipline_events?attorney_id=eq.${attorney.id}&select=*&order=order_date.desc`,
+      {
+        headers: {
+          apikey: options.serviceRoleKey,
+          Authorization: `Bearer ${options.serviceRoleKey}`,
+          "Content-Type": "application/json",
+        },
+      }
+    );
+    if (!r2.ok) {
+      console.error(
+        `attorney_discipline_events HTTP ${r2.status}: ${await r2.text()}`
+      );
+      events = [];
+    } else {
+      events = (await r2.json()) as DisciplineEvent[];
+    }
+  } catch (err) {
+    console.error("attorney_discipline_events fetch error", err);
+    events = [];
+  }
+
+  return { status: "matched", attorney, events };
+}
+
+// Visible for tests (string predicates) — single-source-of-truth so tests
+// don't drift from implementation. NOT part of the public contract.
+export const __INTERNALS = {
+  sanitizeAttorneyName,
+  GARBAGE_REGEX,
+  CTRL_REGEX,
+  POSTGREST_SPECIAL_REGEX,
+};

--- a/supabase/functions/generate-report/lib/banned-phrases.ts
+++ b/supabase/functions/generate-report/lib/banned-phrases.ts
@@ -1,0 +1,58 @@
+// supabase/functions/generate-report/lib/banned-phrases.ts
+//
+// T3.2 + T3.2b (worry-attorney-discipline-wire v2.4) — CANONICAL banned-phrase
+// list for the IB UPL gate. Extracted from
+//   src/lib/intelligence-brief/prompts.ts:34
+// (the BANNED_PHRASES_BLOCK template literal). Only the QUOTED phrases inside
+// that prose block are banned; the substitution suggestions are NOT.
+//
+// Mirrored on the Node side at
+//   src/lib/intelligence-brief/banned-phrases.ts
+// Parity asserted by
+//   src/lib/intelligence-brief/__tests__/banned-phrases-parity.test.ts (T3.2a)
+//
+// Used by:
+//   - The deterministic UPL regex panel (T3.1) at
+//     supabase/functions/generate-report/__tests__/attorney-discipline-upl.test.ts
+//   - The disclaimer-string assertion (Success Criterion 13) — verifies the
+//     attorney-discipline section's footer disclaimer contains zero banned
+//     phrases.
+//
+// Match strategy: case-insensitive substring (`html.toLowerCase().includes(p)`).
+// Phrases are stored lowercase. Multi-character phrasings are precise enough
+// that case-insensitive substring is the right granularity (no word-boundary
+// over-/under-match).
+
+export const BANNED_PHRASES_BLOCK: readonly string[] = Object.freeze([
+  // Direct prescriptive language — banned per UPL.
+  "you should",
+  "should file",
+  "should pursue",
+  "should review",
+  "should consult",
+  "could or should",
+  "you need to",
+  "you must",
+  "you have to",
+
+  // Recommendation language — banned per UPL.
+  "we recommend",
+  "we advise",
+  "i recommend",
+  "i advise",
+
+  // Best-option claims — banned per UPL.
+  "your best option",
+  "the best strategy",
+  "the best option",
+
+  // Threat/judgment framing — banned (interpretive label about attorney
+  // conduct or case posture).
+  "red flag",
+  "warning sign",
+  "escalation ladder",
+
+  // Bare imperatives to the defendant — banned per UPL ("Most defense
+  // attorneys advise against..." is the approved reframe).
+  "do not discuss your case",
+]) as readonly string[];

--- a/supabase/functions/generate-report/lib/render-attorney-discipline.ts
+++ b/supabase/functions/generate-report/lib/render-attorney-discipline.ts
@@ -1,0 +1,305 @@
+// supabase/functions/generate-report/lib/render-attorney-discipline.ts
+//
+// T2.2 + T2.3 + T2.3a + T2.4 (worry-attorney-discipline-wire v2.4) — mechanical
+// markdown renderer for the IB attorney bar-discipline section.
+//
+// Hard rules baked in:
+//   - Output is MARKDOWN, not raw HTML. Renderer flows through `md2html` in
+//     index.ts which wraps headings, paragraphs, and tables. Pre-built `<tr>`
+//     blocks would be shredded by md2html's table-row split regex.
+//   - Every interpolated value passes `cell()` = pipe-escape THEN HTML-escape.
+//     Pipe-escape FIRST keeps "Suspension | 90-day stayed" inside one cell.
+//     HTML-escape SECOND defangs `<` `>` `&` `"` `'`.
+//   - URLs flow through `safeHttpUrl` → '#' on non-http(s) (defangs
+//     `javascript:` and other protocols).
+//   - `safeMdLink` returns plain "(link unavailable)" when URL is null/empty
+//     to avoid clickable `#` anchors.
+//   - No interpretive language. The deterministic UPL panel
+//     (attorney-discipline-upl.test.ts T3.3) fails the build on adjective
+//     leakage like "unreliable", "incompetent", etc.
+//   - Years-of-practice arithmetic is INTENTIONALLY DROPPED (Dreyer v4 CRIT —
+//     "N years" reads as INAA vouching for the credential = UPL surface).
+
+import {
+  getAttorneyDiscipline,
+  type AttorneyRow,
+  type DisciplineEvent,
+  type DisciplineLookupResult,
+} from "./attorney-discipline.ts";
+
+// ─────────────────────────────────────────────────────────────────────────
+// Public anchors / constants — re-imported by tests via fixtures.ts.
+// ─────────────────────────────────────────────────────────────────────────
+
+/** Lead-in for the no-match copy — tests grep for this prefix. */
+export const NO_MATCH_MESSAGE = "We couldn't match";
+export const NO_MATCH_MESSAGE_PREFIX = NO_MATCH_MESSAGE;
+// Footer-disclaimer assembled at render time per
+// "Public {stateBarName} record. Same data, faster than the .gov form: {url}."
+// Tests assert presence of this prefix + the bar URL.
+export const DISCLAIMER_VERBATIM =
+  "Public California State Bar record. Same data, faster than the .gov form.";
+
+export const SECTION_HEADING = "Your Attorney's Public Bar Record";
+export const NICHE_DOMINATION_LINE =
+  "*We check this on every IB — before you do.*";
+
+export const JURISDICTION_BAR_NAMES: Record<string, string> = Object.freeze({
+  CA: "California State Bar",
+  // Multi-state expansion — each entry blocked on a per-state fair-report memo
+  // (T0b extension). Render path enforces CA-only via getAttorneyDiscipline()'s
+  // jurisdiction guard; these labels are pre-pinned for v3 readiness.
+  NJ: "NJ Office of Attorney Ethics",
+  VA: "Virginia State Bar",
+  FL: "The Florida Bar",
+  TX: "State Bar of Texas",
+  NY: "New York State Bar",
+  PA: "Pennsylvania Disciplinary Board",
+  OH: "Ohio Office of Disciplinary Counsel",
+  GA: "State Bar of Georgia",
+  IL: "Illinois ARDC",
+  MI: "Michigan Attorney Grievance Commission",
+});
+
+const CA_BAR_LOOKUP_BASE =
+  "https://apps.calbar.ca.gov/attorney/Licensee/Detail/";
+
+// Linked from the section footnote. Production deploy URL — when the memo
+// directory is mounted on the marketing site, swap in the canonical URL.
+const FAIR_REPORT_MEMO_URL =
+  "https://github.com/rahim0kapadia/ImNotAnAttorney-web/blob/master/docs/legal/2026-04-25-attorney-discipline-fair-report-privilege.md";
+
+// ─────────────────────────────────────────────────────────────────────────
+// Helpers — inline because Deno cannot import from src/lib/email.ts (which
+// transitively imports Next.js modules).
+// ─────────────────────────────────────────────────────────────────────────
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function escapeMarkdownPipe(s: string): string {
+  // Backslash FIRST — otherwise the pipe-escape's own backslash gets
+  // double-escaped on the second pass.
+  return s.replace(/\\/g, "\\\\").replace(/\|/g, "\\|");
+}
+
+/**
+ * Cell helper: escape pipe THEN HTML, in that order.
+ * Pipe-escape first keeps the literal `\|` visible to the markdown parser
+ * (md2html's table split is `(?<!\\)\|`). HTML-escape second defangs angle
+ * brackets, ampersands, quotes.
+ */
+export function cell(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  return escapeHtml(escapeMarkdownPipe(String(value)));
+}
+
+function safeHttpUrl(u: string | null | undefined): string {
+  if (typeof u !== "string") return "#";
+  if (!/^https?:\/\//i.test(u)) return "#";
+  // Strip control chars to defend against "https://example.com/<script>".
+  if (/[\r\n\x00<>"]/.test(u)) return "#";
+  return u;
+}
+
+export function safeMdLink(label: string, url: string | null | undefined): string {
+  const safeLabel = cell(label);
+  if (typeof url !== "string" || url.trim() === "") {
+    return `${safeLabel} (link unavailable)`;
+  }
+  const safe = safeHttpUrl(url);
+  if (safe === "#") return `${safeLabel} (link unavailable)`;
+  // Inside markdown link target, parens / brackets / spaces would corrupt the
+  // link. We'll rely on safeHttpUrl having pre-validated http(s):// already.
+  return `[${safeLabel}](${safe})`;
+}
+
+/**
+ * `formatShortDate("2026-04-25T00:00:00Z")` → "2026-04-25".
+ * Returns "unknown" on null/undefined/NaN — never a raw timestamptz.
+ */
+export function formatShortDate(d: string | null | undefined): string {
+  if (typeof d !== "string" || d.trim() === "") return "unknown";
+  const t = new Date(d);
+  if (isNaN(t.getTime())) return "unknown";
+  return t.toISOString().slice(0, 10);
+}
+
+function admissionYear(d: string | null | undefined): string {
+  if (typeof d !== "string" || d.trim() === "") return "unknown";
+  const t = new Date(d);
+  if (isNaN(t.getTime())) return "unknown";
+  return String(t.getUTCFullYear());
+}
+
+function lookupBaseFor(jurisdiction: string): string {
+  // CA-only in v2; other states fall back to no-link (rendered without CTA).
+  if (jurisdiction === "CA") return CA_BAR_LOOKUP_BASE;
+  return "";
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Renderers
+// ─────────────────────────────────────────────────────────────────────────
+
+export type RenderInput = {
+  result: DisciplineLookupResult;
+  /** USPS state code; controls the displayed bar name + lookup link. */
+  jurisdiction: string;
+  /** Original sanitized intake name — only rendered on no-match. */
+  attorneyName?: string;
+};
+
+/**
+ * Render the section as MARKDOWN. Internal renderer — exposed for in-memory
+ * hostile-input tests (T2.4 + Success Criterion 10) that bypass the DB.
+ */
+export function renderAttorneyDisciplineSection(
+  input: RenderInput,
+): string {
+  const stateBarName =
+    JURISDICTION_BAR_NAMES[input.jurisdiction] ?? "the state bar";
+  const lookupBase = lookupBaseFor(input.jurisdiction);
+
+  const heading = `## ${SECTION_HEADING}`;
+  const niche = NICHE_DOMINATION_LINE;
+  const memoFootnote = `[Public record — here's why we can show it](${FAIR_REPORT_MEMO_URL})`;
+
+  if (input.result.status === "no-match") {
+    const namePart = input.attorneyName
+      ? `"${cell(input.attorneyName)}"`
+      : "your attorney";
+    const verifyLine = lookupBase
+      ? `Try the official lookup yourself: ${lookupBase}`
+      : `Try the official ${stateBarName} lookup yourself.`;
+    return [
+      heading,
+      "",
+      niche,
+      "",
+      `We couldn't match ${namePart} to a ${stateBarName} record. Most often this is a spelling difference, or your attorney is barred in another state. It does NOT mean they're unlicensed. ${verifyLine}`,
+      "",
+      memoFootnote,
+    ].join("\n");
+  }
+
+  const { attorney, events } = input.result;
+
+  const status = cell(attorney.current_status ?? "unknown");
+  const statusLine = `Status (per ${stateBarName} as of ${formatShortDate(attorney.last_seen_at)}): ${status}`;
+  const admissionLine = `Licensed in ${cell(input.jurisdiction)} since ${admissionYear(attorney.admission_date)} (per ${stateBarName}).`;
+  const lookupCta = lookupBase
+    ? `Verify yourself: ${lookupBase}${cell(attorney.bar_number)}`
+    : "";
+
+  if (events.length === 0) {
+    return [
+      heading,
+      "",
+      niche,
+      "",
+      `**Clean public record per the ${stateBarName} — no discipline events on file.**`,
+      "",
+      statusLine,
+      admissionLine,
+      ...(lookupCta ? [lookupCta] : []),
+      "",
+      `Public ${stateBarName} record. Same data, faster than the .gov form.${lookupBase ? ` ${lookupBase}` : ""}`,
+      "",
+      memoFootnote,
+    ].join("\n");
+  }
+
+  const eventCountLabel =
+    events.length === 1 ? "1 event" : `${events.length} events`;
+
+  const tableLines: string[] = [
+    "| Date | Type | Summary | Source |",
+    "|------|------|---------|--------|",
+  ];
+  for (const ev of events) {
+    const dateCell = cell(formatShortDate(ev.order_date));
+    const typeCell = cell(ev.discipline_type ?? "");
+    const summaryCell = cell(ev.violation_summary || ev.discipline_raw || "");
+    const linkCell = safeMdLink("CA Bar order", ev.order_url || ev.source_url);
+    tableLines.push(
+      `| ${dateCell} | ${typeCell} | ${summaryCell} | ${linkCell} |`,
+    );
+  }
+
+  return [
+    heading,
+    "",
+    niche,
+    "",
+    `**Public discipline record on file with the ${stateBarName} (${eventCountLabel}).**`,
+    "",
+    statusLine,
+    admissionLine,
+    ...(lookupCta ? [lookupCta] : []),
+    "",
+    ...tableLines,
+    "",
+    `Public ${stateBarName} record. Same data, faster than the .gov form.${lookupBase ? ` ${lookupBase}` : ""}`,
+    "",
+    memoFootnote,
+  ].join("\n");
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Production wiring — single SOLE public entry point used by index.ts.
+// ─────────────────────────────────────────────────────────────────────────
+
+export type BuildAttorneyDisciplineSectionInput = {
+  attorneyName: unknown;
+  jurisdiction: unknown;
+  supabaseUrl: string;
+  serviceRoleKey: string;
+  /** Optional fetch override for tests. */
+  fetchImpl?: typeof fetch;
+};
+
+/**
+ * Wire-in helper — fetch + render in one call. Returns markdown string ready
+ * to be slotted into the IB sectionOutputs map at key "attorney-discipline".
+ *
+ * Returns "" (empty string) if the section should be suppressed entirely
+ * (kill switch via missing supabaseUrl, non-CA jurisdiction, etc.). The
+ * caller's `.filter((s) => s.trim())` drops empty entries from the final HTML.
+ */
+export async function buildAttorneyDisciplineSection(
+  input: BuildAttorneyDisciplineSectionInput,
+): Promise<string> {
+  if (typeof input.attorneyName !== "string" || !input.attorneyName.trim()) {
+    return "";
+  }
+  if (typeof input.jurisdiction !== "string" || !input.jurisdiction.trim()) {
+    return "";
+  }
+  if (!input.supabaseUrl || !input.serviceRoleKey) return "";
+
+  const result = await getAttorneyDiscipline(
+    input.attorneyName,
+    input.jurisdiction,
+    {
+      supabaseUrl: input.supabaseUrl,
+      serviceRoleKey: input.serviceRoleKey,
+      fetchImpl: input.fetchImpl,
+    },
+  );
+
+  return renderAttorneyDisciplineSection({
+    result,
+    jurisdiction: input.jurisdiction,
+    attorneyName: input.attorneyName.trim(),
+  });
+}
+
+// Re-exports for convenient single-import in tests.
+export type { AttorneyRow, DisciplineEvent, DisciplineLookupResult };

--- a/supabase/functions/generate-report/lib/section-anchors.ts
+++ b/supabase/functions/generate-report/lib/section-anchors.ts
@@ -1,0 +1,54 @@
+// supabase/functions/generate-report/lib/section-anchors.ts
+//
+// T2.1 (worry-attorney-discipline-wire v2.4) — Deno-side canonical IB
+// section-heading anchors. Pinned literals so production renderer + Deno-side
+// tests share a single source of truth.
+//
+// Mirror: src/lib/intelligence-brief/section-anchors.ts (Node-side parity).
+// A parity check keeps both files in lockstep — see
+//   src/lib/intelligence-brief/__tests__/section-anchors-parity.test.ts
+//
+// HOW THESE STRINGS WERE PINNED
+//   - LLM-generated section H2s (case-roadmap, whats-working, case-intelligence,
+//     legal-options, protection, your-plan, court-prep, questions): pinned from
+//     each section's prompt template in
+//     src/lib/intelligence-brief/prompts.ts (the `Output: ## ...` line).
+//   - Static-builder H2s (Table of Contents, Appendix A/C/E): pinned from the
+//     literal `return \`## ...\`` lines in
+//     supabase/functions/generate-report/index.ts:7219-7289.
+//   - Tier-9 + Appendix F/G/H: pinned from index.ts:5328 + 6362 + 6648 + the
+//     mechanical-renderer call sites.
+//   - ATTORNEY_DISCIPLINE: defined here (new in this PR) — used by the
+//     renderer at lib/render-attorney-discipline.ts and by the success-criteria
+//     ordering tests.
+//
+// NOTE: LLM-generated headings (your-plan etc.) carry a non-zero risk of
+// drift if the prompt template is edited. Tests that depend on order should
+// prefer the stable static neighbors as bounds (BRADY_GIGLIO_APPENDIX is the
+// reliable lower bound for the discipline section's ordering check).
+
+export const IB_SECTION_ANCHORS = {
+  // LLM-generated, ordered as in renderIBReportHtml's sections array.
+  CASE_ROADMAP:        "Section 1: Your Case Roadmap",
+  WHATS_WORKING:       "Section 2: What's Working in Your Defense",
+  CASE_INTELLIGENCE:   "Section 3: Case Intelligence",
+  LEGAL_OPTIONS:       "Section 4: Your Legal Options",
+  PROTECTION:          "Section 5: Protecting Yourself",
+  YOUR_PLAN:           "Section 6: Your Plan",
+  COURT_PREP:          "Appendix B: Court Preparation",
+  QUESTIONS:           "Appendix D: Questions for Your Attorney",
+
+  // NEW in this PR — wired between YOUR_PLAN and BRADY_GIGLIO_APPENDIX.
+  ATTORNEY_DISCIPLINE: "Your Attorney's Public Bar Record",
+
+  // Static builders (deterministic literals).
+  TABLE_OF_CONTENTS:        "Table of Contents",
+  BRADY_GIGLIO_APPENDIX:    "Appendix A: Brady/Giglio Checklist",
+  ATTORNEY_SCRIPT_PACK:     "Appendix C: Attorney Script Pack",
+  YOUR_RIGHTS:              "Appendix E: Your Rights During Criminal Proceedings",
+  TIER9_DATA_APPENDIX:      "Appendix F: Data-Driven Defense Intelligence",
+  MOTION_STRATEGY:          "Appendix G: Motion Strategy",
+  LIVE_AUTHORITY_MAP:       "Appendix H: Live Authority Map",
+} as const;
+
+export type IbSectionAnchorKey = keyof typeof IB_SECTION_ANCHORS;

--- a/supabase/migrations/20260425a_attorney_discipline_rls.sql
+++ b/supabase/migrations/20260425a_attorney_discipline_rls.sql
@@ -1,0 +1,32 @@
+-- 20260425a_attorney_discipline_rls.sql
+--
+-- T0a (worry-attorney-discipline-wire v2.4): make RLS posture EXPLICIT on the
+-- attorney directory + discipline tables. Previously RLS-disabled posture was
+-- implicit (anon-key SELECT returned 401 because no anon GRANT existed) — this
+-- migration switches both tables to explicit deny-by-default + service_role
+-- bypass, matching INAA-web ARCHITECTURE Invariant #4 ("RLS provides
+-- defense-in-depth, not primary auth").
+--
+-- Migration role: applied as `postgres` superuser via the Supabase Mgmt API
+-- POST /v1/projects/<ref>/database/query. `postgres` BYPASSES RLS, so this
+-- migration succeeds even though no SELECT policy exists. Subsequent
+-- service-role queries bypass RLS the same way; anon-key queries are blocked
+-- by absence of any policy (deny-by-default).
+--
+-- Post-apply verification:
+--   SELECT relrowsecurity FROM pg_class
+--   WHERE relname IN ('attorneys','attorney_discipline_events');
+--   Both rows should return `t`.
+
+ALTER TABLE public.attorneys                   ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.attorney_discipline_events  ENABLE ROW LEVEL SECURITY;
+
+-- service_role bypasses RLS by default — no policy needed for it.
+-- anon / authenticated have no SELECT policy → empty result set under PostgREST
+-- (HTTP 200 + body `[]`), per Code v2 CRIT #3 verified live 2026-04-25.
+
+COMMENT ON TABLE public.attorneys IS
+  'Cross-state attorney directory. RLS enabled 2026-04-25 (T0a worry-attorney-discipline-wire). Service-role only; anon returns 200 + []. See ARCHITECTURE Invariant #4.';
+
+COMMENT ON TABLE public.attorney_discipline_events IS
+  'Normalized attorney disciplinary history. RLS enabled 2026-04-25 (T0a worry-attorney-discipline-wire). Service-role only; anon returns 200 + []. See ARCHITECTURE Invariant #4.';

--- a/supabase/migrations/20260425b_attorney_discipline_test_fixtures.sql
+++ b/supabase/migrations/20260425b_attorney_discipline_test_fixtures.sql
@@ -1,0 +1,48 @@
+-- 20260425b_attorney_discipline_test_fixtures.sql
+--
+-- T1.3 (worry-attorney-discipline-wire v2.4):
+-- Synthetic CLEAN-only fixture rows for end-to-end testing of the
+-- attorney-discipline IB section. Three attorneys + two events, all
+-- non-hostile.
+--
+-- Sec v3 CRITICAL #2: NEVER seed hostile values (`<script>`, `javascript:`,
+-- pipe-shred) into the prod DB. Hostile-input testing is done in-memory at
+-- test time, passing hostile values directly to renderAttorneyDisciplineSection
+-- without any DB round-trip. See `supabase/functions/generate-report/__tests__/
+-- attorney-discipline-upl.test.ts` (T3.1).
+--
+-- Migration role: applied as `postgres` superuser via Supabase Mgmt API.
+-- `postgres` BYPASSES RLS — INSERT succeeds even though T0a enabled RLS on
+-- both tables.
+--
+-- Idempotent: ON CONFLICT DO NOTHING on the unique keys
+-- (jurisdiction, bar_number) for attorneys and
+-- (jurisdiction, bar_number, order_date, discipline_type) for events.
+--
+-- Cleanup-friendly: bar_number prefix `FIXTURE-` lets future maintenance run
+-- `DELETE FROM attorneys WHERE bar_number LIKE 'FIXTURE-%'` cleanly.
+
+INSERT INTO public.attorneys
+  (jurisdiction, bar_number, full_name,           first_name, last_name,    admission_date, current_status, last_seen_at)
+VALUES
+  ('CA',         'FIXTURE-001', 'Fixture Cleanrecord', 'Fixture',  'Cleanrecord', DATE '2010-01-15', 'active',    TIMESTAMPTZ '2026-04-25T00:00:00Z'),
+  ('CA',         'FIXTURE-002', 'Fixture Disciplined', 'Fixture',  'Disciplined', DATE '2005-06-20', 'suspended', TIMESTAMPTZ '2026-04-25T00:00:00Z'),
+  ('CA',         'FIXTURE-003', 'Fixture Cleanrecord', 'Fixture',  'Cleanrecord', DATE '2012-09-10', 'active',    TIMESTAMPTZ '2026-04-25T00:00:00Z')
+ON CONFLICT (jurisdiction, bar_number) DO NOTHING;
+
+-- Two events, both attached to FIXTURE-002 (the disciplined attorney).
+INSERT INTO public.attorney_discipline_events
+  (attorney_id, jurisdiction, bar_number, full_name, order_date, discipline_type, discipline_raw, violation_summary, order_url, source_url, scraped_at)
+SELECT a.id, 'CA', a.bar_number, a.full_name, e.order_date, e.discipline_type, e.discipline_raw, e.violation_summary, e.order_url, e.source_url, TIMESTAMPTZ '2026-04-25T00:00:00Z'
+FROM public.attorneys a
+CROSS JOIN LATERAL (VALUES
+  ('FIXTURE-002', DATE '2018-03-12', 'Suspension', 'SUSPENSION 90D STAYED', '90-day suspension stayed', 'https://example.com/fixture-002-evt-1', 'https://example.com/fixture-002-source'),
+  ('FIXTURE-002', DATE '2020-07-01', 'Probation',  'PROBATION 1Y',          '1-year probation imposed', 'https://example.com/fixture-002-evt-2', 'https://example.com/fixture-002-source')
+) AS e(bar, order_date, discipline_type, discipline_raw, violation_summary, order_url, source_url)
+WHERE a.jurisdiction = 'CA' AND a.bar_number = e.bar
+ON CONFLICT (jurisdiction, bar_number, order_date, discipline_type) DO NOTHING;
+
+COMMENT ON COLUMN public.attorneys.bar_number IS
+  'Bar number. Synthetic fixtures use prefix `FIXTURE-` to enable cleanup via
+   `DELETE FROM attorneys WHERE bar_number LIKE ''FIXTURE-%''`. See
+   worry-attorney-discipline-wire plan T1.3, 2026-04-25.';

--- a/supabase/migrations/20260425c_attorney_unaccent.sql
+++ b/supabase/migrations/20260425c_attorney_unaccent.sql
@@ -1,0 +1,91 @@
+-- 20260425c_attorney_unaccent.sql
+--
+-- T1.1a + T1.2 RPC (worry-attorney-discipline-wire v2.4):
+-- 1) install `unaccent` extension
+-- 2) wrap as IMMUTABLE function (`unaccent` itself is STABLE; indexes need IMMUTABLE)
+-- 3) create expression index over (jurisdiction, lower(immutable_unaccent(full_name)))
+-- 4) create stored RPC `attorney_match_by_raw_name` for service-role-only access
+--
+-- Why immutable wrapper: STABLE functions can't be used in expression indexes.
+-- Why pin dictionary: pg_dict_unaccent ('unaccent') is the default; pinning matches
+--   the index's frozen dictionary so behavior is deterministic.
+-- Why two-arg form: unaccent(regdictionary, text) — the dictionary name MUST be
+--   cast to regdictionary explicitly. Single-arg form picks "default" dict at runtime
+--   which can drift if a different dict gets installed later.
+--
+-- Why expression index: matches `lower(public.immutable_unaccent($1))` exactly so
+--   PostgREST RPC + raw-input strategy yields O(log n) lookup, accent- and
+--   case-insensitive.
+--
+-- Migration role: applied as `postgres` superuser via Supabase Mgmt API.
+-- `postgres` BYPASSES RLS — fine, no INSERT here.
+--
+-- Post-apply verification:
+--   1. `SELECT n.nspname FROM pg_extension e JOIN pg_namespace n ON e.extnamespace=n.oid
+--       WHERE e.extname='unaccent';`
+--      Supabase typically installs into the `extensions` schema, NOT `public`.
+--      If `extensions`, this migration's `public.unaccent` references will fail —
+--      retry below with `extensions.unaccent` substitution.
+--   2. `EXPLAIN SELECT * FROM attorneys
+--       WHERE jurisdiction='CA'
+--         AND lower(immutable_unaccent(full_name)) = 'jose garcia';`
+--      Should show `Index Scan using idx_attorneys_full_name_norm`.
+--   3. `SELECT * FROM attorney_match_by_raw_name('CA','Jose Garcia');`
+--      Should return zero or more rows; should NOT error.
+
+CREATE EXTENSION IF NOT EXISTS unaccent;
+
+-- IMMUTABLE wrapper — pinned to the 'unaccent' dictionary (default).
+-- The CAST to regdictionary forces overload resolution to the two-arg form.
+CREATE OR REPLACE FUNCTION public.immutable_unaccent(text)
+  RETURNS text
+  LANGUAGE sql
+  IMMUTABLE
+  PARALLEL SAFE
+  STRICT
+AS $$
+  SELECT public.unaccent('public.unaccent'::regdictionary, $1)
+$$;
+
+COMMENT ON FUNCTION public.immutable_unaccent(text) IS
+  'IMMUTABLE wrapper over unaccent() pinned to the public.unaccent dictionary.
+   Required for expression-index use (unaccent itself is STABLE).
+   See worry-attorney-discipline-wire plan T1.1a, 2026-04-25.';
+
+-- Expression index over normalized name. WHERE clause keeps it lean — NULL
+-- full_name rows aren't matchable anyway (per Sec v4 WARN).
+CREATE INDEX IF NOT EXISTS idx_attorneys_full_name_norm
+  ON public.attorneys (jurisdiction, lower(public.immutable_unaccent(full_name)))
+  WHERE full_name IS NOT NULL;
+
+-- Stored RPC — service-role only. Anon-key callers get HTTP 404 + body
+-- `{ code: 'PGRST202' }` because they have no EXECUTE grant (verified
+-- in tests: supabase/functions/__tests__/rls-attorney-discipline.test.ts).
+CREATE OR REPLACE FUNCTION public.attorney_match_by_raw_name(
+  jur       text,
+  raw_name  text
+)
+  RETURNS SETOF public.attorneys
+  LANGUAGE sql
+  STABLE
+  SECURITY INVOKER
+AS $$
+  SELECT *
+  FROM public.attorneys
+  WHERE jurisdiction = jur
+    AND lower(public.immutable_unaccent(full_name))
+      = lower(public.immutable_unaccent(raw_name));
+$$;
+
+COMMENT ON FUNCTION public.attorney_match_by_raw_name(text, text) IS
+  'Exact-match attorney lookup with accent + case folding. Service-role only.
+   Anon callers see PostgREST 404 PGRST202. See worry-attorney-discipline-wire
+   T1.2, 2026-04-25.';
+
+-- Lock down execute privileges. service_role bypasses GRANT/REVOKE because it
+-- bypasses RLS, but PostgREST's anon/authenticated roles require an explicit
+-- EXECUTE grant to call the RPC. Without it, PostgREST returns 404 PGRST202.
+REVOKE ALL ON FUNCTION public.attorney_match_by_raw_name(text, text) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.attorney_match_by_raw_name(text, text) FROM anon;
+REVOKE ALL ON FUNCTION public.attorney_match_by_raw_name(text, text) FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.attorney_match_by_raw_name(text, text) TO service_role;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,24 @@ import path from "path";
 export default defineConfig({
   test: {
     globals: true,
-    exclude: ["e2e/**", "node_modules/**", ".claude/worktrees/**"],
+    // Default vitest include patterns + explicit references to high-value
+    // parity tests (worry-attorney-discipline-wire v2.4 T3.2a) so future
+    // edits to test discovery cannot accidentally drop these CI guards.
+    include: [
+      "**/*.{test,spec}.?(c|m)[jt]s?(x)",
+      "src/lib/intelligence-brief/__tests__/banned-phrases-parity.test.ts",
+      "src/lib/intelligence-brief/__tests__/section-anchors-parity.test.ts",
+    ],
+    exclude: [
+      "e2e/**",
+      "node_modules/**",
+      ".claude/worktrees/**",
+      // Deno tests under supabase/functions/** are run separately via
+      // `deno test`. They import from https://deno.land/... which vitest
+      // cannot resolve; force-excluding them here keeps the npm + deno
+      // suites cleanly separated (Plan T4.2 — separate runners).
+      "supabase/functions/**",
+    ],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary

Wires the existing `attorneys` + `attorney_discipline_events` tables (16,543 events / 11 jurisdictions, loaded over the past week) into the IB ($997) report. Adds a new section **"Your Attorney's Public Bar Record"** between the LLM-generated *Your Plan* section and the static Brady/Giglio appendix. CA-only in v2 — multi-state expansion blocked on per-state fair-report memos.

Closes the worry: *"we have intake.attorneyName, we have the bar tables, we never connect them."*

## Plan

`docs/plans/2026-04-25-worry-attorney-discipline-wire.md` (v2.4, 4 pristine-loop rounds; 2 CRIT + 14 WARN + 11 SUG from round-0-v4. CRITs + WARNs all applied; SUGs deferred.)

## What's new

**3 migrations** (applied via Mgmt API; idempotent):
- `20260425a_attorney_discipline_rls.sql` — enable RLS on both tables (defense-in-depth, ARCHITECTURE Invariant #4).
- `20260425b_attorney_discipline_test_fixtures.sql` — 3 clean fixture attorneys + 2 events. **No hostile values persisted** (Sec v3 CRIT #2 — XSS testing happens in-memory only).
- `20260425c_attorney_unaccent.sql` — `unaccent` extension + `immutable_unaccent` IMMUTABLE wrapper + expression index + `attorney_match_by_raw_name` RPC (service-role only, anon REVOKE).

**Edge Function (Deno-side)**:
- `lib/attorney-discipline.ts` — RPC client. 9-step input contract (type / trim / ctrl / collapse / length / garbage / single-token / postgrest-special / cap). **No JS-side unaccent shim** — Postgres folds on both sides.
- `lib/render-attorney-discipline.ts` — mechanical markdown renderer. `cell()` does pipe-escape THEN HTML-escape. `safeMdLink` falls back to `(link unavailable)` instead of `href="#"`. Three render paths: matched-clean / matched-with-events / no-match. Niche-domination one-liner anchors to defendant's job-to-be-done.
- `lib/section-anchors.ts` + `lib/banned-phrases.ts` — Deno-side canonicals; Node-side mirrors at `src/lib/intelligence-brief/`. Parity-asserted every CI.

**Production wire-up** (`supabase/functions/generate-report/index.ts`):
- `await buildAttorneyDisciplineSection({ ... })` runs after Phase 2 cite-tag strip, before HTML compile.
- `sectionOutputs["attorney-discipline"]` slotted between `sectionOutputs["your-plan"]` and `buildBradyGiglioChecklist()`.
- Empty string suppresses the section (jurisdiction guard, RPC error, missing intake name).

**Tests** (npm + Deno suites, separate per Plan T4.2):
- `attorney-discipline.test.ts` — 17 Deno unit tests (matched / no-match / ambiguous / injection / control-char / garbage / diacritic / network error / sanitizer internals).
- `attorney-discipline-upl.test.ts` — 9 Deno tests: deterministic regex panel × 5 fixtures, T3.3 interpretive-adjective panel, T3.4 entity-decode panel, in-memory hostile-input, double-encoded XSS payload.
- `rls-attorney-discipline.test.ts` — 5 Deno tests: anon role-decode, table SELECT 200+[], RPC denial (404+PGRST202 OR 401+42501), service-role positive control. Auto-refreshes anon key from Mgmt API when stale `.env.local` returns 401.
- `section-anchors-parity.test.ts` + `banned-phrases-parity.test.ts` — Node-side parity guards added to `vitest.config.ts` include glob.

**Legal**:
- `docs/legal/2026-04-25-attorney-discipline-fair-report-privilege.md` — Cal. Civ. Code § 47(d) memo. Verification URLs stored per `no-hallucinated-legal-data.md`. Multi-state expansion gated on per-state memos.

## Verification

- `npm run build` ✅
- `deno check` (8 lib + test files) ✅
- `npm test` — 91 pass / 8 fail. **All 8 failures pre-exist on master** (verified by running master via temp worktree). Zero regressions; +2 passing files added.
- `deno test` (3 suites, 32 tests) — all green.
- CV probe-only — exit 0, zero `INNA-H1.*FAIL`.
- Live verification queries against prod Supabase — RLS enabled on both tables, fixtures loaded, RPC callable.

## Hard constraints satisfied

- ✅ UPL-safe — every disclaimer passes `BANNED_PHRASES_BLOCK` panel; T3.3 interpretive-adjective panel + T3.4 entity-decode panel green.
- ✅ Fair-report memo present.
- ✅ Real bar numbers only (`FIXTURE-` prefixed synthetic rows for tests; no fabrication).
- ✅ All migrations idempotent (`IF NOT EXISTS` / `CREATE OR REPLACE` / `ON CONFLICT DO NOTHING`).
- ✅ Fix-at-root, not symptom — input contract reordered, renderer suppresses on error, parity tests catch future drift.

## Out of scope (per plan v2.4)

- Case Decoder integration (Phase 1.1b — separate plan; CD path goes through `batch-poller.ts:238`).
- Multi-state attorney discipline rendering (FL/TX/NY/PA/OH/GA/IL/MI/NJ/VA already loaded in DB but unrendered until per-state memos exist).
- LLM `evaluate-report` integration (Phase 1.1c — nightly cron sample).
- Backfill of already-delivered IB reports.
- Fuzzy match / disambiguation (defamation surface).

## Test plan

- [ ] Deploy Edge Function: `npx supabase functions deploy generate-report`.
- [ ] Regen one IB for a CA case via `/api/admin/regen-ib?caseId=…&key=$ADMIN_PASSWORD` and visually verify the new section renders with proper escaping + correct slot order.
- [ ] Confirm `/api/cron/refresh-entity-confidence` is unaffected (matview unchanged).
- [ ] Confirm no IB customer sees the section if `intake.attorney_name` is empty (graceful suppression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)