### PR TITLE
chore: rescue platform_posts migrations + plans from concurrent-session stash

### DIFF
--- a/content/queue/twitter/pending/2026-04-24-field-sobriety-test-standards-5103.md
+++ b/content/queue/twitter/pending/2026-04-24-field-sobriety-test-standards-5103.md
@@ -1,0 +1,52 @@
+---
+source: C:\Users\email\projects\ImNotAnAttorney\content\READY-TO-POST\field-sobriety-test-standards\twitter-thread.md
+source_type: ready-to-post
+topic: field-sobriety-test-standards
+platform: twitter
+queued_at: 2026-04-24T13:01:55.103Z
+queued_by: content-scheduler
+---
+The government's own research says field sobriety tests misidentify sober people as impaired 18% of the time.
+
+That's when everything goes perfectly.
+
+Officers rarely administer them perfectly.
+===TWEET===
+NHTSA — the federal agency that created these tests — published accuracy rates:
+
+- HGN: 77% accurate
+- Walk-and-Turn: 68% accurate
+- One-Leg Stand: 65% accurate
+- All three combined: 82% accurate
+
+Read that again: even using all three, they're wrong nearly 1 in 5 times.
+===TWEET===
+Under perfect conditions.
+===TWEET===
+The HGN test (pen follows the eyes): each pass should take 2 seconds. Dashcam footage often shows officers completing the entire test — all 6 passes — in 45 seconds total. That's 1 second per pass. Half the required time. The test is invalid.
+===TWEET===
+The officer's report will say otherwise.
+===TWEET===
+Walk-and-Turn: NHTSA requires a "reasonably dry, hard, level, non-slippery surface."
+
+The shoulder of a highway with gravel and a grade is none of those things.
+
+Try walking heel-to-toe on uneven ground in dress shoes while armed officers watch and cars pass at 60 mph.
+===TWEET===
+At least 38 medical conditions cause nystagmus unrelated to alcohol.
+
+Inner ear disorders. Brain injuries. Certain medications. Eye muscle imbalances.
+
+NHTSA training mentions this.
+
+Officers almost never ask about medical history before administering the HGN test.
+===TWEET===
+Here's the cascade: invalid field sobriety tests → no probable cause for arrest → no lawful basis for the breath test → BAC result excluded. It starts with one question: did the officer follow the standards? Dashcam footage often shows they didn't.
+===TWEET===
+The police report says they did.
+===TWEET===
+The questions to ask your attorney — has the dashcam footage been reviewed? Does it match the report? Were the tests administered on a flat, level surface? Did the officer ask about medical conditions?
+===TWEET===
+Full breakdown on NHTSA standards and where officers deviate:
+
+→ https://imnotanattorney. com/blog/field-sobriety-test-standards? utm_source=twitter&utm_medium=thread&utm_campaign=fst-standards

--- a/content/queue/twitter/pending/2026-04-25-field-test-vs-lab-test-drug-cases-1609.md
+++ b/content/queue/twitter/pending/2026-04-25-field-test-vs-lab-test-drug-cases-1609.md
@@ -1,0 +1,38 @@
+---
+source: C:\Users\email\projects\ImNotAnAttorney\content\READY-TO-POST\field-test-vs-lab-test-drug-cases\twitter-thread.md
+source_type: ready-to-post
+topic: field-test-vs-lab-test-drug-cases
+platform: twitter
+queued_at: 2026-04-25T13:00:41.609Z
+queued_by: content-scheduler
+---
+The officer drops a sample into a little plastic pouch. The liquid changes color. He says: "It tested positive."
+
+That field test is NOT confirmation of anything.
+
+Here's what it actually is — and why your attorney should be fighting it:
+===TWEET===
+A field test — also called a presumptive test or colorimetric reagent test — is a portable kit that gets a quick on-the-spot INDICATION of whether a substance MIGHT be a drug. The key word: might. No molecular analysis. No confirmation.
+===TWEET===
+Just a color change interpreted by an officer at the scene. Documented false positives: chocolate, aspirin, ibuprofen, baking soda, oregano.
+===TWEET===
+A confirmatory lab test is what actually identifies a substance. Methods like GC-MS (gas chromatography-mass spectrometry) determine the exact molecular composition. In one documented case: the defendant was charged based on a field test indicating AMPHETAMINE.
+===TWEET===
+The lab came back: MDMA and MDA. A completely different drug — different charges, different sentencing. A color change doesn't just get the answer wrong. It can get the question wrong.
+===TWEET===
+Why this matters for your defense:
+
+• Field tests are NOT admissible as conclusive evidence in most jurisdictions
+• The prosecution generally needs lab confirmation to prove the substance at trial
+• Many defendants plead guilty BEFORE lab results come back
+• Daubert/Frye challen…
+===TWEET===
+Questions to bring to your attorney:
+
+1. Was the substance identified by field test only, or has a lab test been completed? 2. Do the lab results match the field test? 3. Can we file a Daubert/Frye challenge to the field test evidence? 4.
+===TWEET===
+Has the chain of custody from scene to lab been maintained? 5. Were the field test kits expired or improperly stored?
+===TWEET===
+Why a "presumptive positive" isn't the same as proof — and the 7 questions that hold your attorney accountable for challenging it:
+
+→ https://imnotanattorney.com/blog/field-test-vs-lab-test-drug-cases?utm_source=twitter&utm_medium=thread&utm_campaign=field-test-lab-test

--- a/docs/handoff/2026-04-25-attorney-discipline-wire-phase5-handoff.md
+++ b/docs/handoff/2026-04-25-attorney-discipline-wire-phase5-handoff.md
@@ -1,0 +1,113 @@
+# Phase 5 Handoff — Attorney-Discipline-Events Wiring (2026-04-25, post-v2.4)
+
+## Where this picks up
+
+Plan went through 4 pristine-loop rounds. v2.4 absorbs all v4 CRITs + WARNs. Phase 5 = write the actual code following the plan.
+
+**Plan path** (read this in full first):
+`C:\Users\email\projects\_worktrees\worry-attorney-discipline\docs\plans\2026-04-25-worry-attorney-discipline-wire.md`
+
+**Worktree to work in:**
+`C:\Users\email\projects\_worktrees\worry-attorney-discipline` (branch `worry/attorney-discipline-wire` off origin/master @ `725a8a8e` at fork; parent master is now `241198fd` — rebase before push).
+
+## Pre-flight (verify before any code)
+
+1. `cd C:\Users\email\projects\_worktrees\worry-attorney-discipline && git fetch origin && git rebase origin/master` — pull in PR #133 (NYPD CCRB), PR #148 (NJ bar), PR #149 (VA bar) if any are merged.
+2. Read `ARCHITECTURE.md` (the hook will block edits otherwise).
+3. Pre-execution PR-collision check (Worktree Boundary in plan):
+   ```
+   gh pr list --state open --json number,headRefName,files --limit 50 \
+     | jq '[.[] | select(.files[].path == "supabase/functions/generate-report/index.ts") | {number, headRefName}]'
+   ```
+   If any PR is returned that touches `supabase/functions/generate-report/index.ts`, surface to Rahim BEFORE Phase 5 (rebase target may need to switch from master to that PR's branch).
+
+## Implementation order (each task = its own commit)
+
+Per plan v2.4 § "Numbered Tasks":
+
+1. **T0a** — `supabase/migrations/20260425a_attorney_discipline_rls.sql` (RLS on both tables).
+2. **T0b** — `docs/legal/2026-04-25-attorney-discipline-fair-report-privilege.md` (CA Civ. Code § 47 memo). Cite Eugene Volokh if no cached fair-report expert exists yet — run `expert-triangulation` skill first.
+3. **T1.1a** — `supabase/migrations/20260425c_attorney_unaccent.sql` (extension + `immutable_unaccent` + expression index + RPC `attorney_match_by_raw_name`). Verify extension namespace post-apply (extensions vs public — see plan).
+4. **T1.3** — `supabase/migrations/20260425b_attorney_discipline_test_fixtures.sql` (CLEAN fixtures only, 3 rows; NO hostile rows — Sec v3 CRIT).
+5. **Apply migrations a → c → b in this order** via Supabase Management API (`POST /v1/projects/jxjbjmgdukwkoclydqdr/database/query` with the SUPABASE_ACCESS_TOKEN bearer). Migrations apply as `postgres` superuser → bypass RLS for the fixture INSERT.
+6. **T1.3a** — `supabase/functions/generate-report/__tests__/fixtures.ts` (constants + escapeRegExp).
+7. **T1.2** — `supabase/functions/generate-report/lib/attorney-discipline.ts` (RPC client; `getAttorneyDiscipline` + input contract). NO JS unaccent shim. Pass raw sanitized input to RPC.
+8. **T2.1** — `supabase/functions/generate-report/lib/section-anchors.ts` (Deno-side anchors; grep `index.ts` for every existing `<h2 class="section-h2">` literal, pin them all).
+9. **T2.1 mirror** — `src/lib/intelligence-brief/section-anchors.ts` (Node-side parity mirror).
+10. **T3.2 + T3.2b** — `supabase/functions/generate-report/lib/banned-phrases.ts` (Deno-side canonical) + extraction script reading existing `src/lib/intelligence-brief/prompts.ts:34` template literal.
+11. **T3.2 mirror** — `src/lib/intelligence-brief/banned-phrases.ts` (Node mirror; readFileSync + parse pattern, NOT direct import — matches `whitelist-parity.test.ts` precedent).
+12. **T3.2a** — `src/lib/intelligence-brief/__tests__/banned-phrases-parity.test.ts`. Add to `vitest.config.ts` include glob explicitly.
+13. **T2.2 + T2.3 + T2.3a** — `supabase/functions/generate-report/lib/render-attorney-discipline.ts` (the renderer; `cell()` helper; `safeMdLink`; `formatShortDate`; `JURISDICTION_BAR_NAMES` map). Public symbol = `buildAttorneyDisciplineSection` (the wired one). Internal: `renderAttorneyDisciplineSection`. Tests call `buildAttorneyDisciplineSection` to mirror prod path.
+14. **T2.4** — Modify `supabase/functions/generate-report/index.ts`:
+    - Insert `await buildAttorneyDisciplineSection({ ... })` between the `sectionOutputs["your-plan"]` array entry and the `buildBradyGiglioChecklist()` call.
+    - Heading literal: `## Your Attorney's Public Bar Record`.
+    - Niche-domination one-liner (italicized): `*We check this on every IB — before you do.*`
+    - Update `prompts.ts` to interpolate `BANNED_PHRASES_BLOCK` from the new module (don't break existing callers).
+15. **T1.4** — `supabase/functions/generate-report/__tests__/attorney-discipline.test.ts`. Use built-in `Deno.test`, NOT std/bdd. Cover all 8 cases listed in plan T1.4.
+16. **T3.1 + T3.3 + T3.4** — `supabase/functions/generate-report/__tests__/attorney-discipline-upl.test.ts` (deterministic regex panel + interpretive-adjective panel + entity-decode panel).
+17. **T4.6** — `supabase/functions/__tests__/rls-attorney-discipline.test.ts` (table SELECT + RPC POST anon-denial; positive-control with service-role).
+18. **T4.7** — Live-render smoke: invoke IB renderer with `FIXTURE_DISCIPLINED_BAR_NUMBER` synthetic case; assert `Your Attorney's Public Bar Record` heading + `<tr>` event row + disclaimer verbatim.
+
+## Verification gate (T4)
+
+Run in this order; any failure = stop and fix:
+1. `npm run build` exit 0.
+2. `deno check` on every Deno-side file (T4.1a list).
+3. `npm test` capture vs origin/master baseline (T4.2 npm side).
+4. `deno test --reporter=junit` capture vs origin/master baseline (T4.2 Deno side; if `before-deno.xml` missing, treat as 0/0/0).
+5. `node ~/projects/continuous-verification/verify.mjs --project inna --probe-only --no-trends` exit 0, no `INNA-H1.*FAIL`.
+6. Live IB regen for 1 test case via `/api/admin/regen-ib?caseId=...&key=$ADMIN_PASSWORD` → manually verify the new section renders correctly in the HTML.
+
+## Acceptance criteria (Success Criteria block in plan)
+
+All 17 numbered criteria must pass. Specific gotchas:
+- **Criterion 11** uses tolerant regex `/<h2[^>]*>Your Attorney's Public Bar Record<\/h2>/` (md2html injects `class="section-h2"`).
+- **Criterion 11(c)** ordering uses `BRADY_GIGLIO_APPENDIX` as upper bound (YOUR_PLAN heading is LLM-generated, may not be deterministic).
+- **Criterion 13** asserts `BANNED_PHRASES_BLOCK.length >= 10` (false-green guard).
+
+## PR creation
+
+When all gates green:
+```
+git push -u origin worry/attorney-discipline-wire
+gh pr create --base master --head worry/attorney-discipline-wire --repo rahim0kapadia/ImNotAnAttorney-web \
+  --title "feat(ib): attorney bar-discipline section — fair-report privilege, CA-only" \
+  --body <generated-from-plan-summary>
+```
+
+## Hard constraints (per global rules)
+
+- 100% UPL-safe: every disclaimer string passes the BANNED_PHRASES_BLOCK panel.
+- Fair-report privilege memo MUST exist before merge.
+- Real bar numbers only — no fabrication.
+- All migrations idempotent (`IF NOT EXISTS` / `CREATE OR REPLACE`).
+- Every Deno-side file uses port 5432 if it touches Postgres directly (it doesn't here — RPC via PostgREST).
+- Defensive against root-cause-first hook: if a test fails because of a producer-level issue (e.g., md2html behavior), fix the spec/plan/test, NOT the output.
+
+## Out of scope (do NOT do in Phase 5)
+
+- Case Decoder integration (Phase 1.1b — separate plan).
+- Multi-state bar discipline rendering (blocked on per-state fair-report memos; v2.4 ships CA-only).
+- LLM evaluate-report integration (Phase 1.1c — nightly cron sample, separate plan).
+- Backfill of already-delivered reports.
+- Fuzzy match / disambiguation prompt.
+
+## Status of related work this session
+
+- **PR #148** — NJ Bar discipline scraper (+4,940 events / 3,131 attorneys). Awaiting Rahim merge.
+- **PR #149** — VA Bar discipline scraper (+1,101 events / 1,008 attorneys, gaps 2022-2025 documented). Awaiting Rahim merge.
+- **DB state** — `attorney_discipline_events` now at 16,543 events / 11 jurisdictions (CA, FL, GA, IL, MI, NJ, NY, OH, PA, TX, VA).
+- **P1 next wave** (state expansion) — handoff list at top of session: WA, AZ, TN, MA, IN, MD, CO, MN. Fresh session can dispatch waves of 2 in parallel via the agent recipe in `docs/handoff/<previous-session-handoff>.md`.
+
+## Ready-to-paste prompt for fresh session
+
+```
+Execute Phase 5 of the implementation plan at
+  C:\Users\email\projects\_worktrees\worry-attorney-discipline\docs\plans\2026-04-25-worry-attorney-discipline-wire.md
+
+Pre-flight: read the plan in full + read C:\Users\email\projects\ImNotAnAttorney-web\docs\handoff\2026-04-25-attorney-discipline-wire-phase5-handoff.md.
+
+Work in worktree at C:\Users\email\projects\_worktrees\worry-attorney-discipline (branch worry/attorney-discipline-wire). Rebase onto origin/master before starting. Implement tasks T0a → T4.7 in the order listed in the handoff. All v4 swarm findings (CRITs + WARNs) are already applied; SUGs deferred. Pristine-Or-Nothing applies — fix every test failure at root cause.
+
+When done: push, gh pr create against master, surface to Rahim for review.
+```

--- a/docs/plans/2026-04-25-bar-scrapers-batch.md
+++ b/docs/plans/2026-04-25-bar-scrapers-batch.md
@@ -1,0 +1,525 @@
+# 8-State Bar Discipline Scraper Batch — Phase 5 Spec
+
+> **Audience:** 8 Haiku execution agents — each gets exactly one card, must
+> ship a working scraper + test + PR with **no further research**.
+>
+> **Schema target:** `public.attorneys` + `public.attorney_discipline_events`
+> (migration `supabase/migrations/20260422e_attorney_discipline.sql`).
+>
+> **Helpers (REQUIRED, do NOT rewrite):**
+> - `scripts/lib/pg-bulk-defaults.mjs` — `createBulkClient`, `bulkCopyRows`
+> - `scripts/lib/db.mjs` — Postgres client (port 5432)
+>
+> **Hard rules — every scraper MUST:**
+> 1. Header line 1: `// csv-bulk-checked: <URL or "none-exists — reason">` (rule #19)
+> 2. Header line 2: `// Template: scripts/ingest/<file>.mjs` (rule #18)
+> 3. Header line 3: `// Pattern: cl-bulk-data-defensive #18 (COPY FROM STDIN on insert phase)`
+> 4. Use `bulkCopyRows` for insert — per-row INSERT BANNED
+> 5. Idempotent re-runs — `ON CONFLICT (jurisdiction, bar_number, order_date, discipline_type) DO NOTHING` for events; `ON CONFLICT (jurisdiction, bar_number) DO UPDATE SET last_seen_at = NOW(), …` for attorneys
+> 6. Defensive parsing: try/catch around per-record extraction, log+skip bad rows
+> 7. CLI: `--apply` (default off = dry-run), `--start-date`, `--limit`, `--help`
+> 8. Polite delay: 800–1600 ms randomized between page hits
+> 9. User-Agent: `INAA-Crawler/1.0 (+https://imnotanattorney.com; contact: noreply-legal@inaa.com)`
+> 10. **Never fabricate `source_url`** — populate only with the URL the row was actually scraped from. If the source page links to an order PDF, capture that as `order_url`; otherwise leave NULL.
+>
+> **Discipline-type enum (lower-case strings, applied uniformly across all 8):**
+> `disbarment | suspension | interim_suspension | probation | public_reprimand | resignation_with_charges | censure | admonition | reciprocal_discipline | disability_inactive | unknown`
+>
+> Use the `DISCIPLINE_PATTERNS` regex array from `scrape-calbar-discipline.mjs` lines 55–72 as the canonical normalizer. Extend per state ONLY where the source uses a label not in the existing list (e.g. TN "Censured", MN "Disability Inactive Status").
+
+---
+
+## Summary Table
+
+| State | Source format | Template to copy | Ship/Skip | Est rows | Notes |
+|-------|---------------|-------------------|-----------|----------|-------|
+| WA | ASP.NET search results (server-side paginated, JS controls but renders to HTML) | `scrape-calbar-discipline.mjs` | **SHIP** | ~3,000 (1984–present) | Uses Playwright OR raw POST to `__VIEWSTATE` form |
+| AZ | ASPX yearly matrix tables (1986–present) | `scrape-calbar-discipline.mjs` | **SHIP** | ~1,500 (1986–present) | One URL per year, table per year |
+| TN | Paginated HTML list (`?Page=N`, 25/page, 5,931 records) | `scrape-flbar-discipline.mjs` | **SHIP** ★ | ~5,931 | Cleanest source. Detail pages also linked. |
+| MA | Static research site `decisions.massbbo.org` + FY annual-report PDFs | `scrape-txbar-discipline.mjs` (PDF) | **SHIP** | ~5,000 (1974–present, BBO claims complete archive) | Try research site first; fall back to fyXXXX.pdf |
+| IN | Year-filtered HTML table (in.gov/courts/public-records/orders/discipline) | `scrape-flbar-discipline.mjs` | **SHIP** | ~50/year × 8 years = ~400 | One URL per year, simple table |
+| MD | Annual FY PDF (`/sites/default/files/import/attygrievance/pdfs/sanctionsfyXX.pdf`) | `scrape-txbar-discipline.mjs` (PDF) | **SHIP** | ~50/year × 20 years = ~1,000 | FY06–FY26, prose paragraphs per attorney |
+| CO | Decisia/CanLII-style portal `research.coloradopdj.com/copdj/en/ann.do` | `scrape-flbar-discipline.mjs` | **SHIP** | ~1,500 (1999–present) | "Recent decisions" annual list page |
+| MN | LPRB annual-report PDF + Bench & Bar quarterly columns | `scrape-txbar-discipline.mjs` (PDF) | **SHIP** | ~30–40/year × 5 years = ~175 | OLPR has no browseable list; annual reports are the canonical public source |
+
+**Cross-cutting gotcha:** No two states share a vendor — each is bespoke. There is NO opportunity for a shared adapter. Three states (TX, MA, MD, MN) use PDF-paragraph parsing; three (TN, IN, CO) use HTML-table; two (WA, AZ) use ASP.NET-style server forms requiring Playwright or ViewState handling. **Estimated total Haiku build time: 6–8 hours across 8 parallel agents (avg 60 min/state).**
+
+---
+
+## WA — Washington Bar Discipline Scraper
+
+**Official source:** `https://www.mywsba.org/personifyebusiness/DisciplineNoticeDirectory.aspx`
+**Source format:** ASP.NET WebForms search results (server-side rendered HTML, requires `__VIEWSTATE` postback or Playwright)
+**Pagination:** Result page exposes `1 2 3 4 5 …` numbered links; under the hood these post `__EVENTTARGET` + `__EVENTARGUMENT` with the same `__VIEWSTATE`. Easiest path = Playwright `.click(page-N-link)`.
+**Auth/blockers:** Public, no login. JS required (controls postback). No CAPTCHA observed.
+**Estimated row count:** ~3,000 events (search "since 1984" per page header; ~30/yr × 40 yr).
+**Date range available:** 1984 – present (per WSBA notice text).
+**Copy template:** `scrape-calbar-discipline.mjs` (Playwright + per-row extraction)
+**Why that template:** CA scraper already wraps Playwright + bulkCopyRows; WSBA list is the same shape (paginated HTML, fields per row). Same delay/User-Agent pattern.
+
+**Field mapping:**
+| Source field | Selector / strategy | DB column | Transform |
+|---|---|---|---|
+| Last name, First name | `td.colLastName`, `td.colFirstName` (search results table; Haiku must inspect actual td classes via Playwright `page.locator('table tr')` then verify) | last_name / first_name → also concat to full_name | trim |
+| WSBA license # | `td.colLicenseNo` | bar_number | digits only |
+| Action type (dropdown labels show: Disbarment, Resignation in Lieu of Disbarment, Suspension, Reprimand, Censure, Admonition) | `td.colActionType` | discipline_type (after enum-map) | enum-map below |
+| Date of action | `td.colActionDate` | order_date | parse `MM/DD/YYYY` |
+| Decision document link | `td a[href]` (anchor inside row) | order_url | absolute URL, otherwise NULL |
+| Page URL | `LIST_URL` | source_url | constant |
+
+**Discipline enum mapping (WA labels → DB enum):**
+- "Disbarment" / "Disbarred" → `disbarment`
+- "Resignation in Lieu of Disbarment" → `resignation_with_charges`
+- "Suspension" / "Suspended" → `suspension`
+- "Interim Suspension" → `interim_suspension`
+- "Reprimand" → `public_reprimand`
+- "Censure" → `censure`
+- "Admonition" → `admonition`
+- "Reciprocal Discipline" → `reciprocal_discipline`
+
+**Idempotency key:** `(jurisdiction='WA', bar_number, order_date, discipline_type)` — DB-level UNIQUE constraint already exists.
+
+**Sample row:** Page renders results only after a search is executed. Default load = empty form. Haiku approach: submit empty form with broad date range (1/1/1984 → today), capture rendered table HTML, log first 3 rows verbatim into the script's `--dry-run` output for verification.
+
+**Date format gotchas:** None observed; `MM/DD/YYYY` zero-padded.
+
+**Migration needed?** **YES** — extend `discipline_type` to allow `censure`, `admonition`, `reciprocal_discipline`. Also extend across ALL 8 scraper specs. Migration file: `supabase/migrations/20260425a_extend_discipline_types.sql` (one shared migration; first Haiku to land creates it, others reference it). **CHECK constraint not currently in place** — `discipline_type` is plain TEXT — so no schema change is strictly required to insert these values, BUT add a comment listing the canonical enum to the table.
+
+**Test cases the Haiku MUST cover:**
+- Dedupe on re-run (same (bar_number, order_date, discipline_type) inserted twice → only 1 row)
+- Empty result page (graceful exit, log "no records")
+- Name with diacritic (`José` → preserved as UTF-8)
+- Date edge: pre-2000 entries (1984+ exist; do not assume 4-digit year ≥ 2000)
+
+**Estimated build time:** 90 min (Playwright form interaction + pagination loop).
+
+**Blocker?** SHIP. (Playwright already a dependency; CA scraper proves the pattern.)
+
+---
+
+## AZ — Arizona Bar Discipline Scraper
+
+**Official source:** `https://www.azcourts.gov/attorneydiscipline/DisciplinaryCasesMatrix.aspx` (master list) + per-year matrix pages at `https://www.azcourts.gov/attorneydiscipline/DisciplinaryCasesMatrix/<YEAR>DisciplinaryCasesMatrix.aspx` (1986–2024 confirmed via search results)
+**Source format:** Static HTML table per year (one master + per-year pages). Confirmed columns: **Case Name, Date/Number, Violations Description, Disciplinary Rules** (per `azcourts.gov` matrix description).
+**Pagination:** None within a year — the year IS the page. Iterate `2010..2025` URLs.
+**Auth/blockers:** Public, no login. Some IPs (data-center) get 403 from azcourts.gov — Haiku may need to set a residential `User-Agent` (the INAA crawler UA above is appropriate) and verify 200 from a US-residential connection. If 403 persists, fall back to AZ Bar's PDJ page at `https://www.azcourts.gov/attorneydiscipline/Disposition-of-Attorney-Discipline-Cases`.
+**Estimated row count:** ~1,500 events (1986–present, ~30/yr).
+**Date range available:** 1986 – present (per matrix description).
+**Copy template:** `scrape-calbar-discipline.mjs`
+**Why that template:** Same shape as CA — paginated HTML where each "page" (here: year) is a `<table>` of records. Replace pagination loop with year loop.
+
+**Field mapping:**
+| Source field | Selector / strategy | DB column | Transform |
+|---|---|---|---|
+| Case Name (e.g. "In re Smith") | `td:nth-child(1)` | full_name | strip "In re ", "Matter of ", trailing comma |
+| Date/Number (e.g. "06/12/2023 — SB-23-0001-D") | `td:nth-child(2)` | order_date + bar_number (case#) | split on `—`; parse left half as date, right half as case# (use case# as `bar_number` placeholder when no bar# is on the page — see note below) |
+| Violations Description | `td:nth-child(3)` | violation_summary | trim, max 2000 chars |
+| Disciplinary Rules / Sanction | `td:nth-child(4)` | discipline_type (after enum-map) | enum-map; raw → discipline_raw |
+| Link to opinion | `td a[href]` (any anchor) | order_url | absolute URL |
+| Page URL | `${BASE}/${year}DisciplinaryCasesMatrix.aspx` | source_url | per-year |
+
+**Discipline enum mapping:** same as WA + `disbarment by consent → disbarment`.
+
+**bar_number caveat:** AZ matrix does NOT expose bar numbers consistently. Use the **AZ Supreme Court case#** (e.g. `SB-23-0001-D`) as `bar_number` after a deterministic prefix `AZSC:` — yields `AZSC:SB-23-0001-D`. This keeps the (jurisdiction, bar_number) UNIQUE constraint working even without a true bar #. Document this in the script header comment block.
+
+**Idempotency key:** `(jurisdiction='AZ', bar_number, order_date, discipline_type)`.
+
+**Sample row:** 403 prevented direct WebFetch from this scrape session. Haiku MUST run a one-off curl/Playwright fetch on first execution and log 3 rows verbatim before committing. If fetch returns 403 on Haiku's host, fall back to the PDJ page at `https://www.azcourts.gov/attorneydiscipline/Disposition-of-Attorney-Discipline-Cases` and update the script's source URL constant.
+
+**Date format gotchas:** Some entries pre-2000. Some have date ranges (e.g. "06/12/2023 effective 07/01/2023") — capture left-most as `order_date`, right-most as `effective_date`.
+
+**Migration needed?** No, beyond the shared `20260425a_extend_discipline_types.sql` documented in the WA card.
+
+**Test cases:**
+- 403 retry with backoff (wait 60s, retry once, then SKIP gracefully)
+- "In re " / "Matter of " stripping
+- Case # without bar# (use `AZSC:` prefix)
+- Pre-2000 dates
+- Reciprocal discipline rows
+
+**Estimated build time:** 75 min.
+
+**Blocker?** SHIP. (403 is an IP-reputation issue, not a structural block — Haiku is on a different host.)
+
+---
+
+## TN — Tennessee Bar Discipline Scraper ★ EASIEST
+
+**Official source:** `https://www.tbpr.org/news-publications/recent-disciplinary-actions`
+**Source format:** Server-rendered HTML, paginated table, 25 rows/page, 5,931 total records (verified 2026-04-25 via WebFetch).
+**Pagination:** `?Page=N&page=N` — confirmed both query params required (the source uses Sitefinity which double-encodes). Loop `Page=1` to `Page=⌈5931/25⌉ = 238`.
+**Auth/blockers:** None. Static HTML, no JS required.
+**Estimated row count:** **5,931 (verified)**.
+**Date range available:** Records back through ~2003 based on page-N walk; verified data through 04/23/2026 on Page=1.
+**Copy template:** `scrape-flbar-discipline.mjs`
+**Why that template:** Identical shape — fetch HTML, parse tabular rows, walk pagination, bulkCopyRows. No PDF, no JS.
+
+**Field mapping (verbatim from real fetch):**
+| Source field | Selector / strategy | DB column | Transform |
+|---|---|---|---|
+| Date | column 1 | order_date | parse `MM/DD/YYYY` |
+| Type | column 2 (always "Release") | (ignore) | — |
+| Title (e.g. "Rutherford County Lawyer Censured") | column 3, contains discipline label | discipline_type (extract from title), violation_summary (full text) | regex against title for "Disbarred|Suspended|Censured|Reprimanded|Disability Inactive Status" etc. |
+| BPR # | column 4 | bar_number | digits only |
+| Name (e.g. "Farmer, Dalen L. P.") | column 5, link to attorney profile | full_name | reverse "Last, First M." → "First M. Last" |
+| Title link | `<a href>` on title text (e.g. `/docs/90ad7cbd-…/farmer-101082-4-rel.html`) | order_url | absolute URL `https://www.tbpr.org` + path |
+| Profile link | `<a href>` on name | (use to populate `attorneys.source_url`) | absolute URL |
+| Page URL | `${BASE}?Page=${N}&page=${N}` | source_url (events table) | per-page |
+
+**Discipline enum mapping (TN labels → DB enum):**
+- "Disbarred" → `disbarment`
+- "Suspended" → `suspension`
+- "Temporarily Suspended" → `interim_suspension`
+- "Censured" → `censure`
+- "Publicly Censured" → `censure`
+- "Reprimanded" → `public_reprimand`
+- "Placed on Probation" → `probation`
+- "Disability Inactive Status" → `disability_inactive`
+- "Reinstated" → SKIP (not a discipline event — log and continue)
+- "Resignation" / "Surrendered License" → `resignation_with_charges`
+
+**Idempotency key:** `(jurisdiction='TN', bar_number, order_date, discipline_type)`.
+
+**Sample row (verbatim, captured 2026-04-25):**
+```
+Date: 04/23/2026
+Type: Release
+Title: <a href="/docs/90ad7cbd-0a75-43ec-9d0a-efa587b89717/farmer-101082-4-rel.html">Rutherford County Lawyer Censured</a>
+BPR #: 012629
+Name: <a href="/attorneys/AA19FF0E-3FB2-E411-80D5-0050568F14C6">Farmer, Dalen L. P.</a>
+```
+```
+Date: 04/20/2026
+Type: Release
+Title: Shelby County Lawyer Placed on Disability Inactive Status
+BPR #: 011817
+Name: Fearnley, Michael
+```
+```
+Date: 04/01/2026
+Type: Release
+Title: Madison County Lawyer Disbarred
+BPR #: 036403
+Name: Lipham, Marcus Allen
+```
+
+**Date format gotchas:** None — `MM/DD/YYYY` zero-padded.
+
+**Migration needed?** YES — add `disability_inactive` and `censure` to the canonical enum (shared migration `20260425a_extend_discipline_types.sql`).
+
+**Test cases:**
+- Reverse-name parse: "Farmer, Dalen L. P." → first="Dalen L. P.", last="Farmer"
+- "Reinstated" rows skipped
+- 5,931 total records → at least 5,800 successfully inserted (allow 2% extraction failures, fail the run if >2%)
+- Dedupe on re-run
+
+**Estimated build time:** 30 min. Simplest of the eight.
+
+**Blocker?** SHIP. ★ Recommend this be the first scraper landed to validate the pattern.
+
+---
+
+## MA — Massachusetts BBO Discipline Scraper
+
+**Official source (primary):** `https://decisions.massbbo.org/`
+**Official source (fallback):** Annual report PDFs at `https://bbopublic.massbbo.org/web/f/fy<YYYY>.pdf` (e.g. `fy2020.pdf`, `fy2021.pdf` …).
+**Source format:** Primary site appears to be a static research site (separate from the Salesforce-rendered `massbbo.org/s/decisions` SPA which CSS-errored on WebFetch). Confirmed external description: "research site … contains all attorney discipline cases since the BBO's creation in 1974, including decisions from the SJC as well as the Board of Bar Overseers and its hearing committees."
+**Pagination:** Unknown (was 403 in this session). Haiku MUST first fetch `/` and inspect — if static HTML with browseable list, scrape directly. If SPA or 403, fall back to annual-report PDFs.
+**Auth/blockers:** Possible IP-rep 403. No login required per public-record statute.
+**Estimated row count:** ~5,000 (1974–present, ~100/yr — MA is a high-volume bar).
+**Date range available:** 1974 – present (per BBO statement).
+**Copy template:** `scrape-txbar-discipline.mjs` (PDF path) — fall back to this if `decisions.massbbo.org` is unworkable.
+**Why that template:** Annual-report PDFs are the same shape as TX (yearly PDFs with per-attorney narrative paragraphs).
+
+**Field mapping (annual-report PDF path):**
+| Source field | Strategy | DB column | Transform |
+|---|---|---|---|
+| Attorney name | regex: capitalized name preceding "BBO #<digits>" | full_name | trim |
+| BBO # | regex `BBO\s*#?\s*(\d{6,7})` | bar_number | digits only |
+| Discipline action | regex anchor (e.g. "was disbarred", "was suspended for X months") | discipline_type | enum-map |
+| Date of order | regex anchor "(?:On|Effective)\s+(<Month>\s+\d+,\s+\d{4})" within 500 chars of bar # | order_date | parse Month-name |
+| Violation summary | paragraph text, max 2000 chars | violation_summary | trim |
+| Source URL | annual-report PDF URL | source_url | constant per FY |
+| Order URL | not exposed in PDF | order_url | NULL |
+
+**Field mapping (decisions.massbbo.org path, IF accessible):**
+Haiku must inspect the live page. If HTML table: use selectors. If SPA: fall back to PDF.
+
+**Discipline enum mapping:** same as WA. MA uses "indefinite suspension" → `suspension`; "term suspension" → `suspension`; "disbarment by consent" → `disbarment`; "public reprimand" → `public_reprimand`; "admonition" → `admonition` (private — usually not in the public list, but if encountered).
+
+**bar_number caveat:** MA uses BBO # not bar #. Same field, just labeled differently. No transform needed.
+
+**Idempotency key:** `(jurisdiction='MA', bar_number, order_date, discipline_type)`.
+
+**Sample row:** Could not fetch in this session (`decisions.massbbo.org` 403'd; `fy2020.pdf` returned binary content). Haiku MUST first fetch `https://decisions.massbbo.org/` and log first 5 rows + URL pattern verbatim. If 403 OR SPA, immediately switch to PDF path and use `scrape-txbar-discipline.mjs`'s exact `pdf-parse` + regex pipeline (already battle-tested for prose narratives).
+
+**Date format gotchas:** Annual reports use `Month D, YYYY`; sometimes `Month, YYYY` (no day) — when day missing, default to first of month and flag `effective_date IS NULL`.
+
+**Migration needed?** No new types beyond the shared migration.
+
+**Test cases:**
+- "BBO #" with optional space and `#`
+- Indefinite vs term suspension both → `suspension`
+- Consent vs contested disbarment both → `disbarment`
+- Empty PDF page (graceful)
+
+**Estimated build time:** 90 min (PDF path) or 60 min (HTML path if research site loads).
+
+**Blocker?** SHIP, with a Haiku-side decision branch on first fetch.
+
+---
+
+## IN — Indiana Bar Discipline Scraper
+
+**Official source:** `https://www.in.gov/courts/public-records/orders/discipline/`
+**Source format:** Static HTML reverse-chronological table with year filter; case# / cause# / order or per-curiam type / case caption columns. Verified via WebFetch 2026-04-25.
+**Pagination:** Year archive dropdown `2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025`. URL pattern unclear from fetch — Haiku must inspect form/links. Likely `?year=YYYY` or per-year sub-pages. The default page shows all current-year + recent.
+**Auth/blockers:** None.
+**Estimated row count:** ~50/year × 8 years = ~400.
+**Date range available:** 2018 – present (per archive dropdown).
+**Copy template:** `scrape-flbar-discipline.mjs`
+**Why that template:** Static HTML, simple table, no JS, no PDFs.
+
+**Field mapping:**
+| Source field | Selector / strategy | DB column | Transform |
+|---|---|---|---|
+| Date | column 1 (`MM/DD/YYYY`) | order_date | parse |
+| Cause Number (e.g. `25S-DI-159`) | column 2 | bar_number | use as `INSC:25S-DI-159` (no true bar# — same caveat as AZ) |
+| Document Type ("Order" / "Per Curiam") | column 3 | (ignore) | — |
+| Case Caption (e.g. "In the Matter of Robbin Stewart") | column 4, with PDF link | full_name (after stripping "In the Matter of " / "In re ") | trim |
+| PDF link | `<a href>` on caption | order_url | absolute URL |
+| Page URL | year archive URL | source_url | per-year |
+
+**Discipline enum mapping:** Indiana orders do NOT expose discipline-type in the table; it's only inside the PDF. **Two options:**
+
+- **Option A (recommended for v1):** Set `discipline_type='unknown'`, `discipline_raw='see order_url'`. Skip the `unknown`-type filter that some other scrapers apply. Rationale: the DB still gets the attorney + date + URL; downstream analysis can fetch the PDF later for refinement.
+- **Option B (stretch):** PDF-parse each order with `pdf-parse` and regex for `disbarred|suspended|reprimanded|publicly admonished|private reprimand`. Adds ~30 min build time; recommended only if first-pass coverage looks good.
+
+**bar_number caveat:** Same as AZ — no bar# in the matrix. Use `INSC:<cause-number>` prefix.
+
+**Idempotency key:** `(jurisdiction='IN', bar_number, order_date, discipline_type)`.
+
+**Sample row (verbatim, captured 2026-04-25):**
+```
+04/24/2026 | 25S-DI-159 | Order | In the Matter of Robbin Stewart
+```
+
+**Date format gotchas:** None.
+
+**Migration needed?** No.
+
+**Test cases:**
+- "In the Matter of " stripped → "Robbin Stewart"
+- Cause # with letter+digit-only format preserved as `INSC:25S-DI-159`
+- Year filter walks all years 2018–current
+
+**Estimated build time:** 45 min.
+
+**Blocker?** SHIP.
+
+---
+
+## MD — Maryland Attorney Sanctions Scraper
+
+**Official source:** `https://www.mdcourts.gov/attygrievance/sanctions` (master) + per-FY PDFs at `https://www.courts.state.md.us/sites/default/files/import/attygrievance/pdfs/sanctionsfy<YY>.pdf` (FY06–FY26 confirmed via search; e.g. `sanctionsfy25.pdf`).
+**Source format:** Annual FY PDF, prose-paragraph format (like TX). Each entry: attorney name + sanction action + date + brief misconduct narrative.
+**Pagination:** None within a year; iterate FY URLs.
+**Auth/blockers:** Possible IP-rep 403 (this session got 403); same UA mitigation as AZ.
+**Estimated row count:** ~50/year × 20 years = ~1,000.
+**Date range available:** FY06 – present (master page covers "FY 2006 to Present").
+**Copy template:** `scrape-txbar-discipline.mjs`
+**Why that template:** Identical shape to TX — yearly PDFs, prose narratives, regex-anchor extraction. Uses the same `pdf-parse` + `BAR_RE`-style anchor approach.
+
+**Field mapping:**
+| Source field | Strategy | DB column | Transform |
+|---|---|---|---|
+| Attorney name | Capitalized name run preceding sanction verb (e.g. "Stewart, Craig W." or "Craig W. Stewart") | full_name | normalize "Last, First" → "First Last" |
+| Sanction action | regex: `disbarment by consent\|disbarred\|temporarily suspended\|suspended for\|reprimand` | discipline_type | enum-map |
+| Date | regex `(?:On|Effective)?\s*(<Month>\s+\d+,\s+\d{4})` near sanction verb | order_date | parse |
+| Misconduct narrative | paragraph after sanction line | violation_summary | max 2000 chars |
+| Source URL | per-FY PDF URL | source_url | constant |
+| Order URL | NULL (PDFs don't link to opinions inline) | order_url | NULL |
+
+**Discipline enum mapping:**
+- "disbarred" / "disbarment by consent" → `disbarment`
+- "temporarily suspended" → `interim_suspension`
+- "suspended" (with duration) → `suspension`
+- "reprimand" → `public_reprimand`
+- "Indefinite Suspension" → `suspension`
+
+**bar_number caveat:** Maryland sanctions list does NOT include bar numbers in the prose. Haiku MUST cross-reference via the Maryland Attorney List API — but that's out of scope for v1. **For v1:** synthesize a stable `bar_number` as `MD:<sha1(full_name+order_date)>::8` (8-char hash). Document this in the header comment. This preserves UNIQUE constraint correctness and lets a future enrichment pass populate real bar numbers.
+
+**Idempotency key:** `(jurisdiction='MD', bar_number, order_date, discipline_type)`.
+
+**Sample row (from search-result excerpt, FY25):**
+```
+Stewart, Craig W. — Disbarment by Consent — February 3, 2025
+Mr. Stewart failed to represent his client diligently, failed to adequately
+communicate with his client, engaged in the unauthorized practice of law,
+and engaged in conduct involving dishonesty, fraud, deceit, or
+misrepresentation.
+```
+```
+Stroud, Barron LeGrant Jr. — Temporary Suspension — February 21, 2025
+Following referrals from the Child Support Administration ...
+```
+```
+Kurland, Sari Karson — Disbarment by Consent — May 21, 2025
+```
+
+**Date format gotchas:** Mix of `Month D, YYYY` and `M/D/YYYY`. Month-name format is dominant per FY25 sample.
+
+**Migration needed?** No.
+
+**Test cases:**
+- "Last, First M. Suffix" name parsing (with Jr. / III)
+- Date format detection (Month-name vs slash)
+- "Disbarment by Consent" → `disbarment` (NOT `resignation_with_charges`)
+- Synthetic bar_number stability (same name+date → same hash both runs)
+
+**Estimated build time:** 75 min (PDF + name parse complexity).
+
+**Blocker?** SHIP. Haiku must use `INAA-Crawler/1.0` UA to bypass 403; if persistent, switch User-Agent to something more browser-like (`Mozilla/5.0 (compatible; INAA-Crawler/1.0; +https://imnotanattorney.com)`).
+
+---
+
+## CO — Colorado Bar Discipline Scraper
+
+**Official source:** `https://research.coloradopdj.com/copdj/en/ann.do` (recent decisions chronological list) + browse via `https://research.coloradopdj.com/copdj/en/nav.do` (Decisia/CanLII platform).
+**Source format:** Decisia is a standard Lexum-built legal-research platform (same engine as CanLII). Static HTML index pages with per-decision metadata + linked PDFs. Each decision has: caption, date, citation, link to opinion HTML+PDF.
+**Pagination:** Decisia uses `?startRow=N&endRow=M` style or numeric `?p=N`. Haiku must inspect first fetch.
+**Auth/blockers:** Public, no login. CanLII-style platforms are well-behaved scrapeable.
+**Estimated row count:** ~1,500 (1999–present per PDJ statement).
+**Date range available:** 1999 – present (PDJ inception).
+**Copy template:** `scrape-flbar-discipline.mjs`
+**Why that template:** HTML list with per-row metadata + link, same as FL/TN. No PDF parsing required at v1 — the index page exposes enough metadata.
+
+**Field mapping (verify on first fetch):**
+| Source field | Selector / strategy | DB column | Transform |
+|---|---|---|---|
+| Caption (e.g. "People v. Smith, 23PDJ045") | first column or `<h3>` per decision card | full_name (after stripping "People v. ", trailing case#) | trim |
+| Date | metadata line under caption | order_date | parse |
+| Citation / case# | parens / colon-separated from caption | bar_number | use `COPDJ:<case#>` |
+| Disposition (in metadata or first line of decision summary) | `meta` line or first `<p>` of decision | discipline_type (after enum-map) | enum-map |
+| Link to decision | anchor on caption | order_url | absolute URL |
+| Page URL | `${BASE}/copdj/en/ann.do?…` | source_url | per-page |
+
+**Discipline enum mapping:** same as WA. CO uses "disbarred", "suspended", "publicly censured", "private admonition" (rare in public list).
+
+**bar_number caveat:** CO PDJ uses case# not bar#. Same `COPDJ:` prefix pattern as IN/AZ.
+
+**Idempotency key:** `(jurisdiction='CO', bar_number, order_date, discipline_type)`.
+
+**Sample row:** Could not capture in this session (Decisia portal not loaded; description from search results only). Haiku MUST log first 3 rows verbatim on first dry-run before committing. If `ann.do` is JS-rendered, switch to Playwright (CA template handles this).
+
+**Date format gotchas:** Decisia typically uses `YYYY-MM-DD` ISO. Verify on first fetch.
+
+**Migration needed?** No.
+
+**Test cases:**
+- "People v. " caption stripping
+- ISO date parse
+- Multi-page walk via Decisia pagination
+
+**Estimated build time:** 75 min (Decisia pattern is well-documented; first-fetch inspection + selector tuning is the variable).
+
+**Blocker?** SHIP. If Decisia turns out to be JS-rendered, Haiku must add a Playwright import; the CA template covers this.
+
+---
+
+## MN — Minnesota Bar Discipline Scraper
+
+**Official source:** LPRB Annual Report PDFs at `https://lprb.mncourts.gov/wp-content/uploads/<year>/<month>/<YYYY>-Annual-Report_compressed.pdf` (verified pattern: `2024/05/2023-Annual-Report_compressed.pdf`).
+**Secondary source:** OLPR articles at `https://lprb.mncourts.gov/articles/Articles/PUBLIC%20DISCIPLINE%20in%20<YEAR>.pdf` (e.g. `PUBLIC DISCIPLINE in 2021.pdf` confirmed via search).
+**Source format:** Annual-report PDF (prose, like TX/MD). Each year publishes one consolidated report listing every public discipline.
+**Pagination:** None within a year; iterate years.
+**Auth/blockers:** None.
+**Estimated row count:** ~30–40/year × 5 recent years = ~175.
+**Date range available:** 2019 – present (recent annual reports archived).
+**Copy template:** `scrape-txbar-discipline.mjs`
+**Why that template:** PDF prose narrative, same as TX/MD. Use `pdf-parse` + regex anchors.
+
+**Field mapping:**
+| Source field | Strategy | DB column | Transform |
+|---|---|---|---|
+| Attorney name | Title-case run before sanction verb (full name in PDF, NOT "Last, First") | full_name | trim |
+| Sanction | regex: `disbarred\|suspended for\|publicly reprimanded\|placed on probation\|disability inactive` | discipline_type | enum-map |
+| Date | regex `(<Month>\s+\d+,\s+\d{4})` near sanction | order_date | parse |
+| Narrative | paragraph after sanction line | violation_summary | max 2000 chars |
+| Source URL | per-year report PDF | source_url | constant |
+| Order URL | NULL | order_url | NULL |
+
+**Discipline enum mapping:**
+- "disbarred" → `disbarment`
+- "suspended for X months/years" → `suspension`
+- "indefinite suspension" → `suspension`
+- "publicly reprimanded" → `public_reprimand`
+- "placed on probation" / "probation" → `probation`
+- "disability inactive" → `disability_inactive`
+
+**bar_number caveat:** Annual reports rarely include bar numbers. Use synthesized hash like MD: `MN:<sha1(full_name+order_date)>::8`.
+
+**Idempotency key:** `(jurisdiction='MN', bar_number, order_date, discipline_type)`.
+
+**Sample names from public sources (verified):** James V. Bradley, R. James Jensen Jr., Fong Lee, Madsen Marcellus, Michael Padden (all disbarred 2024 per OLPR public statements). These confirm the source covers expected attorneys.
+
+**Date format gotchas:** Annual reports may give partial dates ("In May 2024, …") — when day missing, default to first of month and set `effective_date = NULL`.
+
+**Migration needed?** No (`disability_inactive` already in shared migration from WA card).
+
+**Test cases:**
+- "James V. Bradley" name parse (3 tokens with middle initial)
+- "R. James Jensen Jr." (initial+name+suffix)
+- Partial date (Month YYYY only) handled
+- 5 disbarments expected for 2024 → assertion in test
+
+**Estimated build time:** 60 min.
+
+**Blocker?** SHIP.
+
+---
+
+## Cross-cutting build instructions for all 8 Haiku
+
+1. **Shared migration:** First Haiku to land creates `supabase/migrations/20260425a_extend_discipline_types.sql`:
+   ```sql
+   -- Document the canonical discipline_type enum values used by the 8 Phase 5
+   -- bar-discipline scrapers. discipline_type is plain TEXT in the table; this
+   -- migration adds a comment listing the canonical values so downstream
+   -- consumers (attorney-vetting $47 SKU, IB appendix) know what to expect.
+   COMMENT ON COLUMN public.attorney_discipline_events.discipline_type IS
+     'Canonical values: disbarment | suspension | interim_suspension | probation | public_reprimand | resignation_with_charges | censure | admonition | reciprocal_discipline | disability_inactive | unknown';
+   ```
+   Subsequent Haiku reference this migration in their PR description but do NOT recreate it.
+
+2. **Test scaffolding:** Each Haiku writes ONE test file `scripts/ingest/__tests__/scrape-<state>bar-discipline.test.mjs` covering:
+   - Discipline-type enum mapping (state's labels → DB enum)
+   - Name parsing (state-specific format)
+   - Date parsing
+   - Idempotency (UPSERT semantics)
+   - One end-to-end fixture from `__fixtures__/<state>-sample.html` or `<state>-sample.pdf` (capture during first dry-run)
+   Test shape matches `seed-statutes-fl.test.mjs` — vitest, no DB required (mock pg client).
+
+3. **PR title format:** `feat(ingest): <STATE> bar discipline scraper (Phase 5 #N/8)`
+
+4. **PR description must include:**
+   - Sample dry-run output (5 rows verbatim)
+   - Estimated total record count
+   - Migration reference (PR #N for shared `20260425a`)
+   - Verification steps (how to re-run and check row count)
+
+5. **Polite scraping:** All 8 use the SAME User-Agent + 800–1600 ms randomized delay. No state needs >2 req/sec.
+
+6. **No primary-domain email:** None of these scrapers send email, but the User-Agent uses `noreply-legal@inaa.com` as a contact — this is the existing canonical pattern, NOT a primary-domain email send. Documented per global rule.
+
+7. **DO NOT FABRICATE source_url.** If the row was scraped from page X, source_url = page X. If the source page links to a per-decision PDF, capture that as `order_url`. Never construct a URL that wasn't in the response. (Cited rule: `~/.claude/rules/no-hallucinated-legal-data.md`.)
+
+---
+
+## Final ship/skip count
+
+- **SHIP: 8/8** (WA, AZ, TN, MA, IN, MD, CO, MN)
+- **SKIP: 0/8**
+- **Estimated total Haiku build time:** 6.5 hours across 8 parallel agents (avg 50 min each, fastest = TN at 30 min, slowest = WA / MA-fallback at 90 min).
+
+The TN scraper is the recommended first lander — cleanest source, fully verified rows, lowest build time, validates the shared migration before 7 parallel Haiku push it concurrently.

--- a/docs/plans/2026-04-25-dormant-data-wiring.md
+++ b/docs/plans/2026-04-25-dormant-data-wiring.md
@@ -1,0 +1,68 @@
+# Dormant-Data Wiring Plan (2026-04-25)
+
+Queued from `/audit` run 2026-04-25 (post #107/#111/#112 merge). Scanned 197 product files across `src/lib`, `src/app/api/{generate,tools,intake,cron}`, `supabase/functions`. 48 strategic intelligence-data tables checked.
+
+## Audit Summary
+- **WIRED (20)**: judge_*, motion_outcome_rates (39 refs), citation_authority_criminal (26), pji (52), attorneys-lookup (91), USSC similar-cases, sentencing distributions, bench/jury divergence, etc.
+- **LIGHT (5)**: motion_success_patterns, defense_theory_outcomes, plea_discount_curves, classified_opinions, scotus_cases — touched in 1-2 places.
+- **DORMANT (23)**: split into populated-but-unused vs built-but-empty.
+
+## Populated + Dormant (the wiring opportunities)
+
+| Table | Rows | Highest-impact use |
+|-------|------|--------------------|
+| `police_stops` | **187,397,678** | Stop Validity Analysis SKU |
+| `fars_crashes/persons/vehicles` | 2.67M | Crash Litigation Report SKU |
+| `cpd_complaints` + `cpd_officers` | 263K + 37K | Officer BG Check Chicago (in motion per #111) |
+| `attorney_discipline_events` | 3,417 | "Your lawyer's CA Bar discipline" inside Case Decoder + IB |
+| `federal_register_actions` | 1,752 | "Recent rule changes affecting your charge" in IB |
+| `co_defendant_analysis` | 2,065 | War Room + Situation Room IP surfacing |
+| `pji_instruction_citations` | 109 | PJI augmentation (base `pji` already wired 52x) |
+| `exoneration_patterns` | 17 | Defense-theory examples |
+| `ppi_parole_rates` | 136 | Parole/sentencing context |
+
+## Built-but-empty (Phase 3 — population pipeline gap, not product gap)
+`cross_case_expert_profiles`, `cross_case_hypothesis_patterns`, `cross_case_prosecution_tactics`, `cross_witness_patterns`, `expert_witness_challenges`, `forensic_lab_profiles`, `lab_report_items`, `judge_conflict_of_interest`, `ao_criminal_by_offense_district`, `data_source_health`. These 10 tables exist in schema but have 0 rows live.
+
+---
+
+## Phase 1 — Enrich existing tiers (hours each)
+
+| # | Item | Wire into | Effort | Value-stack delta |
+|---|------|-----------|--------|-------------------|
+| 1.1 | `attorney_discipline_events` (3,417 rows) | Case Decoder + IB | 30 min | "Your attorney's CA Bar discipline check" — #1 crisis-buyer fear (Bloomstein trust lens) |
+| 1.2 | `co_defendant_analysis` (2,065 rows) | War Room + Situation Room | 1 hr | Surfaces existing War Room IP, justifies $4,997 / $9,997 |
+| 1.3 | `pji_instruction_citations` (109 rows) | Federal Jury Instruction Brief + IB | 1 hr | `pji` already wired heavily, citation map = obvious next layer |
+| 1.4 | `federal_register_actions` (1,752 rows) | IB charge-specific section | 1 hr | "Recent regulatory changes affecting your charge" |
+
+## Phase 2 — New SKUs from biggest dormant data (1-2 weeks each)
+
+| # | SKU | Data | Pricing | Why |
+|---|-----|------|---------|-----|
+| 2.1 | **Officer BG Check — Chicago** | `cpd_*` 300K rows | $97 standalone | Already in motion per #111; first-mover, replicate template per major-city dataset |
+| 2.2 | **Stop Validity Analysis** | `police_stops` 187M | $297 standalone | DUI/drug specific; no competitor has consolidated 33-state stop data |
+| 2.3 | **Crash Litigation Report** | `fars_*` 2.67M | $297 standalone | Vehicular manslaughter, DUI-with-injury; new buyer segment |
+
+## Phase 3 — Pipeline backfill (data ops, not product)
+Populate the 10 empty tables. Each needs its own ingest pipeline. NOT covered in this plan; separate triage.
+
+---
+
+## Execution Order
+1. **Phase 1.1 first** — smallest blast radius, highest trust signal, validates whether dormant-data wiring is high-ROI (Hormozi value-equation test) before committing to bigger plays.
+2. Phase 1.2 → 1.3 → 1.4 in sequence. Each enriches an already-shipped tier.
+3. Phase 2.1 (Officer BG Check Chicago) follows — already partially scoped by #111.
+4. Phase 2.2 + 2.3 → new-SKU launches, separate brief + landing pages.
+5. Phase 3 → after Phase 2.
+
+## Worktree Boundary
+Each item runs in its own worktree off `origin/master` per `pattern-worktree-per-pr-from-master`. Sibling-session collision risk on `intelligence-brief/prompts.ts`, `tier9-reports/`, and `playbook-configs.ts` is real (8+ sessions active 2026-04-24/25) — must check sibling worktree branches before each commit.
+
+## Cited Experts
+- Hormozi value-equation (Dream Outcome × Likelihood ÷ Time × Effort) — applied to enrichment-vs-new-SKU trade
+- Dunford 2026 multi-product positioning — keeps existing tiers central, new SKUs additive
+- Bloomstein vulnerability/trust — driving the attorney-discipline-check framing for Phase 1.1
+- Internal: `feedback-crisis-buyer-lens-mandatory.md`, `decision-ib-mechanical-matrix.md` (IB renders mechanically; Claude only personalizes)
+
+## Audit Artifact
+Audit script: `.tmp/dormant-audit.mjs` (Node-only, no shell deps). Re-run with `node .tmp/dormant-audit.mjs` from repo root for fresh count.

--- a/docs/plans/2026-04-25-worry-attorney-discipline-wire.md
+++ b/docs/plans/2026-04-25-worry-attorney-discipline-wire.md
@@ -1,0 +1,742 @@
+# Worry — Attorney-Discipline-Events Wiring (2026-04-25, v2.4 post-round-0-v4)
+
+> **STATUS:** v2.2 — all 10 v2.1 backlog findings applied. Ready for round 0 v3 swarm.
+> - Round 0 v1: 39 raw findings across 3 reviewers; v2 plan rewrite (scope-cut fuzzy match, CD integration, intake form, multi-state, real-attorney fixtures; added RLS migration, fair-report memo, Deno-fetch helper, escapeHtml/safeHttpUrl, current_status/admission_date, Atti-voice disclaimer, anchor strings, security smokes).
+> - Round 0 v2: 17 unique findings; v2.1 applied 6 CRITICALs (Dreyer md-vs-HTML wiring, Dreyer Deno escapeHtml, Sec column drift, Sec PostgREST wildcard, Code wrong render path, Code Deno-side anchors).
+> - **v2.2 (this revision)**: all 10 backlog findings (Code WARN #4-10 + SUG #11-13) applied:
+>   - WARN #4: T1.4 pins `deno test --allow-net --allow-env`; T4.2a tracks Deno count separately from npm test count.
+>   - WARN #5: T3.1 rewritten — insert fixture `cases` row with `report_html` populated, invoke evaluate-report by caseId; reduce live LLM calls 5→1 (cost ~$2-3); regex panel covers other 4 fixture states.
+>   - WARN #6: `escapeMarkdownPipe()` helper added to T2.3 inline; applied BEFORE `escapeHtml` in every cell value of the discipline-events table.
+>   - WARN #7: T0a migration adds `CREATE EXTENSION IF NOT EXISTS unaccent` + expression index `LOWER(unaccent(full_name))` + RPC `match_attorney(p_name, p_jurisdiction)`. T1.2 calls RPC via `POST /rest/v1/rpc/match_attorney` (not raw `?ilike=`); RPC body uses `LOWER(unaccent(...))` so `José` matches `Jose`.
+>   - WARN #8: `BANNED_PHRASES_LIST` extracted as exported `as const` array next to `BANNED_PHRASES_BLOCK` in `src/lib/intelligence-brief/prompts.ts`; T3.2 test imports the array (Node-side test) and asserts `DISCLAIMER_VERBATIM` contains none.
+>   - WARN #9: T2.4 IB renderer entry adds garbage-name guard — skip section if `attorneyName` is empty, `length<3`, no space, or matches `/^(n\/?a|none|tbd|unknown|skip|pending|asdf|test)$/i`. Helper exported from `render-attorney-discipline.ts` as `isAttorneyNameRenderable()`.
+>   - WARN #10: New T0c task — `gh pr list --state open --json files` pre-flight before worktree creation; abort if any open PR touches `supabase/functions/generate-report/index.ts`. Verified 2026-04-25 against open PRs #102 (score) + #133 (NYPD CCRB) — neither touches the renderer.
+>   - SUG #11: T4.1a adds `deno check supabase/functions/generate-report/index.ts` between npm build and tests.
+>   - SUG #12: Heading is emitted as markdown `## Attorney Bar Record Check` (T2.2 + T2.4 reinforce).
+>   - SUG #13: `last_seen_at` rendered as `YYYY-MM-DD` via `new Date(last_seen_at).toISOString().slice(0,10)`.
+> - **Migration filename collision (2026-04-25 discovery):** PR #133 (NYPD CCRB depth) reserves `20260425a_*.sql` and `20260425b_*.sql`. v2.2 renumbers to `20260425c_attorney_discipline_rls.sql` + `20260425d_attorney_discipline_test_fixtures.sql` to leave merge order intact regardless of which branch lands first.
+> - **Discoveries this session:**
+>   - `.env.local` anon key is stale/invalid — returns 401 on every table including known-RLS-protected `cases`/`orders`. Cleanup task: refresh from Supabase Mgmt API. Documented in T4.6.
+>   - Production IB renders inside Edge Function (`generate-report/index.ts:7322`), NOT `src/lib/intelligence-brief/render.ts` (dev/test only).
+>   - Anchor pinning must be Deno-side; src/lib copy is import-orphaned.
+>   - `evaluate-report` Edge Function entry point: `{ caseId: UUID }` body → fetches `cases.report_html` from DB → strips HTML → runs UPL+Psych on plain text via Anthropic API. Direct HTML POST is NOT supported. (`supabase/functions/evaluate-report/index.ts:381-407`.)
+>   - `unaccent` extension: NOT yet enabled on this Supabase project (only `pg_trgm`, `pgcrypto`, `moddatetime`, `uuid-ossp` per migration audit). T0a enables it.
+> - **Round 0 v3 (2026-04-25 late):** spec-critic passed on retry 1. Round 0 v3 swarm (code-reviewer + security-auditor + chris-dreyer, all opus, with prior-round-attempts blocks) returned 37 NEW findings: 10 CRITICAL, 17 WARNING, 10 SUGGESTION. NOT pristine.
+> - **v2.3 (this revision)** applies fixes:
+>   - **Code CRIT #1 (renderer-async)**: confirmed `renderIBReportHtml` at `generate-report/index.ts:7322` is sync. T2.4 REWRITTEN: build markdown in caller scope at `index.ts:5045-5046` BEFORE `renderIBReportHtml`, assign to `allOutputs["attorney-discipline"]`, add slot in sections array. Caller has natural access to `intake.state`, `phase2.attorney_name`, `supabaseUrl`, `supabaseKey`. Single fix resolves CRIT #1, CRIT #6 (jurisdiction not in scope), and WARN section_outputs persistence.
+>   - **Code CRIT #2 (POST→GET)**: confirmed PostgREST treats POST on table URL as INSERT. T1.2 events fetch now uses GET matching `supabaseSelect()` pattern at index.ts:107.
+>   - **Code CRIT #3 (eval_results path)**: confirmed `eval_results.teams.upl.failed` is the real shape (evaluate-report/index.ts:443-453 + 549-557). SC #12 + T3.1.2 corrected.
+>   - **Code CRIT #4 (cases NOT NULL)**: confirmed migrations/00001_initial_schema.sql:202-204 require `order_id`, `email`, `tier`. T3.1.2 INSERT now includes all three.
+>   - **Code CRIT #5 (operator_tasks dead code)**: confirmed evaluate-report uses Resend `sendEmail()` directly (line 463-481), no operator_tasks writes. T3.1.2 cleanup drops operator_tasks DELETE; gates Resend off via env in test.
+>   - **Code CRIT #6**: resolved by CRIT #1 fix (caller-scope build).
+>   - **Code CRIT #7 (unaccent schema)**: T0a now `CREATE EXTENSION ... WITH SCHEMA extensions`; `immutable_unaccent` body uses `extensions.unaccent('extensions.unaccent', $1)`; pre-flight assertion `SELECT extensions.unaccent('café')` returns `'cafe'` BEFORE index build.
+>   - **Code CRIT #8 (Deno can't import BANNED_PHRASES_LIST)**: confirmed prompts.ts:15 imports `@/lib/tiers` Next.js alias. T3.3 RESHAPED: canonical lives at `supabase/functions/generate-report/lib/banned-phrases-list.ts` (Deno-readable, no aliases); prompts.ts re-exports it via relative path. Both runtimes import the same canonical file.
+>   - **Sec CRIT #1 (XSS centralization)**: T2.3 adds `safeCell(v) = escapeMarkdownPipe(escapeHtml(String(v ?? '')))`; T2.4 + T2.2 require all defendant + scraper-sourced free-text values flow through it. T4.4b lint test greps `render-attorney-discipline.ts` for `${...}` interpolations not routing through safeCell/safeHttpUrl/formatShortDate.
+>   - **Sec CRIT #2 (CV probe pollution)**: T3.1.2 now uses `e2e-attorney-discipline-${Date.now()}@example.com` (matches CV `e2e-%` allowlist), pre-sets `eval_results = {sentinel: true}` BEFORE evaluate-report invocation (so even if function 500s, row never matches `eval_results.is.null`), and adds `scripts/reap-attorney-discipline-fixtures.mjs` running at CI job end regardless of test exit.
+>   - **17 WARNINGs** absorbed: anchor brittle (use `IB_SECTION_ANCHORS.YOUR_PLAN` + `BRADY_GIGLIO` constants pinned to literal H2 markdown forms), formatShortDate explicit null guard, mixed test runner directory (Deno tests pinned to specific files not dir glob), 'Not provided' added to garbage regex, T3.4 bidirectional parity, RPC `WHERE counted.n = 1` (server-side ambiguity policy + LIMIT 1), T4.6 add `pg_policies` zero-rows assertion, T0c race window documented, control-char regex extended to `  `, Resend gating in test env, review_reminder_sent=true on cases fixture, service-role key redact + artifact scrub + explicit `--allow-env` allowlist, common-name silent-no-match documented in cascade, jurisdiction guard ↔ fair-report memo coupling enforced via `FAIR_REPORT_MEMO_PATHS` map + lint, Dreyer no-match copy reframe (own the methodology), Dreyer disclaimer adds bar_number + pull date + "every CA IB" framing.
+>   - **10 SUGGESTIONs** absorbed: bar_number URL encode, input-contract ordering rationale documented, 'should' word-boundary regex, FIXTURE-% defense-in-depth RLS deny policy NOW, RPC server-side ambiguity, FIXTURE-008 pipe edge case fixtures, structured no-match logging (no PII), Dreyer matched-multi-event neutral framing sentence, Dreyer indexed `/attorney/ca/...` URL pattern (deferred to Phase 1.1c follow-on, NOT v2 scope), Dreyer rehabilitation node (deferred to Phase 1.1d follow-on, NOT v2 scope).
+> - **Round 0 v4 (2026-04-25 late):** spec-critic v2.3 PASSED first-shot (40/40 gradeable). Round 0 v4 swarm returned 16 new findings: 5 CRIT, 7 WARN, 4 SUG. Many were v3-fix-induced regressions. NOT pristine.
+> - **v2.4 (this revision)** absorbs v4 CRITs + key WARNs:
+>   - **Code CRIT #1 (orders.amount_cents)**: confirmed `orders` schema (00001_initial_schema.sql:877) has column `amount integer NOT NULL`, NOT `amount_cents`. T3.1.2 + SC #12 corrected to use `amount`.
+>   - **Code CRIT #2 (tsconfig excludes supabase)**: confirmed `tsconfig.json:33` has `"exclude": ["node_modules", "supabase", ...]`. Re-export pattern in T3.3 broken. Fix: T3.2 Node test imports `BANNED_PHRASES_LIST` DIRECTLY from canonical Deno-side file via vitest's runtime resolver (no path alias, no compile-time TS resolution); prompts.ts re-export DROPPED. Vitest resolves runtime imports outside src/.
+>   - **Code CRIT #3 (SC #11 anchor mismatch)**: confirmed prompt at `index.ts:7102` says `Output: ## Section 6` (no ': Your Plan' suffix). SC #11 v2.4 REWRITTEN to assert against `allOutputs` map keys + array index ordering BEFORE md2html runs (deterministic) instead of substring-grepping rendered HTML.
+>   - **Sec CRIT #1 (sentinel eval_results bypass)**: confirmed `/api/deliver` reads `eval_results.gate_passed` and treats `undefined === false` as `false` → renders "PASSED" + allows delivery. Fix: sentinel changed to `'{"sentinel": true, "gate_passed": false}'` so any pre-evaluate-report state correctly blocks delivery; `gate_passed: true` only ever set by evaluate-report itself. Plus reaper runs `if: always()`.
+>   - **Sec CRIT #2 (safeFetch redaction incomplete)**: redact regex extended to also match `apikey: [^\s,;]+` and `eyJhbGc[A-Za-z0-9._-]+` (JWT prefix anywhere) in addition to `Bearer [^\s"']+`.
+>   - **Code WARN absorbed**: T1.4 + T4.2a explicit file lists now include `attorney-discipline-fair-report-paths.test.ts` + `attorney-discipline-common-name.test.ts` (v2.3 added them in worktree boundary but forgot to add to runner lists).
+>   - **Code WARN (cite-tag-strip comment)**: T2.4 caller-scope INSERT POINT moved to BEFORE line 5037's strip loop so the comment is now accurate (`allOutputs['attorney-discipline']` is set BEFORE the cite-strip loop iterates `Object.keys(allOutputs)`).
+>   - **Code WARN (U+0085 regex gap)**: T1.2 input contract regex extended to `/[\x00-\x1f  ]/`.
+>   - **Code WARN (RPC permission status)**: SC #26 accepts `r.status === 401 || r.status === 403 || r.status === 404` (PostgREST returns 404 for missing-EXECUTE on RPC).
+>   - **Dreyer WARN #1 (bar-lookup-url ambiguous)**: T2.2 matched-state copy now interpolates `BAR_LOOKUP_URLS.CA.detail(bar_number)` (deep link); T2.2 no-match uses `BAR_LOOKUP_URLS.CA.base` (generic search). SC #41 NEW asserts both URL patterns appear in the right states.
+>   - **Dreyer WARN #2 (fair-report-memo no public route)**: NEW T2.6 — create public-facing route at `src/app/legal/fair-report-privilege/page.tsx` that renders the T0b memo body (sanitized for public). T2.2 disclaimer uses absolute URL `https://imnotanattorney.com/legal/fair-report-privilege`. SC #42 NEW asserts the route file exists + renders.
+>   - **Code WARN (test_run_id rule compliance)**: per `~/.claude/rules/drafts/test-isolation.md`, T3.1.2 fixture writes are exempt via marker `// test-isolation-justified: e2e fixture uses CV-allowlisted email pattern + sentinel eval_results + reaper safety net; test_run_id column not present in cases/orders schema in this branch yet (test-isolation infra is on a separate worktree)`. Marker added to test files; hook accepts.
+> - **Deferred to Phase 5 acceptance criteria** (documented in Out of Scope as known follow-ons, NOT silent drops):
+>   - Code SUG (cleanup transactional): wrap DELETE-cases + DELETE-orders in single BEGIN/COMMIT block at execution time.
+>   - Code SUG (SC #38 runtime verify): execution agent confirms migration apply success in addition to file-text grep.
+>   - Code WARN (report_html construction): execution agent uses hand-crafted fixture HTML for the e2e UPL smoke (cheaper, isolates test scope to UPL gate, NOT producer fidelity); T2.4 caller-scope wiring is verified separately by SC #11 + #28 lint.
+>   - Dreyer SUG (visual count callout): bold "{N} public discipline event(s) on file" prepended to attribution sentence at execution time.
+>   - Dreyer SUG (DISCLAIMER 'CA' lint coupling): T4.5e adds at execution — Deno test asserts DISCLAIMER_VERBATIM hardcoded jurisdiction matches the SINGLE key in FAIR_REPORT_MEMO_PATHS.
+> - **Phase 5 begins now.** Plan converged enough; remaining items are execution-time polish, not architectural.
+
+## Worry
+We loaded 1,842 California Bar attorneys and 3,417 attorney-discipline events into Supabase (PR shipped 2026-04-22 to 2026-04-24). The `attorneys` table is **populated but unread by product code** — the 91 occurrences of "attorney" in `playbook-configs.ts` and 280 in `generate-report` are all copy/labels referring to "your attorney," not table queries. Zero `from('attorneys')` or `from('attorney_discipline_events')` calls exist in `src/`. The IB Phase-2 intake (`src/app/intake/intelligence-brief/page.tsx:84`) collects `attorneyName` (required), but no surface JOINs that name against the bar tables.
+
+This is the #1 crisis-buyer fear (Bloomstein trust lens, INAA crisis-buyer rule): "is my lawyer trustworthy?" We have the data. We have the intake field. We have not connected them. Every $997 IB customer reads their report and silently asks "did you check my attorney?" — to which the answer right now is "no, even though we could have."
+
+## Expert Lens
+
+**Chris Dreyer** (Rankings.io $34M/yr, *Niching Up*, *From Good to GOAT*, PIMCon 2026) — legal services niche domination. Cached at `~/.claude/experts/chris-dreyer.md`. **Frame:** in legal-adjacent info products, the trust ceiling is set by what the buyer can verify about the named professionals. Surfacing public bar-discipline records puts INAA on the same trust footing as the bar association — a verification layer competitors cannot match without aggregating the data.
+
+**Margaret Hagan** (Stanford Legal Design Lab, A2J methodology) — UPL-safe content audit framework. Cached at `~/.claude/experts/margaret-hagan.md`. **Frame:** factual public records rendered mechanically without interpretation stay on the information side of the UPL line.
+
+**Synthesis:** ship the verification, render mechanically, render only on EXACT-MATCH (no fuzzy — defamation surface).
+
+## Cascade
+- **Us:** zero new acquisition cost; IB tier ($997) gains a trust-signal section competitors cannot match.
+- **Defendant:** answers a question they are already asking silently.
+- **Defendant family:** sees the bar-record check they were Googling at 2am.
+- **Disciplined attorney (worst-affected node):** their public bar record is shown inside the defendant's report. Mitigation: render ONLY on exact match (no false-attribution risk per fuzzy-match defamation surface), include explicit "this is the public CA Bar record" framing, link directly to the bar lookup so the defendant can verify themselves, render fact-only (date/type/outcome) without interpretation. CA Civ. Code § 47 fair-report privilege covers accurate republication of official proceedings — but the privilege is jurisdiction-specific. v2 ships CA-only; multi-state expansion blocked on per-state privilege memo (T0b).
+- **Future-us:** every new state bar (FL/TX/NY/PA/OH already shipped) becomes another row in the same render section once per-state privilege memos exist.
+
+No node loses (under exact-match-only rendering). Cascade-positive.
+
+## v2 Scope Cuts (vs v1)
+
+| v1 element | v2 status | Why |
+|------------|-----------|-----|
+| Fuzzy match (Levenshtein ≤2) | **DROPPED** | Sec CRIT #3 + Code WARN #15 — defamation surface, edge cases. Exact-match only. |
+| Case Decoder integration (T3) | **DEFERRED to Phase 1.1b** | Code CRIT #3+#4 — CD path goes through `batch-poller.ts:238`, not `generate-report` Edge Function; needs separate plan after IB ships. |
+| Intake form changes (T4) | **DROPPED** | Code CRIT #5 — IB intake already has `attorneyName`. Default `attorneyJurisdiction = phase2.state` (defendant's state). 2-bar attorneys (CA-licensed working FL case) are out of v2 scope. |
+| Multi-state expansion stub (T6) | **DROPPED** | Replace with one fact: scrapers share `public.attorneys` + `public.attorney_discipline_events`, jurisdiction-keyed (per `scrape-flbar-discipline.mjs:386`, `scrape-txbar-discipline.mjs:291`). v2 ships CA-only. |
+| Real-attorney test fixtures (SELECT live data) | **DROPPED** | Sec WARN #8 — privacy/optics + Code WARN #12 — drift. v2 inserts synthetic rows with `bar_number LIKE 'FIXTURE-%'`. |
+
+## v2 Adds (vs v1)
+
+| Add | Source | Description |
+|-----|--------|-------------|
+| Explicit RLS migration (T0a) | Sec CRIT #1 | Add `ENABLE ROW LEVEL SECURITY` + service-role-only policy to both tables. Anon currently returns 401 (verified live), but RLS posture is implicit — make explicit. |
+| Fair-report privilege memo (T0b) | Sec WARN #5 | Document CA Civ. Code § 47 coverage at `docs/legal/2026-04-25-attorney-discipline-fair-report-privilege.md`. Block multi-state expansion until per-state memo exists. |
+| Deno-fetch helper for IB Edge Function (T1.4) | Code WARN #10 | IB renders inside `supabase/functions/generate-report/index.ts` — Deno runtime, no `@supabase/supabase-js`. Use `fetch` against PostgREST matching `supabaseSelect()` pattern at `index.ts:107`. |
+| `escapeHtml` + `safeHttpUrl` (T2.4) | Sec WARN #6 | Every interpolated value through `escapeHtml`. `Source URL` through `safeHttpUrl(u)` returning `'#'` for non-`http(s):` protocols. |
+| `current_status` + `admission_date` render (T2.2) | Code WARN #17 + Dreyer WARN #5 | Use literal `attorneys.current_status` from DB ('active'/'inactive'/'disbarred'/'suspended'/'resigned'), not synthesized "in good standing." Render years-of-practice from `admission_date` ("Licensed in CA since YYYY — N years"). |
+| Atti-voice UPL-safe disclaimer (T2.3) | Code WARN #16 + Dreyer WARN #4 | Replace v1's "should review with the attorney" with: "This is the public CA State Bar record. You can pull it yourself at <bar URL>. We pulled it so you didn't have to." Removes "should" (UPL banned phrase per `prompts.ts:34-44`) + adopts insider Atti tone. |
+| Anchor strings pinned to REAL section keys (T2.5) | Code CRIT #1+#2 | Existing IB sections (per `render.ts:311-346`): `case-roadmap`, `whats-working`, `case-intelligence`, `legal-options`, `protection`, `your-plan`, then static appendices. Place attorney-discipline as **new appendix slot** after `your-plan`, before existing static appendices. Export anchor constants from new `src/lib/intelligence-brief/section-anchors.ts` so render + tests share. |
+| Sec smokes (T7.6+) | Sec SUG #9 | Anon-key 401 verified, XSS escape unit, injection unit (`"' OR 1=1 --"` returns no-match). |
+| Worktree boundary expanded | Sec SUG #10 + Code SUG #21 | Add `supabase/migrations/20260425*_attorney_discipline_rls.sql`, `supabase/functions/evaluate-report/__tests__/`, `docs/legal/`, `src/lib/intelligence-brief/section-anchors.ts`. |
+
+## Numbered Tasks (v2)
+
+### T0 — Pre-implementation gates
+- **T0a (RLS + unaccent + match RPC migration)** — Create `supabase/migrations/20260425c_attorney_discipline_rls.sql` (renumbered from `20260425a` to dodge collision with PR #133):
+  ```sql
+  -- 1. Enable RLS deny-by-default. service_role bypasses RLS; no SELECT policy = no anon access.
+  ALTER TABLE public.attorneys ENABLE ROW LEVEL SECURITY;
+  ALTER TABLE public.attorney_discipline_events ENABLE ROW LEVEL SECURITY;
+
+  -- 2. Enable unaccent for Unicode-folded matching (José ↔ Jose ↔ JOSÉ).
+  --    Pin schema to `extensions` per Supabase convention (existing extensions
+  --    pg_trgm / pgcrypto / moddatetime / uuid-ossp all live there per
+  --    migrations/00001_initial_schema.sql:14-16). Without WITH SCHEMA, install
+  --    location varies across Supabase versions and the immutable_unaccent
+  --    wrapper below would fail with `dictionary "..." does not exist` at
+  --    index-build time.
+  CREATE EXTENSION IF NOT EXISTS unaccent WITH SCHEMA extensions;
+
+  -- 2a. Pre-flight smoke (Code CRIT #7 + Sec WARN). MUST succeed BEFORE the
+  --     index in step 3 fires the wrapper for the first time. If this fails,
+  --     the migration aborts and step 3 never runs.
+  DO $$
+  DECLARE folded text;
+  BEGIN
+    SELECT extensions.unaccent('extensions.unaccent', 'café') INTO folded;
+    IF folded <> 'cafe' THEN
+      RAISE EXCEPTION 'unaccent dictionary lookup failed: got % (expected ''cafe'')', folded;
+    END IF;
+  END $$;
+
+  -- 3. Functional index supports the case-folded + accent-folded equality lookup.
+  --    IMMUTABLE wrapper required because unaccent() is STABLE not IMMUTABLE by default,
+  --    and CREATE INDEX rejects non-IMMUTABLE expressions.
+  --    Body references the dictionary as `'extensions.unaccent'` (regdictionary
+  --    is schema-resolved at parse time; pinning the FQN is required because
+  --    SET search_path inside the function body cannot retroactively rebind a
+  --    regdictionary literal).
+  CREATE OR REPLACE FUNCTION public.immutable_unaccent(text) RETURNS text
+    LANGUAGE sql IMMUTABLE PARALLEL SAFE STRICT AS
+    $$ SELECT extensions.unaccent('extensions.unaccent', $1) $$;
+
+  CREATE INDEX IF NOT EXISTS idx_attorneys_jurisdiction_lower_unaccent_full_name
+    ON public.attorneys (jurisdiction, LOWER(public.immutable_unaccent(full_name)));
+
+  -- 3a. Future-proof RLS deny policies for FIXTURE-* rows (Sec SUG defense-in-depth).
+  --     These are no-ops today (RLS is already deny-by-default with no SELECT
+  --     policy) but stay in place if a future migration accidentally adds a
+  --     permissive `FOR SELECT TO anon USING (true)` policy. Postgres ANDs
+  --     policies, so this overlay survives accidentally-permissive additions.
+  CREATE POLICY deny_anon_test_fixtures_attorneys
+    ON public.attorneys FOR SELECT TO anon
+    USING (bar_number NOT LIKE 'FIXTURE-%');
+  CREATE POLICY deny_anon_test_fixtures_events
+    ON public.attorney_discipline_events FOR SELECT TO anon
+    USING (NOT EXISTS (
+      SELECT 1 FROM public.attorneys a
+      WHERE a.id = attorney_discipline_events.attorney_id
+        AND a.bar_number LIKE 'FIXTURE-%'
+    ));
+
+  -- 4. RPC for the match path. Returns the matched attorney row + their discipline events.
+  --    SECURITY DEFINER so the RPC runs as table owner (bypasses caller's RLS posture
+  --    consistently); explicit grant restricts who can CALL it.
+  CREATE OR REPLACE FUNCTION public.match_attorney(p_name text, p_jurisdiction text)
+  RETURNS TABLE (
+    attorney_id BIGINT,
+    bar_number TEXT,
+    full_name TEXT,
+    admission_date DATE,
+    current_status TEXT,
+    last_seen_at TIMESTAMPTZ,
+    match_count INTEGER
+  )
+  LANGUAGE sql
+  STABLE
+  SECURITY DEFINER
+  SET search_path = public, extensions
+  AS $$
+    WITH candidates AS (
+      SELECT id, bar_number, full_name, admission_date, current_status, last_seen_at
+      FROM public.attorneys
+      WHERE jurisdiction = p_jurisdiction
+        AND LOWER(public.immutable_unaccent(full_name))
+            = LOWER(public.immutable_unaccent(p_name))
+    ),
+    counted AS (SELECT COUNT(*)::int AS n FROM candidates)
+    -- Server-side ambiguity policy (Code SUG + Sec): when match_count > 1,
+    -- return ZERO rows. Caller now treats zero-rows uniformly as no-match
+    -- regardless of cause (no candidate vs ambiguous), eliminating the
+    -- comment-only "policy" that future callers would skip.
+    SELECT c.id, c.bar_number, c.full_name, c.admission_date,
+           c.current_status, c.last_seen_at, counted.n
+    FROM candidates c CROSS JOIN counted
+    WHERE counted.n = 1
+    LIMIT 1;
+  $$;
+
+  REVOKE ALL ON FUNCTION public.match_attorney(text, text) FROM PUBLIC;
+  GRANT EXECUTE ON FUNCTION public.match_attorney(text, text) TO service_role;
+  ```
+  Apply via Supabase Management API. Verify post-apply: (a) `relrowsecurity=t` on both tables, (b) anon SELECT returns `200 + []` (NOT 401 — RLS-blocked-anon = empty), (c) service-role `POST /rest/v1/rpc/match_attorney` with body `{"p_name":"José Smith","p_jurisdiction":"CA"}` returns rows when accent variant exists.
+- **T0b (fair-report memo)** — Write `docs/legal/2026-04-25-attorney-discipline-fair-report-privilege.md` documenting CA Civ. Code § 47 coverage of accurate republication of CA State Bar discipline records inside our reports. Cite source: triangulated .01% media/defamation expert OR cached `~/.claude/experts/eugene-volokh.md` (TBD-triangulate if uncached). Reference memo path in section footer disclaimer (T2.3).
+- **T0c (sibling-PR pre-flight)** — Run `gh pr list --repo rahim0kapadia/ImNotAnAttorney-web --state open --json number,headRefName,files --limit 50` immediately BEFORE creating the worktree. Parse `files[].path` for any open PR. Abort with named conflict if ANY open PR's `files[]` contains:
+  - `supabase/functions/generate-report/index.ts` (the production renderer wired by T2.4 — sibling edits would silent-merge-conflict)
+  - `src/lib/intelligence-brief/prompts.ts` (re-exporting `BANNED_PHRASES_LIST` per T3.3)
+  - `src/lib/intelligence-brief/render.ts` (parallel dev mirror per T2.4 optional)
+  - `supabase/functions/generate-report/lib/banned-phrases-list.ts` (canonical T3.3 file, NEW v2.3)
+  - `supabase/migrations/20260425c_*.sql` or `supabase/migrations/20260425d_*.sql` (rename higher if taken)
+  Verified 2026-04-25 baseline: PR #102 (score) and PR #133 (NYPD CCRB depth) — neither touches the five blocking paths above. Re-run this check immediately before `git worktree add` to catch new sibling PRs opened between plan ship and execution.
+
+  **Race window (Code WARN #18)**: between `gh pr list` returning clean and `git worktree add` running, another session may open a PR. Mitigation: (a) wrap pre-flight + worktree-add in a single shell block running `gh pr list` → save JSON → `git worktree add` immediately (one operator action), (b) AFTER `git worktree add` completes, re-run pre-flight; if a new sibling PR appeared touching any blocking path, abort the worktree (`git worktree remove`) and surface to user. The artifact required by SC #25 is the BEFORE-worktree pre-flight JSON; SC #25b (NEW v2.3) requires an AFTER-worktree pre-flight JSON proving the post-creation race window held clean.
+
+### T1 — DB layer (CA-only, exact match)
+- **T1.1** — Schema confirmed (per `supabase/migrations/20260422e_attorney_discipline.sql`):
+  - `attorneys`: `(id BIGSERIAL, jurisdiction CHAR(2), bar_number TEXT, full_name TEXT, first_name TEXT, last_name TEXT, admission_date DATE, current_status TEXT, last_seen_at TIMESTAMPTZ, ...)`. UNIQUE `(jurisdiction, bar_number)`.
+  - `attorney_discipline_events`: `(id BIGSERIAL, attorney_id BIGINT FK→attorneys, jurisdiction CHAR(2), bar_number TEXT, full_name TEXT, order_date DATE, effective_date DATE, discipline_type TEXT, discipline_raw TEXT, violation_summary TEXT, order_url TEXT, source_url TEXT, scraped_at TIMESTAMPTZ)`. UNIQUE `(jurisdiction, bar_number, order_date, discipline_type)`.
+  - Note: there is NO column called `date`/`type`/`outcome`. Render template (T2.2) MUST use the literal column names: `order_date`, `discipline_type`, `violation_summary` (or `discipline_raw` as fallback for human-readable type), `order_url` (preferred for the bar-document link) with fallback to `source_url`. (Sec v2 CRIT #2.)
+- **T1.2** — Write Deno-compatible query helper at `supabase/functions/generate-report/lib/attorney-discipline.ts` (Deno-side, not src/lib) using raw `fetch` to PostgREST matching the `supabaseSelect()` pattern at `generate-report/index.ts:107`. Signature: `getAttorneyDiscipline(attorneyName: string, jurisdiction: string): Promise<{ attorney: AttorneyRow | null, events: DisciplineEvent[], status: 'matched' | 'no-match' }>`.
+  - **Jurisdiction guard via FAIR_REPORT_MEMO_PATHS map** (v2.3 — supersedes hard-coded `=== 'CA'`): see Match strategy below.
+  - **Input contract** (v2.3: ordering rationale documented + Unicode line separators + 'Not provided' added):
+    1. `trim()` whitespace.
+    2. **Reject all control chars + Unicode line/paragraph separators** (one regex, no redundant step): `/[\x00-\x1f  ]/` → return `no-match`. Single regex replaces the prior split. Regex content (v2.4 explicit codepoints): control chars `\x00-\x1f` AND `` (NEXT LINE — codepoint 0x85, OUTSIDE the `\x00-\x1f` range) AND ` ` (LINE SEPARATOR) AND ` ` (PARAGRAPH SEPARATOR). Code WARN v4: prior v2.3 regex had U+2028+U+2029 as literals but missed U+0085; v2.4 explicit codepoint enumeration closes the audit-log injection class fully.
+    3. Cap 200 chars (BEFORE garbage-name guard — see ordering note below).
+    4. Empty after sanitization → `no-match`.
+    5. Garbage-name guard via `isAttorneyNameRenderable()` (T2.3 helper, exported, single source of truth for both T1.2 entry and T2.4 renderer): predicate returns false (caller returns `no-match`) for empty / whitespace-only / `length<3` / no internal space (single-token like `'Smith'`) / matches `/^(n\/?a|none|tbd|unknown|skip|pending|asdf|test|not[ -]?provided)$/i` (note: `not[ -]?provided` catches the renderer's `'Not provided'` fallback at index.ts:5174 — Code WARN #14).
+  - **Ordering rationale (Code SUG)**: cap (step 3) deliberately runs BEFORE garbage-regex (step 5) because the regex is `^...$`-anchored and a 300-char `'A'.repeat(300)` is still single-token after trim (no spaces) so it falls into the no-space branch and returns `no-match` regardless of cap-vs-regex order. The cap is purely a defense-in-depth bound on payload size for downstream JSON serialization. SC #20 covers `'A'.repeat(300)` to verify ordering invariance.
+  - **Match strategy** (v2.3 corrected verbs + jurisdiction-memo coupling):
+    - Step A: `POST ${SUPABASE_URL}/rest/v1/rpc/match_attorney` (POST is correct for RPC) with `Authorization: Bearer ${service_role_key}` + `apikey: ${service_role_key}` headers and JSON body `{"p_name": <sanitized name>, "p_jurisdiction": "CA"}`. Response: array of rows. 0 rows = no candidate OR ambiguous (RPC enforces n=1 server-side); branch identical: `{ attorney: null, events: [], status: 'no-match' }`.
+    - Step B: 1 row returned → fetch discipline events via **GET** (not POST — POST against a table URL is INSERT, not SELECT, per Code CRIT #2): `GET ${SUPABASE_URL}/rest/v1/attorney_discipline_events?attorney_id=eq.${row.attorney_id}&order=order_date.desc.nullslast` matching the `supabaseSelect()` pattern at `generate-report/index.ts:107`. Return `{ attorney: row, events, status: 'matched' }`.
+  - **Why RPC, not raw `?ilike=`**: PostgREST cannot apply `LOWER(unaccent(...))` in a query-string `WHERE`. RPC moves the predicate into SQL where the functional index is usable. Side benefit: removes the wildcard-injection class entirely (`p_name` is a parameterized text arg, not a URL substring).
+  - **Jurisdiction–fair-report-memo coupling (Sec WARN)**: helper imports a `FAIR_REPORT_MEMO_PATHS` map from `attorney-discipline.ts`:
+    ```ts
+    export const FAIR_REPORT_MEMO_PATHS: Record<string, string> = {
+      CA: 'docs/legal/2026-04-25-attorney-discipline-fair-report-privilege.md',
+    };
+    ```
+    The jurisdiction guard is replaced with `if (!FAIR_REPORT_MEMO_PATHS[jurisdiction]) return { attorney: null, events: [], status: 'no-match' };`. Adding a new state to the allowlist requires creating its memo path entry in the SAME edit. Lint test (T4.5c) parses the file and asserts every key in `BAR_LOOKUP_URLS` (T2.3) has a matching key in `FAIR_REPORT_MEMO_PATHS`.
+  - **Structured no-match logging (Sec SUG)**: every silent no-match decision logs one structured JSON line to console (no PII):
+    ```ts
+    console.log(JSON.stringify({
+      component: 'attorney-discipline',
+      reason: 'jurisdiction-guard' | 'control-chars' | 'garbage-name'
+            | 'rpc-status-non-200' | 'rpc-error' | 'no-rows',
+      jurisdiction, name_length: name?.length ?? 0,
+    }));
+    ```
+    Edge Function logs are queryable in Supabase dashboard. Closes the silent-product-regression visibility gap.
+- **T1.3** — Synthetic test fixtures: create `supabase/migrations/20260425d_attorney_discipline_test_fixtures.sql` (renumbered from `20260425b` to dodge PR #133 collision) inserting all 7 fixture attorneys + their events using actual schema column names (`order_date`, `discipline_type`, `violation_summary`, `discipline_raw`, `order_url`, `source_url`):
+  ```sql
+  INSERT INTO public.attorneys
+    (jurisdiction, bar_number, full_name, first_name, last_name, admission_date, current_status, last_seen_at)
+  VALUES
+    ('CA', 'FIXTURE-001', 'Fixture Cleanrecord',  'Fixture', 'Cleanrecord',  '2010-01-15', 'active',     '2026-04-25 00:00:00+00'),
+    ('CA', 'FIXTURE-002', 'Fixture Disciplined',  'Fixture', 'Disciplined',  '2005-06-20', 'suspended',  '2026-04-25 00:00:00+00'),
+    ('CA', 'FIXTURE-003', 'Fixture Cleanrecord',  'Fixture', 'Cleanrecord',  '2012-08-10', 'active',     '2026-04-25 00:00:00+00'),  -- ambiguous duplicate of -001 (same full_name)
+    ('CA', 'FIXTURE-004', 'Fixture Hostile',      'Fixture', 'Hostile',      '2008-04-01', 'suspended',  '2026-04-25 00:00:00+00'),
+    ('CA', 'FIXTURE-005', 'Fixture Pipechar',     'Fixture', 'Pipechar',     '2008-04-01', 'suspended',  '2026-04-25 00:00:00+00'),
+    ('CA', 'FIXTURE-006', 'José García',          'José',    'García',       '2014-09-01', 'active',     '2026-04-25 00:00:00+00'),  -- accented (T4.5a forward direction)
+    ('CA', 'FIXTURE-007', 'Jose Garcia',          'Jose',    'Garcia',       '2014-09-01', 'active',     '2026-04-25 00:00:00+00'),  -- ASCII (T4.5a reverse direction)
+    ('CA', 'FIXTURE-008', 'Fixture Pipeedge',     'Fixture', 'Pipeedge',     '2008-04-01', 'suspended',  '2026-04-25 00:00:00+00');  -- pipe-edge case fixture (Sec SUG)
+
+  -- DISCIPLINED multi-event (FIXTURE-002, count = 2)
+  INSERT INTO public.attorney_discipline_events
+    (attorney_id, jurisdiction, bar_number, full_name, order_date, discipline_type, violation_summary, discipline_raw, order_url, source_url)
+  SELECT id, 'CA', bar_number, full_name, '2018-03-12'::date, 'Suspension', '90-day suspension stayed pending probation', '90-day suspension stayed', 'https://example.com/fixture-002-order-1', 'https://example.com/fixture-002-source-1'
+    FROM public.attorneys WHERE bar_number = 'FIXTURE-002';
+  INSERT INTO public.attorney_discipline_events
+    (attorney_id, jurisdiction, bar_number, full_name, order_date, discipline_type, violation_summary, discipline_raw, order_url, source_url)
+  SELECT id, 'CA', bar_number, full_name, '2020-11-04'::date, 'Reproval', 'Failure to communicate with client', 'public reproval', 'https://example.com/fixture-002-order-2', 'https://example.com/fixture-002-source-2'
+    FROM public.attorneys WHERE bar_number = 'FIXTURE-002';
+
+  -- HOSTILE-INPUT (FIXTURE-004, single event, XSS payloads embedded so render-time escaping is testable end-to-end)
+  INSERT INTO public.attorney_discipline_events
+    (attorney_id, jurisdiction, bar_number, full_name, order_date, discipline_type, violation_summary, discipline_raw, order_url, source_url)
+  SELECT id, 'CA', bar_number, full_name, '2019-07-22'::date, '<script>alert(1)</script>', 'Failure & misappropriation <evil>', 'misappropriation', 'javascript:alert(1)', 'https://example.com/fixture-004-source'
+    FROM public.attorneys WHERE bar_number = 'FIXTURE-004';
+
+  -- PIPE-CHAR (FIXTURE-005, raw markdown-pipe in cell values — covers escapeMarkdownPipe path)
+  INSERT INTO public.attorney_discipline_events
+    (attorney_id, jurisdiction, bar_number, full_name, order_date, discipline_type, violation_summary, discipline_raw, order_url, source_url)
+  SELECT id, 'CA', bar_number, full_name, '2017-02-08'::date, 'Suspension | 90 days', 'Failure to file | client funds | trust account', '90-day suspension', 'https://example.com/fixture-005-order', 'https://example.com/fixture-005-source'
+    FROM public.attorneys WHERE bar_number = 'FIXTURE-005';
+
+  -- PIPE-EDGE (FIXTURE-008, multiple consecutive pipes + literal backslash-pipe — Sec SUG)
+  INSERT INTO public.attorney_discipline_events
+    (attorney_id, jurisdiction, bar_number, full_name, order_date, discipline_type, violation_summary, discipline_raw, order_url, source_url)
+  SELECT id, 'CA', bar_number, full_name, '2016-05-15'::date, '\|', '|||', 'edge case', 'https://example.com/fixture-008-order', 'https://example.com/fixture-008-source'
+    FROM public.attorneys WHERE bar_number = 'FIXTURE-008';
+  ```
+  Test-only marker: bar_numbers all start with `FIXTURE-`. T0a's `deny_anon_test_fixtures_*` policies (added v2.3) keep them invisible to anon SELECT even if a future migration adds a permissive policy.
+- **T1.4** — Deno unit tests at `supabase/functions/generate-report/__tests__/attorney-discipline.test.ts`. **Pinned runner + explicit file list** (Code WARN #4 + WARN #13):
+  ```
+  deno test \
+    --allow-env=SUPABASE_URL,SUPABASE_SERVICE_ROLE_KEY,SUPABASE_ANON_KEY,ANTHROPIC_API_KEY,RESEND_API_KEY \
+    --allow-net=jxjbjmgdukwkoclydqdr.supabase.co,api.anthropic.com \
+    supabase/functions/generate-report/__tests__/attorney-discipline.test.ts \
+    supabase/functions/generate-report/__tests__/upl-regex-panel.test.ts \
+    supabase/functions/generate-report/__tests__/attorney-discipline-guard.test.ts \
+    supabase/functions/generate-report/__tests__/render-attorney-discipline-lint.test.ts \
+    supabase/functions/generate-report/__tests__/attorney-discipline-fair-report-paths.test.ts \
+    supabase/functions/generate-report/__tests__/attorney-discipline-common-name.test.ts \
+    supabase/functions/__tests__/rls-attorney-discipline.test.ts
+  ```
+  Specific file list (NOT directory glob) avoids collision with the existing vitest test at `supabase/functions/generate-report/__tests__/no-mandatory-min-fallback.test.ts` which `import { describe, it, expect } from 'vitest'` and would fail under Deno. Explicit `--allow-env` allowlist (Sec WARN service-role key leak) makes the secret surface auditable; `--allow-net` allowlist pins the only two outbound hosts the tests need. The Node-side `BANNED_PHRASES_LIST` parity test in T3.2 is a SEPARATE Node-side vitest under `src/lib/intelligence-brief/__tests__/`.
+
+  **Test coverage** (each as own `Deno.test()` block):
+  - matched-clean (`FIXTURE_CLEAN_BAR_NUMBER`)
+  - matched-disciplined-multi-event (`FIXTURE_DISCIPLINED_BAR_NUMBER`)
+  - no-match (`'Zzzzz Nonexistent'`)
+  - ambiguous (RPC server-side now returns 0 rows when n>1 per T0a `WHERE counted.n = 1`; test verifies behavior matches `no-match` shape; no fetch to events endpoint occurs)
+  - garbage-name skip 8-input matrix (per SC #20)
+  - control-character input (`"\r\nSmith"`, `" John"`, `"Doe"`)
+  - 300-char input (`'A'.repeat(300)` — SC #20 cap-vs-regex ordering invariance)
+  - unaccent forward (`'Jose Garcia'` returns FIXTURE-006 with `full_name='José García'`)
+  - unaccent reverse (`'José García'` returns FIXTURE-007 with `full_name='Jose Garcia'`)
+  - jurisdiction guard (`getAttorneyDiscipline('Anyone', 'NY')` returns no-match without ANY fetch)
+  - injection input (`"' OR 1=1 --"` returns no-match without error)
+
+  Mock `fetch` via test-scoped `globalThis.fetch` override; assert exact request URL (HTTP verb included — GET vs POST per Code CRIT #2), body shape, and that no fetch is made when garbage-name guard or jurisdiction guard fires (`fetch.mock.calls.length === 0`).
+
+  **Failure-message redaction (Sec WARN service-role key leak)**: the test file's top-level `safeFetch` wrapper redacts `Bearer [^\s"']+` patterns from any thrown error. Pattern:
+  ```ts
+  const REDACT_PATTERNS: Array<[RegExp, string]> = [
+    [/Bearer [^\s"',;]+/g, 'Bearer [REDACTED]'],
+    [/apikey[:=][\s]*[^\s,;}\)"']+/gi, 'apikey: [REDACTED]'],
+    [/eyJhbGc[A-Za-z0-9._-]+/g, '[REDACTED-JWT]'],
+  ];
+  const redact = (s: string): string =>
+    REDACT_PATTERNS.reduce((acc, [re, sub]) => acc.replace(re, sub), s);
+  const safeFetch = async (url: string, init?: RequestInit) => {
+    try { return await fetch(url, init); }
+    catch (e) {
+      if (e instanceof Error) e.message = redact(e.message);
+      throw e;
+    }
+  };
+  ```
+  v2.4 fix per Sec CRIT #2: redact extended beyond just `Bearer` to also catch `apikey:` header form (PostgREST sends both `Authorization: Bearer ...` AND `apikey: ...` with the service-role key — only redacting one was insufficient) AND any JWT-prefix substring (`eyJhbGc`) wherever it appears. Used for all real-network calls.
+
+### T2 — IB section (mechanical render only)
+- **T2.1** — New file: `supabase/functions/generate-report/lib/section-anchors.ts` (Deno-side, NOT `src/lib/...` — Code v2 CRIT #2: src/lib is import-orphaned in Deno runtime). Export `IB_SECTION_ANCHORS = { ... }` with literal H2 heading strings used by the production IB renderer at `supabase/functions/generate-report/index.ts:7322` (`renderIBReportHtml`, sections array at lines 7429-7450). Read existing strings from `index.ts:7429-7450` and from each `buildXxx()` static appendix builder, pin them here. The Edge Function renderer + Deno-side tests both import from this file. Optional parallel mirror at `src/lib/intelligence-brief/section-anchors.ts` for Node-side dev tools (`scripts/test-ib-pipeline.ts`, `render-ib-test.mjs`) with a parity test (mirror pattern from `src/lib/report/__tests__/whitelist-parity.test.ts`).
+- **T2.2** — New section builder in `supabase/functions/generate-report/lib/render-attorney-discipline.ts` (Deno-side, factual mechanical render). Inputs: result of T1.2. Outputs: markdown string (NOT raw HTML — see T2.3a). Heading is always `## Attorney Bar Record Check` (markdown, SUG #12).
+
+  **`last_seen_at` format (SUG #13):** render as short date `YYYY-MM-DD`, never raw timestamptz. Helper: `formatShortDate(ts: string | null): string` returning `new Date(ts).toISOString().slice(0,10)` or `'unknown'` for null. Applied wherever the spec below says `{last_seen_at}`.
+
+  **`admission_date` years-of-practice:** compute via `Math.floor((Date.now() - admission_date) / (365.25 * 24 * 60 * 60 * 1000))` and display as integer.
+
+  **Disclaimer (Atti voice + UPL-safe + methodology proof, Dreyer WARN #2 v3 + WARN #1 v4 disambiguation):**
+  `DISCLAIMER_VERBATIM` is built per-call (NOT a single constant) because it interpolates `bar_number` + pull date. The disclaimer template lives at `attorney-discipline-disclaimer.ts`:
+  ```ts
+  export const buildDisclaimer = (barNumber: string, pullDate: string): string =>
+    `CA State Bar #${barNumber} — pulled from the official State Bar discipline registry on ${pullDate}. Public record. You can pull it yourself at ${BAR_LOOKUP_URLS.CA.detail(barNumber)}; we pulled it as part of every CA Intelligence Brief.`;
+  export const DISCLAIMER_TEMPLATE_VERBATIM = `CA State Bar #{bar_number} — pulled from the official State Bar discipline registry on {pull_date}. Public record. You can pull it yourself at {bar_lookup_detail_url}; we pulled it as part of every CA Intelligence Brief.`;
+  ```
+  v2.4 fix per Dreyer WARN #1: matched-state interpolations explicitly use `BAR_LOOKUP_URLS.CA.detail(bar_number)` (deep link to that licensee — preserves "we pulled it" methodology proof). The DISCLAIMER_TEMPLATE_VERBATIM string with placeholders is what T3.2 + T3.4 BANNED_PHRASES tests assert against (substituted-out form would have variable bar numbers, breaking deterministic comparison).
+
+  States:
+  - **`matched` + `current_status='active'` + `events.length === 0`:**
+    ```
+    ## Attorney Bar Record Check
+
+    **Status (per CA State Bar as of {safeCell(last_seen_at-date)}):** Active
+    **Licensed in CA since {safeCell(YYYY)}** — {N} years of practice
+    **Public discipline record:** none on file.
+
+    {DISCLAIMER_VERBATIM}
+
+    [Why we can show this](https://imnotanattorney.com/legal/fair-report-privilege)
+    ```
+  - **`matched` + `events.length >= 1`:**
+    ```
+    ## Attorney Bar Record Check
+
+    **Status (per CA State Bar as of {safeCell(last_seen_at-date)}):** {safeCell(current_status)}
+    **Licensed in CA since {safeCell(YYYY)}** — {N} years of practice
+
+    The CA State Bar's public registry lists {events.length} discipline event(s) on this licensee's record:
+
+    | Date | Type | Summary | Source |
+    |------|------|---------|--------|
+    | {safeCell(formatShortDate(order_date))} | {safeCell(discipline_type)} | {safeCell(violation_summary \|\| discipline_raw)} | [CA Bar order]({safeHttpUrl(order_url \|\| source_url)}) |
+
+    {DISCLAIMER_VERBATIM}
+
+    [Why we can show this](https://imnotanattorney.com/legal/fair-report-privilege)
+    ```
+    Column-name source per T1.1: `order_date`, `discipline_type`, `violation_summary` (fallback to `discipline_raw`), `order_url` (fallback to `source_url`). EVERY interpolation MUST flow through one of: `safeCell()` (free text), `safeHttpUrl()` (URLs), `formatShortDate()` (dates), or be a literal/structural template piece. The neutral framing sentence "The CA State Bar's public registry lists..." (Dreyer SUG) attributes the data to the State Bar's registry rather than INAA's editorial choice — keeps the section pro-defendant-not-anti-attorney.
+  - **`no-match` (RPC returned 0 rows: includes ambiguous-match collapsed server-side):**
+    ```
+    ## Attorney Bar Record Check
+
+    No exact match for "{safeCell(attorney_name)}" in the California State Bar's public roster.
+
+    We only render bar records on exact name match — fuzzy matching against an attorney's identity is how false accusations happen, and we don't ship that. If the spelling on the State Bar's roster differs from what was entered (initials, hyphenation, married name), the lookup link below resolves it in one click.
+
+    [California State Bar attorney lookup →]({BAR_LOOKUP_URLS.CA.base})
+    ```
+    No-match copy (Dreyer WARN #1 v3) reframes the limitation as INAA's deliberate methodology, NOT a user error. Removes "verify spelling and bar admission state" (burden-shifting per brand-voice.md DO-NOT list). Uses `bar-lookup-base-url` (no bar_number — defendant doesn't know it).
+- **T2.3** — Helpers in the Deno-side `render-attorney-discipline.ts` file (Deno cannot import from `src/lib/intelligence-brief/render.ts` which imports from `../email`):
+  - `escapeHtml(s: string): string` — 5-line, covers `& < > " '`
+  - `safeHttpUrl(u: string | null | undefined): string` — explicit null guard FIRST: `if (!u) return '#'`; then return `u` if matches `/^https?:\/\//i` else `'#'`
+  - `escapeMarkdownPipe(s: string): string` — `s.replace(/\|/g, '\\|')` (Code WARN #6)
+  - `formatShortDate(ts: string | null | undefined): string` — **explicit null/undefined guard FIRST** (Code WARN #11): `if (!ts) return 'unknown'; const d = new Date(ts); if (isNaN(d.getTime())) return 'unknown'; return d.toISOString().slice(0,10);`. Closes the silent `1970-01-01` leak from `new Date(null) || ...`.
+  - `safeCell(v: string | null | undefined): string` — **canonical interpolation gate (Sec CRIT #1)**: `escapeMarkdownPipe(escapeHtml(String(v ?? '')))`. EVERY defendant-supplied AND scraper-fed free-text value in the rendered output flows through this single helper. Lint test (T4.4b) regex-greps `render-attorney-discipline.ts` for any `${...}` inside a markdown table cell or copy block that does NOT route through `safeCell` / `safeHttpUrl` / `formatShortDate` and fails the build.
+  - `isAttorneyNameRenderable(name: string | null | undefined): boolean` — predicate (Code WARN #9 + #14): returns false for `null` / `undefined` / empty after trim / `length<3` / no internal space (single-token) / matches `/^(n\/?a|none|tbd|unknown|skip|pending|asdf|test|not[ -]?provided)$/i` (the `not[ -]?provided` clause catches the renderer's `'Not provided'` fallback at index.ts:5174). Single source of truth — T1.2 helper guard + T2.4 caller-scope guard both import.
+  - `BAR_LOOKUP_URLS: Record<string, { base: string; detail: (barNumber: string) => string }>` — typed structure with URL-encoded detail builder:
+    ```ts
+    export const BAR_LOOKUP_URLS = {
+      CA: {
+        base: 'https://apps.calbar.ca.gov/attorney/LicenseeSearch/QuickSearch',
+        detail: (barNumber: string) => `https://apps.calbar.ca.gov/attorney/Licensee/Detail/${encodeURIComponent(barNumber)}`,
+      },
+    } as const;
+    ```
+    `encodeURIComponent` (Code SUG) prevents URL-injection if a future state's bar numbers contain `+`, `&`, or spaces. CA's numeric bar numbers don't need it today — defense-in-depth.
+  - `FAIR_REPORT_MEMO_PATHS: Record<string, string>` (Sec WARN coupling): single map binding jurisdiction code to its memo path. Adding a new key requires the same edit to also write the memo file (or the lint at T4.5c fails).
+  - `BANNED_PHRASES_LIST` (re-exported): see T3.3 — canonical lives at `supabase/functions/generate-report/lib/banned-phrases-list.ts`; this file re-exports for convenient single-import in tests.
+  - **'should' word-boundary handling (Code SUG)**: BANNED_PHRASES_LIST contains literal `'should'` for substring match. Today's `DISCLAIMER_VERBATIM` does NOT contain 'shoulder' / 'shouldered' / 'should\'ve'. To future-proof, T3.2 test wraps each phrase ending with `should` (or starting with `should`) in regex form `\bshould\b` for the assertion: `if (phrase === 'should') new RegExp('\\bshould\\b', 'i').test(disclaimer) === false; else disclaimer.toLowerCase().includes(phrase.toLowerCase()) === false`. Surfaces only the exception in code, not in the BANNED_PHRASES_LIST data.
+
+  EVERY interpolation in T2.2 routes through one of the helpers above. Lint test enforces.
+- **T2.3a** — Section builder MUST emit **markdown**, not raw HTML — the `md2html` pass at `supabase/functions/generate-report/index.ts:7450` (`.map((s) => md2html(s))`) and its `|`-pipe regex would shred a pre-built `<tr>` block. Output the markdown table per T2.2 (column headers `Date | Type | Summary | Source`, using actual schema column names `order_date / discipline_type / violation_summary || discipline_raw / order_url || source_url` per T1.1). Cell-value pipeline (per T2.2): every free-text scraped value flows through `escapeMarkdownPipe(escapeHtml(v))` BEFORE markdown render. `escapeHtml` runs first to neutralize `< > & " '` from CA Bar HTML; `escapeMarkdownPipe` runs second to neutralize raw `|` characters that would shred the table column count. Order: html-escape THEN pipe-escape so `escapeHtml` does not later double-escape `\|`. (Dreyer v2 WARN #1 + Code v2 WARN #6.)
+- **T2.4 (REWRITTEN v2.3 — caller-scope wiring per Code CRIT #1 + #6 + WARN section_outputs)** — `renderIBReportHtml` at `supabase/functions/generate-report/index.ts:7322` is **synchronous** (`function renderIBReportHtml(...)`, NOT `async function`). Adding `await` inside the sections array fails compilation. The renderer also takes only `(sectionOutputs, meta)` — no `jurisdiction`, no `supabaseUrl`, no `supabaseKey` are in scope. Wire the section in **caller scope** at `index.ts:5045-5046` instead, BEFORE `renderIBReportHtml` is called. This single move resolves CRIT #1, CRIT #6, AND the WARN about section_outputs JSONB persistence.
+
+  **Caller-scope build (insert at line 5036, BEFORE the cite-strip loop at lines 5037-5039):** v2.4 fix per Code WARN — placing the build BEFORE the `for (const key of Object.keys(allOutputs)) { ... stripInvalidCiteTags(...) }` loop means `attorney-discipline` IS iterated by the strip loop (the comment about cite-tag alignment is now true; mechanically harmless since the section has no `<cite>` tags but the load-bearing claim is no longer false).
+  ```ts
+  // Phase B: build attorney-discipline section (mechanical render, no LLM, fail-open empty).
+  // Lives in allOutputs so it persists to cases.section_outputs JSONB (audit trail)
+  // and gets cite-tag-stripped through the same loop as Claude-authored sections.
+  const attorneyDisciplineMd = await buildAttorneyDisciplineSection({
+    attorneyName: phase2.attorney_name,
+    jurisdiction: intake.state || '',
+    supabaseUrl,
+    serviceRoleKey: supabaseKey,
+  });
+  if (attorneyDisciplineMd) {
+    allOutputs['attorney-discipline'] = attorneyDisciplineMd;
+  }
+  ```
+
+  **Section slot (add to sections array at line 7438, BETWEEN `sectionOutputs["your-plan"]` and `buildBradyGiglioChecklist()`):**
+  ```ts
+  sectionOutputs["your-plan"] || "",
+  sectionOutputs["attorney-discipline"] || "",  // NEW v2.3 slot
+  buildBradyGiglioChecklist(),
+  ```
+  The renderer stays sync — the slot just reads from `sectionOutputs` like every sibling. Empty-string filtering at line 7450 (`.filter((s) => s.trim())`) drops the slot cleanly when guard-skipped.
+
+  **`buildAttorneyDisciplineSection()` signature (Deno-side, in `lib/render-attorney-discipline.ts`):**
+  ```ts
+  export async function buildAttorneyDisciplineSection(args: {
+    attorneyName: string | null | undefined;
+    jurisdiction: string;
+    supabaseUrl: string;
+    serviceRoleKey: string;
+  }): Promise<string>;
+  ```
+  Returns `''` (empty) for guard-skip OR no-match-with-no-section-render-decision (currently always renders no-match copy on real no-match per T2.2; only returns `''` on guard skips for cleanest behavior).
+
+  **Caller-scope guards (in order, FAIL-FAST returns empty string from helper):**
+  1. `if (!isAttorneyNameRenderable(args.attorneyName)) return '';` — garbage-name skip (Code WARN #9). Skips the whole section if defendant didn't enter a real attorney name OR the renderer fallback `'Not provided'` is in play.
+  2. `if (!FAIR_REPORT_MEMO_PATHS[args.jurisdiction]) return '';` — jurisdiction-memo coupling guard (Sec WARN). Adding a new state requires writing both a `BAR_LOOKUP_URLS` entry AND a `FAIR_REPORT_MEMO_PATHS` entry; the lint at T4.5c enforces co-modification.
+
+  Both guards run in the helper itself (caller scope) BEFORE any DB call; T1.2's `getAttorneyDiscipline` re-applies them as defense-in-depth (so future direct callers also benefit).
+
+  **Heading + md2html flow:** the helper returns markdown starting `## Attorney Bar Record Check` per T2.2; that string sits in `allOutputs['attorney-discipline']` until line 7450's `.map((s) => md2html(s))` converts it (same path as Claude-authored sections). SC #24 asserts the pre-md2html string starts with `## Attorney Bar Record Check\n`.
+
+  **Optional parallel edit** to `src/lib/intelligence-brief/render.ts` for dev-tool parity (only if `scripts/test-ib-pipeline.ts` or `render-ib-test.mjs` need it; not blocking — production path is the Edge Function).
+- **T2.5** — Skip Case Decoder integration (deferred to Phase 1.1b). v2 = IB-only.
+- **T2.6 (NEW v2.4 per Dreyer WARN #2)** — Create public-facing route at `src/app/legal/fair-report-privilege/page.tsx` (Next.js Server Component) rendering the T0b memo body. The route is the canonical target of the "Why we can show this" link inside the IB section. Body sources from a sanitized markdown file at `content/legal/fair-report-privilege.md` (NOT directly from `docs/legal/...` which contains internal references like expert-cache paths and session keys). `page.tsx` uses the existing MDX loader pattern (mirror `src/app/blog/[slug]/page.tsx` shape — minimal: title H1 + body paragraphs + canonical State Bar URL footer link). Cascade: this becomes a moat asset (other legal-info sites don't publish fair-report justification publicly; INAA does, raises industry floor, signals embedded-insider methodology — Dreyer Search Dominance Engine entity-SEO play). Robots-allowed; structured data: `Article` schema with `author = INAA`, `publisher = INAA`, `mainEntityOfPage = self`. SC #42 verifies route exists + renders.
+
+### T3 — UPL safety
+- **T3.1 (REWRITTEN v2.3 per Code CRIT #3+#4+#5 + Sec CRIT #2)** — `evaluate-report` Edge Function takes `{caseId: UUID}` body and fetches `cases.report_html` from DB (`supabase/functions/evaluate-report/index.ts:381-407`). It writes results to `cases.eval_results` per the SHAPE at lines 549-557:
+  ```ts
+  eval_results = {
+    evaluated_at, eval_version: '1.0', gate_passed: bool, teams: { upl: {...}, psych: {...} },
+    summary: string, cost_usd: number, duration_ms: number,
+  }
+  // teams.upl shape (line 443-453): { name, weight: 'GATE', score, passed, needs_work, failed, criteria, summary, duration_ms }
+  ```
+  **There is NO `eval_results.upl.fail_count` field.** Real path: `eval_results.teams.upl.failed`. evaluate-report does NOT write to `operator_tasks`; UPL-FAIL alerts go via Resend `sendEmail()` (line 463-481) — NOT via DB row insert. Cleanup must NOT touch `operator_tasks`.
+
+  Two-tier UPL coverage:
+  1. **Regex panel (primary, 5 fixture states, no LLM cost):** Deno test `supabase/functions/generate-report/__tests__/upl-regex-panel.test.ts` renders all 5 fixture states (matched-clean, matched-1-event-suspension, matched-multi-event-disbarment, no-match, pipe-edge), then asserts `output.toLowerCase().includes(phrase.toLowerCase()) === false` for every entry in `BANNED_PHRASES_LIST` (T3.3 canonical Deno-readable file) on each state. The 'should' phrase uses word-boundary regex per T2.3 helper note (`\\bshould\\b`) to avoid false positives on `shoulder` / `should've` if those ever enter copy. Cost: $0.
+  2. **Live evaluate-report smoke (1 fixture caseId, end-to-end, CI-path-gated):** Deno test at `supabase/functions/evaluate-report/__tests__/attorney-discipline-e2e.test.ts` (NOT Node — keeps single test runner per WARN #13). Steps:
+     - **Pre-flight (Sec WARN — Resend gating)**: assert `Deno.env.get('RESEND_API_KEY') === '__test_disabled__' OR === ''`. Abort otherwise. Without this gate, a stochastic UPL regression sends a real operator email per evaluate-report:458-481 = alarm fatigue.
+     - **Pre-flight (Sec WARN — service-role key fetch)**: read `SUPABASE_SERVICE_ROLE_KEY` from env (already in `--allow-env` allowlist per T1.4). Wrap all fetches in `safeFetch` redact wrapper.
+     - **Insert fixture orders row first** (cases requires `order_id NOT NULL` per migrations/00001_initial_schema.sql:202; column is `amount` NOT `amount_cents` per same file line 877 — Code v4 CRIT #1): `INSERT INTO public.orders (id, email, tier, status, amount) VALUES (gen_random_uuid(), 'e2e-attorney-discipline-' || extract(epoch from now())::bigint || '@example.com', 'intelligence-brief', 'paid', 99700) RETURNING id` — capture as `orderId`.
+     - **Insert fixture cases row** with ALL three NOT NULL columns + cron-skip flags + sentinel eval_results (Sec CRIT #2 — never matches CV `eval_results.is.null` filter even on mid-test crash):
+       ```sql
+       INSERT INTO public.cases (
+         id, order_id, email, tier, status, charge_type, report_html,
+         review_reminder_sent, is_included_deliverable,
+         eval_results, generated_at
+       ) VALUES (
+         gen_random_uuid(),
+         $orderId,
+         'e2e-attorney-discipline-' || extract(epoch from now())::bigint || '@example.com',
+         'intelligence-brief',
+         'review',
+         'DUI',
+         <rendered IB HTML containing T2.2 matched-multi-event section>,
+         true,                                          -- skip review-reminder cron
+         true,                                          -- skip stuck-intake cron
+         '{"sentinel": true, "gate_passed": false}',    -- v2.4 Sec CRIT: gate_passed:false ensures /api/deliver renderEvalScorecard treats as FAILED (not PASSED) if cleanup misses; prevents bypass of UPL gate in operator UI; evaluate-report overwrites with real {gate_passed: true|false} on completion
+         NULL                                           -- generated_at NULL → review-reminder cron filter drops the row
+       ) RETURNING id;
+       ```
+       Email pattern `e2e-attorney-discipline-${ts}@example.com` matches CV probe allowlist (`e2e-%` per `~/projects/continuous-verification/configs/inna.cv.json:101-127`).
+     - `POST ${SUPABASE_URL}/functions/v1/evaluate-report` with body `{caseId}`.
+     - Read response JSON: assert `body.success === true && body.gate_passed === true`.
+     - Read DB `cases.eval_results` post-call: assert `eval_results.gate_passed === true && eval_results.teams.upl.failed === 0` (correct shape per Code CRIT #3).
+     - **Cleanup (try/finally, ALWAYS runs)**: `DELETE FROM public.cases WHERE id = $caseId; DELETE FROM public.orders WHERE id = $orderId;`. Drop the spurious `operator_tasks` DELETE — evaluate-report never writes there.
+     - Cost: ~$2-3/run (Sonnet UPL + Psych eval).
+  3. **Reaper safety net (Sec CRIT #2 belt-and-suspenders):** add `scripts/reap-attorney-discipline-fixtures.mjs` — runs at end of CI job in a separate step (`if: always()` in CI YAML) regardless of test exit code. Body deletes any `cases` row matching `email LIKE 'e2e-attorney-discipline-%'` AND its parent `orders` row. Catches mid-test SIGKILL or runner crash where the `try/finally` never fires. Idempotent.
+  4. **CI gating**: live e2e test only runs on PRs touching `supabase/functions/generate-report/lib/render-attorney-discipline.ts` OR `lib/attorney-discipline.ts` OR `T3.3` files (paths filter). Regex panel runs on every PR.
+- **T3.2 (REWRITTEN v2.3 per Code CRIT #8 + Sec SUG word-boundary)** — Two parallel banned-phrases tests, one per runtime, both reading from the SAME canonical Deno-readable list file:
+  - **Node-side**: `src/lib/intelligence-brief/__tests__/disclaimer-banned-phrases.test.ts` — vitest. Imports `BANNED_PHRASES_LIST` from `src/lib/intelligence-brief/prompts.ts` (re-exported per T3.3). Imports `DISCLAIMER_VERBATIM` from `src/lib/intelligence-brief/attorney-discipline-disclaimer.ts` (Node-readable mirror, plain string export, no Deno imports).
+  - **Deno-side**: `supabase/functions/generate-report/__tests__/upl-regex-panel.test.ts` (T3.1.1) — imports `BANNED_PHRASES_LIST` directly from canonical Deno path `../lib/banned-phrases-list.ts` (relative path, no Next.js alias).
+  - For each phrase in `BANNED_PHRASES_LIST`: word-boundary check for `'should'` (regex `/\bshould\b/i.test(disclaimer)` MUST be false), substring check for all others (`disclaimer.toLowerCase().includes(phrase.toLowerCase()) === false`).
+  - Both runtimes assert against the SAME canonical list, so drift is impossible.
+- **T3.3 (RESHAPED v2.3 per Code CRIT #8)** — Canonical `BANNED_PHRASES_LIST` lives at `supabase/functions/generate-report/lib/banned-phrases-list.ts` (Deno-readable, NO Next.js path aliases — a plain ES module). `src/lib/intelligence-brief/prompts.ts` re-exports it via relative path (Next.js bundler resolves the relative import; the source file is the single canonical):
+  ```ts
+  // supabase/functions/generate-report/lib/banned-phrases-list.ts (NEW canonical)
+  export const BANNED_PHRASES_LIST = [
+    'you should',
+    'should',           // word-boundary checked in disclaimer test (T3.2)
+    'you need to',
+    'we recommend',
+    'we advise',
+    'your best option',
+    'the best strategy',
+    'red flag',
+    'warning sign',
+    'escalation ladder',
+    'do not',           // bare imperative
+  ] as const;
+  export type BannedPhrase = typeof BANNED_PHRASES_LIST[number];
+  ```
+  **v2.4 CORRECTION (Code CRIT #2)**: `tsconfig.json:33` HAS `"exclude": ["node_modules", "supabase", ...]`. Re-exporting from prompts.ts → supabase/functions/ would fail `npm run build` (TS2307 / TS6059). Drop the re-export. Node tests (T3.2 + T3.4) import `BANNED_PHRASES_LIST` DIRECTLY from the canonical Deno-side file via vitest's runtime resolver:
+  ```ts
+  // src/lib/intelligence-brief/__tests__/disclaimer-banned-phrases.test.ts
+  import { BANNED_PHRASES_LIST } from '../../../../supabase/functions/generate-report/lib/banned-phrases-list';
+  ```
+  Vitest's runtime module resolution does NOT honor tsconfig.exclude; it resolves the file at test runtime regardless. `prompts.ts` is NOT modified. The `BANNED_PHRASES_BLOCK` prose stays in prompts.ts for production prompt text (Next.js compiles prompts.ts; vitest tests touch prompts.ts only in tests so no cross-tree compile is triggered). Drift between the canonical list and prompts.ts's prose is caught by T3.4 parity test, which imports BOTH files via vitest runtime.
+
+  Match-rule notes: case-insensitive substring for all entries EXCEPT `'should'` which is matched as `\bshould\b` (word-boundary) so future copy with `'shoulder'` / `'shouldered'` doesn't false-positive. The `'should'` rule still catches every directive use ("should file", "should pursue", "you should").
+- **T3.4 (parity test, BIDIRECTIONAL v2.3 per Code WARN #15)** — Node test at `src/lib/intelligence-brief/__tests__/banned-phrases-parity.test.ts`:
+  - **Forward**: every entry in `BANNED_PHRASES_LIST` (case-insensitive substring) appears in the prose `BANNED_PHRASES_BLOCK` text. (Catches: phrase added to list but block not updated.)
+  - **Reverse (NEW v2.3)**: regex-extract every quoted phrase from `BANNED_PHRASES_BLOCK` using strict pattern `/^- "([^"]+)"/gm`. For each extracted phrase, assert it appears (case-insensitive substring) in `BANNED_PHRASES_LIST`. (Catches: phrase added to prose block but list not updated — Code WARN #15.)
+  - Symmetric coverage closes drift in both directions.
+
+### T4 — Verification
+- **T4.1** — `npm run build` exit 0.
+- **T4.1a (new v2.2 per SUG #11)** — `deno check supabase/functions/generate-report/index.ts` exit 0. Catches Deno-side TS errors npm build cannot see (Deno has its own type-checker against the function's `deno.json` import map). Run between T4.1 and T4.2.
+- **T4.2 (Node tests)** — `npm test -- --reporter=json --outputFile=/tmp/after.json`. Capture `before.json` from `origin/master` via fresh worktree at `.tmp/baseline-test-counts/`. Assert `after.numPassedTests >= before.numPassedTests` AND `before.passing[]` ∩ `after.failing[]` is empty.
+- **T4.2a (Deno tests, REWRITTEN v2.3 per Code WARN #13 + Sec WARN service-role-key)** — Use the SAME explicit file list from T1.4 (NOT directory glob — vitest collision):
+  ```
+  deno test \
+    --allow-env=SUPABASE_URL,SUPABASE_SERVICE_ROLE_KEY,SUPABASE_ANON_KEY,ANTHROPIC_API_KEY,RESEND_API_KEY \
+    --allow-net=jxjbjmgdukwkoclydqdr.supabase.co,api.anthropic.com \
+    --reporter=json \
+    supabase/functions/generate-report/__tests__/attorney-discipline.test.ts \
+    supabase/functions/generate-report/__tests__/upl-regex-panel.test.ts \
+    supabase/functions/generate-report/__tests__/attorney-discipline-guard.test.ts \
+    supabase/functions/generate-report/__tests__/render-attorney-discipline-lint.test.ts \
+    supabase/functions/generate-report/__tests__/attorney-discipline-fair-report-paths.test.ts \
+    supabase/functions/generate-report/__tests__/attorney-discipline-common-name.test.ts \
+    supabase/functions/generate-report/__tests__/attorney-discipline-fair-report-paths.test.ts \
+    supabase/functions/generate-report/__tests__/attorney-discipline-common-name.test.ts \
+    supabase/functions/__tests__/rls-attorney-discipline.test.ts \
+    supabase/functions/evaluate-report/__tests__/attorney-discipline-e2e.test.ts \
+    > /tmp/deno-after.json
+  ```
+  Track Deno test count INDEPENDENTLY of npm test count; the two runners report into separate JSON files. Assert `deno-after.passed === deno-before.passed + N_NEW_DENO_TESTS` (where `N_NEW_DENO_TESTS` = sum of new Deno tests across all 6 files).
+  **Artifact scrub (Sec WARN service-role key leak)**: before any artifact upload (CI step `Upload deno-after.json`), grep the JSON for `Bearer [^\s"']+` and `eyJhbGc[^\s"']+` (JWT prefix) — if found, fail the build. Keys never appear in artifacts.
+- **T4.3** — CV probe-only: `node ~/projects/continuous-verification/verify.mjs --project inna --probe-only --no-trends` exits 0 AND no `INNA-H1.*FAIL` in stdout (no substring count assertion).
+- **T4.4** — XSS smoke: insert a third fixture row with `discipline.type='<script>alert(1)</script>'` and `source_url='javascript:alert(1)'`; render via T2.2; assert HTML contains escaped `&lt;script&gt;` and `href="#"` (not `href="javascript:..."`).
+- **T4.4a (markdown-pipe smoke, v2.2 per WARN #6)** — `FIXTURE-005` event with raw pipes in `discipline_type` + `violation_summary`. Render via T2.2; flow through `md2html`; assert exactly 4 `<th>` columns; assert literal `|` characters appear in the rendered cell text (escapeMarkdownPipe's `\|` survives md2html unescape per index.ts:7355).
+- **T4.4b (XSS centralization lint, NEW v2.3 per Sec CRIT #1)** — Deno test at `supabase/functions/generate-report/__tests__/render-attorney-discipline-lint.test.ts`:
+  - Read `supabase/functions/generate-report/lib/render-attorney-discipline.ts` source as plain text via `Deno.readTextFile`.
+  - Strip block comments `/* ... */` and line comments `// ...` and string literals `'...'` / `"..."` / template-literal NON-interpolation parts.
+  - Regex-find every `${...}` interpolation in the remaining template-literal expressions.
+  - For each match, assert the expression is one of: a `safeCell(...)` call, `safeHttpUrl(...)` call, `formatShortDate(...)` call, OR a literal call in the allowlist `['events.length', 'N', 'plural', 'YYYY']` (numeric/structural placeholders).
+  - Any other interpolation fails the test with `interpolation '${EXPR}' must route through safeCell/safeHttpUrl/formatShortDate`. Catches future PRs that bypass the centralized escape pipeline (Sec CRIT #1).
+- **T4.4c (markdown-pipe edge cases, NEW v2.3 per Sec SUG)** — `FIXTURE-008` event with `discipline_type='\\|'` (literal backslash-pipe) AND `violation_summary='|||'` (three consecutive pipes). Render → md2html. Assert exactly 4 columns AND row count is 1 (no shred from `|||`) AND `discipline_type` cell-text contains `\|` rendered as literal backslash-pipe (or just `|` after unescape — whichever md2html produces; both safe).
+- **T4.5** — Injection smoke: `getAttorneyDiscipline("' OR 1=1 --", 'CA')` returns `{ status: 'no-match', attorney: null, events: [] }`, no error thrown.
+- **T4.5a (unaccent smoke, v2.2 per WARN #7)** — `FIXTURE-006` (`'José García'`) ↔ `FIXTURE-007` (`'Jose Garcia'`). Bidirectional match assertion confirms RPC `LOWER(unaccent(...))` works both directions.
+- **T4.5b (garbage-name skip, v2.2 per WARN #9 + Code WARN #14)** — Test caller-scope `buildAttorneyDisciplineSection` for inputs: `''`, `'  '`, `'Bo'`, `'Smith'`, `'asdf'`, `'n/a'`, `'TBD'`, `'pending'`, `'Not provided'`. Assert returns `''` AND `fetch.mock.calls.length === 0`.
+- **T4.5c (FAIR_REPORT_MEMO_PATHS lint, NEW v2.3 per Sec WARN coupling)** — Deno test asserts every key in `BAR_LOOKUP_URLS` (T2.3) has a matching key in `FAIR_REPORT_MEMO_PATHS` AND every memo path file exists on disk (`Deno.stat()`). Adding a new state to either map without the other fails the build. Closes the prose-only "block multi-state expansion until per-state memo" gate as a hook-or-harder enforcement.
+- **T4.5d (Sec — defamation surface acknowledgment, NEW v2.3)** — Test at `attorney-discipline-common-name.test.ts`: insert TWO `FIXTURE-John-Smith` attorneys (different bar_numbers, identical `full_name='John Smith'`). Call `getAttorneyDiscipline('John Smith', 'CA')` — assert `status === 'no-match'` AND `events.length === 0` (RPC server-side n>1 collapses to no-match per T0a). Document in test comment: this is the EXPECTED defamation-protection behavior for common-name attorneys; common-name attorneys with discipline records will silently no-render. The cascade and Out of Scope sections name this trade-off.
+- **T4.6** — Anon-key denial smoke: in `supabase/functions/__tests__/rls-attorney-discipline.test.ts`, FIRST decode the ANON_KEY JWT and assert `role === 'anon'` (otherwise abort — wrong-key misconfig produces a false-green per Sec v2 WARN #4). THEN `curl ${SUPABASE_URL}/rest/v1/attorney_discipline_events?select=* -H "apikey: ${ANON_KEY}"` returns **HTTP 200 + body `[]`** (RLS-blocked-anon returns empty, NOT 401 — Code v2 CRIT #3 verified live 2026-04-25 against legacy JWT + new sb_publishable_* keys). Equivalent assertion: `r.status === 200 && JSON.parse(await r.text()).length === 0`. Run against both `attorneys` and `attorney_discipline_events` tables. Pre-flight: anon-key in test env must come from Supabase Mgmt API at runtime (`/v1/projects/<ref>/api-keys?reveal=true`) NOT `.env.local` (which can carry a stale key — discovered 2026-04-25 in this session: stale .env.local anon key returned 401 "Invalid API key" on every table including known-RLS-protected `cases`/`orders`, masking actual RLS posture). Aligns with INAA-web ARCHITECTURE.md invariant #4 (service-role only for production DB; RLS is defense-in-depth). Update `.env.local` anon key as a separate cleanup task.
+  - **Additional anon assertion for the RPC**: `POST /rest/v1/rpc/match_attorney` with anon key + body `{"p_name":"Anyone","p_jurisdiction":"CA"}` returns **HTTP 401 or 403** (RPC has explicit `REVOKE FROM PUBLIC` + `GRANT TO service_role` per T0a — anon must NOT be able to invoke the RPC even though attorneys table allows anon to read empty `[]` via RLS).
+  - **pg_policies posture assertion (NEW v2.3 per Code WARN false-green risk)**: query `SELECT count(*) FROM pg_policies WHERE schemaname='public' AND tablename IN ('attorneys','attorney_discipline_events') AND cmd='SELECT' AND roles::text LIKE '%anon%' AND qual <> 'false' AND qual NOT LIKE '%FIXTURE-%';` — assert `count === 0`. Catches a future regression that adds a permissive `FOR SELECT TO anon USING (true)` policy (would defeat T0a's RLS posture). The `LIKE '%FIXTURE-%'` exception lets the deny-test-fixtures policies coexist as defense-in-depth (those have `USING (bar_number NOT LIKE 'FIXTURE-%')` — not permissive, just deny-overlay).
+- **T4.7** — Live render smoke: invoke IB renderer with the synthetic `FIXTURE-002` case fixture; assert rendered HTML contains "Attorney Bar Record Check" exactly once, with the discipline event row, with `DISCLAIMER_VERBATIM` verbatim, with `last_seen_at` rendered as `YYYY-MM-DD` (regex `/\d{4}-\d{2}-\d{2}/`) AND NO raw timestamptz substring (`/T\d{2}:\d{2}:\d{2}/`) AND NO literal `1970-01-01` (catches null-coalesce silent fallback per Code WARN #11).
+
+## Out of Scope (v2.3)
+- Case Decoder integration → **Phase 1.1b** separate plan (path: `batch-poller.ts:238` post-Opus markdown injection).
+- Multi-state attorney discipline (FL/TX/NY/PA/OH) → blocked on per-state fair-report privilege memos. T4.5c lint enforces the gate.
+- Fuzzy match / disambiguation prompt → defamation surface; not until exact-match version is shipped + observed.
+- Intake form jurisdiction field → 2-bar attorneys are an edge case; default to defendant's state until real demand observed.
+- Attorney rating / scoring → interpretation, breaks UPL safety.
+- Officer-discipline parallel section → separate worry, separate plan.
+- Backfill of already-delivered reports → not in scope; new section only for reports generated after deploy.
+- **Common-name silent no-match (Sec WARN, intentional)** → an attorney named `'John Smith'` with discipline events will never render in the section because exact-match-only + RPC server-side ambiguity-collapse means n>1 returns no-match. SC #20b (T4.5d) tests + documents this. **This is intentional defamation-surface protection**, not a bug. Bar-number-based exact match (defendant types the State Bar number from the attorney's signature line) is a possible future enhancement; deferred to Phase 1.1b CD plan or later.
+- **Indexed `/attorney/ca/[bar_number]/discipline-record` URL pattern (Dreyer SUG)** → niche-domination follow-on. Treats public bar discipline as entity-SEO surface. Defamation profile identical to in-report (exact-match + fair-report). Tracked as Phase 1.1c follow-on, NOT v2 blocking.
+- **Rehabilitation timeline copy (Dreyer SUG)** → matched-events render shows ALL historical events without recency/rehabilitation context. v2 ships mechanical-only; computed `Most recent event: {ago}` summary deferred to Phase 1.1d follow-on.
+
+## Success Criteria
+
+**Fixture declarations (defined in T1.3 migration; constants exported from `supabase/functions/generate-report/__tests__/fixtures.ts`):**
+- `FIXTURE_CLEAN_BAR_NUMBER = 'FIXTURE-001'`
+- `FIXTURE_CLEAN_ATTORNEY_NAME = 'Fixture Cleanrecord'`
+- `FIXTURE_DISCIPLINED_BAR_NUMBER = 'FIXTURE-002'`
+- `FIXTURE_DISCIPLINED_ATTORNEY_NAME = 'Fixture Disciplined'`
+- `FIXTURE_DISCIPLINED_EVENT_COUNT = 2`
+- `FIXTURE_AMBIGUOUS_BAR_NUMBER = 'FIXTURE-003'` (second 'Fixture Cleanrecord' row to test ambiguous-match no-match return)
+- `FIXTURE_HOSTILE_BAR_NUMBER = 'FIXTURE-004'` (XSS payload event — T4.4)
+- `FIXTURE_PIPE_BAR_NUMBER = 'FIXTURE-005'` (raw `|` in `discipline_type` and `violation_summary` — T4.4a)
+- `FIXTURE_ACCENT_BAR_NUMBER = 'FIXTURE-006'` (full_name `'José García'` — T4.5a)
+- `FIXTURE_ACCENT_REVERSE_BAR_NUMBER = 'FIXTURE-007'` (full_name `'Jose Garcia'` plain ASCII — T4.5a reverse)
+- `IB_SECTION_ANCHORS.ATTORNEY_DISCIPLINE = '## Attorney Bar Record Check'` (raw markdown H2 form)
+- `IB_SECTION_ANCHORS.YOUR_PLAN = '## Section 6: Your Plan'` (literal H2 form pinned for slot-order assertion)
+- `IB_SECTION_ANCHORS.BRADY_GIGLIO_APPENDIX = '## Appendix A: Brady/Giglio Checklist'` (forward-slash form per actual code at index.ts:7236; SC #11 brittleness fix)
+- `DISCLAIMER_VERBATIM` exported from `src/lib/intelligence-brief/attorney-discipline-disclaimer.ts` (Node-readable mirror so T3.2 + T3.4 Node tests + Deno tests both import the same string)
+- `BANNED_PHRASES_LIST` canonical at `supabase/functions/generate-report/lib/banned-phrases-list.ts` (Deno-readable, no aliases); re-exported from `src/lib/intelligence-brief/prompts.ts` for Node test convenience
+
+**Worry-intent coverage map** (every clause in worry text → at least one PASS/FAIL criterion):
+- "1,842 attorneys + 3,417 events loaded but unread" → SC #5/#6 (helper queries return live rows)
+- "intake.attorneyName collected" → SC #11 (renderer threads intake meta into helper call)
+- "no surface JOINs" → SC #11 (production renderer wires section + section appears in output)
+- "#1 crisis-buyer fear (trust)" → SC #12 + #13 (UPL-safe disclaimer + LLM evaluator pass)
+- "render only on EXACT-MATCH (defamation surface)" → SC #7 (ambiguous returns no-match) + SC #21 (RPC unaccent match deterministic)
+- "fair-report privilege framing" → SC #14 (memo file present + cited)
+
+1. **RLS posture explicit.** `psql` against the project: `SELECT relrowsecurity FROM pg_class WHERE relname IN ('attorneys','attorney_discipline_events')` returns `t` for both rows. (Verifiable PASS/FAIL via single SQL query post-T0a.)
+2. **Anon denial smoke.** Live `curl ${SUPABASE_URL}/rest/v1/attorney_discipline_events?select=* -H "apikey: ${ANON_KEY}"` (anon key fetched from Supabase Mgmt API at runtime) returns `r.status === 200 && JSON.parse(await r.text()).length === 0` (RLS-blocked-anon = empty array, NOT 401). Test at `supabase/functions/__tests__/rls-attorney-discipline.test.ts`. Pre-flight asserts JWT `role === 'anon'`.
+3. **Function exists.** `import { getAttorneyDiscipline } from 'supabase/functions/generate-report/lib/attorney-discipline'` resolves; `typeof getAttorneyDiscipline === 'function'`; `getAttorneyDiscipline.length === 2`.
+4. **Shape test passes.** Test `'returns expected shape'` calls `getAttorneyDiscipline(FIXTURE_DISCIPLINED_ATTORNEY_NAME, 'CA')`; asserts result keys deep-equal `['attorney', 'events', 'status']`.
+5. **Clean attorney match.** Test `'matches clean attorney'` calls `getAttorneyDiscipline(FIXTURE_CLEAN_ATTORNEY_NAME, 'CA')`; asserts `result.status === 'matched' && result.events.length === 0 && result.attorney.current_status === 'active' && result.attorney.bar_number === FIXTURE_CLEAN_BAR_NUMBER`.
+6. **Disciplined attorney match.** Test asserts `result.status === 'matched' && result.events.length === FIXTURE_DISCIPLINED_EVENT_COUNT && result.attorney.current_status === 'suspended'`. Each event has `typeof e.order_date === 'string' && typeof e.discipline_type === 'string' && (typeof e.violation_summary === 'string' || typeof e.discipline_raw === 'string')` (column names per T1.1, NOT legacy `date/type/outcome`).
+7. **Ambiguous match returns no-match.** Test inserts duplicate fixture row `FIXTURE-003` with same `full_name` as `FIXTURE-001`; asserts `getAttorneyDiscipline(FIXTURE_CLEAN_ATTORNEY_NAME, 'CA').status === 'no-match'`.
+8. **Injection-resistant.** Test asserts `getAttorneyDiscipline("' OR 1=1 --", 'CA')` deep-equals `{ attorney: null, events: [], status: 'no-match' }` AND no error thrown.
+9. **No-match path.** Test asserts `getAttorneyDiscipline('Zzzzz Nonexistent', 'CA')` deep-equals `{ attorney: null, events: [], status: 'no-match' }`.
+10. **Renderer escapes hostile HTML input.** Test inserts fixture `FIXTURE-004` with discipline event having `discipline_type='<script>alert(1)</script>'` and `source_url='javascript:alert(1)'`; renders section; asserts output HTML contains `&lt;script&gt;alert(1)&lt;/script&gt;` AND contains `href="#"` AND does NOT contain literal `<script>` or literal `javascript:`.
+11. **IB renders attorney-discipline section in correct slot — pre-render assertion (CORRECTED v2.4 per Code CRIT #3).** SC #11 v2.3 asserted against rendered HTML, but the LLM prompt at `index.ts:7102` instructs `Output: ## Section 6` (NOT `: Your Plan`), and post-md2html the markdown anchors don't survive in HTML. Both surfaces make HTML substring assertions unreliable. v2.4 instead asserts against `allOutputs` map ordering BEFORE `renderIBReportHtml` runs. Test invokes the Phase B caller flow with `FIXTURE_DISCIPLINED_BAR_NUMBER`; captures `allOutputs` keys in insertion order (or per the sections array at lines 7429-7450). Asserts: (a) `'attorney-discipline' in allOutputs && typeof allOutputs['attorney-discipline'] === 'string' && allOutputs['attorney-discipline'].length > 0` (key present + non-empty), (b) the position of `'attorney-discipline'` in the literal sections-array source code at lines 7429-7450 sits AFTER `sectionOutputs["your-plan"]` AND BEFORE `buildBradyGiglioChecklist()` — verifiable by reading `index.ts` and asserting line ordering of those three string literals. (c) `allOutputs['attorney-discipline'].startsWith('## Attorney Bar Record Check')` (markdown heading present). All three assertions are deterministic and don't depend on LLM output formatting.
+12. **UPL evaluator passes — live caseId smoke (CORRECTED v2.3 per Code CRIT #3+#4+#5).** Test:
+    a. Insert fixture orders row (provides NOT NULL `order_id` for cases per migrations/00001_initial_schema.sql:202).
+    b. Insert fixture `cases` row with ALL three NOT NULL columns (`order_id`, `email`, `tier`), `email='e2e-attorney-discipline-${ts}@example.com'` (CV-allowlisted per `inna.cv.json`), `eval_results='{"sentinel": true, "evaluated_at": null}'` sentinel, `review_reminder_sent=true`, `is_included_deliverable=true`, `generated_at=NULL`, `report_html=<rendered IB containing T2.2 matched-multi-event>`, `gen_random_uuid()` caseId.
+    c. Pre-flight assertion: `Deno.env.get('RESEND_API_KEY') === '__test_disabled__' OR === ''` (Resend gating per Sec WARN — prevents real operator email on flaky LLM regression).
+    d. `POST ${SUPABASE_URL}/functions/v1/evaluate-report` with body `{caseId}`.
+    e. Assert response JSON: `body.success === true && body.gate_passed === true`.
+    f. Read `cases.eval_results` post-call: assert `eval_results.gate_passed === true && eval_results.teams.upl.failed === 0` (CORRECT shape per evaluate-report/index.ts:443-453 + 549-557; NOT `eval_results.upl.fail_count` which does not exist).
+    g. Cleanup in `try/finally`: `DELETE FROM public.cases WHERE id = $caseId; DELETE FROM public.orders WHERE id = $orderId;`. Drop the spurious `operator_tasks` DELETE — evaluate-report writes via Resend `sendEmail()`, NOT to a `operator_tasks` table.
+    h. Reaper script `scripts/reap-attorney-discipline-fixtures.mjs` runs in CI `if: always()` step, deletes any `cases` row with `email LIKE 'e2e-attorney-discipline-%'` AND its parent `orders` row, idempotent. Catches mid-test SIGKILL.
+    Cost: ~$2-3/run (Sonnet UPL + Psych eval). CI path-filtered to attorney-discipline file changes only.
+13. **Disclaimer is UPL-banned-phrase-free (BANNED_PHRASES_LIST canonical, WARN #8).** Node test at `disclaimer-banned-phrases.test.ts` imports `DISCLAIMER_VERBATIM` and `BANNED_PHRASES_LIST`; iterates every entry in `BANNED_PHRASES_LIST` (canonical list extracted from `prompts.ts:34-44`); asserts `DISCLAIMER_VERBATIM.toLowerCase().includes(phrase.toLowerCase()) === false` for each. Hand-rolled phrase subsets are NOT acceptable — must use the imported `BANNED_PHRASES_LIST` constant.
+14. **Fair-report privilege memo present.** File `docs/legal/2026-04-25-attorney-discipline-fair-report-privilege.md` exists; contains the literal substring `California Civil Code § 47`. (Reader runs `test -f` and `grep -F`.)
+15. **Build green.** `npm run build` exit 0.
+16. **Node tests green — count-pinned.** Capture `npm test -- --reporter=json --outputFile=before.json` on `origin/master` via temporary `.tmp/baseline-checkout/`; capture `after.json` on PR branch; assert `after.numPassedTests >= before.numPassedTests` AND no test name in `before.passing[]` appears in `after.failing[]`.
+17. **CV probe-only green.** `node ~/projects/continuous-verification/verify.mjs --project inna --probe-only --no-trends` exits 0 AND stdout has zero lines matching `/INNA-H1.*FAIL/`.
+18. **Deno tests green (separately tracked from npm, WARN #4).** `deno test --allow-net --allow-env --reporter=json supabase/functions/{generate-report,evaluate-report}/__tests__/ supabase/functions/__tests__/` exits 0; baseline captured pre-PR; assert `deno-after.passed === deno-before.passed + N_NEW_DENO_TESTS` where `N_NEW_DENO_TESTS = sum(new tests added in T1.4 + T3.1.1 + T3.1.2 + T4.4a + T4.5a + T4.5b + T4.6)`. Failing this criterion catches Deno-runtime test regressions that npm test cannot detect.
+19. **Deno typecheck green (SUG #11).** `deno check supabase/functions/generate-report/index.ts` exits 0. Catches Deno-side TS errors npm build cannot see.
+20. **Garbage-name skip — programmatic (WARN #9).** Deno test at `attorney-discipline-guard.test.ts` invokes `buildAttorneyDisciplineSection({ attorneyName, jurisdiction: 'CA', supabaseUrl, serviceRoleKey })` for each of: `''`, `'   '`, `'Bo'`, `'Smith'` (single-token), `'asdf'`, `'n/a'`, `'TBD'`, `'pending'`. For each input, asserts (a) returns `''`, (b) `fetch.mock.calls.length === 0` after the call. Confirms guard fires before any DB hit.
+21. **Unaccent match works both directions (WARN #7).** Deno test inserts `FIXTURE-006` with `full_name='José García'` then calls `getAttorneyDiscipline('Jose Garcia', 'CA')` — asserts `status === 'matched' && attorney.bar_number === 'FIXTURE-006'`. Reverse: insert `FIXTURE-007` `'Jose Garcia'` (ASCII), query `'José García'` — same assertion against `FIXTURE-007`. Confirms RPC `LOWER(unaccent(...))` works both directions via the functional index.
+22. **Markdown-pipe escape works (WARN #6).** Deno test inserts `FIXTURE-005` event with `discipline_type='Suspension | 90 days'` and `violation_summary='Failure to file | client funds'`. Renders T2.2 section, runs through `md2html` (the same pass T2.4 production uses). Asserts: (a) rendered HTML contains exactly 4 `<th>` headers in the discipline-events table (Date / Type / Summary / Source), (b) the cell text content for `discipline_type` shows `Suspension | 90 days` with literal pipe character (after escapeMarkdownPipe + md2html unescape cycle), (c) row count is 1 (not pipe-shred into 2+ rows).
+23. **`last_seen_at` short-date format (SUG #13).** Test asserts rendered HTML for matched fixtures contains a date matching `/\d{4}-\d{2}-\d{2}/` for the `last_seen_at` value AND does NOT contain raw timestamptz strings (negative-match `/T\d{2}:\d{2}:\d{2}/`).
+24. **Markdown heading (SUG #12).** Test asserts the RAW PRE-md2html output of `buildAttorneyDisciplineSection()` starts with `## Attorney Bar Record Check\n` (markdown), NOT raw `<h2>`. Catches drift if a future edit re-introduces inline HTML headers.
+25. **Sibling-PR pre-flight artifact (T0c, WARN #10).** Reader runs:
+    a. `grep -F '```json t0c-pre-flight' docs/plans/2026-04-25-worry-attorney-discipline-wire-rounds.md` → exit 0 (the fenced block tag exists).
+    b. Extract the fenced JSON payload after that tag. The payload is the raw output of `gh pr list --repo rahim0kapadia/ImNotAnAttorney-web --state open --json number,headRefName,files --limit 50` captured immediately before `git worktree add` in Phase 5.
+    c. For every PR object in the payload AND every `files[].path` entry within each PR: assert NONE matches any of the five blocking paths: `supabase/functions/generate-report/index.ts`, `src/lib/intelligence-brief/prompts.ts`, `src/lib/intelligence-brief/render.ts`, glob `supabase/migrations/20260425c_*.sql`, glob `supabase/migrations/20260425d_*.sql`.
+    PASS iff steps (a) and (c) both succeed (binary). FAIL if the tag missing, payload unparseable, or any path matches. Verifiable script: `node scripts/verify-t0c-preflight.mjs <rounds-file-path>` exits 0 on PASS, non-zero on FAIL.
+26. **RPC permissions — anon blocked (v2.4 status set per Code WARN — PostgREST returns 404 for missing-EXECUTE).** Test calls `POST /rest/v1/rpc/match_attorney` with anon key; asserts `r.status === 401 || r.status === 403 || r.status === 404` (PostgREST returns 404 with body `{"code": "42883", "message": "Could not find the function ... in the schema cache"}` when the calling role lacks EXECUTE — the function is treated as not-in-API). Additional body assertion: `JSON.parse(await r.text()).code === '42883'` if status is 404. Service-role call returns rows. Confirms T0a `REVOKE FROM PUBLIC` + `GRANT TO service_role` is applied.
+27. **`BANNED_PHRASES_LIST` parity test bidirectional (T3.4 v2.3).** TWO assertions: (a) every entry in `BANNED_PHRASES_LIST` (case-insensitive substring) appears in `BANNED_PHRASES_BLOCK` prose; (b) every quoted phrase regex-extracted from `BANNED_PHRASES_BLOCK` via `/^- "([^"]+)"/gm` exists (case-insensitive substring) in `BANNED_PHRASES_LIST`. Symmetric coverage closes drift in both directions.
+28. **XSS centralization lint (NEW v2.3 per Sec CRIT #1).** Test at `render-attorney-discipline-lint.test.ts` reads source of `lib/render-attorney-discipline.ts`, strips comments + string literals, regex-finds every `${...}` interpolation, asserts each is one of: `safeCell(...)`, `safeHttpUrl(...)`, `formatShortDate(...)`, OR a literal in allowlist `['events.length', 'N', 'plural', 'YYYY']`. Fails fast on any other interpolation pattern. Catches future PRs that bypass the centralized escape pipeline.
+29. **CV-probe pollution prevention (NEW v2.3 per Sec CRIT #2).** Test asserts the e2e fixture `cases` row inserted by SC #12 satisfies BOTH: (a) `email` matches CV allowlist pattern `e2e-%` per `~/projects/continuous-verification/configs/inna.cv.json` `email.not.ilike` filter, (b) `eval_results IS NOT NULL` at insert time (sentinel `{"sentinel": true}`). Both conditions ensure the fixture row never matches `inna-missed-evals` probe filter (`status.eq=review AND eval_results.is.null`) even on mid-test crash before evaluate-report writes results. Reaper script `scripts/reap-attorney-discipline-fixtures.mjs` exists at the cited path (`test -f` exit 0).
+30. **Resend gating in test env (NEW v2.3 per Sec WARN).** Pre-flight test asserts `process.env.RESEND_API_KEY === '__test_disabled__'` OR empty before invoking evaluate-report e2e smoke. Without this, a stochastic UPL regression triggers a real operator email per evaluate-report:458-481.
+31. **Cron-skip flags on cases fixture (NEW v2.3 per Sec WARN review_reminder).** Test asserts inserted fixture cases row has `review_reminder_sent=true` AND `is_included_deliverable=true` AND `generated_at IS NULL`. Documented invariant: every test fixture must be invisible to all 6 cron tasks in `src/lib/cron/`.
+32. **FAIR_REPORT_MEMO_PATHS lint (NEW v2.3 per Sec WARN coupling).** Deno test at `attorney-discipline-fair-report-paths.test.ts` asserts (a) every key in `BAR_LOOKUP_URLS` has a matching key in `FAIR_REPORT_MEMO_PATHS`, (b) every value in `FAIR_REPORT_MEMO_PATHS` resolves via `Deno.stat()` to an existing file. Catches: adding a new state's bar lookup without writing the memo. Hook-or-harder for the prose "block multi-state expansion until per-state memo" gate.
+33. **pg_policies posture (NEW v2.3 per Code WARN false-green).** Query `SELECT count(*) FROM pg_policies WHERE schemaname='public' AND tablename IN ('attorneys','attorney_discipline_events') AND cmd='SELECT' AND roles::text LIKE '%anon%' AND qual <> 'false' AND qual NOT LIKE '%FIXTURE-%'` returns count = 0. Catches future migration that adds permissive `anon SELECT USING (true)` defeating T0a's RLS posture.
+34. **Common-name silent no-match (NEW v2.3 per Sec WARN).** Test inserts two `'John Smith'` fixture attorneys (different bar_numbers, identical full_name); calls `getAttorneyDiscipline('John Smith', 'CA')`; asserts `status === 'no-match' && events.length === 0` AND no fetch is made to discipline-events endpoint (RPC server-side n>1 collapse per T0a). Documents intentional defamation-protection trade-off.
+35. **Markdown-pipe edge cases (NEW v2.3 per Sec SUG).** Test FIXTURE-008 with `discipline_type='\\|'` AND `violation_summary='|||'`. Render → md2html. Asserts (a) exactly 4 `<th>` columns, (b) row count = 1 (no shred from `|||`), (c) cell text contains the literal pipe character (escapeMarkdownPipe + md2html unescape).
+36. **Structured no-match logging (NEW v2.3 per Sec SUG).** Mock `console.log` in helper test; assert every no-match path emits one JSON object with shape `{ component: 'attorney-discipline', reason: <enum>, jurisdiction: string, name_length: number }` AND `attorneyName` substring NEVER appears in any log line (PII safety). Verifiable via `JSON.parse` round-trip on captured log output.
+37. **T0c post-worktree race-window check (NEW v2.3 per Code WARN race).** Pre-Phase-5 ops: AFTER `git worktree add`, re-run `gh pr list` and append the JSON to `rounds.md` under fenced tag `t0c-pre-flight-post`. Verifier script (same as SC #25, but reads the post-tag) exits 0 if no new sibling PR appeared touching any of the 5 blocking paths during the worktree-creation race window. FAIL if the post-flight detected drift; recovery path: `git worktree remove` + abort.
+38. **Unaccent extension pre-flight (NEW v2.3 per Code CRIT #7).** T0a migration body includes `DO $$ ... SELECT extensions.unaccent('extensions.unaccent', 'café') INTO folded; IF folded <> 'cafe' THEN RAISE EXCEPTION ... END IF; END $$;` BEFORE the index in step 3 fires. Verifiable: migration apply succeeds end-to-end (indicates pre-flight passed); a deliberate misconfig (e.g. unaccent installed in wrong schema) would abort migration with the EXCEPTION text. Test inspects migration file via `Deno.readTextFile + grep` to confirm the DO block exists with the exact RAISE EXCEPTION text.
+39. **RPC server-side ambiguity collapse (NEW v2.3 per Code SUG).** Test calls `match_attorney('John Smith', 'CA')` against fixtures with two `'John Smith'` rows; asserts response array is empty `[]` (NOT a row with `match_count=2`). Confirms the `WHERE counted.n = 1` clause is server-side enforced.
+40. **Fixture future-proof RLS deny policies (NEW v2.3 per Sec SUG).** Test asserts `SELECT count(*) FROM pg_policies WHERE schemaname='public' AND tablename IN ('attorneys','attorney_discipline_events') AND policyname IN ('deny_anon_test_fixtures_attorneys','deny_anon_test_fixtures_events')` returns count = 2. Confirms T0a's defense-in-depth deny policies survive even if a future migration adds permissive anon SELECT.
+41. **Bar-lookup-url disambiguation (NEW v2.4 per Dreyer WARN #1).** Test renders T2.2 matched-state output AND T2.2 no-match output. Asserts: (a) matched-state HTML contains substring `apps.calbar.ca.gov/attorney/Licensee/Detail/` (deep link via `BAR_LOOKUP_URLS.CA.detail(barNumber)`) AND does NOT contain `LicenseeSearch/QuickSearch` (the base URL would defeat the methodology proof); (b) no-match-state HTML contains substring `apps.calbar.ca.gov/attorney/LicenseeSearch/QuickSearch` (defendant doesn't have bar_number to deep-link with) AND does NOT contain `Licensee/Detail/`.
+42. **Fair-report public route exists + renders (NEW v2.4 per Dreyer WARN #2).** (a) `test -f src/app/legal/fair-report-privilege/page.tsx` exit 0; (b) `test -f content/legal/fair-report-privilege.md` exit 0; (c) Playwright smoke: `await page.goto('https://imnotanattorney.com/legal/fair-report-privilege'); expect(page.locator('h1')).toContainText('Fair Report')` (or equivalent dev-server `localhost:3000/legal/fair-report-privilege` for CI); (d) page contains substring "California Civil Code § 47" (matches T0b memo + SC #14). Closes the dead-link surface where IB disclaimer would 404 on click.
+43. **test_run_id rule compliance — justified marker (NEW v2.4 per Code WARN).** Per `~/.claude/rules/drafts/test-isolation.md`, test files writing to Supabase tables MUST satisfy one of: withTestTx, newTestRunId marker, `test-isolation-justified: <reason ≥15 chars>` comment, OR `test-isolation-na: <reason>` comment. T3.1.2 e2e test file SHALL contain at line 1-20 the comment: `// test-isolation-justified: e2e fixture uses CV-allowlisted email pattern + sentinel eval_results gate_passed:false + reaper safety net; cases/orders test_run_id columns not yet present on this branch (test-isolation infra is on a separate worktree planned for 2026-05).` Verifiable via `grep -F 'test-isolation-justified:' supabase/functions/evaluate-report/__tests__/attorney-discipline-e2e.test.ts` exit 0.
+
+## Worktree Boundary (v2.3)
+Run in isolated worktree at `.claude/worktrees/worry-attorney-discipline/` off `origin/master` (currently `81721f28`). Touch only:
+- `supabase/migrations/20260425c_attorney_discipline_rls.sql` (new, T0a — renamed from `20260425a`)
+- `supabase/migrations/20260425d_attorney_discipline_test_fixtures.sql` (new, T1.3 — renamed from `20260425b`)
+- `docs/legal/2026-04-25-attorney-discipline-fair-report-privilege.md` (new, T0b)
+- `supabase/functions/generate-report/lib/attorney-discipline.ts` (new, T1.2 — RPC caller)
+- `supabase/functions/generate-report/lib/render-attorney-discipline.ts` (new, T2.2 — markdown emitter)
+- `supabase/functions/generate-report/lib/section-anchors.ts` (new, T2.1 — Deno-side anchor constants)
+- `supabase/functions/generate-report/lib/banned-phrases-list.ts` (NEW v2.3, T3.3 — canonical Deno-readable list)
+- `src/lib/intelligence-brief/attorney-discipline-disclaimer.ts` (new, T3.2 mirror — DISCLAIMER_VERBATIM constant)
+- `supabase/functions/generate-report/__tests__/attorney-discipline.test.ts` (new, T1.4)
+- `supabase/functions/generate-report/__tests__/upl-regex-panel.test.ts` (new, T3.1.1)
+- `supabase/functions/generate-report/__tests__/attorney-discipline-guard.test.ts` (new, T4.5b)
+- `supabase/functions/generate-report/__tests__/render-attorney-discipline-lint.test.ts` (NEW v2.3, T4.4b — XSS centralization lint)
+- `supabase/functions/generate-report/__tests__/attorney-discipline-fair-report-paths.test.ts` (NEW v2.3, T4.5c)
+- `supabase/functions/generate-report/__tests__/attorney-discipline-common-name.test.ts` (NEW v2.3, T4.5d)
+- `supabase/functions/generate-report/__tests__/fixtures.ts` (new — fixture constants)
+- `supabase/functions/evaluate-report/__tests__/attorney-discipline-e2e.test.ts` (new, T3.1.2 — Deno test)
+- `supabase/functions/__tests__/rls-attorney-discipline.test.ts` (new, T4.6 — anon + RPC permission + pg_policies posture)
+- `supabase/functions/generate-report/index.ts` (modify — caller-scope wiring at line 5045-5046 + slot in sections array between line 7438 and 7439 per T2.4 v2.3 REWRITE)
+- `src/lib/intelligence-brief/prompts.ts` (modify — re-export `BANNED_PHRASES_LIST` from canonical Deno-side file per T3.3)
+- `src/lib/intelligence-brief/__tests__/disclaimer-banned-phrases.test.ts` (new, T3.2 Node-side)
+- `src/lib/intelligence-brief/__tests__/banned-phrases-parity.test.ts` (new, T3.4 Node-side bidirectional)
+- `src/lib/intelligence-brief/render.ts` (OPTIONAL modify — dev-tool parity per T2.4; not blocking)
+- `src/lib/intelligence-brief/section-anchors.ts` (OPTIONAL new — Node-side parallel mirror with parity test, per T2.1)
+- `scripts/reap-attorney-discipline-fixtures.mjs` (NEW v2.3 per Sec CRIT #2 — CI `if: always()` cleanup safety net)
+- `scripts/verify-t0c-preflight.mjs` (NEW v2.3 per SC #25 — verifier script for sibling-PR pre-flight artifact)
+- `.github/workflows/attorney-discipline-e2e.yml` (NEW v2.3 — CI path-gated job for T3.1.2 e2e + reaper)
+- `src/app/legal/fair-report-privilege/page.tsx` (NEW v2.4 per Dreyer WARN #2 — public route for "Why we can show this" link; T2.6)
+- `content/legal/fair-report-privilege.md` (NEW v2.4 per Dreyer WARN #2 — sanitized public-facing memo body, sourced from T0b internal memo)
+- `docs/plans/2026-04-25-worry-attorney-discipline-wire.md` (this file)
+- `docs/plans/2026-04-25-worry-attorney-discipline-wire-findings.md` (rounds findings, new)
+- `docs/plans/2026-04-25-worry-attorney-discipline-wire-rounds.md` (per-round log, new)
+
+**Pre-execution check (T0c, restated here)**: run `gh pr list --repo rahim0kapadia/ImNotAnAttorney-web --state open --json number,headRefName,files --limit 50` immediately before `git worktree add`. Abort with named conflict if any open PR's `files[]` contains: `supabase/functions/generate-report/index.ts`, `src/lib/intelligence-brief/prompts.ts`, `src/lib/intelligence-brief/render.ts`, or any `supabase/migrations/20260425c_*.sql` / `20260425d_*.sql`. As of 2026-04-25: PRs #102 (score) and #133 (NYPD CCRB) are open — neither hits the four blocking paths above (verified via JSON grep).
+
+Do NOT touch sibling-owned files: anything modified in any open sibling PR.
+
+## Phase 1.1b — Case Decoder integration (deferred plan, queued)
+After v2 ships:
+- Audit `src/lib/cron/batch-poller.ts:202-238` to find the post-Opus markdown injection seam.
+- Add a CD-side mechanical render appended to `cleaned` markdown before `renderReportHtml(cleaned, meta)` call.
+- Verify CD intake (`src/app/api/intake/route.ts`) collects `attorney_name` (audit needed; v2 does not assume).
+- Tier-monotonicity: CD section shows `current_status` + lookup link only (no event table); IB shows full table. (Dreyer WARN #3.)
+
+This is a separate `/worry-to-pristine` invocation, not part of v2.

--- a/docs/plans/2026-04-25-worry-product-tier-data-audit-findings.md
+++ b/docs/plans/2026-04-25-worry-product-tier-data-audit-findings.md
@@ -1,0 +1,86 @@
+# Round 0 Findings — Plan Review (Pre-Execution)
+
+**Date:** 2026-04-25
+**Plan:** `docs/plans/2026-04-25-worry-product-tier-data-audit.md`
+**Reviewers:** code-reviewer (22), security-auditor (6), alex-hormozi (12) = **40 total findings**
+
+| Severity | Count |
+|---|---|
+| CRITICAL | 9 |
+| WARNING | 17 |
+| SUGGESTION | 14 |
+
+## CRITICAL findings (9 — must close before Phase 5)
+
+| ID | Reviewer | One-line |
+|---|---|---|
+| **cr-1** | code-reviewer | Current branch is `feat/hormozi-guarantee-attribution`, NOT `master`. Do-not-touch list stale (test-pollution-hotfix gone; arch-pointer + scoped-rls missing). All PR base-branch ordering compromised until resync. |
+| **cr-2** | code-reviewer | T12 adds tier-conditional gates inside `prompts.ts` but plan never specifies how tier is observable in the IB sub-case context. Two implementers will diverge. |
+| **cr-3** | code-reviewer | T13/T14/T15 ship `*-session-manifest.ts` with NO consumer. Operator UI explicitly out-of-scope. INV-7 PASS condition is satisfied by static manifest existence — operator still hand-writes reports without the manifest reaching them. |
+| **cr-4** | code-reviewer | SC-9 regex `Grep -n 'v\.X\b'` produces false negatives on destructured access (`const { judge_quote_library } = v`). Will silently mis-grade T10 PASS when slot was deleted from destructured form but not declared. |
+| **az-1** | hormozi | INV-2 counts "distinct named tables" — gameable. Adding one trivial lookup table satisfies the test without lifting Dream Outcome by a dollar. Buyer never feels a table count. |
+| **az-2** | hormozi | T10 wires 4 orphan IBVariables slots (judge_quote_library, officer_reliability_crosscase, codefendant_divergence_summary, plea_discount_curve_summary) into IB ($997). But ARCHITECTURE.md:252-254 promises 3 of these as X-Ray/WR/SR differentiators. After T10, IB will ship the SR ($9,997) value step. **Ladder collapses by 10x.** |
+| **az-3** | hormozi | T11-T15 PRs all have Done-iff = "INV passes" = test green. ZERO buyer-visible artifacts. A buyer paying $4,997 more for War Room over X-Ray will read the SAME report after T14 ships. **Tests don't sell.** |
+| **az-4** | hormozi | INV-6 manifest test passes trivially because the upsell target is wrong: `judge-report-card.upsellTier = 'case-decoder'` (same price tier!). Smart buyer pays $591 for 3 standalones + skips IB at $997 = $406 savings. **Cannibalization is already live in products.ts.** |
+| **az-5** | hormozi | "Sales-page positioning conflict" was deferred to "Out of Scope." But cannibalization happens in the buyer's head 30 seconds after they hit pricing — not in TypeScript. The buyer never sees the manifest. |
+
+## WARNING findings (17)
+
+| ID | Reviewer | One-line |
+|---|---|---|
+| sec-1 | security-auditor | INV-5 doesn't name runtime trust source for `tier` — must be `cases.tier` server-loaded, not request-derived |
+| sec-2 | security-auditor | T13/14/15 manifests need explicit case-scoping joinKey to prevent cross-case PII bleed |
+| sec-3 | security-auditor | INV-8 only validates IB/CD render path — X-Ray/WR/SR session output deferred from no-hallucinated-legal-data filter while being formalized |
+| sec-4 | security-auditor | TIER_DATA_MANIFEST is test-time only. No runtime call site uses it. ad-hoc `ALLOWED_TIERS` Sets at motion-drafts/route.ts:44 will drift. |
+| cr-5 | code-reviewer | Plan citations to `variables.ts:743/749` are wrong — actual locations 158/159. Multiple line-number drift. Will trip docs-freshness CI. |
+| cr-6 | code-reviewer | DispatcherTierSlug only includes CD/IB. T13-T15 add files for tiers NOT in DispatcherTierSlug. Plan doesn't say whether to extend the union. |
+| cr-7 | code-reviewer | `recap_dockets` table name TBD pending sibling worktree. T2 done-iff doesn't require resolving. SC-12 omits it. |
+| cr-8 | code-reviewer | Plan asserts `report.mjs:53-57` is the x-ray branch — it's a guidance string, not a fetch site. WR/SR sentencing/officer claims may be similarly misread. |
+| cr-9 | code-reviewer | T9 "failing assertions are EXPECTED" will fail to commit because pre-commit hook hard-blocks unless tests pass. No --no-verify authorized. |
+| cr-10 | code-reviewer | INV-1 `dataSourcesFor(T)` recursion through `includesTiers` not formalized. Sibling-cases pattern means union semantics need explicit spec. |
+| cr-11 | code-reviewer | SC-11 regex `_worktrees|*-worktree` is malformed (glob `*` in regex). May silently pass when PR diff touches `oh-statutes-worktree/...`. |
+| cr-12 | code-reviewer | T10 edits 7,671-line generate-report/index.ts — triggers auto-security-precommit. Plan has no T10.5 security pre-flight; per pristine-or-nothing this blocks T11+. |
+| cr-13 | code-reviewer | T11/T12 both edit ARCHITECTURE.md but framed as "ship in parallel." Will trigger branch-stomp / docs-freshness CI. Must serialize. |
+| az-6 | hormozi | T7 ignores Time axis: playbook is INSTANT, CD takes 48HR. On Hormozi value equation, time-delay 50x dominates personalization edge. Silent ladder leakage. |
+| az-7 | hormozi | INV-8 only filters at render time. Verification badge / source URL footer NOT in scope. Invisible quality = uncompensated quality. |
+| az-8 | hormozi | INV-7 manifest ships, operator UI deferred — operator still hand-writes 23-table reports without the manifest. Documented-but-unenforced rule. |
+| az-10 | hormozi | INV-2 doesn't validate price-step proportionality (CD→IB 5x needs 5+ new synthesized features; X-Ray→WR 2x needs 2+). Audit can certify a ladder buyer doesn't feel. |
+
+## SUGGESTION findings (14)
+
+| ID | Reviewer | One-line |
+|---|---|---|
+| sec-5 | security-auditor | T10 wired slots should emit one-time provenance log entry (forensics for "when did this tier first render this data") |
+| sec-6 | security-auditor | Mode-config DispatcherTierSlug union needs contract test for future auto-path re-light |
+| cr-14 | code-reviewer | INV-3 treats ARCHITECTURE.md as ground truth — but per code-conventions ARCHITECTURE.md is derived. Invert flow. |
+| cr-15 | code-reviewer | T7 says "$147 playbook" — most expensive playbook is $147 but cheapest (DUI) is $127. Use most expensive for stronger test. |
+| cr-16 | code-reviewer | T16 iterates STANDALONE_PRODUCTS where `upsellTier` includes 'judge-report-card' (a standalone, not a main tier). Lookup throws. |
+| cr-17 | code-reviewer | T1 creates `src/lib/tiers/` directory alongside `src/lib/tiers.ts` file — import ambiguity. |
+| cr-18 | code-reviewer | T2 file list confuses "in-repo HEAD files (read freely)" vs "sibling worktree paths (do-not-touch)." |
+| cr-19 | code-reviewer | Plan says `psql -c "SELECT count(*)"` for row probes — risky on big tables without statement_timeout. Use PostgREST `?select=count` HEAD. |
+| cr-20 | code-reviewer | SC-10 enforced via `gh pr view` regex but no script specified. Manual compliance will drift across 8 PRs. |
+| cr-21 | code-reviewer | "Future-us" cascade aspiration — adding new tier requires manual edits across 3 files. No scaffold. |
+| cr-22 | code-reviewer | "Orphan" verdict needs third bucket: "park with TODO + tracked task" beyond wire/delete. |
+| az-9 | hormozi | WR/SR deliveryDetail strings are feature lists not Dream Outcome statements. T19 copy rewrite needed. |
+| az-11 | hormozi | Public /trust/tier-integrity page with last-passed badge converts internal QA into Likelihood lift. |
+| az-12 | hormozi | Playbook static at $127 reads "cheap" in 2026, degrading every uplevel. T21 jurisdiction-personalization minimum. |
+
+## Verdict / Path Forward
+
+The audit framework (INV-1..INV-8) is structurally sound. The execution scope is wrong-shaped per Hormozi:
+- The plan ships **test infrastructure** but the buyer pays for **rendered value**.
+- Several CRITICAL findings reveal the audit would CERTIFY a passing ladder while the buyer still rationally walks away (cannibalization already live; SR-only data leaking to IB after T10; zero buyer-visible artifacts).
+
+**Three viable paths forward:**
+
+| Path | Scope | Time | Pros | Cons |
+|---|---|---|---|---|
+| **A. Apply all 40 findings → re-swarm round 0 → execute** | Massive plan rewrite (T10 split, T15.5 UI added, T18 sales-page, T19 copy, T20 trust badge, T21 playbook, INV-2 reframe) → 23+ tasks → 12+ PRs over 5-10 days | 1-3 weeks elapsed, 5-15M tokens | Pristine ladder, every Hormozi axis defended | Massive scope; many decisions Rahim-only (re-pricing, copy, sales-page positioning) |
+| **B. Apply 9 CRITICAL findings only, accept warnings as deferred, execute scoped audit** | Fix branch issue (cr-1), split T10 to gate orphan slots correctly (az-2), reframe INV-2 to value-weighted (az-1), kill T13-T15 dead-end manifests until UI ships (cr-3), fix cannibalization at standalone level (az-4), defer rest | 2-4 days elapsed, 1-2M tokens | Defends the ladder against immediate collapse | Doesn't defend against full Hormozi value-equation reframe; warnings accumulate |
+| **C. Pivot to top-3 highest-leverage CRITICAL fixes, ship as 3 surgical PRs, re-plan rest later** | (1) Fix products.ts upsellTier pointers + add IB/X-Ray inheritance of standalone data (az-4 fix). (2) Tier-gate the 4 orphan IBVariables slots BEFORE wiring (az-2 fix — delete cleanup PR). (3) Add 1 buyer-visible deliverable per tier T11-T15 collapsed into a single tier-render PR (az-3 fix). | 1 day, 200-500k tokens | Fastest defense of the ladder; minimal new code | Doesn't ship the audit framework or test suite; later worry will need to revisit |
+
+**Recommended (per Cascade rule + Bootstrap mode + Hormozi expert-decides):** Path C.
+
+Path C delivers the buyer-visible value step (Hormozi's main critique) without the multi-week test-infrastructure investment. Path A is the "right" engineering answer but burns weeks of token+wall-clock for a ladder that 3 surgical fixes can defend immediately. Path B is the worst of both — fixes the criticals but produces a passing test suite no buyer sees.
+
+**Open question for Rahim:** Path A vs B vs C? Or Path C with a Path B follow-up (audit framework as a separate worry next week)?

--- a/docs/plans/2026-04-25-worry-product-tier-data-audit.md
+++ b/docs/plans/2026-04-25-worry-product-tier-data-audit.md
@@ -1,0 +1,522 @@
+# Worry: Product Tier Data Audit + Tier-Integrity Enforcement
+
+**Date:** 2026-04-25
+**Slug:** product-tier-data-audit
+**Skill:** worry-to-pristine (auto-mode)
+**Status:** Phase 1 (Capture) complete; Phase 3 (Plan drafting) in flight
+
+## Worry (verbatim from Rahim)
+
+> Every paid product tier (Standalone SKUs, Playbook, Case Decoder, Intelligence Brief, X-Ray, War Room, Situation Room) may not be using the best available data we have, AND lower tiers may be matching or outperforming higher tiers in actual rendered output. We have massive data assets (jurisdiction_statutes 4.7k rows, statute_case_law, case_law_references, classified_opinions 33k+, judges 15k+, judge_quotes 15k+, USSC sentencing 27k vars, JUSTFAIR, federal docket cache, officer_external_intel, common_charges) but the generate-report Edge Function may not be wiring them all in, and tier inclusion logic may not be enforcing strict-monotonic value (every higher tier MUST include everything lower tiers get + more). Audit every product top-to-bottom in tier order (highest → lowest), document what data currently flows in, identify enhancement opportunities, and ship tier-integrity fixes. Auto-mode: do not gate on approval.
+
+## Triangulated Experts (Phase 2)
+
+| Domain | Expert | Source | Cache |
+|---|---|---|---|
+| Tier ladders + value equation + grand slam offers | **Alex Hormozi** | `~/.claude/experts/alex-hormozi.md` | HIT |
+| Multi-product positioning, tier differentiation | **April Dunford** | `~/.claude/experts/april-dunford.md` | HIT |
+| Cross-tier strategic coherence (CMO orchestration) | **Apex** | `apex` agent | HIT (agent) |
+
+All three .01% triangulated. Cache hit, no WebSearch needed. **Synthesis approach:** Hormozi defines the value-stack invariants (each tier's perceived value MUST justify the price step + ladder MUST be strict-monotonic), Dunford defines the differentiation per tier (each tier sells a different "use case for / against" narrative), Apex enforces cross-tier coherence (no silos, no internal contradictions).
+
+## Cascade Map (HARD RULE)
+
+| Node | Win |
+|---|---|
+| Us (Atlas/INAA) | Closes the cross-tier audit gap once and for all; produces a reusable inventory artifact |
+| Direct counterparty (paying defendants) | Higher-tier customers actually get more value than lower-tier; lower-tier customers stop accidentally getting "the good stuff" they didn't pay for; trust restored |
+| Their downstream (defense attorneys reading reports) | Reports reflect the full data depth we claim on the sales pages — attorneys treat us as serious infrastructure rather than "a glorified search wrapper" |
+| Ecosystem (legal-tech category) | Sets a public standard for tier-integrity in legal-data products (post-PR memo can be published) |
+| Future-us | Every new SKU added in the future inherits the strict-monotonic test; future seed pipelines know which tier they unlock |
+| Adjacent players (other defendant-side legal-tech) | Floor rises; competitors must either match or differentiate — both outcomes good |
+
+No node loses. Cascade-positive.
+
+## Out of Scope (do-not-touch list)
+
+Sibling sessions are actively working in these worktrees. **Do not edit files inside any of these.**
+- `_worktrees/test-pollution-{verify,polish,hotfix,work}` — test-isolation sweep
+- `oh-statutes-worktree` — OH statute seed Phase 2
+- `va-statutes-worktree` — VA statute seed Phase 2
+- `usc-v3-worktree` — USC seed expansion v3
+- `mandatory-fix-worktree` — already-merged PR #134, may be cleanup
+- `recap-cache-web` — federal docket cache
+- `score-r1-fixes` — score pipeline R1 fixes
+- `*bar-work` (ga, il, mi, oh) — bar-discipline ingest
+- `officer-bg-chicago-work` — NYPD CCRB depth
+- `pji-work` — CL bulk ingest scripts
+- `similar-cases-motion-join-work` — similar-cases motion join
+- `warroom-monthly-cron-work` — WR monthly precedent delta
+- `wave-pristine-r1-work` — wave pristine R1
+- `xray-pji-histogram-work` — XR PJI judge histogram
+- `fl-refresh-worktree` — FL refresh cron (already merged PR #120, may be stale)
+
+## Plan Structure
+
+### MAJOR Architectural Finding (read this first)
+
+The Phase 3 audit surfaced a structural reality that reshapes the entire enforcement strategy:
+
+**The Edge Function `supabase/functions/generate-report/index.ts` (7,671 lines) ONLY auto-generates Case Decoder + Intelligence Brief.** Tier branching happens in TWO places only — line 6631 (`tier === "fading"` — unrelated, citation-tier label) and line 7598 (`tier === "intelligence-brief"` — IB upgrade-link banner).
+
+X-Ray, War Room, and Situation Room are all in `tier_generation_config.mode='session'` since 2026-04-24 per zero-hallucination mandate (`ARCHITECTURE.md` row "Per-Tier Generation Mode" + `src/lib/report/mode-config.ts:38-129`). "session" means the operator writes the report by hand at `/api/admin/session-report/[caseId]/route.ts`. The dispatcher (`src/app/api/generate/case-decoder/route.ts:119`) flips the case directly to `awaiting-session-generation` and fires a Telegram handoff via `src/lib/report/dispatch-session.ts:38-63` — no automated generation runs.
+
+The `ImNotAnAttorney-engine` worker (`src/workers/report.mjs`) DOES still run a tier-aware Claude assembly (`tier === 'x-ray' | 'war_room' | 'situation_room'` branches at `report.mjs:30-57`, with `gatherAnalysisData` at `report.mjs:134-388` reading 41-worker outputs) — but the customer never sees it without operator review.
+
+**Implication:** "tier integrity" must be enforced on TWO surfaces, not one:
+
+1. **Data-pipeline surface** — what tables / queries each tier *can* pull (Edge Function for CD + IB; engine `gatherAnalysisData` for X-Ray/WR/SR; tier9-reports/generate.ts switch for Tier 9 standalones). This IS hookable and testable today.
+2. **Operator session-brief manifest** — what data sources the operator-session UI exposes per tier when writing X-Ray/WR/SR by hand. This is currently undefined; the plan must define it.
+
+Tier-integrity invariants below distinguish between these surfaces explicitly.
+
+---
+
+### Per-Tier Audit Inventory
+
+#### Tier 1 — Situation Room ($9,997)
+
+**Render path / generation mode:**
+- Mode resolution: `src/lib/report/mode-config.ts:47` (`DispatcherTierSlug` union excludes SR — no auto path), default fallback = `'session'`.
+- Operator session brief: `src/app/api/admin/session-report/[caseId]/route.ts` (operator writes by hand).
+- Engine internal assembly (operator reference, not customer-delivered): `ImNotAnAttorney-engine/src/workers/report.mjs:342-344` (`tier === 'situation_room'` adds attorney perspectives + urgency framing).
+- SR-specific tools (LIVE auto-paths within session mode):
+  - `src/app/api/generate/motion-drafts/route.ts:1-80` — `ALLOWED_TIERS = {x-ray, war-room, situation-room}` (motion-drafts available for all 3 senior tiers, gated 403 otherwise; line 44).
+  - `src/app/api/generate/trial-strategy-memo/route.ts:1-80` — same `ALLOWED_TIERS` set; line 27.
+
+**Sales-page promises** (`src/lib/tiers.ts:229-244`):
+- "All deliverables ship within 24-48 hours per stage. Trial Intelligence Operations activate when trial begins."
+- `requiresWarRoom: true` (must own WR first).
+- `includesTiers: ["case-decoder", "intelligence-brief", "x-ray", "war-room"]`.
+- ARCHITECTURE.md line 254 promises Tier 9 additions: "co-defendant divergence, plea discount modeling".
+
+**Data tables currently read** (verifiable via grep against engine `report.mjs:gatherAnalysisData` + the SR-only motion/trial-memo tools):
+- All War Room tables (see WR row).
+- `case_motions` (full motion drafts via `case_motions` join, `report.mjs:298`).
+- `attorney_perspectives` (assumed from `report.mjs:342-344` urgency branch — verify in T2).
+- `trial_materials` (cross-exam scripts, voir dire, closing themes per ARCHITECTURE.md line 247).
+- `IBVariables.codefendant_divergence_summary` + `IBVariables.plea_discount_curve_summary` slots EXIST in `src/lib/intelligence-brief/variables.ts:171-172` BUT — and this is critical — these fields are passed through IB Phase A/B, NOT Situation Room. **Tier-integrity violation candidate: SR-tier additive Tier 9 data is shaped to be poured into IB's $997 prompt, not into the SR session brief.**
+
+**Concrete data assets NOT currently used by SR session brief** (enhancement opportunities):
+- `co_defendant_analysis` table (Tier 9 angle 8 per ARCHITECTURE.md:235): no grep hit in `engine/src/workers/*.mjs` other than the dedicated `cross-case-aggregator.mjs` — verify in T2.
+- `plea_discount_curves` table (Tier 9 angle 9): same — verify.
+- `bench_jury_divergence` table (currently War Room+ promise per ARCHITECTURE.md:253): need to confirm SR inherits.
+- `recap_dockets` (federal docket cache — name TBD pending sibling worktree `recap-cache-web` per worry-doc do-not-touch list): not surfaced in either auto path.
+
+**Tier-integrity violations (suspected, T2 verifies):**
+- SR includes nothing from Tier 9 unless the operator manually pulls — no system enforces "every Tier-9 table promised in ARCHITECTURE.md:254 actually appears in the operator session-brief manifest."
+- The SR `includesTiers` chain produces 5 cases (CD + IB + X-Ray + WR + SR) per webhook — but the SR primary case still routes through `awaiting-session-generation`, so the customer perceives 4 fast deliverables (CD/IB ship via auto path, then 1 long wait for the bundle plus SR session brief). Tier 9 surface must verify each included case actually fires its own auto path.
+
+---
+
+#### Tier 2 — War Room ($4,997)
+
+**Render path / generation mode:**
+- Same as SR: `mode='session'`, operator-written. `mode-config.ts:47` excludes WR from auto path.
+- Engine internal assembly: `report.mjs:212-220` (`tier === 'war_room' || tier === 'situation_room'` branch), `report.mjs:232-309` (full Phase 5 case_law_references join with `verified_case_law(confidence_tier, is_good_law, verification_url, verification_urls, holding_validation, age_status, negative_treatment)` — confidence-tier classification logic at lines 261-275).
+- WR-specific cron: `worktrees/warroom-monthly-cron-work` (DO-NOT-TOUCH per worry-doc; warroom monthly precedent delta).
+- `src/lib/tier9-reports/warroom-precedent-delta.ts` exists (per `Glob src/lib/tier9-reports/*.ts`) with test at `src/lib/tier9-reports/__tests__/warroom-precedent-delta.test.ts`.
+
+**Sales-page promises** (`tiers.ts:213-228`):
+- "25-28 days + weekly updates" / "Weekly updates begin immediately after initial delivery."
+- `includesTiers: ["case-decoder", "intelligence-brief", "x-ray"]`.
+- ARCHITECTURE.md:253: "judge-prosecutor pairing, bench/jury divergence, similar-case matching".
+
+**Data tables currently read:**
+- All X-Ray tables (see X-Ray row).
+- `case_law_references` ⨯ `verified_case_law` (full join with confidence-tier logic, `report.mjs:236`).
+- `case_motions` (full motion drafts, `report.mjs:298+`).
+- `prosecution_counter_predictions` (per `engine/src/workers/prosecution-counter-prediction.mjs` — verify whether report.mjs reads it for WR+).
+- `trap_tracks` (per `trap-track-assignment.mjs` worker — verify).
+- `wave_plans` (per `wave-coordination.mjs` worker — verify).
+- `witness_dossiers` (per `witness-dossier.mjs` + `witness-dossier-p2.mjs` workers — verify).
+- `judge_prosecutor_pairings`, `bench_jury_divergence`, `case_feature_vectors` — promised in ARCHITECTURE.md but NOT verified in `report.mjs` grep yet (T3 task).
+- WR monthly precedent delta cron uses `citation_velocity_criminal` table.
+
+**Concrete data assets NOT currently used:**
+- `IBVariables.pairing_matrix_summary`, `IBVariables.bench_jury_divergence_summary`, `IBVariables.similar_case_matches` slots exist (`variables.ts:166-168`) — but they're injected into IB Phase A/B (`prompts.ts:168-172, 263-267, 377-381`), NOT into a WR-specific assembly. Same pattern as SR: Tier-9 War-Room data pours into the $997 product, not the $4,997.
+- `appellate_trends` table (Tier 9 angle 7): exists, no grep hit in `report.mjs` (verify in T3).
+
+**Tier-integrity violations (suspected):**
+- Same operator-session-manifest gap as SR.
+- WR's "weekly updates" cadence is enforced by `worktrees/warroom-monthly-cron-work` (do-not-touch); existence of cron registration + `RisingPrecedentRow`-class data flow must be probed without editing the worktree (read-only via Grep).
+
+---
+
+#### Tier 3 — X-Ray ($2,497)
+
+**Render path / generation mode:**
+- Same `mode='session'`. Operator writes by hand.
+- Engine internal assembly: `report.mjs:53-54` (`tier === 'x-ray'` branch — "Discovery findings, red flags, targeted questions, timeline, evidence, judge/prosecutor intelligence summary, motion recommendations (summary only — do NOT include full motion drafts). Case law: cite top references only").
+- Engine `gatherAnalysisData`:
+  - `report.mjs:144-160` (case_intelligence with tier-disclosure filter for `'x-ray' || 'intelligence-brief'`).
+  - `report.mjs:193-211` (Phase 4 intelligence — "all tiers ≥ x-ray").
+  - `report.mjs:221-230` (Phase 5 partial — `LIMIT 10` for x-ray vs `LIMIT 50` for war-room+).
+- X-Ray-only auto-render sections (LIVE — added by E2): `src/app/api/generate/xray-sections/route.ts:1-80`:
+  - X1: Federal PJI Cross-Reference (`src/lib/xray-sections/federal-pji-cross-ref.ts`).
+  - X2: Full Judge Motion Histogram (`src/lib/xray-sections/judge-motion-histogram.ts`).
+- X-Ray sibling (DO-NOT-TOUCH per worry-doc): `xray-pji-histogram-work` worktree.
+
+**Sales-page promises** (`tiers.ts:197-212`):
+- "10 business days" delivery.
+- `requiresDiscovery: true`.
+- `includesTiers: ["case-decoder", "intelligence-brief"]`.
+- ARCHITECTURE.md:252: "sentencing outliers, officer reliability".
+
+**Data tables currently read:**
+- All IB tables (via included IB case).
+- `case_intelligence` (filtered on disclosure_level + verified rows, `report.mjs:162-176`).
+- `trial_materials` (`report.mjs:178-191`, all tiers).
+- `intelligence_findings` (Phase 4, `report.mjs:193-211`).
+- `motion_recommendations` (`report.mjs:221-230`, top 10 for x-ray).
+- `case_law_references` (no `verified_case_law` join for X-Ray — engine reads top refs only — `report.mjs:53` "case law: cite top references only").
+- `judge_intelligence` (per `engine/src/workers/judge-intelligence.mjs` — verify in T4).
+- `prosecutor_research` (per `engine/src/workers/prosecutor-research.mjs` — verify).
+- X-Ray-specific via xray-sections: `pattern_jury_instructions` (X1) + `judge_profiles` motion histogram (X2).
+
+**Concrete data assets NOT currently used:**
+- `sentencing_distributions` Tier-9 outlier flagging promised in ARCHITECTURE.md:252: `IBVariables.sentencing_outlier_flags` slot exists at `variables.ts:162` — wired only into IB Phase A/B (`prompts.ts:488-492`). **Same Tier-9-flows-into-IB-not-X-Ray pattern.**
+- `officer_reliability` table promised in ARCHITECTURE.md:252: `IBVariables.officer_reliability_crosscase` slot exists at `variables.ts:163` — unused in `prompts.ts` grep. **Verifiable orphan slot.**
+
+**Tier-integrity violations (suspected):**
+- Tier 9 "X-Ray adds: sentencing outliers, officer reliability" (ARCHITECTURE.md:252) is contradicted by code: the sentencing-outlier slot only renders inside IB; the officer-reliability slot is dead code in `variables.ts`. Either the spec is wrong or the wiring is missing — a tier-integrity test forces resolution.
+
+---
+
+#### Tier 4 — Intelligence Brief ($997)
+
+**Render path / generation mode:**
+- Mode resolution: `mode-config.ts:47` includes `'intelligence-brief'`. Per ARCHITECTURE.md line 58: "CD + IB + X-Ray + War Room + Situation Room flipped to `session` 2026-04-24". So IB is also session-mode now (auto path is dormant but still ships in `generate-report/index.ts`).
+- Auto path (when mode flips back):
+  - Phase A: `generate-report/index.ts:4530-4732` (`handleIBPhaseA` — 5 parallel calls).
+  - Phase B: `generate-report/index.ts:4734-5130` (`handleIBPhaseB` — 4 sequential calls including Appendix F via `buildTier9DataAppendix`).
+  - Variables: `src/lib/intelligence-brief/variables.ts` (~250 lines).
+  - Prompts: `src/lib/intelligence-brief/prompts.ts` — 9 builders + `PHASE_B_BUILDERS` array at line 1192 includes 4 entries ending with `buildTier9DataAppendix` (Appendix F).
+  - Render: `src/lib/intelligence-brief/render.ts` (HTML).
+- IB judge-research staging: `src/app/api/generate/intelligence-brief/judge-research/route.ts`.
+- IB intake handoff: 2-phase intake per ARCHITECTURE.md:213.
+
+**Sales-page promises** (`tiers.ts:182-196`):
+- "72 hours" total.
+- `includesTiers: ["case-decoder"]`.
+- ARCHITECTURE.md:255: baseline upgrades = "judge quotes, appeal correlations".
+
+**Data tables currently read** (auto path — when mode='api'):
+- All CD tables (via included CD case).
+- IB Phase A/B injects:
+  - `judge_demographics` + `sentencing_distributions` + `outcome_benchmarks` (JUSTFAIR, federal-judge-only) — `generate-report/index.ts:4611-4634, 4815-4847`.
+  - `charge_type_top_authorities` — `generate-report/index.ts:5517, 6264, 6495` (Appendices G + H + Live Authority Map).
+  - `citation_velocity_criminal` — Appendix G/H rising precedents.
+  - `judge_profiles` — appellate-motion-authored pattern, `generate-report/index.ts:5904`.
+  - `entities_judges` — disambiguation, `generate-report/index.ts:6221`.
+  - `federal_sentencing_distributions` — `generate-report/index.ts:5774`.
+  - `pattern_jury_instructions` (federal PJI cascade).
+- IB Tier-9 data slots wired into `prompts.ts`:
+  - `bench_jury_divergence_summary` (line 168).
+  - `similar_case_matches` (line 263).
+  - `pairing_matrix_summary` (line 377).
+  - `sentencing_outlier_flags` (line 488).
+  - `judge_quote_library` + `appellate_trends_summary` (lines 743+749).
+- Defense intelligence: `src/lib/defense-intelligence/query.ts:queryDefenseIntelligence` (called from `generate-report/index.ts` at `fetchDefenseIntelligenceForIB` line 5271).
+
+**Concrete data assets NOT currently used:**
+- `co_defendant_analysis`, `plea_discount_curves` — slots `codefendant_divergence_summary` + `plea_discount_curve_summary` exist at `variables.ts:171-172` BUT are documented as "Tier 9, Situation Room" only and have NO grep hit in `prompts.ts`. Either wire them in (and re-tier them) or delete the orphan slots.
+- `officer_reliability_crosscase` slot (`variables.ts:163`) — unwired.
+- `jurisdiction_courts` — only used for IB Section 5 court inventory (verify in T5).
+
+**Tier-integrity violations:**
+- IB pulls in Tier-9 data that ARCHITECTURE.md promises only at WR / SR levels (the `pairing_matrix_summary`, `bench_jury_divergence_summary`, `similar_case_matches`). Either ARCHITECTURE.md is wrong, the gates inside `prompts.ts` (`v.pairing_matrix_summary ? ...` ternaries at lines 168/263/377) are missing tier checks, or — most likely — the slot is supposed to be tier-conditional but `extractVariables` populates it for IB. **One auto-graded test will resolve this.**
+
+---
+
+#### Tier 5 — Case Decoder ($197)
+
+**Render path / generation mode:**
+- Same `'session'` mode flip 2026-04-24 (ARCHITECTURE.md:58).
+- Auto path (when flipped back to `'api'`):
+  - `src/app/api/generate/case-decoder/route.ts:51-119` (dispatcher, fire-and-forget to Edge Function).
+  - `generate-report/index.ts:2908-3725` (`buildUserPrompt`).
+  - `generate-report/index.ts:3726-3798` (`callClaudeAPI` — Opus extended thinking).
+
+**Sales-page promises** (`tiers.ts:167-181`):
+- "48 hours" / priority "Same-day (4 hours)".
+- `includesTiers: []` (no inclusion).
+
+**Data tables currently read** (`generate-report/index.ts`):
+- `cases` + `intakes` (via `supabaseSelect` calls, lines 2908+).
+- `charge_types` + `experts` (`getChargeContext`, line 2103).
+- `jurisdiction_statutes` (line 2130, 2581) — strategic enrichment 2026-04-07.
+- `case_law_references` (line 2563, pre_research only).
+- `statute_case_law` (fallback, line 2591, joined via charge_slug + jurisdiction).
+- `wex_definitions` (per code comment line 2521).
+- `judge_profiles` (line 2624 — only when judge name provided, but CD intake doesn't always have one).
+- `sentencing_distributions` + `outcome_benchmarks` (JUSTFAIR sentencing context, lines 2944-2955).
+- `entities_statutes` (Phase 2 cite-tag whitelist).
+- `v_entity_confidence` matview (Phase 2 verification badges).
+- `defendant_profile` + `case_intelligence` (via `fetchDefendantProfileBlock` + `fetchCaseIntelligenceBlock`, lines 2746+2833).
+
+**Concrete data assets NOT currently used:**
+- `judge_quotes` (15K+ rows per worry doc). Promised at "all tiers" in ARCHITECTURE.md:255 ("baseline upgrades — judge quotes"). NO grep hit in CD code path. **Verifiable miss.**
+- `classified_opinions` (33K+ rows) — only used downstream of `classify-case-law.mjs` script. CD reads from the projected `case_law_references` / `statute_case_law` tables, never directly from `classified_opinions`.
+- `officer_external_intel` — only Tier 9 (Officer Background Check) reads this.
+- `common_charges` — verify usage; suspected dead in CD path.
+- `appellate_trends` — promised baseline ARCHITECTURE.md:255, no grep hit.
+
+**Tier-integrity violations:**
+- "Baseline upgrades (all tiers): judge quotes, appeal correlations" (ARCHITECTURE.md:255) is provably violated for CD + IB. Either drop the "all tiers" claim or wire judge_quotes + appellate_trends into CD prompt.
+
+---
+
+#### Tier 6 — Playbook ($127–$147)
+
+**Render path:**
+- Pure copy-driven static MDX-style render via `src/lib/playbook-configs.ts` (8 configs, ~100 lines/config schema at lines 14-89). Single component `PlaybookSalesPage` consumes a `PlaybookConfig`.
+- Delivered as PDF via `download_token`; no DB-backed personalization per buyer.
+
+**Sales-page promises** (`tiers.ts:33-166`, 8 entries — `dui-first-offense`, `drug-possession`, `probation-violation`, `white-collar`, `sex-offense`, `federal-criminal`, `drug-trafficking`, `self-defense`):
+- "Instant download" / "Your playbook is delivered instantly to your email after purchase."
+- `includesTiers: []`.
+- `live: true` for all 8.
+
+**Data tables read:** NONE. This is static copy.
+
+**Tier-integrity question:** Playbook's value-stack must NOT exceed Case Decoder's per Hormozi monotonicity. Currently a $127 playbook has:
+- 26 questions + breathalyzer checklist + case stage roadmap + red flag checklist + attorney scorecard (per `tiers.ts:97`).
+- Static reference content.
+
+CD ($197) must offer MORE than playbook → MORE means: personalized to actual case facts, statute_case_law for that defendant's jurisdiction, judge profile when available, JUSTFAIR sentencing context, charge_specific_data rendering. T6 verifies this is true via test fixture comparing CD output for a synthetic case vs the playbook PDF for the same charge.
+
+---
+
+#### Tier 7 — Standalone SKUs ($47–$497)
+
+**Render path:**
+- All Tier-9 data-driven SKUs route through `src/lib/tier9-reports/generate.ts:97-557` (switch statement on `slug` at lines 145-477).
+- Other standalones (research products $97–$497) route through `src/app/api/generate/standalone/route.ts` (separate path — uses Claude API, NOT Tier-9 tables).
+
+**Active data-driven SKUs** (per `tier9-reports/generate.ts` switch, with table dependencies):
+| SKU | Price | Tables read |
+|---|---|---|
+| `judge-report-card` | $197 | `queryJudgeReportCard` + `queryDefenseIntelligence` + `queryJustfairJudge` + `querySentencingFingerprint` (lines 146-183) |
+| `officer-background-check` | $97 | `queryOfficerBackground` (line 185-200; reads cross-case from CL classified opinions) |
+| `similar-cases-analyzer` | $297 | `querySimilarCases` + `queryDefenseIntelligence` + USSC matview augmentation `queryBucket`/`queryDistrictDisplay` (lines 202-272) |
+| `district-court-intelligence` (Courthouse $147) | $147 | `queryCourthouseIntelligence` (line 274-297) |
+| `federal-sentencing-distribution` | $297 | `queryDistribution` + `queryDistrictDisplay` (line 299-356) |
+| `motion-success-report` | $197 | `queryMotionSuccessReport` (line 358-375) |
+| `arrest-survival-kit` | $47 | `queryArrestSurvivalKit` (line 377-385) |
+| `federal-jury-instruction-brief` | $97 | `queryFederalJuryBrief` (line 387-414, federal-only gate) |
+| `precedent-watchlist` | $47 | `queryPrecedentWatchlist` + `buildVelocitySnapshot` + 30-day drip seed (line 416-458) |
+| `charge-authority-pack` | $97 | `queryChargeAuthorityPack` (line 460-476) |
+
+**Tier-integrity questions for standalones:**
+- A buyer who buys 4 standalones for ~$641 (judge-report-card + officer-bg + similar-cases + courthouse) gets MORE distinct table coverage than the Case Decoder $197 buyer. By Hormozi's value-stack rule that's fine (because they paid 3.3× more), but the X-Ray buyer at $2,497 should ALSO get all of this PLUS more — and currently doesn't unless the operator manually pulls these queries during the session brief.
+
+---
+
+### Data Asset Inventory
+
+> Row counts are READ-ONLY: do NOT execute writes. Use `psql -c "SELECT count(*) FROM <table>"` or PostgREST `?select=count` head request.
+
+| Table | Suggested probe | Used by tiers (verified file:line) | Bound into auto path? |
+|---|---|---|---|
+| `jurisdiction_statutes` | `?select=count` HEAD | CD (`generate-report/index.ts:2130, 2581`); IB transitively via Appendix G/H | Yes (CD + IB) |
+| `statute_case_law` | same | CD (`generate-report/index.ts:2591`) | Yes (CD only) |
+| `case_law_references` | same | CD (`index.ts:2563`); IB Phase A/B; engine WR/SR (`report.mjs:236`) | Yes |
+| `verified_case_law` (join target) | same | engine WR/SR only (`report.mjs:236`) | Engine-only |
+| `classified_opinions` | same | Tier 9 standalones only (officer-bg, motion-success, similar-cases) | NO for CD/IB |
+| `judges` | same | Indirectly via `judge_profiles`; `judge_demographics` for federal | Partial |
+| `judge_quotes` | same | NOT FOUND in CD/IB grep — `IBVariables.judge_quote_library` slot exists but no fetch wiring | ORPHAN slot |
+| `judge_profiles` | same | CD (`index.ts:2624` conditional); IB (`index.ts:5904`); X-Ray X2 histogram | Yes |
+| `judge_demographics` | same | CD JUSTFAIR (`index.ts:2944`); IB Phase A/B (`index.ts:4611, 4815`) | Yes |
+| `judge_sentencing_demographics` | same | (Verify — not grepped yet) | Unknown |
+| `officer_external_intel` | same | Tier 9 `arrest-survival-kit` + `officer-background-check` | Tier 9 only |
+| `common_charges` | same | (Verify — suspected unused in tier paths) | Unknown |
+| `jurisdiction_courts` | same | (Verify in T5) | Unknown |
+| `entities_statutes` | same | Phase 2 cite-tag whitelist (CD + IB) | Yes |
+| `entities_judges` | same | IB disambiguation (`index.ts:6221`) | Yes (IB) |
+| `sentencing_distributions` | same | CD JUSTFAIR; IB Phase A/B | Yes |
+| `outcome_benchmarks` | same | CD JUSTFAIR; IB Phase A/B | Yes |
+| `federal_sentencing_distributions` | same | IB (`index.ts:5774`); Tier-9 FSD SKU | Yes |
+| `charge_type_top_authorities` | same | IB Appendix G/H/Live Authority Map (`index.ts:5517, 6264, 6495`); Tier-9 `charge-authority-pack` | Yes (IB + Tier 9) |
+| `citation_velocity_criminal` | same | IB Appendix G/H; Tier-9 `precedent-watchlist`; WR monthly cron | Yes |
+| `judge_prosecutor_pairings` | same | `IBVariables.pairing_matrix_summary` slot — verify whether `extractVariables` populates it | Partial |
+| `case_feature_vectors` | same | Tier-9 `similar-cases-analyzer` only | Tier 9 only |
+| `bench_jury_divergence` | same | `IBVariables.bench_jury_divergence_summary` slot — verify | Partial |
+| `officer_reliability` | same | `IBVariables.officer_reliability_crosscase` slot — UNWIRED | ORPHAN slot |
+| `appellate_trends` | same | NO grep hit in `prompts.ts` despite `IBVariables.appellate_trends_summary` slot | ORPHAN slot |
+| `co_defendant_analysis` | same | `IBVariables.codefendant_divergence_summary` slot — UNWIRED | ORPHAN slot |
+| `plea_discount_curves` | same | `IBVariables.plea_discount_curve_summary` slot — UNWIRED | ORPHAN slot |
+| `pattern_jury_instructions` | same | X-Ray X1 (`xray-sections/federal-pji-cross-ref.ts`); IB (PJI cascade) | Yes |
+| `recap_dockets` (federal docket cache, name TBD) | same | Sibling worktree `recap-cache-web` (do-not-touch) — read-only verify table name in T2 | Sibling work |
+| `v_entity_confidence` matview | same | Phase 2 cite-tag verification (CD + IB report HTML transform) | Yes |
+| `cases` | n/a | All tiers | Yes |
+| `intakes` | n/a | All tiers | Yes |
+| `processing_jobs` | n/a | Engine-side only (X-Ray/WR/SR) | Engine |
+| `score_aggregates` | n/a | Score quiz (free), not tier-paid | n/a |
+| `defendant_profile` | n/a | CD (`fetchDefendantProfileBlock`, `index.ts:2746`); IB | Yes |
+| `case_intelligence` | n/a | CD; X-Ray (engine `report.mjs:144-176`) | Yes |
+| `trial_materials` | n/a | All engine tiers (`report.mjs:178-191`) | Yes |
+| `intelligence_findings` (Phase 4) | n/a | X-Ray+ engine path (`report.mjs:193-211`) | Yes |
+| `motion_recommendations` | n/a | X-Ray (top 10) + WR/SR (top 50) per `report.mjs:221-230` | Yes |
+| `case_motions` | n/a | WR/SR only — full motion drafts (`report.mjs:298+`) | Yes |
+| `motion_drafts_*` (live LLM-generated) | n/a | `/api/generate/motion-drafts/route.ts` for X-Ray/WR/SR | Yes (LIVE) |
+| `trial_strategy_memo` (live LLM-generated) | n/a | `/api/generate/trial-strategy-memo/route.ts` for X-Ray/WR/SR | Yes (LIVE) |
+
+**Net new findings:**
+- 4 ORPHAN slots in `IBVariables`: `judge_quote_library`, `officer_reliability_crosscase`, `codefendant_divergence_summary`, `plea_discount_curve_summary`. Either delete or wire.
+- `appellate_trends_summary` slot also suspected orphan — verify in T5.
+- 5 promised "all-tiers baseline" data assets (per ARCHITECTURE.md:255) NOT in CD path: judge_quotes, appellate_trends.
+
+---
+
+### Tier-Integrity Invariants (Hormozi value-equation grounded)
+
+Citation: `~/.claude/experts/alex-hormozi.md` — "Value Equation: Dream Outcome × Likelihood ÷ (Time × Effort). Each tier in a ladder MUST monotonically increase value and the higher tier MUST include everything lower tiers offer plus meaningful new value, or the buyer perceives the higher tier as a tax."
+
+**INV-1 (Inclusion-superset):** For every tier T and its `includesTiers` chain, the union of data tables read by T's auto path + included-case auto paths MUST be a superset of any single included tier's data tables. Operationalized as: `dataSourcesFor(T) ⊇ dataSourcesFor(T_included_i)` for every i. **Why Hormozi:** if SR doesn't strictly include WR, the buyer's $5,000 step-up has zero verifiable Dream Outcome lift.
+
+**INV-2 (Strict-monotonic distinct-source count, paid tiers ≥ Case Decoder):** Distinct named data tables read MUST monotonically increase across the upgrade path: CD ≤ IB ≤ X-Ray ≤ WR ≤ SR. Operationalized as integer counter from a static analyzer over the auto-path code. **Why Hormozi:** monotonic value lift is the single most-violated grand-slam-offer rule when tiers are added incrementally.
+
+**INV-3 (Promised-data parity):** Every data asset claimed in ARCHITECTURE.md (lines 250-263 + 320-322) for tier T MUST appear in T's render path OR T's session-brief manifest. Source of truth = `ARCHITECTURE.md`. **Why Hormozi:** Likelihood (verification confidence) collapses if marketing copy promises data the report doesn't deliver.
+
+**INV-4 (No-orphan-slots):** Every typed field in `IBVariables` interface MUST either be (a) populated by a code path in `extractVariables`/`handleIBPhaseA`/`handleIBPhaseB`, or (b) deleted. Found 4–5 orphans during this audit. **Why Hormozi:** dead slots = future contractor sees the slot, assumes the data flows, builds downstream against ghosts → Effort goes UP, Likelihood DOWN.
+
+**INV-5 (Tier-conditional data gates):** When a data slot is gated for tier ≥ X (per ARCHITECTURE.md), the populating code path MUST guard on `tier >= X` (or equivalent inclusion check). Currently several Tier-9 slots ride into IB without a guard. Either re-tier the spec or add the guard. **Why Hormozi:** if IB ($997) ships SR-only data, SR ($9,997) is no longer differentiated → ladder collapses to a single product and CRO model breaks.
+
+**INV-6 (Standalone-vs-tier coverage):** A buyer who purchases standalone Tier-9 SKUs covering domain D MUST NOT receive richer D-domain data than a higher-paid main-tier buyer would receive for the same case. (E.g., judge-report-card $197 buyer must not get more judge data than IB $997 buyer.) **Why Hormozi:** product-line cannibalization rule — when a $197 SKU outperforms the $997 product on its own dimension, the $997 buyer rationally regrets.
+
+**INV-7 (Operator session-brief manifest parity):** When a tier is in `mode='session'` (currently CD/IB/X-Ray/WR/SR per ARCHITECTURE.md:58), the operator session UI MUST surface every data table promised by INV-3 for that tier. **Why Hormozi:** a $9,997 SR buyer can't tell if Time/Effort dropped by 80% if the operator has to manually remember which 23 tables to query.
+
+**INV-8 (No-hallucinated-legal-data — every cited row sourced):** All legal claims rendered MUST trace to `source_urls[]`-bearing rows (per `~/.claude/rules/no-hallucinated-legal-data.md`). Already enforced in PR #115 entity-whitelist filter — codify as a tier-integrity test that fails if any cite-tag in a tier's output points to a row with empty `source_urls`. **Why Hormozi:** Likelihood goes to zero if a citation is fabricated; entire ladder collapses.
+
+---
+
+### Numbered Tasks
+
+Each task is GRADEABLE: binary done-iff condition stated. Tasks 2–9 are read-only audits (no PR per task — they feed the audit artifact). Tasks 10–17 are PRs.
+
+**Dependency order:** T1 → T2 → ... → T9 → T10 → T11–T17 (T11–T17 can ship in parallel after T10 lands).
+
+#### T1 — Build the tier-integrity invariant test suite (Vitest)
+- **Files:** `src/lib/tiers/__tests__/tier-integrity.test.ts` (new); `src/lib/tiers/tier-data-manifest.ts` (new — declarative source of truth describing which tables each tier surfaces).
+- **Blast radius:** 2 new files, no existing-file edits.
+- **Done iff:** `npm test -- tier-integrity` exits 0 AND the test file contains 8 `describe()` blocks named `INV-1`..`INV-8` AND each describe contains ≥1 `it()` that asserts the invariant against the new manifest. Initial run can have failing assertions (red tests document gaps); test FILE existence + structure is the gate.
+- **PR count:** 1.
+- **Depends on:** none.
+
+#### T2 — Audit Situation Room
+- **Files (read-only):** `ImNotAnAttorney-engine/src/workers/report.mjs`, `src/app/api/generate/motion-drafts/route.ts`, `src/app/api/generate/trial-strategy-memo/route.ts`, `src/app/api/admin/session-report/[caseId]/route.ts`, all `src/lib/tier9-reports/warroom-precedent-delta.ts` (read sibling-worktree headers ONLY for table name confirmation; do NOT edit).
+- **Blast radius:** appends T2 section to a NEW audit artifact at `docs/plans/2026-04-25-worry-product-tier-data-audit-artifact.md`.
+- **Done iff:** artifact contains a "Situation Room" section listing every table SR's auto+session paths read (verified via Grep in this repo + engine repo) AND every table SR is *promised* (per ARCHITECTURE.md lines 250-263) AND the diff (promised − actual) named explicitly.
+- **PR count:** 0 (audit only).
+- **Depends on:** T1.
+
+#### T3 — Audit War Room (same shape as T2)
+- **Done iff:** artifact contains "War Room" section with promised vs actual table inventory + diff.
+- **PR count:** 0. **Depends on:** T2.
+
+#### T4 — Audit X-Ray (same shape, includes engine `report.mjs` x-ray branch + xray-sections + tier 9 `coverage.ts:queryArrestSurvivalKit` if shared)
+- **Done iff:** artifact contains "X-Ray" section with the same shape AND an explicit verdict on whether `IBVariables.sentencing_outlier_flags` and `IBVariables.officer_reliability_crosscase` orphans should ship to X-Ray render path or be deleted.
+- **PR count:** 0. **Depends on:** T3.
+
+#### T5 — Audit Intelligence Brief
+- **Done iff:** artifact contains "Intelligence Brief" section with: full Phase A + Phase B fetch inventory, every IBVariables slot mapped to either a populating code path or marked ORPHAN, and a verdict on whether each IB-tier Tier 9 slot should be gated by tier (INV-5).
+- **PR count:** 0. **Depends on:** T4.
+
+#### T6 — Audit Case Decoder
+- **Done iff:** artifact contains "Case Decoder" section listing every fetch in `buildUserPrompt`, `fetchLegalResearchData`, `fetchDefendantProfileBlock`, `fetchCaseIntelligenceBlock` AND a verdict on whether `judge_quotes` + `appellate_trends` baseline-promise gap should be patched in CD or the promise downgraded in ARCHITECTURE.md.
+- **PR count:** 0. **Depends on:** T5.
+
+#### T7 — Audit Playbook static configs
+- **Files (read-only):** `src/lib/playbook-configs.ts`, all 8 `playbook-configs.ts`-referenced exports.
+- **Done iff:** artifact contains "Playbook" section confirming zero DB reads AND a documented value-stack delta proving why $197 CD strictly outperforms $147 playbook on Hormozi's 4 dimensions (with specific table citations).
+- **PR count:** 0. **Depends on:** T6.
+
+#### T8 — Audit Standalone SKUs (Tier 9 + research products)
+- **Done iff:** artifact contains a table per active SKU: name, price, render path, table dependencies. AND a verdict per SKU on whether it overlaps with a higher-tier promise without that higher tier inheriting the data (INV-6).
+- **PR count:** 0. **Depends on:** T7.
+
+#### T9 — Compile findings into tier-integrity manifest
+- **Files:** `src/lib/tiers/tier-data-manifest.ts` (the file created in T1 — populate with concrete arrays per tier of: required tables, optional tables, promised tables, missing tables).
+- **Done iff:** running `npm test -- tier-integrity` shows the per-invariant pass/fail counts AND every failure has a corresponding row in T9 (no surprises). Failing assertions are EXPECTED at this stage; the gate is COMPLETENESS.
+- **PR count:** 1.
+- **Depends on:** T8.
+
+#### T10 — Wire orphan IBVariables slots OR delete (the cleanup PR)
+- **Files:** `src/lib/intelligence-brief/variables.ts`, `src/lib/intelligence-brief/prompts.ts`, `supabase/functions/generate-report/index.ts` (only the Phase A/B helpers, not the global SYSTEM_PROMPT).
+- **Decision per orphan (per T5 verdicts):** wire OR delete. No "leave-for-later" allowed.
+- **Done iff:** every interface field in `IBVariables` has either a populating fetch in Phase A/B OR is removed from the interface. Re-run T1 test suite — INV-4 must now PASS.
+- **PR count:** 1.
+- **Depends on:** T9.
+
+#### T11 — Tier-integrity enforcement: Case Decoder boundary (PR per integrity boundary)
+- **Files:** `src/lib/tiers/__tests__/tier-integrity.test.ts` (extend), `supabase/functions/generate-report/index.ts` (only `buildUserPrompt` if a fetch needs adding for judge_quotes / appellate_trends per T6 verdict), `ARCHITECTURE.md` (downgrade promise if T6 verdict was "remove from spec").
+- **Done iff:** INV-1 + INV-2 + INV-3 PASS for the CD boundary AND no other invariant regresses.
+- **PR count:** 1. **Depends on:** T10.
+
+#### T12 — Tier-integrity enforcement: Intelligence Brief boundary
+- Same shape; targets IB boundary. Files: `src/lib/intelligence-brief/prompts.ts` (add tier-conditional gates per INV-5), `tier-integrity.test.ts`, possibly `ARCHITECTURE.md`.
+- **Done iff:** INV-1+2+3+5 PASS for IB.
+- **PR count:** 1. **Depends on:** T11.
+
+#### T13 — Tier-integrity enforcement: X-Ray boundary
+- Surface a manifest of what `/api/generate/xray-sections` exposes plus what the engine `report.mjs` x-ray branch reads. Add a session-brief-manifest fixture that codifies INV-7 for X-Ray.
+- **Files:** `src/lib/tiers/x-ray-session-manifest.ts` (new), `tier-integrity.test.ts`, possibly minor edit to `xray-sections/*.ts` if T4 found a missing fetch.
+- **Done iff:** INV-1+2+3+5+7 PASS for X-Ray.
+- **PR count:** 1. **Depends on:** T12.
+
+#### T14 — Tier-integrity enforcement: War Room boundary
+- Same shape. Adds `src/lib/tiers/war-room-session-manifest.ts`.
+- **Done iff:** INV-1+2+3+5+7 PASS for WR.
+- **PR count:** 1. **Depends on:** T13.
+
+#### T15 — Tier-integrity enforcement: Situation Room boundary
+- Same shape. Adds `src/lib/tiers/situation-room-session-manifest.ts`.
+- **Done iff:** INV-1+2+3+5+7 PASS for SR.
+- **PR count:** 1. **Depends on:** T14.
+
+#### T16 — Standalone-vs-tier coverage enforcement (INV-6)
+- **Files:** `src/lib/tiers/__tests__/tier-integrity.test.ts` (extend), the affected standalone OR the affected tier's manifest entry — pick one per overlap surfaced in T8.
+- **Done iff:** INV-6 PASSES for every standalone SKU active per `STANDALONE_PRODUCTS` (`src/lib/products.ts`).
+- **PR count:** 1. **Depends on:** T15.
+
+#### T17 — Verification-URL enforcement test for tier-paid output (INV-8)
+- **Files:** `src/lib/tiers/__tests__/tier-integrity-no-hallucinated.test.ts` (new), reusing `entity-whitelist.ts` already shipped in PR #115. Test asserts a render-time fixture for each tier filters out cite tags pointing to rows with empty `source_urls`.
+- **Done iff:** INV-8 PASSES per tier in test runner; existing PR #115 entity-whitelist filter is the runtime enforcement, this test locks the contract.
+- **PR count:** 1. **Depends on:** T16.
+
+---
+
+### Success Criteria
+
+Every criterion is binary PASS/FAIL on independent re-read. Re-graded by spec-critic.
+
+- **SC-1:** PASS iff `npm test -- tier-integrity` exits 0 after T17 ships AND coverage report shows ≥1 assertion per `INV-1` through `INV-8` × ≥1 assertion per tier (CD, IB, X-Ray, WR, SR) — ≥40 distinct assertions total.
+- **SC-2:** PASS iff `Grep -n "tier === " src/lib/intelligence-brief/prompts.ts | wc -l` returns ≥3 (currently 0 — IB-tier slots are tier-agnostic per audit, INV-5 enforcement adds explicit tier guards).
+- **SC-3:** PASS iff for each of the 5 named slots `judge_quote_library`, `officer_reliability_crosscase`, `codefendant_divergence_summary`, `plea_discount_curve_summary`, `appellate_trends_summary`: `Grep -n "<slot>\s*[:=]" supabase/functions/generate-report/index.ts src/lib/intelligence-brief/prompts.ts` returns ≥1 line OR the slot does not appear in `Grep -n "<slot>" src/lib/intelligence-brief/variables.ts`.
+- **SC-4:** PASS iff `src/lib/tiers/tier-data-manifest.ts` exists AND exports a `TIER_DATA_MANIFEST` const-typed `Record<TierSlug, { tables: readonly string[]; promisedTables: readonly string[]; sessionBriefTables: readonly string[] }>` covering all 5 service tiers.
+- **SC-5:** PASS iff `docs/plans/2026-04-25-worry-product-tier-data-audit-artifact.md` exists AND contains 7 sections (Situation Room / War Room / X-Ray / Intelligence Brief / Case Decoder / Playbook / Standalone SKUs) AND each section has subsections: "Tables read", "Tables promised", "Diff (promised − actual)", "Verdict".
+- **SC-6:** PASS iff `Grep -n "X-Ray adds\|War Room adds\|Situation Room adds\|Baseline upgrades" ARCHITECTURE.md` lines and the manifest in SC-4 are byte-for-byte consistent on every tier-data promise — verified by a Vitest test reading both files. Test name = `architecture-md-parity.test.ts`.
+- **SC-7:** PASS iff for every paid main-tier T (CD/IB/X-Ray/WR/SR), `len(TIER_DATA_MANIFEST[T].tables) >= len(TIER_DATA_MANIFEST[T_lower].tables) + 1` for the immediately-lower main tier — encoded as INV-2 assertion.
+- **SC-8:** PASS iff for every standalone SKU S in `STANDALONE_PRODUCTS` where `S.upsellTier` is set, the data tables S reads MUST be a SUBSET of `TIER_DATA_MANIFEST[S.upsellTier].tables` — encoded as INV-6 assertion.
+- **SC-9:** PASS iff after T10 lands, for every field name X declared between `// Tier 9` and the next top-level `interface`/`}` boundary in `src/lib/intelligence-brief/variables.ts`, `Grep -n "v\\.X\\b" src/lib/intelligence-brief/prompts.ts` returns ≥1 line. The T10 PR description must enumerate the X-list explicitly so this criterion is checkable line-by-line.
+- **SC-10:** PASS iff for every PR P in T10–T17, `gh pr view <P> --json body` body contains literal substring `Artifact verdict: T<n>` (where T<n> is the upstream artifact task) AND ≥1 line matching regex `INV-\d+ before=\d+ after=\d+` per invariant the PR claims to move.
+- **SC-11:** PASS iff zero file under any worktree listed in the worry doc's "Out of Scope (do-not-touch list)" appears in any T10–T17 PR diff (`gh pr diff <num> --name-only | Grep -E "_worktrees|*-worktree"` returns 0 lines).
+- **SC-12:** PASS iff the post-ship inventory artifact (T9 output) records exact row counts for the 6 most-load-bearing tables (jurisdiction_statutes, statute_case_law, case_law_references, classified_opinions, judges, judge_quotes) — verified via `?select=count` HEAD requests captured in artifact.
+
+---
+
+### Out of Scope (Tracked for Future PRs)
+
+| Surface | Why deferred | Owner / Tracker |
+|---|---|---|
+| Federal docket cache table integration | Active sibling worktree `recap-cache-web` (do-not-touch). Read-only verify table name in T2 — actual wiring into X-Ray/WR/SR session brief blocks on that worktree merging. | Track via existing worktree |
+| Engine worker tier-aware refactor | The engine's `report.mjs` is a separate repo; its tier-integrity invariants would need their own audit pass + a second `tier-integrity.test.ts` shipped in `ImNotAnAttorney-engine`. | New worry doc, parallel scope |
+| Operator session-brief UI build | T13–T15 ship MANIFESTS only (data structures). Actual UI changes to `src/app/api/admin/session-report/[caseId]/route.ts` to render the manifest belong to a UX-design pass. | Follow-up PR after T15 |
+| Tier-9 SKU pricing rebalance | If T16 surfaces standalone overlap with main-tier promises, the fix could be either (a) inherit data into the higher tier, (b) re-price the standalone, (c) delist the standalone. (a) is in scope here; (b)+(c) are pricing decisions for Rahim | Decision tree appended to T16 PR |
+| Playbook personalization | Currently zero DB reads (T7). Personalizing playbooks against jurisdiction_statutes is a Hormozi-positive direction but doubles the playbook surface area. | New worry doc |
+| Re-tiering Tier-9 slots that landed in IB | If T5 verdict says "$997 IB shouldn't have SR-only Tier-9 data," removing it from IB is a CRO regression (current IB customers see the data and would lose it). Migration path: dual-tier slot for 90 days, deprecate after. | T12 PR description; track for 2026-Q3 |
+| Engine repo's parallel `tier_generation_config` reads | Engine doesn't currently read mode-config; if the engine's auto path is ever resurrected, it must respect mode='session'. Requires engine-side guard. | New ImNotAnAttorney-engine worry doc |
+| Auto-flip from session→api for tier where verifiable-opus path is built | ARCHITECTURE.md:58 mentions "verified-opus replacement path queued for a separate rebuild." When that rebuild ships, all the per-tier auto paths re-light and INV-3 testing must extend to them. | Reference the rebuild plan |
+| Phase 2 cite-tag whitelist coverage gap per tier | PR #115 added `entity-whitelist.ts`. INV-8 (T17) tests it. But each tier's render path may emit cite tags from sources whitelist doesn't yet cover (e.g., X-Ray engine output) — a separate per-tier cite-tag conformance pass. | New PR after T17 |
+

--- a/scripts/apply-platform-posts-immutability.mjs
+++ b/scripts/apply-platform-posts-immutability.mjs
@@ -1,0 +1,63 @@
+/**
+ * apply-platform-posts-immutability.mjs — one-shot apply of
+ * supabase/migrations/20260424e_platform_posts_immutability_triggers.sql
+ * via Supabase Management API. Phase X-R2 (2026-04-24).
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const envPath = path.resolve(__dirname, '..', '.env.local');
+const env = fs.readFileSync(envPath, 'utf8')
+  .split('\n')
+  .filter(l => l && !l.trimStart().startsWith('#'))
+  .reduce((m, l) => {
+    const i = l.indexOf('=');
+    if (i > 0) m[l.slice(0, i).trim()] = l.slice(i + 1).trim();
+    return m;
+  }, {});
+
+const SUPABASE_ACCESS_TOKEN = env.SUPABASE_ACCESS_TOKEN;
+if (!SUPABASE_ACCESS_TOKEN) { console.error('missing SUPABASE_ACCESS_TOKEN'); process.exit(1); }
+
+const PROJECT_REF = 'jxjbjmgdukwkoclydqdr';
+const migrationPath = path.resolve(__dirname, '..', 'supabase', 'migrations', '20260424e_platform_posts_immutability_triggers.sql');
+const sql = fs.readFileSync(migrationPath, 'utf8');
+
+const res = await fetch(
+  `https://api.supabase.com/v1/projects/${PROJECT_REF}/database/query`,
+  {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${SUPABASE_ACCESS_TOKEN}`,
+      'Content-Type': 'application/json',
+      'User-Agent': 'inaa-apply-migration/1.0',
+    },
+    body: JSON.stringify({ query: sql }),
+  },
+);
+const text = await res.text();
+if (!res.ok) {
+  console.error(`migration failed (${res.status}):`, text.slice(0, 2000));
+  process.exit(2);
+}
+console.log('migration applied:', text.slice(0, 400));
+
+// Verify triggers
+const verify = await fetch(
+  `https://api.supabase.com/v1/projects/${PROJECT_REF}/database/query`,
+  {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${SUPABASE_ACCESS_TOKEN}`,
+      'Content-Type': 'application/json',
+      'User-Agent': 'inaa-apply-migration/1.0',
+    },
+    body: JSON.stringify({
+      query: "SELECT tgname FROM pg_trigger WHERE tgrelid='platform_posts'::regclass AND NOT tgisinternal;",
+    }),
+  },
+);
+console.log('triggers:', (await verify.text()).slice(0, 500));

--- a/scripts/apply-platform-posts-length-checks.mjs
+++ b/scripts/apply-platform-posts-length-checks.mjs
@@ -1,0 +1,68 @@
+/**
+ * apply-platform-posts-length-checks.mjs — one-shot apply of
+ * supabase/migrations/20260424d_platform_posts_length_checks.sql via
+ * the Supabase Management API.
+ *
+ * Phase X-R1 (2026-04-24).
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const envPath = path.resolve(__dirname, '..', '.env.local');
+const env = fs.readFileSync(envPath, 'utf8')
+  .split('\n')
+  .filter(l => l && !l.trimStart().startsWith('#'))
+  .reduce((m, l) => {
+    const i = l.indexOf('=');
+    if (i > 0) m[l.slice(0, i).trim()] = l.slice(i + 1).trim();
+    return m;
+  }, {});
+
+const SUPABASE_ACCESS_TOKEN = env.SUPABASE_ACCESS_TOKEN;
+if (!SUPABASE_ACCESS_TOKEN) {
+  console.error('Missing SUPABASE_ACCESS_TOKEN in ImNotAnAttorney-web/.env.local');
+  process.exit(1);
+}
+
+const PROJECT_REF = 'jxjbjmgdukwkoclydqdr';
+const migrationPath = path.resolve(__dirname, '..', 'supabase', 'migrations', '20260424d_platform_posts_length_checks.sql');
+const sql = fs.readFileSync(migrationPath, 'utf8');
+
+const res = await fetch(
+  `https://api.supabase.com/v1/projects/${PROJECT_REF}/database/query`,
+  {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${SUPABASE_ACCESS_TOKEN}`,
+      'Content-Type': 'application/json',
+      'User-Agent': 'inaa-apply-migration/1.0',
+    },
+    body: JSON.stringify({ query: sql }),
+  },
+);
+const text = await res.text();
+if (!res.ok) {
+  console.error(`Migration failed (${res.status}):`, text.slice(0, 2000));
+  process.exit(2);
+}
+console.log('Migration applied:', text.slice(0, 400));
+
+const verifyRes = await fetch(
+  `https://api.supabase.com/v1/projects/${PROJECT_REF}/database/query`,
+  {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${SUPABASE_ACCESS_TOKEN}`,
+      'Content-Type': 'application/json',
+      'User-Agent': 'inaa-apply-migration/1.0',
+    },
+    body: JSON.stringify({
+      query: "SELECT conname, pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid='platform_posts'::regclass AND contype='c' ORDER BY conname;",
+    }),
+  },
+);
+console.log('Constraints:', (await verifyRes.text()).slice(0, 1500));

--- a/scripts/apply-platform-posts-migration.mjs
+++ b/scripts/apply-platform-posts-migration.mjs
@@ -1,0 +1,75 @@
+/**
+ * apply-platform-posts-migration.mjs — one-shot application of
+ * supabase/migrations/20260424c_platform_posts.sql via the Supabase
+ * Management API (no exec_sql RPC available on hosted Supabase).
+ *
+ * Pattern source: scripts/migrate-009-tier-inclusion.mjs (cached template).
+ *
+ * Plan: C:/Users/email/projects/ImNotAnAttorney/docs/handoff/2026-04-24-unified-container-gap-closure.md Phase O
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// Read SUPABASE_ACCESS_TOKEN from this repo's .env.local (service-role is not needed for Management API).
+const envPath = path.resolve(__dirname, '..', '.env.local');
+const env = fs.readFileSync(envPath, 'utf8')
+  .split('\n')
+  .filter(l => l && !l.trimStart().startsWith('#'))
+  .reduce((m, l) => {
+    const i = l.indexOf('=');
+    if (i > 0) m[l.slice(0, i).trim()] = l.slice(i + 1).trim();
+    return m;
+  }, {});
+
+const SUPABASE_ACCESS_TOKEN = env.SUPABASE_ACCESS_TOKEN;
+if (!SUPABASE_ACCESS_TOKEN) {
+  console.error('Missing SUPABASE_ACCESS_TOKEN in ImNotAnAttorney-web/.env.local');
+  process.exit(1);
+}
+
+const PROJECT_REF = 'jxjbjmgdukwkoclydqdr';
+
+const migrationPath = path.resolve(__dirname, '..', 'supabase', 'migrations', '20260424c_platform_posts.sql');
+const sql = fs.readFileSync(migrationPath, 'utf8');
+
+const res = await fetch(
+  `https://api.supabase.com/v1/projects/${PROJECT_REF}/database/query`,
+  {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${SUPABASE_ACCESS_TOKEN}`,
+      'Content-Type': 'application/json',
+      'User-Agent': 'inaa-apply-migration/1.0',
+    },
+    body: JSON.stringify({ query: sql }),
+  },
+);
+
+const text = await res.text();
+if (!res.ok) {
+  console.error(`Migration failed (${res.status}):`, text.slice(0, 2000));
+  process.exit(2);
+}
+console.log('Migration applied:', text.slice(0, 400));
+
+// Verify table shape.
+const verifyRes = await fetch(
+  `https://api.supabase.com/v1/projects/${PROJECT_REF}/database/query`,
+  {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${SUPABASE_ACCESS_TOKEN}`,
+      'Content-Type': 'application/json',
+      'User-Agent': 'inaa-apply-migration/1.0',
+    },
+    body: JSON.stringify({
+      query: "SELECT column_name, data_type FROM information_schema.columns WHERE table_name='platform_posts' ORDER BY ordinal_position;",
+    }),
+  },
+);
+const verifyText = await verifyRes.text();
+console.log('Verification:', verifyText);

--- a/supabase/migrations/20260424c_platform_posts.sql
+++ b/supabase/migrations/20260424c_platform_posts.sql
@@ -1,0 +1,70 @@
+-- platform_posts — unified post ledger for the five new destinations that
+-- are NOT rooted in the abandoned_questions workflow (twitter_x, youtube,
+-- instagram, facebook, tiktok). Reddit + quora stay on posted_answers.
+--
+-- Plan: C:\Users\email\projects\ImNotAnAttorney\docs\handoff\2026-04-24-unified-container-gap-closure.md Phase O
+-- Cluster rate-limit + per-account-cap helpers query this table directly
+-- via blog-pipeline/lib/cluster-rate-limit.mjs.
+
+CREATE TABLE IF NOT EXISTS platform_posts (
+  id                 bigserial   PRIMARY KEY,
+  destination        text        NOT NULL CHECK (destination IN ('twitter_x','youtube','instagram','facebook','tiktok')),
+  charge_type_slug   text        NOT NULL,
+  pain_point_slug    text        NOT NULL,
+  source_url         text,
+  posted_body_md     text        NOT NULL,
+  posted_at          timestamptz NOT NULL DEFAULT now(),
+  status             text        NOT NULL DEFAULT 'pending'
+                       CHECK (status IN ('pending','ok','failed','removed')),
+  moderation_status  text        NOT NULL DEFAULT 'pending'
+                       CHECK (moderation_status IN ('ok','collapsed','removed','shadowbanned','shadow-suspect','pending')),
+  llm_cited          boolean     NOT NULL DEFAULT false,
+  click_count        integer     NOT NULL DEFAULT 0,
+  posting_account    text,
+  matched_blog_slug  text,
+  last_checked_at    timestamptz,
+  raw_meta           jsonb
+);
+
+-- Hot path: cluster-rate-limit query joins (destination, charge, pain, moderation, posted_at DESC).
+CREATE INDEX IF NOT EXISTS platform_posts_cluster_idx
+  ON platform_posts (destination, charge_type_slug, pain_point_slug, posted_at DESC)
+  WHERE moderation_status IN ('pending','ok');
+
+-- Per-account daily cap: (destination, posted_at DESC).
+CREATE INDEX IF NOT EXISTS platform_posts_daily_cap_idx
+  ON platform_posts (destination, posted_at DESC)
+  WHERE moderation_status IN ('pending','ok');
+
+-- Dedupe posts by URL (when the platform returns one).
+CREATE UNIQUE INDEX IF NOT EXISTS platform_posts_url_uq
+  ON platform_posts (source_url)
+  WHERE source_url IS NOT NULL;
+
+-- Moderation sweep: non-ok rows pending re-check.
+CREATE INDEX IF NOT EXISTS platform_posts_modstatus_idx
+  ON platform_posts (moderation_status, last_checked_at)
+  WHERE moderation_status <> 'ok';
+
+-- Attribution back to blog slug.
+CREATE INDEX IF NOT EXISTS platform_posts_blog_idx
+  ON platform_posts (matched_blog_slug)
+  WHERE matched_blog_slug IS NOT NULL;
+
+ALTER TABLE platform_posts ENABLE ROW LEVEL SECURITY;
+-- No policies → default deny for anon/authenticated. Service role bypasses RLS.
+
+COMMENT ON TABLE platform_posts IS
+  'Every post we publish to Twitter/X, YouTube, Instagram, Facebook, TikTok. Parallel to posted_answers (reddit/quora). Feeds cluster-rate-limit, daily-cap, moderation survival sweep.';
+
+COMMENT ON COLUMN platform_posts.charge_type_slug IS
+  'Stored directly on the row (NOT via abandoned_questions) so the cluster-rate-limit helper can filter without an inner join. The five new destinations do discovery + post in a single script, not via the Stage 1D SELECT block used by reddit/quora.';
+
+COMMENT ON COLUMN platform_posts.status IS
+  'Post lifecycle — pending (pre-create before API call), ok (API returned success), failed (API returned error), removed (we deleted it manually).';
+
+COMMENT ON COLUMN platform_posts.moderation_status IS
+  'Platform moderation outcome — same vocabulary as posted_answers so sibling survival-sweep code can share normalization.';
+
+COMMENT ON COLUMN platform_posts.posting_account IS
+  'Handle/channel/page that posted. Lets us split metrics per account during multi-account ramp.';

--- a/supabase/migrations/20260424d_platform_posts_length_checks.sql
+++ b/supabase/migrations/20260424d_platform_posts_length_checks.sql
@@ -13,22 +13,44 @@
 -- 64 char posting_account cap aligns with validPostingAccount regex.
 --
 -- Plan: docs/handoff/2026-04-24-unified-container-gap-closure.md Phase X.
+-- Idempotent: each ADD CONSTRAINT guarded by NOT EXISTS check on pg_constraint.
+-- Replay-safe per Brandur Leach migration-safety guidance.
 
-ALTER TABLE platform_posts
-  ADD CONSTRAINT platform_posts_body_len_chk
-    CHECK (char_length(posted_body_md) > 0 AND char_length(posted_body_md) <= 70000);
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'platform_posts_body_len_chk') THEN
+    ALTER TABLE platform_posts
+      ADD CONSTRAINT platform_posts_body_len_chk
+        CHECK (char_length(posted_body_md) > 0 AND char_length(posted_body_md) <= 70000);
+  END IF;
+END $$;
 
-ALTER TABLE platform_posts
-  ADD CONSTRAINT platform_posts_source_url_len_chk
-    CHECK (source_url IS NULL OR char_length(source_url) <= 2048);
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'platform_posts_source_url_len_chk') THEN
+    ALTER TABLE platform_posts
+      ADD CONSTRAINT platform_posts_source_url_len_chk
+        CHECK (source_url IS NULL OR char_length(source_url) <= 2048);
+  END IF;
+END $$;
 
-ALTER TABLE platform_posts
-  ADD CONSTRAINT platform_posts_matched_blog_slug_len_chk
-    CHECK (matched_blog_slug IS NULL OR char_length(matched_blog_slug) <= 120);
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'platform_posts_matched_blog_slug_len_chk') THEN
+    ALTER TABLE platform_posts
+      ADD CONSTRAINT platform_posts_matched_blog_slug_len_chk
+        CHECK (matched_blog_slug IS NULL OR char_length(matched_blog_slug) <= 120);
+  END IF;
+END $$;
 
-ALTER TABLE platform_posts
-  ADD CONSTRAINT platform_posts_posting_account_len_chk
-    CHECK (posting_account IS NULL OR char_length(posting_account) <= 64);
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'platform_posts_posting_account_len_chk') THEN
+    ALTER TABLE platform_posts
+      ADD CONSTRAINT platform_posts_posting_account_len_chk
+        CHECK (posting_account IS NULL OR char_length(posting_account) <= 64);
+  END IF;
+END $$;
 
 COMMENT ON CONSTRAINT platform_posts_body_len_chk ON platform_posts IS
   'Server-side length CHECK added Phase X-R1 — covers FB 63k cap + safety margin.';

--- a/supabase/migrations/20260424d_platform_posts_length_checks.sql
+++ b/supabase/migrations/20260424d_platform_posts_length_checks.sql
@@ -1,0 +1,34 @@
+-- platform_posts length CHECK constraints — Phase X-R1 security-auditor W1.
+--
+-- Parent migration: 20260424c_platform_posts.sql ships without server-side
+-- length limits, relying on client-side validation in
+-- blog-pipeline/scripts/lib/platform-auto-core.mjs. Adding belt-and-suspenders
+-- CHECK constraints so a client-side bypass (fresh script that skips the new
+-- validPostingAccount / validSlug / length guards) can't insert multi-MB
+-- rows + bloat the hot-path cluster index.
+--
+-- 70000 char body cap covers Facebook's 63k limit + safety margin.
+-- 2048 char source_url cap is the de-facto Chrome limit.
+-- 120 char slug cap aligns with the client-side validSlug regex.
+-- 64 char posting_account cap aligns with validPostingAccount regex.
+--
+-- Plan: docs/handoff/2026-04-24-unified-container-gap-closure.md Phase X.
+
+ALTER TABLE platform_posts
+  ADD CONSTRAINT platform_posts_body_len_chk
+    CHECK (char_length(posted_body_md) > 0 AND char_length(posted_body_md) <= 70000);
+
+ALTER TABLE platform_posts
+  ADD CONSTRAINT platform_posts_source_url_len_chk
+    CHECK (source_url IS NULL OR char_length(source_url) <= 2048);
+
+ALTER TABLE platform_posts
+  ADD CONSTRAINT platform_posts_matched_blog_slug_len_chk
+    CHECK (matched_blog_slug IS NULL OR char_length(matched_blog_slug) <= 120);
+
+ALTER TABLE platform_posts
+  ADD CONSTRAINT platform_posts_posting_account_len_chk
+    CHECK (posting_account IS NULL OR char_length(posting_account) <= 64);
+
+COMMENT ON CONSTRAINT platform_posts_body_len_chk ON platform_posts IS
+  'Server-side length CHECK added Phase X-R1 — covers FB 63k cap + safety margin.';

--- a/supabase/migrations/20260424e_platform_posts_immutability_triggers.sql
+++ b/supabase/migrations/20260424e_platform_posts_immutability_triggers.sql
@@ -1,0 +1,95 @@
+-- platform_posts immutability + shape triggers — Phase X-R2 security W4 (partial).
+--
+-- The full fix for security-auditor W4 is "scoped service-account role
+-- instead of full SUPABASE_SERVICE_ROLE_KEY" — that requires a DB role +
+-- custom-role JWT signed with the project secret, which needs a browser-
+-- session via the Supabase dashboard. That step is tracked in
+-- ImNotAnAttorney/TERMINAL-TODO.md.
+--
+-- Meanwhile, these triggers raise the bar server-side so a compromised
+-- service-role key can't easily retroactively rewrite post history. RLS
+-- is bypassed by service-role; triggers are NOT.
+--
+-- Trigger 1 — BEFORE INSERT shape validation: regex-check
+-- posting_account, matched_blog_slug, source_url (belt-and-suspenders on
+-- the client-side validation in blog-pipeline/scripts/lib/platform-auto-core.mjs).
+--
+-- Trigger 2 — BEFORE UPDATE immutability: once status transitions to
+-- 'ok', destination + charge_type_slug + pain_point_slug become
+-- read-only (structural identity is fixed at publish time). Also
+-- prevents rewriting status away from 'ok' to an earlier lifecycle
+-- state — only 'ok' -> 'failed' -> 'removed' transitions are legit.
+--
+-- Plan: ImNotAnAttorney/docs/handoff/2026-04-24-unified-container-live-flip.md P9.
+
+-- ── Trigger 1: shape validation on INSERT ───────────────────────────────
+
+CREATE OR REPLACE FUNCTION platform_posts_shape_check()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF NEW.posting_account IS NOT NULL
+     AND NEW.posting_account !~ '^[A-Za-z0-9_.\-]{1,64}$' THEN
+    RAISE EXCEPTION 'posting_account "%" violates shape [A-Za-z0-9_.-]{1,64}', NEW.posting_account;
+  END IF;
+  IF NEW.matched_blog_slug IS NOT NULL
+     AND NEW.matched_blog_slug !~ '^[a-z0-9-]{1,120}$' THEN
+    RAISE EXCEPTION 'matched_blog_slug "%" violates shape [a-z0-9-]{1,120}', NEW.matched_blog_slug;
+  END IF;
+  IF NEW.source_url IS NOT NULL
+     AND NEW.source_url !~ '^https?://' THEN
+    RAISE EXCEPTION 'source_url "%" must start with http:// or https://', NEW.source_url;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS platform_posts_shape_check_trg ON platform_posts;
+CREATE TRIGGER platform_posts_shape_check_trg
+  BEFORE INSERT OR UPDATE ON platform_posts
+  FOR EACH ROW
+  EXECUTE FUNCTION platform_posts_shape_check();
+
+-- ── Trigger 2: immutability on UPDATE after first 'ok' ──────────────────
+
+CREATE OR REPLACE FUNCTION platform_posts_immutability_check()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  -- Once a row is 'ok', its identity columns freeze.
+  IF OLD.status = 'ok' THEN
+    IF NEW.destination       <> OLD.destination       THEN
+      RAISE EXCEPTION 'destination is immutable after status=''ok''';
+    END IF;
+    IF NEW.charge_type_slug  <> OLD.charge_type_slug  THEN
+      RAISE EXCEPTION 'charge_type_slug is immutable after status=''ok''';
+    END IF;
+    IF NEW.pain_point_slug   <> OLD.pain_point_slug   THEN
+      RAISE EXCEPTION 'pain_point_slug is immutable after status=''ok''';
+    END IF;
+    IF NEW.posted_body_md    <> OLD.posted_body_md    THEN
+      RAISE EXCEPTION 'posted_body_md is immutable after status=''ok''';
+    END IF;
+    -- Status may transition 'ok' -> 'failed' -> 'removed' (operator
+    -- take-downs), but must never rewind to 'pending'.
+    IF NEW.status = 'pending' THEN
+      RAISE EXCEPTION 'status cannot transition from ok back to pending';
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS platform_posts_immutability_trg ON platform_posts;
+CREATE TRIGGER platform_posts_immutability_trg
+  BEFORE UPDATE ON platform_posts
+  FOR EACH ROW
+  EXECUTE FUNCTION platform_posts_immutability_check();
+
+COMMENT ON FUNCTION platform_posts_shape_check() IS
+  'Phase X-R2 security W4 (partial) — regex-checks shape of posting_account / matched_blog_slug / source_url on INSERT + UPDATE. Defense-in-depth on top of client-side validation in platform-auto-core.mjs.';
+
+COMMENT ON FUNCTION platform_posts_immutability_check() IS
+  'Phase X-R2 security W4 (partial) — freezes identity columns once a row reaches status=ok. Prevents retroactive rewrite via any key type including compromised service-role. Status transitions ok -> failed -> removed only; never ok -> pending.';


### PR DESCRIPTION
## Summary

The 2026-04-24 Phase O unified-container work created the `platform_posts` table on prod via Supabase Management API one-shots, but the **migration files were never committed** — they were stuck in a parallel-session uncommitted tree.

This PR ports them so schema state is reproducible from the migrations folder.

### Migrations rescued
| File | Purpose |
|------|---------|
| `20260424c_platform_posts.sql` | Table + indexes (5 destinations: twitter_x, youtube, instagram, facebook, tiktok) |
| `20260424d_platform_posts_length_checks.sql` | Body length CHECK constraints |
| `20260424e_platform_posts_immutability_triggers.sql` | Write-once invariant triggers |

### Why this matters
The existing `20260425a_platform_post_writer_role.sql` migration GRANTs on `platform_posts`. That migration applied OK on prod because the table existed via Management-API one-shot, but it would NOT replay cleanly on a fresh DB without these earlier schema migrations.

### Also rescued from same stash
- 2 twitter queue files for 2026-04-24/25 publication
- 2026-04-25 attorney-discipline-wire phase5 handoff
- 5 docs/plans (bar-scrapers-batch, dormant-data-wiring, attorney-discipline-wire worry, product-tier-data-audit + findings)

## Test plan
- [x] tsc clean (`./node_modules/.bin/tsc --noEmit --skipLibCheck` after `.next` cache clear)
- [ ] Reviewer: confirm migration content matches what was applied to prod (compare against live `platform_posts` schema)

🤖 Generated with [Claude Code](https://claude.com/claude-code)