### PR TITLE
fix(scripts): backport spawnSync shell-injection fix to pipeline-runner

### DIFF
--- a/docs/plans/2026-04-26-pipeline-runner-shell-injection-fix.md
+++ b/docs/plans/2026-04-26-pipeline-runner-shell-injection-fix.md
@@ -1,0 +1,65 @@
+# Pipeline Runner Shell-Injection Fix — 2026-04-26
+
+## Worry / Source
+
+Audit Angle 3 (`docs/plans/2026-04-26-german-audit-angle-3-duplication.md`)
+finding **F-3 Family C**: `scripts/pipeline-runner.mjs:89` uses `execSync`
+with shell-interpolated message string. Parent's `blog-pipeline/scripts/
+quora-auto.mjs:912` already migrated to `spawnSync` (array form, shell:false,
+timeout, length cap, windowsHide:true). Backport not propagated to web.
+
+## Architectural Invariants Touched
+
+ARCHITECTURE.md inventory of 14 invariants — none violated by either the bug
+or the fix. The fix is a defense-in-depth hardening on a shell-quoting hole
+that pre-dated the invariant list. Adding it raises the floor.
+
+## Subsystem context (scripts/CONTEXT.md)
+
+`pipeline-runner.mjs` is in the "Tier 9 Data Pipeline" cluster of scripts
+that chain bulk extractors. Calling pattern: invoked manually or via cron,
+sequentially runs hardcoded `STAGES` array, sends a Telegram summary at end.
+Fix preserves that calling pattern.
+
+## Files to Modify
+
+`scripts/pipeline-runner.mjs` (single file, three localized edits):
+- Line 12: import — add `spawnSync` to existing `child_process` import
+- Lines 89-98: `sendTelegram` — replace execSync with spawnSync array-form
+- Lines 121-125: `runStage` — add `windowsHide: true` to options
+
+## Files to Create
+
+None.
+
+## Tasks
+
+1. Edit import line (1 line change)
+2. Replace `sendTelegram` body (~10 lines)
+3. Add `windowsHide: true` to `runStage` execSync options
+4. Smoke-test: `node scripts/pipeline-runner.mjs --dry-run`
+5. Commit + push to `fix/pipeline-runner-shell-injection`
+6. Open PR
+
+## Out of Scope
+
+- The `runStage` execSync(stage.cmd) shell-mode call — `stage.cmd` is
+  hardcoded in STAGES array (lines 58-83), no user input flows in.
+- The other 9 sendTelegram copies elsewhere in web (cron routes use the
+  inline-fetch pattern, separate fix at F-3 Family A in audit findings).
+- Re-architecting pipeline-runner.mjs into a stage-runner abstraction.
+
+## Success Criteria
+
+- `git diff` shows changes only in `scripts/pipeline-runner.mjs`
+- `node scripts/pipeline-runner.mjs --dry-run` runs without error
+- New `sendTelegram` cannot be exploited by message contents (verifiable by
+  reading the code: array form with `shell: false`, no string interpolation)
+- `windowsHide: true` present in both subprocess calls
+- PR opens cleanly off `master`
+
+## Cited Source
+
+- Parent canonical implementation: `C:/Users/email/projects/ImNotAnAttorney/blog-pipeline/scripts/quora-auto.mjs:912-925`
+- Rule: `~/.claude/rules/drafts/enforce-windowshide.md`
+- Audit finding: `~/projects/ImNotAnAttorney/docs/plans/2026-04-26-german-audit-angle-3-duplication.md` F-3 Family C

--- a/scripts/pipeline-runner.mjs
+++ b/scripts/pipeline-runner.mjs
@@ -9,7 +9,7 @@
  *   node scripts/pipeline-runner.mjs --dry-run
  */
 
-import { execSync } from 'child_process';
+import { execSync, spawnSync } from 'child_process';
 import { existsSync, mkdirSync, appendFileSync, writeFileSync } from 'fs';
 import { join } from 'path';
 
@@ -87,11 +87,24 @@ const STAGES = [
 // ---------------------------------------------------------------------------
 
 function sendTelegram(message) {
+  // spawnSync array form (shell:false) — message can contain stage error
+  // text with backticks, $(...), \n, ;, etc. that MUST NOT go through a
+  // shell. Backport from blog-pipeline/scripts/quora-auto.mjs:912 (parent-
+  // canonical pattern). 1000-char cap matches parent. windowsHide:true per
+  // ~/.claude/rules/drafts/enforce-windowshide.md.
   try {
-    execSync(
-      `node "${TELEGRAM_SCRIPT}" --bot legal --message "${message.replace(/"/g, '\\"')}"`,
-      { stdio: 'inherit', cwd: PROJECT_ROOT }
+    if (!existsSync(TELEGRAM_SCRIPT)) {
+      log('WARN: Telegram script not found, skipping notification');
+      return;
+    }
+    const r = spawnSync(
+      'node',
+      [TELEGRAM_SCRIPT, '--bot', 'legal', '--message', String(message).slice(0, 1000)],
+      { cwd: PROJECT_ROOT, stdio: 'inherit', shell: false, timeout: 15000, windowsHide: true }
     );
+    if (r.status !== 0) {
+      log(`WARN: Telegram notification exit=${r.status}`);
+    }
   } catch (err) {
     log(`WARN: Telegram notification failed, ${err.message}`);
   }
@@ -118,9 +131,13 @@ function runStage(stage) {
   }
 
   const t0 = Date.now();
+  // stage.cmd is a hardcoded string from STAGES (no user input flows in),
+  // so shell-mode is safe here. windowsHide:true suppresses conhost flash
+  // per ~/.claude/rules/drafts/enforce-windowshide.md.
   execSync(stage.cmd, {
     cwd:   PROJECT_ROOT,
     stdio: 'inherit',
+    windowsHide: true,
     // surface non-zero exit as thrown error
   });
   const elapsed = Date.now() - t0;


### PR DESCRIPTION
## Summary

Closes **F-3 Family C** from the [German-Engineering Audit findings](https://github.com/rahim0kapadia/ImNotAnAttorney/blob/master/docs/plans/2026-04-26-german-engineering-audit-findings.md).

`scripts/pipeline-runner.mjs:89` `sendTelegram` was using `execSync` with shell-interpolated message string. Stage error text flowing in can contain backticks, \`\$(...)\`, newlines, semicolons, etc. that escape the naive `\"` quote replacement → arbitrary command execution under the script's privileges.

Parent's `blog-pipeline/scripts/quora-auto.mjs:912` already migrated to `spawnSync` array-form (shell:false). This backports that pattern.

## Changes

| File | Change |
|------|--------|
| `scripts/pipeline-runner.mjs` | `sendTelegram` rewritten with `spawnSync(..., { shell: false, timeout: 15000, windowsHide: true })`; 1000-char message cap; existsSync probe; `runStage` gains `windowsHide: true` for conhost-flash hygiene |
| `docs/plans/2026-04-26-pipeline-runner-shell-injection-fix.md` | Mini-plan documenting scope + invariants + cited source |

## Test plan
- [x] `node scripts/pipeline-runner.mjs --dry-run` — all 6 stages run + Telegram delivers (verified locally, message_id 322)
- [x] `npx tsc --noEmit --skipLibCheck` — `pipeline-runner.mjs` clean (.mjs not type-checked); 4 pre-existing errors are stale `.next/types` cache for unrelated sibling-session cron routes
- [ ] Manual: trigger pipeline-runner with a malformed stage error (backtick, `\$(...)`) and confirm message arrives literally, no shell expansion

## Out of scope
- Other 9 `sendTelegram` copies elsewhere in web (F-3 Family A — different fix shape, separate PR)
- The 4 stale `.next/types` cache errors (sibling-session routes; not blog-pipeline scope)

## Cited
- Parent canonical: `C:/Users/email/projects/ImNotAnAttorney/blog-pipeline/scripts/quora-auto.mjs:912-925`
- Rule: `~/.claude/rules/drafts/enforce-windowshide.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)