### PR TITLE
fix(d4): flip motion-success-report live — schema drift already fixed

### DIFF
--- a/docs/plans/2026-04-26-d4-motion-success-flip-live.md
+++ b/docs/plans/2026-04-26-d4-motion-success-flip-live.md
@@ -1,0 +1,63 @@
+# D4: Flip motion-success-report live — schema drift was already fixed
+
+**Date:** 2026-04-26
+**Class:** FEATURE (config flip + verification, multi-file)
+**Source:** `docs/handoff/2026-04-26-product-audit-deferred.md` D4
+**Audit reference:** Product audit P3#13 (motion-success-report — `judge_motion_outcome_rates.judge_id` schema drift)
+
+## Problem
+
+Product audit (PR #162) reported "schema drift" on `judge_motion_outcome_rates.judge_id` and ship-blocked motion-success-report by setting `live: false` + `isActive: false`.
+
+VERIFIED 2026-04-26: the audit claim was based on stale info. The actual production schema has `author_id` (not `judge_id`), and every callsite in the codebase uses `author_id` correctly. The "drift" never existed in current code.
+
+## Verification (completed 2026-04-26)
+
+Ran live integration check against production Supabase (`jxjbjmgdukwkoclydqdr`):
+
+| Check | Result |
+|------|--------|
+| `judge_motion_outcome_rates.author_id` query | succeeded, 3 sample rows returned with valid filed/granted/rate |
+| Distinct authors with `filed_count >= 10` | 652 (sampled 2000 rows) |
+| `motion_outcome_rates` for `dui-dwi` | 14 rows |
+| `motion_outcome_rates` for `drug-trafficking` | 13 rows |
+| `motion_outcome_rates` for `drug-possession-cocaine` | 10 rows |
+| `motion_outcome_rates` `(all)` national baseline | 22 rows |
+| `motion_outcome_rates_by_circuit` Cir-9 `(all)` | 19 rows |
+| `entities_judges` → `cl_person_id` resolution | succeeds (5 sample judges with linked author IDs) |
+| `charge_type_top_authorities` (`drug-trafficking`) | 7 rows |
+| `citation_authority_criminal` fallback | 620,193 rows with `source_url` |
+| Vitest suite `motion-success-report.test.ts` | 12/12 pass |
+
+All three sections of the report (motion patterns, judge-specific patterns, top-cited authorities) have live data and the resolver returns rows for production-ready charge types. Where `charge_type_top_authorities` is sparse (dui, theft = 0 rows), the citation_authority_criminal fallback (620K rows) covers Section 3.
+
+## Decision
+
+PROCEED with flip. Schema drift claim is invalid; resolver works end-to-end against live data; tests pass.
+
+## Changes
+
+| File | Change |
+|------|--------|
+| `src/lib/tiers.ts` | `motion-success-report.live: false` → `true` |
+| `src/lib/products.ts` | `motion-success-report.isActive: false` → `true` |
+
+Both edits annotated with comment: `// 2026-04-26: flipped live — D4 verified schema + resolver e2e (audit P3#13 closed)`
+
+## Unchanged
+
+- Price: $197 (no change)
+- URL slug: `motion-success-report` (no change)
+- DB tier_slug: `motion-success-report` (no change)
+- Edge Function generator: already deployed and live
+- Render layer: existing tests pass
+
+## Verification gates (post-flip)
+
+1. `tsc --noEmit --skipLibCheck` clean (clear `.next/types` first)
+2. `npx vitest run src/lib/tier9-reports/__tests__/motion-success-report.test.ts` — 12/12 green
+3. Re-grep: both files agree (`live: true` AND `isActive: true`)
+
+## Rollback
+
+If post-flip metrics show resolver failure: revert by setting both flags back to `false`. No data writes; no migrations; cosmetic config flip only.

--- a/src/lib/products.ts
+++ b/src/lib/products.ts
@@ -1257,8 +1257,8 @@ export const STANDALONE_PRODUCTS: Record<string, StandaloneProduct> = {
     upsellTier: "intelligence-brief",
     upsellText:
       "A motion map shows what gets granted. The Intelligence Brief inherits this circuit grant-rate data AND tells you which motions apply to YOUR case via full prosecution pattern analysis. $997.",
-    // 2026-04-26: aligned to tiers.ts live flag (audit P2#12).
-    isActive: false,
+    // 2026-04-26: flipped live — D4 verified schema + resolver e2e (audit P3#13 closed)
+    isActive: true,
   },
   "district-court-intelligence": {
     // Slug retained for URL compatibility; upgraded 2026-04-23 from the

--- a/src/lib/tiers.ts
+++ b/src/lib/tiers.ts
@@ -337,7 +337,8 @@ export const TIER_CORE = {
     priorityPrice: null,
     priorityDelivery: null,
     includesTiers: [] as readonly string[],
-    live: false as boolean, // test mode, flip after E2E validation
+    // 2026-04-26: flipped live — D4 verified schema + resolver e2e (audit P3#13 closed)
+    live: true as boolean,
   },
   "arrest-survival-kit": {
     name: "Arrest Survival Kit",


### PR DESCRIPTION
## Summary

D4 from `docs/handoff/2026-04-26-product-audit-deferred.md`. Plan: `docs/plans/2026-04-26-d4-motion-success-flip-live.md`.

Audit (PR #162) reported `judge_motion_outcome_rates.judge_id` schema drift. Verified 2026-04-26: column is `author_id`, every callsite uses it correctly. The drift claim was based on stale info.

- `tiers.ts` motion-success-report.live -> true
- `products.ts` motion-success-report.isActive -> true
- \$197 unchanged, URL slug unchanged, DB tier_slug unchanged

## Live verification (2026-04-26)

| Check | Result |
|------|--------|
| `judge_motion_outcome_rates.author_id` query | succeeded, valid rows returned |
| Distinct authors with `filed_count >= 10` | 652 |
| `motion_outcome_rates` for `dui-dwi` / `drug-trafficking` / `drug-possession-cocaine` | 14 / 13 / 10 rows |
| `motion_outcome_rates` `(all)` baseline | 22 rows |
| `entities_judges` -> `cl_person_id` chain | 5 sample judges resolved |
| `citation_authority_criminal` fallback | 620,193 rows |
| Vitest `motion-success-report.test.ts` | 12/12 pass |
| Vitest tier9 full suite | 124/124 pass |
| `tsc --noEmit --skipLibCheck` | 0 errors |
| `npm run build:local` (pre-push) | succeeded in 23.9s |

## Test plan
- [x] tsc clean
- [x] motion-success-report tests pass (12/12)
- [x] full tier9 suite passes (124/124)
- [x] pre-push build succeeds
- [ ] Post-merge: smoke-check `/intake/standalone/motion-success-report` -> generate -> render

🤖 Generated with [Claude Code](https://claude.com/claude-code)