### PR TITLE
fix(d2): similar-cases state-coverage gating + federal fallback

### DIFF
--- a/docs/plans/2026-04-26-pr-168-review-fixes.md
+++ b/docs/plans/2026-04-26-pr-168-review-fixes.md
@@ -1,0 +1,107 @@
+# PR #168 Review Findings Fix Plan
+
+**Branch:** `fix/d2-similar-cases-state-coverage`
+**Date:** 2026-04-26
+**Source:** PR #168 review — 4 WARN + 3 SUG findings
+**Pristine-Or-Nothing:** every finding fixed, no severity-based skip.
+
+## Findings to fix
+
+### W1 — Sentencing state count corrected (7 states + federal, was incorrectly 8)
+
+The query.ts comments at lines 342 and 990 claim "8 states + federal" but
+actually enumerate only seven ISO codes (AZ, DE, IL, MI, NE, VA, WI).
+The numeric codes seen elsewhere in `sentencing_distributions.jurisdiction`
+are federal-district codes, not US states.
+
+**Files:**
+- `src/lib/tier9-reports/query.ts` lines 339-344, 989-990 — comment fix
+- Add a `SENTENCING_SUPPORTED_STATES` Set near the federal-fallback block
+  with the seven ISO codes for future single-source-of-truth use.
+
+### W2 — AvailabilityChecker banner covers sentencing-state gap too
+
+Banner currently only fires on `pleaState===0 && pleaFederal>0`. A
+defendant with state plea data but no state sentencing data sees the
+federal-fallback caption inside the rendered report's sentencing
+section without pre-purchase disclosure.
+
+**File:** `src/components/tier9/AvailabilityChecker.tsx`
+**Fix:** Branch on coverage shape:
+- both plea + sentencing missing state → combined banner copy
+- only plea state missing → existing copy
+- only sentencing state missing → new sentencing-only copy
+
+### W3 — Don't show pleaFederal in coverage list when pleaState>0
+
+When `pleaState>0`, the report only consumes state plea data — showing
+`pleaFederal: N` in the dl grid implies it's separate, used inventory.
+Same logic for `outcomeNational` when state-level data covers the path.
+
+**File:** `src/components/tier9/AvailabilityChecker.tsx`
+**Fix:** Filter `pleaFederal` from `entries` when `pleaState>0`. Filter
+`outcomeNational` only when sentencing or plea fall back.
+
+### W4 — Test asserts federal query NOT issued on state-data path
+
+Existing "pleaSource === 'state'" test never verifies the federal
+fallback query was skipped. A regression that always fires both
+queries would silently pass.
+
+**File:** `src/lib/tier9-reports/__tests__/similar-cases-fallback.test.ts`
+**Fix:** Add `expect(queryLog.filter(q => q.table === 'plea_discount_curves').length).toBe(1)`
+in the state-source test. Mirror for sentencing-state path.
+
+### S1 — renderFederalFallbackNote helper extracted (DRY render.ts captions)
+
+Two near-identical caption blocks at lines 1319-1325 and 1367-1373.
+Same inline style, only differ in section label.
+
+**File:** `src/lib/tier9-reports/render.ts`
+**Fix:** Extract `renderFederalFallbackNote(stateCode: string, sectionLabel: string): string`
+helper at the top of file. Both caption sites call helper.
+
+### S2 — Error-path test (table-missing → pleaSource='none')
+
+Production code has `vectors.count ?? 0` defensive coalesce but no
+test exercises the supabase-error path.
+
+**File:** `src/lib/tier9-reports/__tests__/similar-cases-fallback.test.ts`
+**Fix:** Add test where the supabase mock returns
+`{ data: null, error: { code: 'PGRST200' }, count: null }` for
+`plea_discount_curves`. Assert pleaSource === 'none'.
+
+### S3 — stateNameOrCode normalizes fallback to uppercase
+
+`stateNameOrCode("XY")` returns "XY", `stateNameOrCode("xy")`
+returns "xy" — inconsistent fallback case for unknown codes.
+
+**File:** `src/lib/states.ts`
+**Fix:** Uppercase the fallback return; JSDoc note "case-insensitive
+lookup; fallback returns uppercase".
+
+## Verification
+
+- `node node_modules/typescript/bin/tsc --noEmit --skipLibCheck` — 0 errors
+- `npx vitest run src/lib/tier9-reports/__tests__/similar-cases-fallback.test.ts`
+  — all green including new error-path test (W4 + S2 add new assertions)
+- Existing tier9 suite still 115/115
+
+## Cascade
+
+- us: PR ships pristine, no review-debt rolling forward
+- direct counterparty (defendant in 38 unsupported states): pre-purchase
+  disclosure when state sentencing data is missing too — no surprise inside
+  the rendered report
+- downstream (future Tier 9 SKUs hitting same coverage cliff):
+  `renderFederalFallbackNote` helper + `SENTENCING_SUPPORTED_STATES` Set are
+  reusable
+- future-us: tests now lock in the federal-query-skip invariant; regression
+  protection compounds
+- ecosystem: defensive states.ts pattern (uppercase fallback) generalizes
+- No node loses.
+
+## Commit
+
+Single commit on top of existing branch with the message specified by the
+session prompt.

--- a/src/components/tier9/AvailabilityChecker.tsx
+++ b/src/components/tier9/AvailabilityChecker.tsx
@@ -139,6 +139,11 @@ const COVERAGE_LABELS: Record<string, string> = {
   cpdComplaints: 'Chicago PD misconduct complaints',
   nypdOfficers: 'NYPD officer roster matches (CCRB)',
   nypdAllegations: 'NYPD CCRB allegations on the matched officer',
+  // similar-cases-analyzer state-coverage gating (D2 plan, 2026-04-26)
+  pleaState: 'state plea-discount records',
+  pleaFederal: 'federal plea-discount records',
+  sentencingState: 'state sentencing records',
+  outcomeNational: 'national outcome benchmarks',
 };
 
 const LOCALSTORAGE_KEY = 'inna_email';
@@ -354,6 +359,26 @@ export default function AvailabilityChecker({ slug, productName, priceDisplay }:
         <p className="text-zinc-300 text-sm mb-6">
           We have enough data to generate your {productName}. Here is what we found:
         </p>
+
+        {/* Similar-cases state-coverage info banner (D2 plan, 2026-04-26).
+            Surfaces federal-fallback BEFORE purchase so defendants in the 38
+            unsupported states know the plea-discount section will use federal
+            data. Buy button stays — disclosure, not a hard block. */}
+        {slug === 'similar-cases-analyzer' &&
+          (coverage.pleaState ?? 0) === 0 &&
+          (coverage.pleaFederal ?? 0) > 0 && (
+            <div
+              className="bg-amber-950/30 border-l-4 border-amber-500 rounded-r-lg p-4 mb-6"
+              role="note"
+            >
+              <p className="text-amber-200 text-sm">
+                <strong>Heads up:</strong> State-specific plea-discount data is not yet
+                available for{' '}
+                {US_STATES.find((s) => s.value === state)?.label ?? state}.
+                The report will use federal-level data as the closest available reference.
+              </p>
+            </div>
+          )}
 
         {entries.length > 0 && (
           <dl className="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-3 mb-8">

--- a/src/components/tier9/AvailabilityChecker.tsx
+++ b/src/components/tier9/AvailabilityChecker.tsx
@@ -344,7 +344,65 @@ export default function AvailabilityChecker({ slug, productName, priceDisplay }:
 
   /* Available state */
   if (componentState === 'available') {
-    const entries = Object.entries(coverage).filter(([, count]) => count > 0);
+    /* Similar-cases coverage shape — used for both the pre-purchase banner
+       (W2) and the dl filter (W3). When state-level data covers a section,
+       the federal/national fallback metric is not consumed by the renderer
+       and showing it in the dl grid double-counts inventory. */
+    const isSimilarCases = slug === 'similar-cases-analyzer';
+    const pleaStateMissing =
+      isSimilarCases &&
+      (coverage.pleaState ?? 0) === 0 &&
+      (coverage.pleaFederal ?? 0) > 0;
+    const sentencingStateMissing =
+      isSimilarCases &&
+      (coverage.sentencingState ?? 0) === 0 &&
+      (coverage.outcomeNational ?? 0) > 0;
+    const pleaStateCovers =
+      isSimilarCases && (coverage.pleaState ?? 0) > 0;
+    const sentencingStateCovers =
+      isSimilarCases && (coverage.sentencingState ?? 0) > 0;
+    const stateLabel =
+      US_STATES.find((s) => s.value === state)?.label ?? state;
+
+    /* Banner copy (W2): branch on which side(s) of the report fall back
+       to federal so the customer sees the right disclosure pre-purchase. */
+    let fallbackBanner: React.ReactNode = null;
+    if (pleaStateMissing && sentencingStateMissing) {
+      fallbackBanner = (
+        <p className="text-amber-200 text-sm">
+          <strong>Heads up:</strong> State-specific plea-discount and
+          sentencing-distribution data are not yet available for{' '}
+          {stateLabel}. The report will use federal-level data as the closest
+          available reference.
+        </p>
+      );
+    } else if (pleaStateMissing) {
+      fallbackBanner = (
+        <p className="text-amber-200 text-sm">
+          <strong>Heads up:</strong> State-specific plea-discount data is not yet
+          available for {stateLabel}. The report will use federal-level data as
+          the closest available reference.
+        </p>
+      );
+    } else if (sentencingStateMissing) {
+      fallbackBanner = (
+        <p className="text-amber-200 text-sm">
+          <strong>Heads up:</strong> State-specific sentencing-distribution data
+          is not yet available for {stateLabel}. Plea-discount data is
+          state-specific. The report will use federal-level sentencing data as
+          the closest available reference.
+        </p>
+      );
+    }
+
+    /* dl filter (W3): drop fallback-only metrics that this customer's
+       path does not actually consume. */
+    const entries = Object.entries(coverage).filter(([key, count]) => {
+      if (count <= 0) return false;
+      if (pleaStateCovers && key === 'pleaFederal') return false;
+      if (sentencingStateCovers && key === 'outcomeNational') return false;
+      return true;
+    });
 
     return (
       <div
@@ -360,25 +418,19 @@ export default function AvailabilityChecker({ slug, productName, priceDisplay }:
           We have enough data to generate your {productName}. Here is what we found:
         </p>
 
-        {/* Similar-cases state-coverage info banner (D2 plan, 2026-04-26).
-            Surfaces federal-fallback BEFORE purchase so defendants in the 38
-            unsupported states know the plea-discount section will use federal
-            data. Buy button stays — disclosure, not a hard block. */}
-        {slug === 'similar-cases-analyzer' &&
-          (coverage.pleaState ?? 0) === 0 &&
-          (coverage.pleaFederal ?? 0) > 0 && (
-            <div
-              className="bg-amber-950/30 border-l-4 border-amber-500 rounded-r-lg p-4 mb-6"
-              role="note"
-            >
-              <p className="text-amber-200 text-sm">
-                <strong>Heads up:</strong> State-specific plea-discount data is not yet
-                available for{' '}
-                {US_STATES.find((s) => s.value === state)?.label ?? state}.
-                The report will use federal-level data as the closest available reference.
-              </p>
-            </div>
-          )}
+        {/* Similar-cases state-coverage info banner (D2 plan, 2026-04-26;
+            extended 2026-04-26 PR #168 review W2). Surfaces federal-fallback
+            BEFORE purchase so defendants without ingested state-level
+            plea-discount OR sentencing data know the affected sections will
+            use federal data. Buy button stays — disclosure, not a hard block. */}
+        {fallbackBanner && (
+          <div
+            className="bg-amber-950/30 border-l-4 border-amber-500 rounded-r-lg p-4 mb-6"
+            role="note"
+          >
+            {fallbackBanner}
+          </div>
+        )}
 
         {entries.length > 0 && (
           <dl className="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-3 mb-8">

--- a/src/lib/states.ts
+++ b/src/lib/states.ts
@@ -65,12 +65,14 @@ export const US_STATE_NAMES: Record<string, string> = {
 };
 
 /**
- * Resolve a US state code to its full name. When the code is unknown
- * (anything outside the 50 states + DC) the original input is returned
- * unchanged so the caller can still render *something* in customer-facing
- * surfaces — never an empty string.
+ * Resolve a US state code to its full name. Lookup is case-insensitive;
+ * fallback (when the code is outside the 50 states + DC) returns the
+ * input UPPER-CASED so customer-facing surfaces never render an empty
+ * string and the casing stays consistent regardless of how the caller
+ * passed the code in.
  */
 export function stateNameOrCode(code: string): string {
   if (!code) return code;
-  return US_STATE_NAMES[code.toUpperCase()] ?? code;
+  const upper = code.toUpperCase();
+  return US_STATE_NAMES[upper] ?? upper;
 }

--- a/src/lib/states.ts
+++ b/src/lib/states.ts
@@ -1,0 +1,76 @@
+/**
+ * Shared US state code → name lookup.
+ *
+ * Used by:
+ *   - src/lib/tier9-reports/coverage.ts (district coverage state-name match)
+ *   - src/lib/tier9-reports/render.ts   (federal-fallback caption rendering)
+ *
+ * Steal-Before-Building: extracted from inline literal in coverage.ts so the
+ * federal-fallback caption + any future Tier 9 SKU hitting the same coverage
+ * cliff can reuse a single source of truth.
+ */
+
+export const US_STATE_NAMES: Record<string, string> = {
+  AL: "Alabama",
+  AK: "Alaska",
+  AZ: "Arizona",
+  AR: "Arkansas",
+  CA: "California",
+  CO: "Colorado",
+  CT: "Connecticut",
+  DE: "Delaware",
+  DC: "District of Columbia",
+  FL: "Florida",
+  GA: "Georgia",
+  HI: "Hawaii",
+  ID: "Idaho",
+  IL: "Illinois",
+  IN: "Indiana",
+  IA: "Iowa",
+  KS: "Kansas",
+  KY: "Kentucky",
+  LA: "Louisiana",
+  ME: "Maine",
+  MD: "Maryland",
+  MA: "Massachusetts",
+  MI: "Michigan",
+  MN: "Minnesota",
+  MS: "Mississippi",
+  MO: "Missouri",
+  MT: "Montana",
+  NE: "Nebraska",
+  NV: "Nevada",
+  NH: "New Hampshire",
+  NJ: "New Jersey",
+  NM: "New Mexico",
+  NY: "New York",
+  NC: "North Carolina",
+  ND: "North Dakota",
+  OH: "Ohio",
+  OK: "Oklahoma",
+  OR: "Oregon",
+  PA: "Pennsylvania",
+  RI: "Rhode Island",
+  SC: "South Carolina",
+  SD: "South Dakota",
+  TN: "Tennessee",
+  TX: "Texas",
+  UT: "Utah",
+  VT: "Vermont",
+  VA: "Virginia",
+  WA: "Washington",
+  WV: "West Virginia",
+  WI: "Wisconsin",
+  WY: "Wyoming",
+};
+
+/**
+ * Resolve a US state code to its full name. When the code is unknown
+ * (anything outside the 50 states + DC) the original input is returned
+ * unchanged so the caller can still render *something* in customer-facing
+ * surfaces — never an empty string.
+ */
+export function stateNameOrCode(code: string): string {
+  if (!code) return code;
+  return US_STATE_NAMES[code.toUpperCase()] ?? code;
+}

--- a/src/lib/tier9-reports/__tests__/similar-cases-fallback.test.ts
+++ b/src/lib/tier9-reports/__tests__/similar-cases-fallback.test.ts
@@ -1,0 +1,283 @@
+/**
+ * Unit tests for the similar-cases-analyzer state-coverage gating + federal
+ * fallback (D2 plan, 2026-04-26).
+ *
+ * Focus:
+ *   - querySimilarCases pleaSource discriminator (state | federal | none)
+ *   - querySimilarCases sentencingSource discriminator (state | federal | none)
+ *   - checkSimilarCasesCoverage exposes the four new counts
+ *   - Federal fallback only fires when state-level returns 0 rows
+ *
+ * The Supabase admin client is mocked at module level. Each `from(...)` call
+ * is replayed against a per-test scripted query log so the federal-fallback
+ * second-query path can be observed.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// ── Supabase mock ────────────────────────────────────────────────────
+// Each test seeds a script keyed by `${table}|${jurisdictionFilter}`.
+// The mock client returns canned rows for matching scripts and `[]` otherwise.
+// `count` queries return { count: rows.length }.
+
+interface QueryRecord {
+  table: string;
+  filters: Array<{ col: string; val: unknown }>;
+  isCount: boolean;
+}
+
+let queryLog: QueryRecord[] = [];
+let scriptedRows: Map<string, unknown[]> = new Map();
+
+function rowsKey(table: string, jurisdiction?: string): string {
+  return jurisdiction === undefined ? table : `${table}|${jurisdiction}`;
+}
+
+function mockBuilder(table: string, isCount: boolean) {
+  const filters: Array<{ col: string; val: unknown }> = [];
+  const record: QueryRecord = { table, filters, isCount };
+  queryLog.push(record);
+
+  const builder: Record<string, unknown> = {};
+  builder.eq = (col: string, val: unknown) => {
+    filters.push({ col, val });
+    return builder;
+  };
+  builder.in = (col: string, val: unknown) => {
+    filters.push({ col, val });
+    return builder;
+  };
+  builder.order = () => builder;
+  builder.limit = () => builder;
+  builder.then = (resolve: (val: unknown) => unknown) => {
+    const jurisdictionFilter = filters.find((f) => f.col === "jurisdiction")?.val as
+      | string
+      | undefined;
+    const rows =
+      scriptedRows.get(rowsKey(table, jurisdictionFilter)) ??
+      scriptedRows.get(rowsKey(table)) ??
+      [];
+    if (isCount) {
+      return Promise.resolve({ count: rows.length, data: null }).then(resolve);
+    }
+    return Promise.resolve({ data: rows, error: null }).then(resolve);
+  };
+  return builder;
+}
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: () => ({
+    from: (table: string) => ({
+      select: (_cols: string, opts?: { count?: string; head?: boolean }) => {
+        const isCount = !!(opts && opts.count === "exact");
+        return mockBuilder(table, isCount);
+      },
+    }),
+  }),
+}));
+
+vi.mock("@/lib/feature-flags", () => ({
+  isFeatureEnabled: async () => false,
+}));
+
+vi.mock("../cpd-match", () => ({
+  parseOfficerName: () => ({ lastName: "", firstName: "" }),
+}));
+
+vi.mock("../nypd-match", () => ({
+  parseNypdName: () => ({ lastName: "", firstName: "" }),
+  classifyNypdSignal: () => null,
+  fetchNypdCandidates: async () => ({ candidates: [], truncated: false }),
+  chooseNypdMatch: () => ({ status: "none", matchedTaxId: null }),
+}));
+
+import { querySimilarCases } from "../query";
+import { checkSimilarCasesCoverage } from "../coverage";
+
+const PLEA_STATE_ROW = {
+  charge_slug: "drug-possession",
+  base_sentence: 36,
+  plea_sentence: 18,
+  cooperation_bonus: 6,
+  sample_size: 120,
+  source_urls: ["https://example.com/state-source"],
+};
+
+const PLEA_FEDERAL_ROW = {
+  charge_slug: "drug-possession",
+  base_sentence: 60,
+  plea_sentence: 30,
+  cooperation_bonus: 12,
+  sample_size: 800,
+  source_urls: ["https://example.com/federal-source"],
+};
+
+const SENT_STATE_ROW = {
+  judge_id: null,
+  charge_slug: "drug-possession",
+  median_months: 12,
+  p25: 6,
+  p75: 18,
+  sample_size: 90,
+  source_urls: ["https://example.com/state-sent"],
+};
+
+const SENT_FEDERAL_ROW = {
+  judge_id: null,
+  charge_slug: "drug-possession",
+  median_months: 24,
+  p25: 12,
+  p75: 36,
+  sample_size: 500,
+  source_urls: ["https://example.com/fed-sent"],
+};
+
+beforeEach(() => {
+  queryLog = [];
+  scriptedRows = new Map();
+});
+
+describe("querySimilarCases — pleaSource fallback", () => {
+  it("pleaSource === 'state' when state-level rows exist", async () => {
+    scriptedRows.set(rowsKey("plea_discount_curves", "FL"), [PLEA_STATE_ROW]);
+    scriptedRows.set(rowsKey("sentencing_distributions", "FL"), [SENT_STATE_ROW]);
+
+    const data = await querySimilarCases({
+      chargeType: "drug-possession",
+      state: "FL",
+    });
+
+    expect(data.pleaSource).toBe("state");
+    expect(data.pleaDiscountCurves.length).toBe(1);
+    expect(data.pleaDiscountCurves[0].plea_sentence).toBe(18);
+  });
+
+  it("pleaSource === 'federal' when state empty but federal has rows", async () => {
+    scriptedRows.set(
+      rowsKey("plea_discount_curves", "federal"),
+      [PLEA_FEDERAL_ROW],
+    );
+    // Provide federal sentencing too so the fallback path also exercises it
+    scriptedRows.set(
+      rowsKey("sentencing_distributions", "federal"),
+      [SENT_FEDERAL_ROW],
+    );
+
+    const data = await querySimilarCases({
+      chargeType: "drug-possession",
+      state: "WY",
+    });
+
+    expect(data.pleaSource).toBe("federal");
+    expect(data.pleaDiscountCurves.length).toBe(1);
+    expect(data.pleaDiscountCurves[0].plea_sentence).toBe(30);
+
+    // Confirm the second query targeted jurisdiction='federal'
+    const pleaQueries = queryLog.filter((q) => q.table === "plea_discount_curves");
+    expect(pleaQueries.length).toBe(2);
+    const federalQuery = pleaQueries[1];
+    expect(
+      federalQuery.filters.find((f) => f.col === "jurisdiction")?.val,
+    ).toBe("federal");
+  });
+
+  it("pleaSource === 'none' when neither state nor federal has rows", async () => {
+    // No scripted rows for plea_discount_curves at all.
+    const data = await querySimilarCases({
+      chargeType: "drug-possession",
+      state: "WY",
+    });
+
+    expect(data.pleaSource).toBe("none");
+    expect(data.pleaDiscountCurves).toEqual([]);
+  });
+});
+
+describe("querySimilarCases — sentencingSource fallback", () => {
+  it("sentencingSource === 'state' when state-level rows exist", async () => {
+    scriptedRows.set(rowsKey("sentencing_distributions", "IL"), [SENT_STATE_ROW]);
+
+    const data = await querySimilarCases({
+      chargeType: "drug-possession",
+      state: "IL",
+    });
+
+    expect(data.sentencingSource).toBe("state");
+    expect(data.sentencingDistributions.length).toBe(1);
+    expect(data.sentencingDistributions[0].median_months).toBe(12);
+  });
+
+  it("sentencingSource === 'federal' when state empty but federal has rows", async () => {
+    scriptedRows.set(
+      rowsKey("sentencing_distributions", "federal"),
+      [SENT_FEDERAL_ROW],
+    );
+
+    const data = await querySimilarCases({
+      chargeType: "drug-possession",
+      state: "WY",
+    });
+
+    expect(data.sentencingSource).toBe("federal");
+    expect(data.sentencingDistributions.length).toBe(1);
+    expect(data.sentencingDistributions[0].median_months).toBe(24);
+  });
+
+  it("sentencingSource === 'none' when neither state nor federal has rows", async () => {
+    const data = await querySimilarCases({
+      chargeType: "drug-possession",
+      state: "WY",
+    });
+
+    expect(data.sentencingSource).toBe("none");
+    expect(data.sentencingDistributions).toEqual([]);
+  });
+});
+
+describe("checkSimilarCasesCoverage — new counts", () => {
+  it("returns six distinct counts including the four new keys", async () => {
+    // Seed feature_vectors so the gate-relevant similarCases is non-zero
+    scriptedRows.set(rowsKey("case_feature_vectors", "FL"), [
+      { id: "a" },
+      { id: "b" },
+      { id: "c" },
+    ]);
+    scriptedRows.set(rowsKey("appellate_trends", "FL"), [{ id: "x" }]);
+    scriptedRows.set(rowsKey("plea_discount_curves", "FL"), [PLEA_STATE_ROW]);
+    scriptedRows.set(rowsKey("plea_discount_curves", "federal"), [
+      PLEA_FEDERAL_ROW,
+    ]);
+    scriptedRows.set(rowsKey("sentencing_distributions", "FL"), [SENT_STATE_ROW]);
+    scriptedRows.set(rowsKey("outcome_benchmarks"), [{ id: "n" }]);
+
+    const result = await checkSimilarCasesCoverage("drug-possession", "FL");
+
+    expect(result.coverage).toMatchObject({
+      similarCases: 3,
+      appellate: 1,
+      pleaState: 1,
+      pleaFederal: 1,
+      sentencingState: 1,
+      outcomeNational: 1,
+    });
+    expect(result.available).toBe(true);
+  });
+
+  it("flags federal-only coverage (state plea = 0, federal plea > 0)", async () => {
+    scriptedRows.set(rowsKey("case_feature_vectors", "WY"), [
+      { id: "a" },
+      { id: "b" },
+      { id: "c" },
+    ]);
+    scriptedRows.set(rowsKey("plea_discount_curves", "federal"), [
+      PLEA_FEDERAL_ROW,
+    ]);
+    // No WY state plea row, no WY sentencing.
+
+    const result = await checkSimilarCasesCoverage("drug-possession", "WY");
+
+    expect(result.coverage.pleaState).toBe(0);
+    expect(result.coverage.pleaFederal).toBeGreaterThan(0);
+    expect(result.coverage.sentencingState).toBe(0);
+    expect(result.available).toBe(true); // similarCases >= 3 is the gate
+  });
+});

--- a/src/lib/tier9-reports/__tests__/similar-cases-fallback.test.ts
+++ b/src/lib/tier9-reports/__tests__/similar-cases-fallback.test.ts
@@ -27,6 +27,8 @@ interface QueryRecord {
 
 let queryLog: QueryRecord[] = [];
 let scriptedRows: Map<string, unknown[]> = new Map();
+/** S2: scripted Supabase error responses for the table+jurisdiction key. */
+let scriptedErrors: Map<string, { code: string; message: string }> = new Map();
 
 function rowsKey(table: string, jurisdiction?: string): string {
   return jurisdiction === undefined ? table : `${table}|${jurisdiction}`;
@@ -52,6 +54,17 @@ function mockBuilder(table: string, isCount: boolean) {
     const jurisdictionFilter = filters.find((f) => f.col === "jurisdiction")?.val as
       | string
       | undefined;
+    const errorKey =
+      scriptedErrors.get(rowsKey(table, jurisdictionFilter)) ??
+      scriptedErrors.get(rowsKey(table));
+    if (errorKey) {
+      // S2: Supabase error path — production code coalesces null data
+      // and null count into pleaSource='none' / coverage 0.
+      if (isCount) {
+        return Promise.resolve({ count: null, data: null, error: errorKey }).then(resolve);
+      }
+      return Promise.resolve({ data: null, error: errorKey }).then(resolve);
+    }
     const rows =
       scriptedRows.get(rowsKey(table, jurisdictionFilter)) ??
       scriptedRows.get(rowsKey(table)) ??
@@ -134,6 +147,7 @@ const SENT_FEDERAL_ROW = {
 beforeEach(() => {
   queryLog = [];
   scriptedRows = new Map();
+  scriptedErrors = new Map();
 });
 
 describe("querySimilarCases — pleaSource fallback", () => {
@@ -149,6 +163,13 @@ describe("querySimilarCases — pleaSource fallback", () => {
     expect(data.pleaSource).toBe("state");
     expect(data.pleaDiscountCurves.length).toBe(1);
     expect(data.pleaDiscountCurves[0].plea_sentence).toBe(18);
+
+    // PR #168 W4: federal-fallback query MUST NOT fire when state has rows.
+    // A regression that always issues both queries would otherwise pass.
+    const pleaQueries = queryLog.filter(
+      (q) => q.table === "plea_discount_curves",
+    );
+    expect(pleaQueries.length).toBe(1);
   });
 
   it("pleaSource === 'federal' when state empty but federal has rows", async () => {
@@ -190,6 +211,24 @@ describe("querySimilarCases — pleaSource fallback", () => {
     expect(data.pleaSource).toBe("none");
     expect(data.pleaDiscountCurves).toEqual([]);
   });
+
+  // PR #168 S2: error-path coverage. Production code defensively coalesces
+  // null/error responses with `?? []` and `?? 0`. Without this test a
+  // regression that surfaced raw nulls would slip through unnoticed.
+  it("pleaSource === 'none' when Supabase returns an error for plea_discount_curves", async () => {
+    scriptedErrors.set(rowsKey("plea_discount_curves"), {
+      code: "PGRST200",
+      message: "simulated table-missing error",
+    });
+
+    const data = await querySimilarCases({
+      chargeType: "drug-possession",
+      state: "WY",
+    });
+
+    expect(data.pleaSource).toBe("none");
+    expect(data.pleaDiscountCurves).toEqual([]);
+  });
 });
 
 describe("querySimilarCases — sentencingSource fallback", () => {
@@ -204,6 +243,12 @@ describe("querySimilarCases — sentencingSource fallback", () => {
     expect(data.sentencingSource).toBe("state");
     expect(data.sentencingDistributions.length).toBe(1);
     expect(data.sentencingDistributions[0].median_months).toBe(12);
+
+    // PR #168 W4: federal-fallback query MUST NOT fire when state has rows.
+    const sentencingQueries = queryLog.filter(
+      (q) => q.table === "sentencing_distributions",
+    );
+    expect(sentencingQueries.length).toBe(1);
   });
 
   it("sentencingSource === 'federal' when state empty but federal has rows", async () => {

--- a/src/lib/tier9-reports/coverage.ts
+++ b/src/lib/tier9-reports/coverage.ts
@@ -6,6 +6,7 @@
 
 import { createAdminClient } from "@/lib/supabase/admin";
 import { isFeatureEnabled } from "@/lib/feature-flags";
+import { US_STATE_NAMES } from "@/lib/states";
 import { parseOfficerName } from "./cpd-match";
 import {
   parseNypdName,
@@ -240,23 +241,10 @@ export async function checkDistrictCoverage(
   const supabase = createAdminClient();
   const safeState = escapeIlike(stateCode);
 
-  // Map state code to state name for district ilike match
-  const stateNames: Record<string, string> = {
-    AL: "Alabama", AK: "Alaska", AZ: "Arizona", AR: "Arkansas",
-    CA: "California", CO: "Colorado", CT: "Connecticut", DE: "Delaware",
-    DC: "District of Columbia", FL: "Florida", GA: "Georgia", HI: "Hawaii",
-    ID: "Idaho", IL: "Illinois", IN: "Indiana", IA: "Iowa",
-    KS: "Kansas", KY: "Kentucky", LA: "Louisiana", ME: "Maine",
-    MD: "Maryland", MA: "Massachusetts", MI: "Michigan", MN: "Minnesota",
-    MS: "Mississippi", MO: "Missouri", MT: "Montana", NE: "Nebraska",
-    NV: "Nevada", NH: "New Hampshire", NJ: "New Jersey", NM: "New Mexico",
-    NY: "New York", NC: "North Carolina", ND: "North Dakota", OH: "Ohio",
-    OK: "Oklahoma", OR: "Oregon", PA: "Pennsylvania", RI: "Rhode Island",
-    SC: "South Carolina", SD: "South Dakota", TN: "Tennessee", TX: "Texas",
-    UT: "Utah", VT: "Vermont", VA: "Virginia", WA: "Washington",
-    WV: "West Virginia", WI: "Wisconsin", WY: "Wyoming",
-  };
-  const stateName = stateNames[safeState.toUpperCase()] ?? safeState;
+  // Map state code to state name for district ilike match (shared lookup
+  // lives in src/lib/states.ts so the federal-fallback caption layer reuses
+  // the same source of truth).
+  const stateName = US_STATE_NAMES[safeState.toUpperCase()] ?? safeState;
   const safeStateName = escapeIlike(stateName).toLowerCase();
 
   const [judges, benchmarks] = await Promise.all([
@@ -312,7 +300,22 @@ export async function checkSimilarCasesCoverage(
 ): Promise<CoverageResult> {
   const supabase = createAdminClient();
 
-  const [vectors, appellate] = await Promise.all([
+  // Six parallel COUNT queries:
+  //   - similarCases / appellate     — existing case_feature_vectors gate
+  //   - pleaState / pleaFederal      — plea_discount_curves coverage cliff
+  //   - sentencingState              — sentencing_distributions coverage cliff
+  //   - outcomeNational              — national-only outcome benchmarks (today)
+  // The four new counts power the pre-purchase yellow info-banner in
+  // AvailabilityChecker.tsx — surfacing federal-fallback to defendants in
+  // the 38 states without ingested plea/sentencing data.
+  const [
+    vectors,
+    appellate,
+    pleaState,
+    pleaFederal,
+    sentencingState,
+    outcomeNational,
+  ] = await Promise.all([
     supabase
       .from("case_feature_vectors")
       .select("id", { count: "exact", head: true })
@@ -322,13 +325,40 @@ export async function checkSimilarCasesCoverage(
       .from("appellate_trends")
       .select("id", { count: "exact", head: true })
       .eq("jurisdiction", state),
+    supabase
+      .from("plea_discount_curves")
+      .select("charge_slug", { count: "exact", head: true })
+      .eq("charge_slug", chargeType)
+      .eq("jurisdiction", state),
+    supabase
+      .from("plea_discount_curves")
+      .select("charge_slug", { count: "exact", head: true })
+      .eq("charge_slug", chargeType)
+      .eq("jurisdiction", "federal"),
+    supabase
+      .from("sentencing_distributions")
+      .select("charge_slug", { count: "exact", head: true })
+      .eq("charge_slug", chargeType)
+      .eq("jurisdiction", state),
+    supabase
+      .from("outcome_benchmarks")
+      .select("id", { count: "exact", head: true })
+      .eq("offense_type", chargeType)
+      .eq("jurisdiction_level", "national"),
   ]);
 
   const coverage = {
     similarCases: vectors.count ?? 0,
     appellate: appellate.count ?? 0,
+    pleaState: pleaState.count ?? 0,
+    pleaFederal: pleaFederal.count ?? 0,
+    sentencingState: sentencingState.count ?? 0,
+    outcomeNational: outcomeNational.count ?? 0,
   };
 
+  // `available` boolean stays gated on similarCases only — D-4 in the plan.
+  // Federal-fallback exists precisely so we DON'T hard-block customers in
+  // unsupported states; the banner discloses, the customer chooses.
   const available = coverage.similarCases >= 3;
 
   return {

--- a/src/lib/tier9-reports/query.ts
+++ b/src/lib/tier9-reports/query.ts
@@ -327,6 +327,21 @@ export interface SimilarCasesData {
     sample_size: number;
     source_urls: string[] | null;
   }>;
+  /**
+   * Provenance discriminator for `pleaDiscountCurves`.
+   * - `state`   — rows came from the requested state's jurisdiction.
+   * - `federal` — state had zero rows; federal fallback returned data.
+   * - `none`    — neither state nor federal had matching rows.
+   * Drives the yellow caption in render.ts so customers in the 38 states
+   * without ingested plea data see explicit data-provenance disclosure.
+   */
+  pleaSource: "state" | "federal" | "none";
+  /**
+   * Provenance discriminator for `sentencingDistributions`.
+   * Same semantics as `pleaSource`. `sentencing_distributions` covers 8
+   * states + federal today (AZ, DE, IL, MI, NE, VA, WI, federal).
+   */
+  sentencingSource: "state" | "federal" | "none";
   isEmpty: boolean;
 }
 
@@ -944,18 +959,68 @@ export async function querySimilarCases(
       .limit(10),
   ]);
 
+  // ── Federal fallback (D2 plan, 2026-04-26) ─────────────────────────
+  // plea_discount_curves covers only 12 states + federal today
+  // (FL/IA/IL/MI/MN/MS/NC/NE/NJ/TN/VA/WV). For defendants in the 38
+  // unsupported states, fall back to the federal-level row keyed by the
+  // same charge_slug rather than emit a blank section. The caller-facing
+  // discriminator (pleaSource / sentencingSource) lets render.ts label
+  // the fallback so the customer knows the source is federal, not state.
+  // The conditional second-query keeps the cold path single-query for
+  // the 12 supported states.
+  let pleaRows = plea.data ?? [];
+  let pleaSource: "state" | "federal" | "none" =
+    pleaRows.length > 0 ? "state" : "none";
+  if (pleaRows.length === 0) {
+    const { data: pleaFederal } = await supabase
+      .from("plea_discount_curves")
+      .select(
+        "charge_slug, base_sentence, plea_sentence, cooperation_bonus, sample_size, source_urls",
+      )
+      .eq("charge_slug", chargeSlug)
+      .eq("jurisdiction", "federal")
+      .limit(20);
+    if ((pleaFederal?.length ?? 0) > 0) {
+      pleaRows = pleaFederal ?? [];
+      pleaSource = "federal";
+    }
+  }
+
+  // sentencing_distributions covers 8 states + federal
+  // (AZ/DE/IL/MI/NE/VA/WI + federal). Same fallback shape as plea.
+  let sentencingRows = sentencing.data ?? [];
+  let sentencingSource: "state" | "federal" | "none" =
+    sentencingRows.length > 0 ? "state" : "none";
+  if (sentencingRows.length === 0) {
+    const { data: sentencingFederal } = await supabase
+      .from("sentencing_distributions")
+      .select(
+        "judge_id, charge_slug, median_months, p25, p75, sample_size, source_urls",
+      )
+      .eq("charge_slug", chargeSlug)
+      .eq("jurisdiction", "federal")
+      .order("sample_size", { ascending: false })
+      .limit(50);
+    if ((sentencingFederal?.length ?? 0) > 0) {
+      sentencingRows = sentencingFederal ?? [];
+      sentencingSource = "federal";
+    }
+  }
+
   const hasData =
     (vectors.data?.length ?? 0) > 0 ||
-    (sentencing.data?.length ?? 0) > 0 ||
-    (plea.data?.length ?? 0) > 0 ||
+    sentencingRows.length > 0 ||
+    pleaRows.length > 0 ||
     (benchmarks.data?.length ?? 0) > 0;
 
   return {
     featureVectors: vectors.data ?? [],
-    sentencingDistributions: sentencing.data ?? [],
-    pleaDiscountCurves: plea.data ?? [],
+    sentencingDistributions: sentencingRows,
+    pleaDiscountCurves: pleaRows,
     appellateTrends: appellate.data ?? [],
     outcomeBenchmarks: benchmarks.data ?? [],
+    pleaSource,
+    sentencingSource,
     isEmpty: !hasData,
   };
 }

--- a/src/lib/tier9-reports/query.ts
+++ b/src/lib/tier9-reports/query.ts
@@ -338,8 +338,10 @@ export interface SimilarCasesData {
   pleaSource: "state" | "federal" | "none";
   /**
    * Provenance discriminator for `sentencingDistributions`.
-   * Same semantics as `pleaSource`. `sentencing_distributions` covers 8
-   * states + federal today (AZ, DE, IL, MI, NE, VA, WI, federal).
+   * Same semantics as `pleaSource`. `sentencing_distributions` covers 7
+   * states + federal today (AZ, DE, IL, MI, NE, VA, WI). Numeric
+   * `jurisdiction` values seen on this table are federal-district codes,
+   * not US states.
    */
   sentencingSource: "state" | "federal" | "none";
   isEmpty: boolean;
@@ -913,6 +915,24 @@ export async function queryOfficerBackground(
   };
 }
 
+/**
+ * State ISO codes for which `sentencing_distributions` has ingested
+ * state-level rows today. The numeric `jurisdiction` values that also
+ * appear in this table are federal-district codes, NOT US states — those
+ * are reached only via the federal-fallback branch keyed on
+ * `jurisdiction='federal'`. Source-of-truth for AvailabilityChecker
+ * banner copy + future Tier 9 SKUs hitting the same coverage cliff.
+ */
+export const SENTENCING_SUPPORTED_STATES = new Set([
+  "AZ",
+  "DE",
+  "IL",
+  "MI",
+  "NE",
+  "VA",
+  "WI",
+]);
+
 export async function querySimilarCases(
   intake: SimilarCasesIntake
 ): Promise<SimilarCasesData> {
@@ -986,8 +1006,10 @@ export async function querySimilarCases(
     }
   }
 
-  // sentencing_distributions covers 8 states + federal
-  // (AZ/DE/IL/MI/NE/VA/WI + federal). Same fallback shape as plea.
+  // sentencing_distributions covers 7 states + federal
+  // (AZ/DE/IL/MI/NE/VA/WI). Numeric jurisdiction codes seen on this
+  // table are federal-district codes, NOT US states. Same fallback
+  // shape as plea — surfaces via SENTENCING_SUPPORTED_STATES below.
   let sentencingRows = sentencing.data ?? [];
   let sentencingSource: "state" | "federal" | "none" =
     sentencingRows.length > 0 ? "state" : "none";

--- a/src/lib/tier9-reports/render.ts
+++ b/src/lib/tier9-reports/render.ts
@@ -5,6 +5,7 @@
  */
 
 import { escapeHtml } from "@/lib/email";
+import { stateNameOrCode } from "@/lib/states";
 import type {
   JudgeReportCardData,
   OfficerBackgroundData,
@@ -1311,6 +1312,17 @@ export function renderSimilarCases(
   // Sentencing Distributions
   body += sectionHeader("Sentencing Distribution");
   if (data.sentencingDistributions.length > 0) {
+    // Federal-fallback caption (D2 plan, 2026-04-26): when the requested
+    // state has no sentencing_distributions rows but federal data backed
+    // the section, surface the provenance to the reader. Clinical tone,
+    // no UPL drift ("you should" / "consult your attorney" banned).
+    if (data.sentencingSource === "federal") {
+      body += `
+      <p style="color: #FBBF24; background: #422006; border-left: 3px solid #F59E0B; padding: 12px 16px; margin-bottom: 16px; font-size: 14px;">
+        <strong>Note:</strong> State-specific sentencing data is not yet ingested for ${escapeHtml(stateNameOrCode(intake.state))}. Showing federal-level data as the closest available reference.
+      </p>
+      `;
+    }
     body += `
       <p style="color: #A1A1AA; margin-bottom: 16px; font-size: 14px;">
         Sentencing patterns across judges for ${escapeHtml(intake.chargeType)} cases.
@@ -1349,6 +1361,16 @@ export function renderSimilarCases(
   // Plea Discount Curves
   body += sectionHeader("Plea Discount Analysis");
   if (data.pleaDiscountCurves.length > 0) {
+    // Federal-fallback caption (D2 plan, 2026-04-26): same provenance
+    // disclosure as the sentencing section above. plea_discount_curves
+    // covers 12 states + federal today.
+    if (data.pleaSource === "federal") {
+      body += `
+      <p style="color: #FBBF24; background: #422006; border-left: 3px solid #F59E0B; padding: 12px 16px; margin-bottom: 16px; font-size: 14px;">
+        <strong>Note:</strong> State-specific plea-discount data is not yet ingested for ${escapeHtml(stateNameOrCode(intake.state))}. Showing federal-level data as the closest available reference.
+      </p>
+      `;
+    }
     body += `
       <p style="color: #A1A1AA; margin-bottom: 16px; font-size: 14px;">
         Comparison of sentences for defendants who took plea deals vs went to trial.

--- a/src/lib/tier9-reports/render.ts
+++ b/src/lib/tier9-reports/render.ts
@@ -125,6 +125,30 @@ function countSources(...arrays: (string[] | null | undefined)[]): number {
   return count;
 }
 
+/**
+ * Federal-fallback caption helper (D2 plan, 2026-04-26).
+ *
+ * Both the sentencing and the plea-discount sections in the Similar Cases
+ * renderer surface the same provenance disclosure when their respective
+ * federal-fallback path fires. This helper keeps the inline-styled HTML
+ * in one place. Tone stays clinical — no UPL drift ("you should" /
+ * "consult your attorney" remain banned).
+ *
+ * @param stateCode  Two-letter ISO state code from the intake.
+ * @param sectionLabel  Human-readable name of the section, e.g.
+ *                      "sentencing" or "plea-discount".
+ */
+function renderFederalFallbackNote(
+  stateCode: string,
+  sectionLabel: string,
+): string {
+  return `
+      <p style="color: #FBBF24; background: #422006; border-left: 3px solid #F59E0B; padding: 12px 16px; margin-bottom: 16px; font-size: 14px;">
+        <strong>Note:</strong> State-specific ${escapeHtml(sectionLabel)} data is not yet ingested for ${escapeHtml(stateNameOrCode(stateCode))}. Showing federal-level data as the closest available reference.
+      </p>
+      `;
+}
+
 function wrapReport(title: string, body: string, sourceCount: number): string {
   return `
     <div style="font-family: 'Segoe UI', Arial, sans-serif; max-width: 800px; margin: 0 auto; background: #0C0A09; color: #D4D4D8; padding: 32px;">
@@ -1314,14 +1338,10 @@ export function renderSimilarCases(
   if (data.sentencingDistributions.length > 0) {
     // Federal-fallback caption (D2 plan, 2026-04-26): when the requested
     // state has no sentencing_distributions rows but federal data backed
-    // the section, surface the provenance to the reader. Clinical tone,
-    // no UPL drift ("you should" / "consult your attorney" banned).
+    // the section, surface the provenance to the reader. Helper keeps
+    // the markup DRY across the sentencing and plea-discount sections.
     if (data.sentencingSource === "federal") {
-      body += `
-      <p style="color: #FBBF24; background: #422006; border-left: 3px solid #F59E0B; padding: 12px 16px; margin-bottom: 16px; font-size: 14px;">
-        <strong>Note:</strong> State-specific sentencing data is not yet ingested for ${escapeHtml(stateNameOrCode(intake.state))}. Showing federal-level data as the closest available reference.
-      </p>
-      `;
+      body += renderFederalFallbackNote(intake.state, "sentencing");
     }
     body += `
       <p style="color: #A1A1AA; margin-bottom: 16px; font-size: 14px;">
@@ -1365,11 +1385,7 @@ export function renderSimilarCases(
     // disclosure as the sentencing section above. plea_discount_curves
     // covers 12 states + federal today.
     if (data.pleaSource === "federal") {
-      body += `
-      <p style="color: #FBBF24; background: #422006; border-left: 3px solid #F59E0B; padding: 12px 16px; margin-bottom: 16px; font-size: 14px;">
-        <strong>Note:</strong> State-specific plea-discount data is not yet ingested for ${escapeHtml(stateNameOrCode(intake.state))}. Showing federal-level data as the closest available reference.
-      </p>
-      `;
+      body += renderFederalFallbackNote(intake.state, "plea-discount");
     }
     body += `
       <p style="color: #A1A1AA; margin-bottom: 16px; font-size: 14px;">


### PR DESCRIPTION
## Summary

D2 from `docs/handoff/2026-04-26-product-audit-deferred.md`.
Plan: `docs/plans/2026-04-26-d2-similar-cases-state-coverage.md`.

`plea_discount_curves` covers 12 states + federal. `sentencing_distributions` covers 8 states + federal. Defendants in non-covered states paid `$297` and silently received reports with empty plea/sentencing sections. This PR ships the **option (b) interim** from the audit: code-only gating + federal fallback. Data ingestion (option a) stays deferred.

- **Pre-purchase** — `AvailabilityChecker` surfaces a yellow info-banner when the customer's state has zero plea-discount records but federal data exists. Buy button stays — disclosure, not a hard block.
- **Post-purchase renderer** — `querySimilarCases` auto-falls-back to `jurisdiction='federal'` when state-level returns 0 rows for both `plea_discount_curves` and `sentencing_distributions`. New `pleaSource` / `sentencingSource` discriminators flow through to `render.ts`, which surfaces an explicit "State-specific data is not yet ingested for [STATE]. Showing federal-level data as the closest available reference." caption.
- **Shared module** — `src/lib/states.ts` extracts the duplicated state-code → name map so both `coverage.ts` and `render.ts` use one source of truth.

No data ingestion this pass. Slug (`similar-cases-analyzer`), Stripe price ID, and `$297` price all unchanged.

## Test plan

- [x] `tsc --noEmit --skipLibCheck` — 0 errors after `.next/types` clear
- [x] New `src/lib/tier9-reports/__tests__/similar-cases-fallback.test.ts` — 8 tests covering state / federal / none for `pleaSource` + `sentencingSource` plus coverage-shape assertions
- [x] Full tier9 suite (`vitest run src/lib/tier9-reports/__tests__/`) — 115 tests pass
- [x] `next build --webpack` (pre-push hook) — clean compile
- [ ] Manual smoke on `/standalone/similar-cases-analyzer`: pick FL (banner hidden) then WY (banner visible)
- [ ] Manual report-render smoke for a WY drug-possession case (expect federal caption above plea + sentencing tables)

🤖 Generated with [Claude Code](https://claude.com/claude-code)