### PR TITLE
fix(d5): federal-jury-instruction-brief circuit-coverage gating + flip live

### DIFF
--- a/docs/plans/2026-04-26-d5-fjib-circuit-coverage.md
+++ b/docs/plans/2026-04-26-d5-fjib-circuit-coverage.md
@@ -1,0 +1,159 @@
+# D5 — Federal Jury Instruction Brief: Circuit Coverage Transparency + Flip Live
+
+**Date:** 2026-04-26
+**Repo:** `C:\Users\email\projects\ImNotAnAttorney-web`
+**Status:** Plan ready for execution
+**Worry source:** `docs/handoff/2026-04-26-product-audit-deferred.md` D5 entry
+**Related shipped patterns:**
+- `docs/plans/2026-04-26-d2-similar-cases-state-coverage.md` (D2 — federal-fallback caption + AvailabilityChecker yellow banner)
+- `docs/plans/2026-04-26-d3-officer-bg-check-coverage.md` (D3 — thin-state external-intel banner)
+
+---
+
+## 1. Worry (verbatim from product audit, D5)
+
+> $97 dark. `v_pji_public` empty for circuits 2, 4, 10, 11, DC, FC (6/13). PJI ingestion work for missing circuits.
+
+This pass is **disclosure transparency + flip live**, not data ingestion. PJI ingestion for missing circuits is multi-week. The existing M4 resolver in `src/lib/tier9-reports/federal-jury-instruction-brief.ts` already implements graceful fallback: when the user's circuit has zero rows, it picks the closest-available circuit and adds a `limitations` line. That resolver behavior is already shipped and tested.
+
+The remaining gap is **pre-purchase**: a customer in (e.g.) the 4th Circuit selects FJIB, sees no warning, pays $97, and only then learns "we used the 5th Circuit's pattern instruction as the closest available." That's the disclosure cliff D2/D3 closed for similar-cases and officer-bg-check. This plan applies the same yellow-banner pattern to FJIB.
+
+### Verified data state (live prod, 2026-04-26)
+
+```
+v_pji_public total: 1,772 rows
+Per circuit:
+  1:  72   3: 285   5: 251   6: 140   7:  67   8: 141   9:  44
+Missing circuits: 2, 4, 10, 11, DC, FC
+```
+
+**Confirmed:** circuit 10 has **zero** rows despite the existing
+`PJI_COVERED_CIRCUITS = new Set([1, 3, 5, 6, 7, 8, 9, 10])` constant claiming
+otherwise. Constant must be corrected to `[1, 3, 5, 6, 7, 8, 9]` (7 circuits).
+
+### Existing infra (do NOT change semantics)
+
+- **Resolver graceful fallback** — `queryFederalJuryBrief()` already picks
+  closest-sibling circuit + adds limitation note. Post-purchase reports stay
+  identical.
+- **Federal-only gate** — `isFederalCharge()` rejects non-federal charges
+  before anything else. Unchanged.
+- **Stripe price** — `stripePriceId: null` (deferred-payment intake flow).
+  Unchanged.
+- **DB tier slug** — `federal-jury-instruction-brief`. Unchanged.
+
+---
+
+## 2. Plan
+
+### Files to modify (4 production files + 1 test)
+
+1. **`src/lib/tier9-reports/federal-jury-instruction-brief.ts`** — fix
+   `PJI_COVERED_CIRCUITS` to drop circuit 10 (it has zero rows in prod).
+   Update the `limitations` copy to say "First, Third, Fifth, Sixth, Seventh,
+   Eighth, and Ninth Circuits" instead of "...and Tenth". Update the
+   `circuitPref` selector to drop `10` from preference list.
+
+2. **`src/lib/tier9-reports/coverage.ts`** — add
+   `checkFJIBCoverage(federalCharge, circuit)` returning `CoverageResult`
+   with `coverage = { pjiTotal, pjiInCircuit, supported }` and
+   `available: true` (graceful fallback always renders something). Imports
+   `PJI_COVERED_CIRCUITS` + `isFederalCharge` from the FJIB module to keep
+   the supported-circuit list as a single source of truth.
+
+3. **`src/app/api/check-availability/[slug]/route.ts`** — add
+   `'federal-jury-instruction-brief'` to `TIER9_SLUGS`. Add a new switch
+   case that requires `federalCharge` (must be a key of `FEDERAL_CHARGES`)
+   + optional `circuit` (must be `1`–`11` or `DC`); cascades from `state`
+   when `circuit` is omitted (reuses existing `STATE_TO_CIRCUIT` map). State
+   stays mandatory (existing top-level guard).
+
+4. **`src/components/tier9/AvailabilityChecker.tsx`** —
+   - Add `'federal-jury-instruction-brief'` to `Slug` union.
+   - Add federal-charge `<select>` (sourced from `FEDERAL_CHARGES`) and
+     circuit `<select>` (sourced from `CIRCUIT_NAMES`) input fields, gated
+     to this slug only.
+   - Pass `federalCharge` + `circuit` into the POST body.
+   - Pre-purchase yellow banner pattern (matches D2/D3): when
+     `coverage.pjiInCircuit === 0` AND `coverage.pjiTotal > 0`, render the
+     amber-styled `<div role="note">` with copy:
+     "**Heads up:** Pattern jury instructions for the [Nth] Circuit are not
+     yet ingested. The report will use the closest available circuit's
+     instruction as a reference, with the deviation called out clearly."
+   - Pass `federalCharge` + `circuit` into `buildCheckoutUrl()`.
+   - Add coverage labels for new keys (`pjiTotal`, `pjiInCircuit`).
+
+5. **`src/lib/tiers.ts`** — flip
+   `federal-jury-instruction-brief.live` from `false` to `true`. Comment:
+   "2026-04-26 D5 PR — circuit-coverage gating + transparent fallback
+   disclosure satisfies $97 pricing without backfilling 6 circuits."
+
+6. **`src/lib/products.ts`** — flip
+   `federal-jury-instruction-brief.isActive` from `false` to `true`. Same
+   audit-trail comment.
+
+7. **`src/lib/tier9-reports/__tests__/fjib-coverage.test.ts`** — NEW. Mock
+   the Supabase admin client, exercise three paths:
+   - Circuit with rows → `coverage.pjiInCircuit > 0`, no banner-trigger
+   - Circuit without rows → `coverage.pjiInCircuit === 0`, banner-trigger
+   - Non-federal charge → still returns coverage shape (federal-only check
+     is downstream, this helper is for ANY federal charge by definition —
+     route-layer enforces `isFederalCharge` validation)
+
+### Out of scope
+
+- **PJI ingestion for missing circuits.** Per audit framing, deferred
+  (multi-week — each circuit has its own publication source).
+- **Stripe price changes.** $97 unchanged.
+- **DB slug renames.** Unchanged.
+- **Resolver behavior in `queryFederalJuryBrief`.** The existing
+  closest-sibling fallback IS the post-purchase honesty layer — banner is
+  pre-purchase only.
+- **New landing page.** `/services/federal-jury-instruction-brief` (the
+  generic services route) becomes accessible automatically via
+  `isActive: true`. A dedicated landing page with embedded
+  AvailabilityChecker is a downstream PR.
+
+### Hard constraints (from prompt)
+
+- Stripe price ID UNCHANGED ($97)
+- DB tier_slug UNCHANGED
+- URL slug UNCHANGED
+- Existing graceful fallback in resolver UNCHANGED — banner is pre-purchase
+  only
+- Tone: clinical, no UPL slop
+- AvailabilityChecker pattern matches D2/D3 yellow-banner styling
+- 7 supported circuits hardcoded in shared module (the FJIB module)
+
+---
+
+## 3. Success criteria
+
+- `npx tsc --noEmit --skipLibCheck` → 0 errors
+- `npx vitest run src/lib/tier9-reports/__tests__/` → all green including
+  new fjib-coverage tests
+- Existing `federal-jury-instruction-brief.test.ts` → still green
+- POST `/api/check-availability/federal-jury-instruction-brief` returns
+  expected shape for both supported and unsupported circuits
+- `tiers.ts` + `products.ts` reflect live state for FJIB
+- No changes to Stripe price ID, slug, or resolver fallback behavior
+
+---
+
+## 4. Cascade
+
+- **us:** D5 closed; one fewer dark $97 SKU; transparency pattern stays
+  consistent across D2/D3/D5 — easier to extend for D1/D4 later.
+- **direct counterparty (defendant):** before paying $97, sees a
+  one-sentence amber heads-up that their circuit's instruction will be
+  served by the closest sibling. No surprise post-purchase.
+- **downstream (attorney reviewing the brief):** report has the same
+  transparent limitations note + closest-sibling label; pre/post parity.
+- **ecosystem:** UPL stays intact (no advice; only disclosure of the
+  data-state); Hormozi-style "make it impossible to feel scammed" pricing
+  defense.
+- **future-us:** when ingestion lands for circuit 4 (etc.), drop
+  `PJI_COVERED_CIRCUITS` update + the helper auto-clears the banner.
+  No customer code change required.
+
+No node loses. Cascade-positive.

--- a/docs/plans/2026-04-26-pr-171-review-fixes.md
+++ b/docs/plans/2026-04-26-pr-171-review-fixes.md
@@ -1,0 +1,126 @@
+# PR #171 Review Fixes — D5 FJIB Circuit Coverage
+
+Date: 2026-04-26
+Branch: `fix/d5-fjib-circuit-coverage`
+Findings: 2 WARN + 3 SUG (5 total — pristine-or-nothing closure)
+
+## Why this exists
+
+PR #171 shipped the circuit-coverage banner for the Federal Jury Instruction
+Brief ($97 SKU). Review found 5 follow-ups that gate against post-purchase
+disappointment and a couple of latent bugs. Closing all five before the merge
+preserves the pre/post-purchase parity contract that D2/D3/D5 share.
+
+## W1 — Charge-specific PJI count
+
+**Problem.** `checkFJIBCoverage` only counts ALL PJI rows in the user's
+circuit. The resolver in `queryFederalJuryBrief` filters those rows by
+`statutePatterns` + `titleKeywords` and may find ZERO rows for the user's
+charge even when the circuit has 44 unrelated PJI rows. Customer pays $97 and
+sees a closest-match limitation post-purchase.
+
+**Fix.**
+- `checkFJIBCoverage(circuit, state, federalCharge?)` accepts a third arg.
+- When `federalCharge` is supplied AND found in `FEDERAL_CHARGES`, run two
+  additional Supabase counts:
+  - `pjiInCircuitMatchingCharge`: rows in `v_pji_public` filtered by circuit
+    AND title matching the charge's `titleKeywords` via PostgREST `or`
+    ILIKE — the same server-side pre-filter used by `queryFederalJuryBrief`.
+  - `pjiInAnyCircuitMatchingCharge`: same title filter, no circuit restriction.
+- Title-keyword extraction reuses the regex-source-stripping logic already
+  in `queryFederalJuryBrief` so the pre-filter shape stays identical (false
+  negatives on statute-only matches are tolerable here — banner is pre-purchase
+  disclosure, not the binding gate).
+- The route layer calls `checkFJIBCoverage(rawCircuit || null, state, federalCharge)`.
+- Banner rule (in `AvailabilityChecker.tsx`):
+  - `pjiInAnyCircuitMatchingCharge === 0` (charge missing entirely): stronger
+    banner.
+  - `pjiInCircuitMatchingCharge === 0 && pjiInAnyCircuitMatchingCharge > 0`
+    (charge exists in another circuit): existing closest-circuit banner.
+- Tests cover both new branches.
+
+## W2 — Waitlist row collision on circuit
+
+**Problem.** `handleWaitlist(result, federalCharge, federalCharge)` uses
+`federalCharge` as both `searchName` and `chargeTypeOverride`. Two customers
+in VA — one waitlisting circuit-4, one explicitly picking circuit-2 — collide
+on the unique key `(product_slug, search_name, search_state, email)`. The
+upsert silently merges both into one row.
+
+**Fix.** Change the FJIB case to call:
+```ts
+const waitlistKey = circuit
+  ? `${federalCharge}|c${rawCircuit}`
+  : `${federalCharge}|auto`;
+return handleWaitlist(result, waitlistKey, federalCharge);
+```
+Search-name carries the circuit; `search_charge_type` stays `federalCharge`
+so future operator filters by charge still work.
+
+## S1 — FJB_CHARGES sync test
+
+**Problem.** `FJB_CHARGES` (client) duplicates `FEDERAL_CHARGES` (server).
+Drift = silent UI-vs-server mismatch.
+
+**Fix.** Add a test in `fjib-coverage.test.ts` that imports `FEDERAL_CHARGES`
+and the client-side slug list. Since `FEDERAL_CHARGES` lives in the FJIB
+module (which imports `createAdminClient`), we extract the slug list to a
+client-safe module: `src/lib/tier9-reports/fjib-charges.ts` exports
+`FJB_CHARGE_SLUGS: readonly string[]` derived from `Object.keys(FEDERAL_CHARGES)`
+at import time. The client imports the slug list from the new module; the
+test asserts `FJB_CHARGES.map(c => c.value).sort()` equals
+`[...FJB_CHARGE_SLUGS].sort()`. Drift trips the test on next edit.
+
+Implementation note: `FEDERAL_CHARGES` itself is fine to read at import time
+because it's a plain object literal — but the FJIB module also exports
+`queryFederalJuryBrief` which imports the supabase admin client. We can't
+let the client bundle pull that. So the new `fjib-charges.ts` module
+re-exports JUST the slug list extracted at module load time, no admin imports.
+
+## S2 — Fallback string grammar
+
+**Problem.** When `matchedName` is null and circuit is empty, the banner
+renders "Pattern jury instructions for the your are not yet ingested".
+
+**Fix.** Replace `'your'` with `'this'` in the FJIB circuit-label fallback
+in `AvailabilityChecker.tsx`.
+
+## S3 — Tighten Promise.resolve type in coverage.ts
+
+**Problem.** `Promise.resolve({ count: 0 } as { count: number | null })` does
+not match the Supabase response shape (`{ count, data, error }`). Future
+destructuring on the result tuple fails.
+
+**Fix.** Change to
+`Promise.resolve({ count: 0, data: null, error: null })`. Three call sites
+in `checkFJIBCoverage` (W1 adds two more parallel queries that need the same
+shape).
+
+## Verification
+
+- `node node_modules/typescript/bin/tsc --noEmit --skipLibCheck`
+  (clear `.next/types` first) — 0 errors
+- `npx vitest run src/lib/tier9-reports/__tests__/fjib-coverage.test.ts`
+  — all green
+- `npx vitest run src/lib/tier9-reports/__tests__/` — full tier9 suite passes
+
+## Files touched
+
+- `src/app/api/check-availability/[slug]/route.ts` — W1 third-arg, W2 waitlist key
+- `src/lib/tier9-reports/coverage.ts` — W1 charge-specific counts, S3 type tighten
+- `src/lib/tier9-reports/fjib-charges.ts` — NEW client-safe slug list (S1)
+- `src/components/tier9/AvailabilityChecker.tsx` — W1 new banner branch, S2 grammar, S1 import slugs
+- `src/lib/tier9-reports/__tests__/fjib-coverage.test.ts` — W1 tests + S1 sync test
+
+## Cascade (Pristine-Or-Nothing closure)
+
+- Us: PR #171 merges clean; no carry-forward worry.
+- Customer: pays $97 only when the report will actually find their charge in
+  their circuit (W1) — not just any PJI in the circuit. Pre-purchase banner
+  matches post-purchase reality.
+- Operator: per-circuit waitlist rows (W2) so operator can prioritize by
+  ingest target.
+- Future-us: drift catcher (S1) blocks silent slug divergence on the next
+  client/server edit.
+- Ecosystem: pattern reusable for any future SKU using the same data-coverage
+  banner shape.

--- a/src/app/api/check-availability/[slug]/route.ts
+++ b/src/app/api/check-availability/[slug]/route.ts
@@ -165,8 +165,21 @@ export async function POST(
             { status: 400 },
           );
         }
-        const result = await checkFJIBCoverage(rawCircuit || null, state);
-        return handleWaitlist(result, federalCharge, federalCharge);
+        const result = await checkFJIBCoverage(
+          rawCircuit || null,
+          state,
+          federalCharge,
+        );
+        // W2 (PR #171 review): include the circuit in the waitlist key so a
+        // VA customer waitlisting circuit-4 and another VA customer
+        // explicitly picking circuit-2 do NOT collide on
+        // (product_slug, search_name, search_state, email). Auto-detect
+        // (blank circuit) gets its own bucket so per-circuit ingest demand
+        // is countable.
+        const waitlistKey = rawCircuit
+          ? `${federalCharge}|c${rawCircuit}`
+          : `${federalCharge}|auto`;
+        return handleWaitlist(result, waitlistKey, federalCharge);
       }
 
       default:

--- a/src/app/api/check-availability/[slug]/route.ts
+++ b/src/app/api/check-availability/[slug]/route.ts
@@ -5,12 +5,31 @@
  */
 import { NextRequest, NextResponse } from "next/server";
 import { createAdminClient } from "@/lib/supabase/admin";
-import { checkJudgeCoverage, checkOfficerCoverage, checkSimilarCasesCoverage, checkDistrictCoverage, checkArrestKitCoverage, type CoverageResult } from "@/lib/tier9-reports/coverage";
+import {
+  checkJudgeCoverage,
+  checkOfficerCoverage,
+  checkSimilarCasesCoverage,
+  checkDistrictCoverage,
+  checkArrestKitCoverage,
+  checkFJIBCoverage,
+  type CoverageResult,
+} from "@/lib/tier9-reports/coverage";
 import { isValidChargeType } from "@/lib/charge-types";
+import {
+  FEDERAL_CHARGES,
+  CIRCUIT_NAMES as FJB_CIRCUIT_NAMES,
+} from "@/lib/tier9-reports/federal-jury-instruction-brief";
 import { checkRateLimit } from "@/lib/rate-limit";
 import { getClientIp } from "@/lib/request";
 
-const TIER9_SLUGS = new Set(["judge-report-card", "officer-background-check", "similar-cases-analyzer", "district-court-intelligence", "arrest-survival-kit"]);
+const TIER9_SLUGS = new Set([
+  "judge-report-card",
+  "officer-background-check",
+  "similar-cases-analyzer",
+  "district-court-intelligence",
+  "arrest-survival-kit",
+  "federal-jury-instruction-brief",
+]);
 const VALID_STATES = new Set(["AL","AK","AZ","AR","CA","CO","CT","DE","FL","GA","HI","ID","IL","IN","IA","KS","KY","LA","ME","MD","MA","MI","MN","MS","MO","MT","NE","NV","NH","NJ","NM","NY","NC","ND","OH","OK","OR","PA","RI","SC","SD","TN","TX","UT","VT","VA","WA","WV","WI","WY","DC"]);
 
 export async function POST(
@@ -116,6 +135,38 @@ export async function POST(
       case "arrest-survival-kit": {
         const result = await checkArrestKitCoverage(state);
         return handleWaitlist(result, state);
+      }
+
+      case "federal-jury-instruction-brief": {
+        // Federal-only gate first — D5 plan, 2026-04-26.
+        const federalCharge =
+          typeof body.federalCharge === "string"
+            ? body.federalCharge.trim()
+            : "";
+        if (
+          !federalCharge ||
+          !Object.prototype.hasOwnProperty.call(FEDERAL_CHARGES, federalCharge)
+        ) {
+          return NextResponse.json(
+            {
+              error:
+                "Federal charge required (this product covers federal criminal code only)",
+            },
+            { status: 400 },
+          );
+        }
+        // Circuit is optional at the API layer — when blank, the helper
+        // cascades from the state code (existing STATE_TO_CIRCUIT map).
+        const rawCircuit =
+          typeof body.circuit === "string" ? body.circuit.trim() : "";
+        if (rawCircuit && !FJB_CIRCUIT_NAMES[rawCircuit]) {
+          return NextResponse.json(
+            { error: "Invalid federal circuit (1-11 or DC)" },
+            { status: 400 },
+          );
+        }
+        const result = await checkFJIBCoverage(rawCircuit || null, state);
+        return handleWaitlist(result, federalCharge, federalCharge);
       }
 
       default:

--- a/src/app/api/intake/standalone/[slug]/route.ts
+++ b/src/app/api/intake/standalone/[slug]/route.ts
@@ -101,9 +101,11 @@ const VALID_CH_CATEGORIES = new Set(["1", "2", "3", "4", "5", "6"]);
 
 // Federal circuits accepted by federal-jury-instruction-brief. Values are
 // the twelve federal judicial circuits. Coverage in pattern_jury_instructions
-// is currently circuits 1, 3, 5, 6, 7, 8, 9, 10 (verified 2026-04-23); the
-// remaining circuits are accepted at intake time but the query module
-// resolves to the closest-sibling circuit with a limitation note.
+// is currently circuits 1, 3, 5, 6, 7, 8, 9 (verified live 2026-04-26 —
+// 1,772 rows total); the remaining circuits (2, 4, 10, 11, DC) are accepted
+// at intake time but the query module resolves to the closest-sibling
+// circuit with a limitation note. The pre-purchase AvailabilityChecker
+// yellow banner discloses the fallback before payment (D5 plan, 2026-04-26).
 const VALID_FJB_CIRCUITS = new Set([
   "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "DC",
 ]);

--- a/src/components/tier9/AvailabilityChecker.tsx
+++ b/src/components/tier9/AvailabilityChecker.tsx
@@ -23,6 +23,7 @@
  */
 
 import { useState, useEffect, useCallback, useRef } from 'react';
+import { FJB_CHARGES } from '@/lib/tier9-reports/fjib-charges';
 
 /* ────────────────────────────────────────────────────────── */
 /* Constants                                                   */
@@ -149,41 +150,17 @@ const COVERAGE_LABELS: Record<string, string> = {
   // federal-jury-instruction-brief circuit-coverage gating (D5 plan, 2026-04-26)
   pjiTotal: 'verified federal pattern instructions',
   pjiInCircuit: 'instructions in your circuit',
+  // W1 (PR #171 review) charge-specific PJI counts. Surfaced on the
+  // dl grid only when present (resolver returns them only when a federal
+  // charge was supplied to checkFJIBCoverage).
+  pjiInCircuitMatchingCharge: 'matching instructions in your circuit',
+  pjiInAnyCircuitMatchingCharge: 'matching instructions across all circuits',
 };
 
-/* Federal Jury Instruction Brief — intake options (D5 plan, 2026-04-26).
-   Source of truth for the slugs is FEDERAL_CHARGES in the FJIB module;
-   we duplicate the display labels here so the client bundle does not pull
-   the entire query module. The route layer re-validates the slug against
-   FEDERAL_CHARGES, so this list cannot grant access to any charge the
-   server does not also support. */
-const FJB_CHARGES: { value: string; label: string }[] = [
-  { value: 'wire-fraud', label: 'Wire Fraud (18 U.S.C. § 1343)' },
-  { value: 'mail-fraud', label: 'Mail Fraud (18 U.S.C. § 1341)' },
-  { value: 'conspiracy-general', label: 'Conspiracy (18 U.S.C. § 371)' },
-  { value: 'drug-conspiracy', label: 'Drug Conspiracy (21 U.S.C. § 846)' },
-  { value: 'drug-distribution', label: 'Distribution of a Controlled Substance (21 U.S.C. § 841(a)(1))' },
-  { value: 'drug-possession-intent', label: 'Possession with Intent to Distribute (21 U.S.C. § 841(a)(1))' },
-  { value: 'drug-manufacture', label: 'Manufacture of a Controlled Substance (21 U.S.C. § 841(a)(1))' },
-  { value: 'felon-in-possession', label: 'Felon in Possession of Firearm (18 U.S.C. § 922(g))' },
-  { value: 'firearm-during-drug-crime', label: 'Using/Carrying a Firearm During a Drug Trafficking Crime (18 U.S.C. § 924(c))' },
-  { value: 'bank-robbery', label: 'Bank Robbery (18 U.S.C. § 2113)' },
-  { value: 'hobbs-act', label: 'Hobbs Act Robbery/Extortion (18 U.S.C. § 1951)' },
-  { value: 'money-laundering', label: 'Money Laundering (18 U.S.C. §§ 1956, 1957)' },
-  { value: 'tax-evasion', label: 'Tax Evasion (26 U.S.C. § 7201)' },
-  { value: 'false-statement-agency', label: 'False Statement to a Federal Agency (18 U.S.C. § 1001)' },
-  { value: 'aggravated-identity-theft', label: 'Aggravated Identity Theft (18 U.S.C. § 1028A)' },
-  { value: 'bribery-public-official', label: 'Bribery of a Public Official (18 U.S.C. § 201)' },
-  { value: 'obstruction-justice', label: 'Obstruction of Justice (18 U.S.C. § 1503 / § 1512)' },
-  { value: 'perjury', label: 'Perjury (18 U.S.C. § 1621)' },
-  { value: 'rico', label: 'RICO — Racketeering (18 U.S.C. § 1962)' },
-  { value: 'child-pornography-possession', label: 'Possession of Child Pornography (18 U.S.C. § 2252 / § 2252A)' },
-  { value: 'illegal-reentry', label: 'Illegal Re-entry After Deportation (8 U.S.C. § 1326)' },
-  { value: 'immigration-fraud', label: 'Immigration Fraud (18 U.S.C. § 1546 / 8 U.S.C. § 1325(c))' },
-  { value: 'kidnapping-federal', label: 'Federal Kidnapping (18 U.S.C. § 1201)' },
-  { value: 'healthcare-fraud', label: 'Health Care Fraud (18 U.S.C. § 1347)' },
-  { value: 'aiding-abetting', label: 'Aiding and Abetting (18 U.S.C. § 2)' },
-];
+/* Federal Jury Instruction Brief — intake options now come from the
+   client-safe `@/lib/tier9-reports/fjib-charges` module so a sync test
+   (S1, PR #171 review) can assert the slug list matches the server-side
+   `FEDERAL_CHARGES` without forcing the test to import a JSX component. */
 
 const FJB_CIRCUITS: { value: string; label: string }[] = [
   { value: '', label: 'Auto-detect from state' },
@@ -489,11 +466,30 @@ export default function AvailabilityChecker({ slug, productName, priceDisplay }:
       !officerHasCpd &&
       !officerHasNypd;
 
-    /* FJIB circuit-coverage derivation (D5 plan, 2026-04-26).
-       Banner fires when the user's circuit has zero PJI rows AND the corpus
-       itself has rows (so the issue is "not yet ingested for your circuit",
-       not "no data"). The resolver always falls back to the closest sibling
-       with a limitations line — banner is pre-purchase disclosure only. */
+    /* FJIB circuit-coverage derivation (D5 plan, 2026-04-26; extended
+       2026-04-26 PR #171 review W1).
+       Two distinct missing-data signals — order matters because the
+       charge-specific banner is the stronger disclosure:
+         (a) charge has ZERO matches anywhere in the corpus → strongest
+             banner, customer should waitlist for THIS charge.
+         (b) charge has matches elsewhere but not in user's circuit OR the
+             user's circuit has zero rows at all → existing closest-circuit
+             banner.
+       The resolver always falls back to the closest sibling with a
+       limitations line — banner is pre-purchase disclosure only. */
+    const pjiInCircuitMatchingCharge =
+      coverage.pjiInCircuitMatchingCharge as number | undefined;
+    const pjiInAnyCircuitMatchingCharge =
+      coverage.pjiInAnyCircuitMatchingCharge as number | undefined;
+    const fjibChargeMissingEverywhere =
+      isFjib &&
+      pjiInAnyCircuitMatchingCharge !== undefined &&
+      pjiInAnyCircuitMatchingCharge === 0;
+    const fjibChargeMissingInCircuit =
+      isFjib &&
+      pjiInCircuitMatchingCharge !== undefined &&
+      pjiInCircuitMatchingCharge === 0 &&
+      (pjiInAnyCircuitMatchingCharge ?? 0) > 0;
     const fjibCircuitMissing =
       isFjib &&
       (coverage.pjiTotal ?? 0) > 0 &&
@@ -501,15 +497,48 @@ export default function AvailabilityChecker({ slug, productName, priceDisplay }:
     /* Display label for the resolved circuit. Prefers the user-selected
        value; falls back to the matchedName from the API (which is the
        state-cascaded resolved circuit's name) when the user picked the
-       auto-detect option. */
+       auto-detect option. S2 (PR #171 review): the final fallback was
+       the literal string 'your', which produced "for the your" copy
+       when matchedName was null. Switched to 'this' so the sentence
+       reads cleanly even on the unreachable null path. */
     const fjibCircuitLabel = circuit
       ? FJB_CIRCUIT_LABELS[circuit] ?? circuit
-      : matchedName ?? 'your';
+      : matchedName ?? 'this';
 
-    /* Banner copy (W2): branch on which side(s) of the report fall back
-       to federal so the customer sees the right disclosure pre-purchase. */
+    /* Display label for the user-selected federal charge (W1). The slug
+       carries no human label client-side without paying for the full
+       FJB_CHARGES map; we look it up for the strong-banner copy. */
+    const fjibChargeLabel = isFjib
+      ? FJB_CHARGES.find((c) => c.value === federalCharge)?.label ?? federalCharge
+      : '';
+
+    /* Banner copy (W2 of PR #168, extended W1 of PR #171): branch on
+       which signal trips so the customer sees the right disclosure pre-
+       purchase. Charge-missing-everywhere is strongest and overrides the
+       circuit-only banner. */
     let fallbackBanner: React.ReactNode = null;
-    if (fjibCircuitMissing) {
+    if (fjibChargeMissingEverywhere) {
+      fallbackBanner = (
+        <p className="text-amber-200 text-sm">
+          <strong>Heads up:</strong> No pattern jury instruction in our corpus
+          matches{fjibChargeLabel ? ` ${fjibChargeLabel}` : ' your charge'} yet.
+          The report will use national criminal authorities as a fallback. We
+          recommend waitlisting for this charge so we can notify you when
+          coverage lands.
+        </p>
+      );
+    } else if (fjibChargeMissingInCircuit) {
+      fallbackBanner = (
+        <p className="text-amber-200 text-sm">
+          <strong>Heads up:</strong> No pattern instruction for
+          {fjibChargeLabel ? ` ${fjibChargeLabel}` : ' your charge'} cached for
+          the {fjibCircuitLabel}
+          {circuit ? ' Circuit' : ''}. The report will use the closest
+          available circuit&rsquo;s instruction as a reference, with the
+          deviation called out clearly.
+        </p>
+      );
+    } else if (fjibCircuitMissing) {
       fallbackBanner = (
         <p className="text-amber-200 text-sm">
           <strong>Heads up:</strong> Pattern jury instructions for the{' '}

--- a/src/components/tier9/AvailabilityChecker.tsx
+++ b/src/components/tier9/AvailabilityChecker.tsx
@@ -146,6 +146,75 @@ const COVERAGE_LABELS: Record<string, string> = {
   outcomeNational: 'national outcome benchmarks',
   // officer-background-check state-coverage gating (D3 plan, 2026-04-26)
   externalIntelState: 'state-level external-intelligence records',
+  // federal-jury-instruction-brief circuit-coverage gating (D5 plan, 2026-04-26)
+  pjiTotal: 'verified federal pattern instructions',
+  pjiInCircuit: 'instructions in your circuit',
+};
+
+/* Federal Jury Instruction Brief — intake options (D5 plan, 2026-04-26).
+   Source of truth for the slugs is FEDERAL_CHARGES in the FJIB module;
+   we duplicate the display labels here so the client bundle does not pull
+   the entire query module. The route layer re-validates the slug against
+   FEDERAL_CHARGES, so this list cannot grant access to any charge the
+   server does not also support. */
+const FJB_CHARGES: { value: string; label: string }[] = [
+  { value: 'wire-fraud', label: 'Wire Fraud (18 U.S.C. § 1343)' },
+  { value: 'mail-fraud', label: 'Mail Fraud (18 U.S.C. § 1341)' },
+  { value: 'conspiracy-general', label: 'Conspiracy (18 U.S.C. § 371)' },
+  { value: 'drug-conspiracy', label: 'Drug Conspiracy (21 U.S.C. § 846)' },
+  { value: 'drug-distribution', label: 'Distribution of a Controlled Substance (21 U.S.C. § 841(a)(1))' },
+  { value: 'drug-possession-intent', label: 'Possession with Intent to Distribute (21 U.S.C. § 841(a)(1))' },
+  { value: 'drug-manufacture', label: 'Manufacture of a Controlled Substance (21 U.S.C. § 841(a)(1))' },
+  { value: 'felon-in-possession', label: 'Felon in Possession of Firearm (18 U.S.C. § 922(g))' },
+  { value: 'firearm-during-drug-crime', label: 'Using/Carrying a Firearm During a Drug Trafficking Crime (18 U.S.C. § 924(c))' },
+  { value: 'bank-robbery', label: 'Bank Robbery (18 U.S.C. § 2113)' },
+  { value: 'hobbs-act', label: 'Hobbs Act Robbery/Extortion (18 U.S.C. § 1951)' },
+  { value: 'money-laundering', label: 'Money Laundering (18 U.S.C. §§ 1956, 1957)' },
+  { value: 'tax-evasion', label: 'Tax Evasion (26 U.S.C. § 7201)' },
+  { value: 'false-statement-agency', label: 'False Statement to a Federal Agency (18 U.S.C. § 1001)' },
+  { value: 'aggravated-identity-theft', label: 'Aggravated Identity Theft (18 U.S.C. § 1028A)' },
+  { value: 'bribery-public-official', label: 'Bribery of a Public Official (18 U.S.C. § 201)' },
+  { value: 'obstruction-justice', label: 'Obstruction of Justice (18 U.S.C. § 1503 / § 1512)' },
+  { value: 'perjury', label: 'Perjury (18 U.S.C. § 1621)' },
+  { value: 'rico', label: 'RICO — Racketeering (18 U.S.C. § 1962)' },
+  { value: 'child-pornography-possession', label: 'Possession of Child Pornography (18 U.S.C. § 2252 / § 2252A)' },
+  { value: 'illegal-reentry', label: 'Illegal Re-entry After Deportation (8 U.S.C. § 1326)' },
+  { value: 'immigration-fraud', label: 'Immigration Fraud (18 U.S.C. § 1546 / 8 U.S.C. § 1325(c))' },
+  { value: 'kidnapping-federal', label: 'Federal Kidnapping (18 U.S.C. § 1201)' },
+  { value: 'healthcare-fraud', label: 'Health Care Fraud (18 U.S.C. § 1347)' },
+  { value: 'aiding-abetting', label: 'Aiding and Abetting (18 U.S.C. § 2)' },
+];
+
+const FJB_CIRCUITS: { value: string; label: string }[] = [
+  { value: '', label: 'Auto-detect from state' },
+  { value: '1', label: 'First Circuit' },
+  { value: '2', label: 'Second Circuit' },
+  { value: '3', label: 'Third Circuit' },
+  { value: '4', label: 'Fourth Circuit' },
+  { value: '5', label: 'Fifth Circuit' },
+  { value: '6', label: 'Sixth Circuit' },
+  { value: '7', label: 'Seventh Circuit' },
+  { value: '8', label: 'Eighth Circuit' },
+  { value: '9', label: 'Ninth Circuit' },
+  { value: '10', label: 'Tenth Circuit' },
+  { value: '11', label: 'Eleventh Circuit' },
+  { value: 'DC', label: 'D.C. Circuit' },
+];
+
+/** Display label for the resolved circuit on the banner copy. */
+const FJB_CIRCUIT_LABELS: Record<string, string> = {
+  '1': 'First',
+  '2': 'Second',
+  '3': 'Third',
+  '4': 'Fourth',
+  '5': 'Fifth',
+  '6': 'Sixth',
+  '7': 'Seventh',
+  '8': 'Eighth',
+  '9': 'Ninth',
+  '10': 'Tenth',
+  '11': 'Eleventh',
+  DC: 'D.C.',
 };
 
 const LOCALSTORAGE_KEY = 'inna_email';
@@ -154,7 +223,13 @@ const LOCALSTORAGE_KEY = 'inna_email';
 /* Types                                                       */
 /* ────────────────────────────────────────────────────────── */
 
-type Slug = 'judge-report-card' | 'officer-background-check' | 'similar-cases-analyzer' | 'district-court-intelligence' | 'arrest-survival-kit';
+type Slug =
+  | 'judge-report-card'
+  | 'officer-background-check'
+  | 'similar-cases-analyzer'
+  | 'district-court-intelligence'
+  | 'arrest-survival-kit'
+  | 'federal-jury-instruction-brief';
 
 interface AvailabilityCheckerProps {
   slug: Slug;
@@ -199,6 +274,7 @@ export default function AvailabilityChecker({ slug, productName, priceDisplay }:
   // all render branches.
   const isSimilarCases = slug === 'similar-cases-analyzer';
   const isOfficerBgCheck = slug === 'officer-background-check';
+  const isFjib = slug === 'federal-jury-instruction-brief';
 
   const [componentState, setComponentState] = useState<ComponentState>('idle');
   const [errorMsg, setErrorMsg] = useState('');
@@ -209,6 +285,10 @@ export default function AvailabilityChecker({ slug, productName, priceDisplay }:
   const [name, setName] = useState('');
   const [state, setState] = useState('');
   const [chargeType, setChargeType] = useState('');
+  // FJIB-only intake (D5 plan, 2026-04-26). Kept as plain strings so the
+  // existing `payload: Record<string, string>` pattern carries them.
+  const [federalCharge, setFederalCharge] = useState('');
+  const [circuit, setCircuit] = useState('');
 
   // Waitlist
   const [email, setEmail] = useState('');
@@ -261,6 +341,10 @@ export default function AvailabilityChecker({ slug, productName, priceDisplay }:
     if (slug === 'judge-report-card') payload.judgeName = name;
     else if (slug === 'officer-background-check') payload.officerName = name;
     else if (slug === 'similar-cases-analyzer') payload.chargeType = chargeType;
+    else if (slug === 'federal-jury-instruction-brief') {
+      payload.federalCharge = federalCharge;
+      if (circuit) payload.circuit = circuit;
+    }
     // arrest-survival-kit: state-only (already in base payload)
 
     try {
@@ -283,7 +367,7 @@ export default function AvailabilityChecker({ slug, productName, priceDisplay }:
       setErrorMsg(err instanceof Error ? err.message : 'Something went wrong. Please try again.');
       setComponentState('error');
     }
-  }, [slug, name, state, chargeType]);
+  }, [slug, name, state, chargeType, federalCharge, circuit]);
 
   /* ── Waitlist submit ── */
 
@@ -296,6 +380,10 @@ export default function AvailabilityChecker({ slug, productName, priceDisplay }:
     if (slug === 'judge-report-card') payload.judgeName = name;
     else if (slug === 'officer-background-check') payload.officerName = name;
     else if (slug === 'similar-cases-analyzer') payload.chargeType = chargeType;
+    else if (slug === 'federal-jury-instruction-brief') {
+      payload.federalCharge = federalCharge;
+      if (circuit) payload.circuit = circuit;
+    }
     // arrest-survival-kit: state-only (already in base payload)
 
     try {
@@ -325,7 +413,7 @@ export default function AvailabilityChecker({ slug, productName, priceDisplay }:
       setErrorMsg(err instanceof Error ? err.message : 'Something went wrong. Please try again.');
       setComponentState('error');
     }
-  }, [slug, name, state, chargeType, email]);
+  }, [slug, name, state, chargeType, federalCharge, circuit, email]);
 
   /* ── Retry from error ── */
 
@@ -342,6 +430,10 @@ export default function AvailabilityChecker({ slug, productName, priceDisplay }:
     if (slug === 'officer-background-check') params.set('officerName', name);
     params.set('state', state);
     if (slug === 'similar-cases-analyzer') params.set('chargeType', chargeType);
+    if (slug === 'federal-jury-instruction-brief') {
+      params.set('federalCharge', federalCharge);
+      if (circuit) params.set('circuit', circuit);
+    }
     return `/checkout?${params.toString()}`;
   }
 
@@ -397,10 +489,37 @@ export default function AvailabilityChecker({ slug, productName, priceDisplay }:
       !officerHasCpd &&
       !officerHasNypd;
 
+    /* FJIB circuit-coverage derivation (D5 plan, 2026-04-26).
+       Banner fires when the user's circuit has zero PJI rows AND the corpus
+       itself has rows (so the issue is "not yet ingested for your circuit",
+       not "no data"). The resolver always falls back to the closest sibling
+       with a limitations line — banner is pre-purchase disclosure only. */
+    const fjibCircuitMissing =
+      isFjib &&
+      (coverage.pjiTotal ?? 0) > 0 &&
+      (coverage.pjiInCircuit ?? 0) === 0;
+    /* Display label for the resolved circuit. Prefers the user-selected
+       value; falls back to the matchedName from the API (which is the
+       state-cascaded resolved circuit's name) when the user picked the
+       auto-detect option. */
+    const fjibCircuitLabel = circuit
+      ? FJB_CIRCUIT_LABELS[circuit] ?? circuit
+      : matchedName ?? 'your';
+
     /* Banner copy (W2): branch on which side(s) of the report fall back
        to federal so the customer sees the right disclosure pre-purchase. */
     let fallbackBanner: React.ReactNode = null;
-    if (pleaStateMissing && sentencingStateMissing) {
+    if (fjibCircuitMissing) {
+      fallbackBanner = (
+        <p className="text-amber-200 text-sm">
+          <strong>Heads up:</strong> Pattern jury instructions for the{' '}
+          {fjibCircuitLabel}
+          {circuit ? ' Circuit' : ''} are not yet ingested. The report will use
+          the closest available circuit&rsquo;s instruction as a reference, with
+          the deviation called out clearly.
+        </p>
+      );
+    } else if (pleaStateMissing && sentencingStateMissing) {
       fallbackBanner = (
         <p className="text-amber-200 text-sm">
           <strong>Heads up:</strong> State-specific plea-discount and
@@ -444,6 +563,8 @@ export default function AvailabilityChecker({ slug, productName, priceDisplay }:
       if (count <= 0) return false;
       if (pleaStateCovers && key === 'pleaFederal') return false;
       if (sentencingStateCovers && key === 'outcomeNational') return false;
+      // FJIB internal flag — not customer-meaningful as a number.
+      if (key === 'supported') return false;
       return true;
     });
 
@@ -507,7 +628,7 @@ export default function AvailabilityChecker({ slug, productName, priceDisplay }:
           onClick={handleRetry}
           className="w-full text-center text-sm text-zinc-400 hover:text-zinc-200 transition-colors mt-3 h-10 focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2 focus:ring-offset-zinc-950 rounded-lg"
         >
-          Check a different {slug === 'similar-cases-analyzer' ? 'charge' : (slug === 'district-court-intelligence' || slug === 'arrest-survival-kit') ? 'state' : 'name'}
+          Check a different {slug === 'similar-cases-analyzer' || slug === 'federal-jury-instruction-brief' ? 'charge' : (slug === 'district-court-intelligence' || slug === 'arrest-survival-kit') ? 'state' : 'name'}
         </button>
       </div>
     );
@@ -537,7 +658,7 @@ export default function AvailabilityChecker({ slug, productName, priceDisplay }:
           onClick={handleRetry}
           className="text-sm text-zinc-400 hover:text-zinc-200 transition-colors mt-4 h-10 focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2 focus:ring-offset-zinc-950 rounded-lg"
         >
-          Check a different {slug === 'similar-cases-analyzer' ? 'charge' : (slug === 'district-court-intelligence' || slug === 'arrest-survival-kit') ? 'state' : 'name'}
+          Check a different {slug === 'similar-cases-analyzer' || slug === 'federal-jury-instruction-brief' ? 'charge' : (slug === 'district-court-intelligence' || slug === 'arrest-survival-kit') ? 'state' : 'name'}
         </button>
       </div>
     );
@@ -649,6 +770,58 @@ export default function AvailabilityChecker({ slug, productName, priceDisplay }:
             disabled={isChecking}
           />
         </div>
+      )}
+
+      {/* Federal charge + circuit (federal-jury-instruction-brief) */}
+      {isFjib && (
+        <>
+          <div>
+            <label htmlFor={`${id}-federalCharge`} className={labelClass}>
+              Federal charge{' '}
+              <span className="text-red-400" aria-hidden="true">
+                *
+              </span>
+            </label>
+            <select
+              id={`${id}-federalCharge`}
+              ref={firstInputRef as React.RefObject<HTMLSelectElement>}
+              required
+              aria-required="true"
+              value={federalCharge}
+              onChange={(e) => setFederalCharge(e.target.value)}
+              className={inputClass}
+              disabled={isChecking}
+            >
+              <option value="">Select federal charge</option>
+              {FJB_CHARGES.map((c) => (
+                <option key={c.value} value={c.value}>
+                  {c.label}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label htmlFor={`${id}-circuit`} className={labelClass}>
+              Federal circuit
+            </label>
+            <select
+              id={`${id}-circuit`}
+              value={circuit}
+              onChange={(e) => setCircuit(e.target.value)}
+              className={inputClass}
+              disabled={isChecking}
+            >
+              {FJB_CIRCUITS.map((c) => (
+                <option key={c.value || 'auto'} value={c.value}>
+                  {c.label}
+                </option>
+              ))}
+            </select>
+            <p className="text-xs text-zinc-500 mt-1">
+              Optional. If left blank, we use the circuit covering your state.
+            </p>
+          </div>
+        </>
       )}
 
       {/* Charge type select (similar-cases-analyzer) */}

--- a/src/lib/products.ts
+++ b/src/lib/products.ts
@@ -1328,7 +1328,7 @@ export const STANDALONE_PRODUCTS: Record<string, StandaloneProduct> = {
     priceDisplay: "$97",
     delivery: "Instant",
     deliveryDetail:
-      "Your Federal Jury Instruction Brief is generated on demand from 1,808 verified pattern instructions within 60 seconds.",
+      "Your Federal Jury Instruction Brief is generated on demand from 1,772 verified pattern instructions within 60 seconds.",
     description:
       "The pattern jury instruction your federal trial judge is likely to read — verbatim — plus burden-of-proof callouts, top-5 historical attack authorities, and alternative circuit variants. Federal charges only.",
     // Required: federalCharge, circuit. Optional: state (display context /
@@ -1338,8 +1338,11 @@ export const STANDALONE_PRODUCTS: Record<string, StandaloneProduct> = {
     upsellTier: "case-decoder",
     upsellText:
       "Pattern instructions set the legal floor. The Case Decoder maps how to attack them with your specific facts.",
-    // 2026-04-26: aligned to tiers.ts live flag (audit P2#12).
-    isActive: false,
+    // 2026-04-26 D5 PR — flipped to true. AvailabilityChecker yellow banner
+    // discloses circuit-coverage gap pre-purchase; resolver already falls
+    // back to closest-sibling circuit post-purchase. 1,772 verified rows
+    // across 7 circuits (1, 3, 5, 6, 7, 8, 9).
+    isActive: true,
   },
   "precedent-watchlist": {
     name: "Precedent Watchlist",

--- a/src/lib/tier9-reports/__tests__/fjib-coverage.test.ts
+++ b/src/lib/tier9-reports/__tests__/fjib-coverage.test.ts
@@ -16,12 +16,20 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 interface QueryRecord {
   table: string;
   filters: Array<{ col: string; val: unknown }>;
+  orClause: string | null;
   isCount: boolean;
 }
 
 let queryLog: QueryRecord[] = [];
 /** Map keyed by `${table}|${circuit}` (or just `${table}` for unfiltered total). */
 let scriptedCounts: Map<string, number> = new Map();
+/**
+ * Map keyed by `${table}|charge` for any-circuit charge-match counts and
+ * `${table}|charge|${circuit}` for circuit-restricted charge-match counts.
+ * These are looked up when the query has an `or(...)` ILIKE clause set
+ * (W1 path).
+ */
+let scriptedChargeCounts: Map<string, number> = new Map();
 
 function key(table: string, circuit?: number | string): string {
   return circuit === undefined ? table : `${table}|${circuit}`;
@@ -29,7 +37,8 @@ function key(table: string, circuit?: number | string): string {
 
 function mockBuilder(table: string, isCount: boolean) {
   const filters: Array<{ col: string; val: unknown }> = [];
-  const record: QueryRecord = { table, filters, isCount };
+  let orClause: string | null = null;
+  const record: QueryRecord = { table, filters, orClause, isCount };
   queryLog.push(record);
 
   const builder: Record<string, unknown> = {};
@@ -37,14 +46,30 @@ function mockBuilder(table: string, isCount: boolean) {
     filters.push({ col, val });
     return builder;
   };
+  builder.or = (clause: string) => {
+    orClause = clause;
+    record.orClause = clause;
+    return builder;
+  };
   builder.then = (resolve: (val: unknown) => unknown) => {
     const circuitFilter = filters.find((f) => f.col === "circuit")?.val as
       | number
       | string
       | undefined;
-    const explicitCount =
-      scriptedCounts.get(key(table, circuitFilter)) ??
-      scriptedCounts.get(key(table));
+    let explicitCount: number | undefined;
+    if (orClause) {
+      // W1 charge-match path. Look up by `charge` token first, optionally
+      // narrowed by circuit.
+      const chargeKey =
+        circuitFilter !== undefined
+          ? `${table}|charge|${circuitFilter}`
+          : `${table}|charge`;
+      explicitCount = scriptedChargeCounts.get(chargeKey);
+    } else {
+      explicitCount =
+        scriptedCounts.get(key(table, circuitFilter)) ??
+        scriptedCounts.get(key(table));
+    }
     if (isCount) {
       const count = explicitCount ?? 0;
       return Promise.resolve({ count, data: null, error: null }).then(resolve);
@@ -66,11 +91,16 @@ vi.mock("@/lib/supabase/admin", () => ({
 }));
 
 import { checkFJIBCoverage } from "../coverage";
-import { PJI_COVERED_CIRCUITS } from "../federal-jury-instruction-brief";
+import {
+  PJI_COVERED_CIRCUITS,
+  FEDERAL_CHARGES,
+} from "../federal-jury-instruction-brief";
+import { FJB_CHARGES, FJB_CHARGE_SLUGS } from "../fjib-charges";
 
 beforeEach(() => {
   queryLog = [];
   scriptedCounts = new Map();
+  scriptedChargeCounts = new Map();
 });
 
 describe("PJI_COVERED_CIRCUITS — live data shape", () => {
@@ -205,5 +235,101 @@ describe("checkFJIBCoverage — edge inputs", () => {
     expect(result.coverage.pjiInCircuit).toBe(0);
     expect(result.coverage.supported).toBe(0);
     expect(result.available).toBe(true);
+  });
+});
+
+describe("checkFJIBCoverage — charge-specific counts (W1, PR #171)", () => {
+  it("emits pjiInCircuitMatchingCharge + pjiInAnyCircuitMatchingCharge when charge supplied", async () => {
+    // Total / circuit shape (mimic the Ninth Circuit case)
+    scriptedCounts.set(key("v_pji_public"), 1772);
+    scriptedCounts.set(key("v_pji_public", 9), 44);
+    // Charge-specific: wire-fraud has matches in any circuit AND in circuit 9
+    scriptedChargeCounts.set("v_pji_public|charge", 30);
+    scriptedChargeCounts.set("v_pji_public|charge|9", 4);
+
+    const result = await checkFJIBCoverage("9", "CA", "wire-fraud");
+
+    expect(result.coverage.pjiInCircuit).toBe(44);
+    expect(result.coverage.pjiInAnyCircuitMatchingCharge).toBe(30);
+    expect(result.coverage.pjiInCircuitMatchingCharge).toBe(4);
+    expect(result.available).toBe(true);
+  });
+
+  it("strong banner trips when charge has zero matches in ANY circuit", async () => {
+    scriptedCounts.set(key("v_pji_public"), 1772);
+    scriptedCounts.set(key("v_pji_public", 9), 44);
+    // Zero charge-specific matches anywhere — corpus exists but the charge
+    // title-keywords don't hit any row.
+    scriptedChargeCounts.set("v_pji_public|charge", 0);
+    scriptedChargeCounts.set("v_pji_public|charge|9", 0);
+
+    const result = await checkFJIBCoverage("9", "CA", "wire-fraud");
+
+    expect(result.coverage.pjiInAnyCircuitMatchingCharge).toBe(0);
+    expect(result.coverage.pjiInCircuitMatchingCharge).toBe(0);
+    // Banner-trip condition for the strongest banner (mirrors
+    // AvailabilityChecker logic):
+    const strongBannerWouldFire =
+      result.coverage.pjiInAnyCircuitMatchingCharge === 0;
+    expect(strongBannerWouldFire).toBe(true);
+  });
+
+  it("medium banner trips when charge has matches elsewhere but not in user's circuit", async () => {
+    scriptedCounts.set(key("v_pji_public"), 1772);
+    scriptedCounts.set(key("v_pji_public", 9), 44);
+    scriptedChargeCounts.set("v_pji_public|charge", 12);
+    scriptedChargeCounts.set("v_pji_public|charge|9", 0);
+
+    const result = await checkFJIBCoverage("9", "CA", "wire-fraud");
+
+    expect(result.coverage.pjiInAnyCircuitMatchingCharge).toBe(12);
+    expect(result.coverage.pjiInCircuitMatchingCharge).toBe(0);
+    const mediumBannerWouldFire =
+      result.coverage.pjiInCircuitMatchingCharge === 0 &&
+      (result.coverage.pjiInAnyCircuitMatchingCharge ?? 0) > 0;
+    expect(mediumBannerWouldFire).toBe(true);
+  });
+
+  it("omits charge-specific keys when no federalCharge supplied", async () => {
+    scriptedCounts.set(key("v_pji_public"), 1772);
+    scriptedCounts.set(key("v_pji_public", 9), 44);
+
+    const result = await checkFJIBCoverage("9", "CA");
+
+    expect(result.coverage.pjiInAnyCircuitMatchingCharge).toBeUndefined();
+    expect(result.coverage.pjiInCircuitMatchingCharge).toBeUndefined();
+  });
+
+  it("unknown federalCharge slug: skips charge-specific path silently", async () => {
+    scriptedCounts.set(key("v_pji_public"), 1772);
+    scriptedCounts.set(key("v_pji_public", 9), 44);
+
+    const result = await checkFJIBCoverage("9", "CA", "no-such-charge");
+
+    expect(result.coverage.pjiInAnyCircuitMatchingCharge).toBeUndefined();
+    expect(result.coverage.pjiInCircuitMatchingCharge).toBeUndefined();
+  });
+});
+
+describe("FJB_CHARGES (client) ↔ FEDERAL_CHARGES (server) sync (S1, PR #171)", () => {
+  it("FJB_CHARGE_SLUGS matches Object.keys(FEDERAL_CHARGES) byte-for-byte after sort", () => {
+    const clientSlugs = [...FJB_CHARGE_SLUGS].sort();
+    const serverSlugs = Object.keys(FEDERAL_CHARGES).sort();
+    expect(clientSlugs).toEqual(serverSlugs);
+  });
+
+  it("FJB_CHARGES (component) values align with FJB_CHARGE_SLUGS — drift catcher", () => {
+    const componentValues = FJB_CHARGES.map((c) => c.value).sort();
+    const slugList = [...FJB_CHARGE_SLUGS].sort();
+    expect(componentValues).toEqual(slugList);
+  });
+
+  it("every FJB_CHARGES label is non-empty and unique", () => {
+    const labels = FJB_CHARGES.map((c) => c.label);
+    const labelSet = new Set(labels);
+    expect(labels.length).toBe(labelSet.size);
+    for (const l of labels) {
+      expect(l.length).toBeGreaterThan(0);
+    }
   });
 });

--- a/src/lib/tier9-reports/__tests__/fjib-coverage.test.ts
+++ b/src/lib/tier9-reports/__tests__/fjib-coverage.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Unit tests for the federal-jury-instruction-brief circuit-coverage
+ * gating (D5 plan, 2026-04-26). Mirrors the officer-coverage test pattern.
+ *
+ * Focus:
+ *   - checkFJIBCoverage exposes pjiTotal + pjiInCircuit
+ *   - Supported circuit (e.g., 9): pjiInCircuit > 0, banner does NOT fire
+ *   - Unsupported circuit (e.g., 4): pjiInCircuit === 0, banner WOULD fire
+ *   - State cascade: blank circuit cascades through STATE_TO_CIRCUIT
+ *   - DC: valid in CIRCUIT_NAMES but not in PJI_COVERED_CIRCUITS, so
+ *     pjiInCircuit === 0 (banner fires)
+ *   - PJI_COVERED_CIRCUITS reflects the live 7-circuit set (sanity check)
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+interface QueryRecord {
+  table: string;
+  filters: Array<{ col: string; val: unknown }>;
+  isCount: boolean;
+}
+
+let queryLog: QueryRecord[] = [];
+/** Map keyed by `${table}|${circuit}` (or just `${table}` for unfiltered total). */
+let scriptedCounts: Map<string, number> = new Map();
+
+function key(table: string, circuit?: number | string): string {
+  return circuit === undefined ? table : `${table}|${circuit}`;
+}
+
+function mockBuilder(table: string, isCount: boolean) {
+  const filters: Array<{ col: string; val: unknown }> = [];
+  const record: QueryRecord = { table, filters, isCount };
+  queryLog.push(record);
+
+  const builder: Record<string, unknown> = {};
+  builder.eq = (col: string, val: unknown) => {
+    filters.push({ col, val });
+    return builder;
+  };
+  builder.then = (resolve: (val: unknown) => unknown) => {
+    const circuitFilter = filters.find((f) => f.col === "circuit")?.val as
+      | number
+      | string
+      | undefined;
+    const explicitCount =
+      scriptedCounts.get(key(table, circuitFilter)) ??
+      scriptedCounts.get(key(table));
+    if (isCount) {
+      const count = explicitCount ?? 0;
+      return Promise.resolve({ count, data: null, error: null }).then(resolve);
+    }
+    return Promise.resolve({ data: [], error: null }).then(resolve);
+  };
+  return builder;
+}
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: () => ({
+    from: (table: string) => ({
+      select: (_cols: string, opts?: { count?: string; head?: boolean }) => {
+        const isCount = !!(opts && opts.count === "exact");
+        return mockBuilder(table, isCount);
+      },
+    }),
+  }),
+}));
+
+import { checkFJIBCoverage } from "../coverage";
+import { PJI_COVERED_CIRCUITS } from "../federal-jury-instruction-brief";
+
+beforeEach(() => {
+  queryLog = [];
+  scriptedCounts = new Map();
+});
+
+describe("PJI_COVERED_CIRCUITS — live data shape", () => {
+  it("matches the 7 circuits with rows in v_pji_public (verified 2026-04-26)", () => {
+    const supported = [...PJI_COVERED_CIRCUITS].sort((a, b) => a - b);
+    expect(supported).toEqual([1, 3, 5, 6, 7, 8, 9]);
+  });
+
+  it("does NOT include circuit 10 (zero rows in prod)", () => {
+    expect(PJI_COVERED_CIRCUITS.has(10)).toBe(false);
+  });
+
+  it("does NOT include circuits 2, 4, 11", () => {
+    expect(PJI_COVERED_CIRCUITS.has(2)).toBe(false);
+    expect(PJI_COVERED_CIRCUITS.has(4)).toBe(false);
+    expect(PJI_COVERED_CIRCUITS.has(11)).toBe(false);
+  });
+});
+
+describe("checkFJIBCoverage — supported circuits", () => {
+  it("returns positive pjiInCircuit when user's circuit has rows", async () => {
+    // Live shape: 1,772 total, circuit 9 has 44 rows.
+    scriptedCounts.set(key("v_pji_public"), 1772);
+    scriptedCounts.set(key("v_pji_public", 9), 44);
+
+    const result = await checkFJIBCoverage("9", "CA");
+
+    expect(result.coverage.pjiTotal).toBe(1772);
+    expect(result.coverage.pjiInCircuit).toBe(44);
+    expect(result.coverage.supported).toBe(1);
+    expect(result.available).toBe(true);
+    expect(result.matchedName).toBe("Ninth Circuit");
+  });
+
+  it("cascades from state when circuit is blank (CA -> 9th Circuit)", async () => {
+    scriptedCounts.set(key("v_pji_public"), 1772);
+    scriptedCounts.set(key("v_pji_public", 9), 44);
+
+    const result = await checkFJIBCoverage(null, "CA");
+
+    expect(result.coverage.pjiInCircuit).toBe(44);
+    expect(result.coverage.supported).toBe(1);
+    expect(result.matchedName).toBe("Ninth Circuit");
+  });
+
+  it("cascades from state when circuit is empty string", async () => {
+    scriptedCounts.set(key("v_pji_public"), 1772);
+    scriptedCounts.set(key("v_pji_public", 5), 251);
+
+    const result = await checkFJIBCoverage("", "TX");
+
+    expect(result.coverage.pjiInCircuit).toBe(251);
+    expect(result.matchedName).toBe("Fifth Circuit");
+  });
+});
+
+describe("checkFJIBCoverage — unsupported circuits (banner trips)", () => {
+  it("user picks 4th Circuit explicitly: pjiInCircuit === 0 (banner fires)", async () => {
+    scriptedCounts.set(key("v_pji_public"), 1772);
+    // No entry for circuit 4 — defaults to 0 via mockBuilder.
+
+    const result = await checkFJIBCoverage("4", "VA");
+
+    expect(result.coverage.pjiTotal).toBe(1772);
+    expect(result.coverage.pjiInCircuit).toBe(0);
+    expect(result.coverage.supported).toBe(0);
+    expect(result.available).toBe(true); // graceful fallback always available
+
+    // Banner-trip condition (mirrors AvailabilityChecker logic):
+    const bannerWouldFire =
+      (result.coverage.pjiTotal ?? 0) > 0 &&
+      (result.coverage.pjiInCircuit ?? 0) === 0;
+    expect(bannerWouldFire).toBe(true);
+  });
+
+  it("VA cascade hits 4th Circuit (no rows): banner fires", async () => {
+    scriptedCounts.set(key("v_pji_public"), 1772);
+
+    const result = await checkFJIBCoverage(null, "VA");
+
+    expect(result.coverage.pjiInCircuit).toBe(0);
+    expect(result.coverage.supported).toBe(0);
+    expect(result.matchedName).toBe("Fourth Circuit");
+  });
+
+  it("DC cascade: valid label but zero rows (banner fires)", async () => {
+    scriptedCounts.set(key("v_pji_public"), 1772);
+
+    const result = await checkFJIBCoverage("DC", "DC");
+
+    expect(result.coverage.pjiTotal).toBe(1772);
+    expect(result.coverage.pjiInCircuit).toBe(0);
+    expect(result.coverage.supported).toBe(0);
+    expect(result.matchedName).toBe("D.C. Circuit");
+  });
+
+  it("circuit 10 is NOT supported (was the audit-found bug): banner fires", async () => {
+    scriptedCounts.set(key("v_pji_public"), 1772);
+
+    const result = await checkFJIBCoverage("10", "CO");
+
+    expect(result.coverage.pjiInCircuit).toBe(0);
+    expect(result.coverage.supported).toBe(0);
+  });
+
+  it("11th Circuit (FL): banner fires when rows are zero", async () => {
+    scriptedCounts.set(key("v_pji_public"), 1772);
+
+    const result = await checkFJIBCoverage("11", "FL");
+
+    expect(result.coverage.pjiInCircuit).toBe(0);
+    expect(result.coverage.supported).toBe(0);
+  });
+});
+
+describe("checkFJIBCoverage — edge inputs", () => {
+  it("unknown circuit string: matchedName falls back to null", async () => {
+    scriptedCounts.set(key("v_pji_public"), 1772);
+
+    const result = await checkFJIBCoverage("99", "ZZ");
+
+    expect(result.coverage.pjiInCircuit).toBe(0);
+    expect(result.coverage.supported).toBe(0);
+    expect(result.matchedName).toBeNull();
+  });
+
+  it("blank circuit + blank state: no resolution, banner triggers, available stays true", async () => {
+    scriptedCounts.set(key("v_pji_public"), 1772);
+
+    const result = await checkFJIBCoverage(null, "");
+
+    expect(result.coverage.pjiInCircuit).toBe(0);
+    expect(result.coverage.supported).toBe(0);
+    expect(result.available).toBe(true);
+  });
+});

--- a/src/lib/tier9-reports/coverage.ts
+++ b/src/lib/tier9-reports/coverage.ts
@@ -14,6 +14,11 @@ import {
   fetchNypdCandidates,
   chooseNypdMatch,
 } from "./nypd-match";
+import {
+  PJI_COVERED_CIRCUITS,
+  STATE_TO_CIRCUIT,
+  CIRCUIT_NAMES,
+} from "./federal-jury-instruction-brief";
 
 function escapeIlike(input: string): string {
   return input.replace(/[%_\\]/g, (ch) => `\\${ch}`);
@@ -404,6 +409,83 @@ export async function checkSimilarCasesCoverage(
     available,
     coverage,
     matchedName: null,
+    matchedCourt: null,
+  };
+}
+
+/**
+ * Federal Jury Instruction Brief coverage probe (D5 plan, 2026-04-26).
+ *
+ * Returns row counts so the AvailabilityChecker can show a yellow
+ * "closest-circuit fallback" banner when the customer's circuit has zero
+ * PJI rows. Mirrors D2/D3 transparency pattern: post-purchase resolver
+ * already falls back gracefully — this is pre-purchase disclosure only.
+ *
+ * `available` is always `true` because the resolver always has SOMETHING
+ * to render (closest sibling). Customers self-gate via the banner.
+ *
+ * Coverage shape:
+ *   - `pjiTotal`     — total verified rows across all 7 supported circuits
+ *   - `pjiInCircuit` — rows in the user's circuit (0 when not yet ingested)
+ *   - `circuit`      — numeric circuit consumed (cascaded from state when
+ *                      circuit not provided directly)
+ *   - `supported`    — 1 if circuit is in the supported set, 0 otherwise
+ *
+ * Inputs:
+ *   - `circuit` accepts "1".."11" or "DC". When blank or unrecognized, falls
+ *     back to STATE_TO_CIRCUIT (same map the resolver consumes).
+ *   - `state` is the 2-letter postal code (uppercased) used for the cascade.
+ */
+export async function checkFJIBCoverage(
+  circuit: string | null,
+  state: string,
+): Promise<CoverageResult> {
+  const supabase = createAdminClient();
+
+  const rawCircuit = (circuit ?? "").trim();
+  const upperState = state.trim().toUpperCase();
+  let resolvedCircuit: string | null = null;
+  if (rawCircuit && CIRCUIT_NAMES[rawCircuit]) {
+    resolvedCircuit = rawCircuit;
+  } else if (upperState && STATE_TO_CIRCUIT[upperState]) {
+    resolvedCircuit = STATE_TO_CIRCUIT[upperState];
+  }
+
+  // Numeric circuit for the supported-set check. "DC" is valid in
+  // CIRCUIT_NAMES but not in PJI_COVERED_CIRCUITS (zero rows), so a
+  // bare Number("DC") = NaN naturally falls into the "not supported" path.
+  const numericCircuit = resolvedCircuit ? Number(resolvedCircuit) : NaN;
+  const supported =
+    Number.isFinite(numericCircuit) && PJI_COVERED_CIRCUITS.has(numericCircuit);
+
+  // Two parallel COUNT queries: total verified inventory + rows for the
+  // resolved circuit. `head: true` keeps payload empty.
+  const [totalRes, circuitRes] = await Promise.all([
+    supabase.from("v_pji_public").select("id", { count: "exact", head: true }),
+    supported && Number.isFinite(numericCircuit)
+      ? supabase
+          .from("v_pji_public")
+          .select("id", { count: "exact", head: true })
+          .eq("circuit", numericCircuit)
+      : Promise.resolve({ count: 0 } as { count: number | null }),
+  ]);
+
+  const pjiTotal = totalRes.count ?? 0;
+  const pjiInCircuit = circuitRes.count ?? 0;
+
+  const coverage: Record<string, number> = {
+    pjiTotal,
+    pjiInCircuit,
+    supported: supported ? 1 : 0,
+  };
+
+  // `available: true` always — the resolver guarantees a closest-sibling
+  // fallback. The banner (powered by pjiInCircuit === 0) is the customer-
+  // facing signal.
+  return {
+    available: true,
+    coverage,
+    matchedName: resolvedCircuit ? CIRCUIT_NAMES[resolvedCircuit] ?? null : null,
     matchedCourt: null,
   };
 }

--- a/src/lib/tier9-reports/coverage.ts
+++ b/src/lib/tier9-reports/coverage.ts
@@ -18,6 +18,7 @@ import {
   PJI_COVERED_CIRCUITS,
   STATE_TO_CIRCUIT,
   CIRCUIT_NAMES,
+  FEDERAL_CHARGES,
 } from "./federal-jury-instruction-brief";
 
 function escapeIlike(input: string): string {
@@ -414,12 +415,15 @@ export async function checkSimilarCasesCoverage(
 }
 
 /**
- * Federal Jury Instruction Brief coverage probe (D5 plan, 2026-04-26).
+ * Federal Jury Instruction Brief coverage probe (D5 plan, 2026-04-26;
+ * extended 2026-04-26 PR #171 review W1).
  *
  * Returns row counts so the AvailabilityChecker can show a yellow
  * "closest-circuit fallback" banner when the customer's circuit has zero
- * PJI rows. Mirrors D2/D3 transparency pattern: post-purchase resolver
- * already falls back gracefully — this is pre-purchase disclosure only.
+ * PJI rows OR (W1) when the user's specific federal charge has zero PJI
+ * rows in their circuit. Mirrors D2/D3 transparency pattern: post-purchase
+ * resolver already falls back gracefully — this is pre-purchase disclosure
+ * only.
  *
  * `available` is always `true` because the resolver always has SOMETHING
  * to render (closest sibling). Customers self-gate via the banner.
@@ -430,15 +434,31 @@ export async function checkSimilarCasesCoverage(
  *   - `circuit`      — numeric circuit consumed (cascaded from state when
  *                      circuit not provided directly)
  *   - `supported`    — 1 if circuit is in the supported set, 0 otherwise
+ *   - `pjiInCircuitMatchingCharge`     — (W1, only present when
+ *                                         `federalCharge` supplied) rows in
+ *                                         user's circuit whose `title`
+ *                                         matches the charge's title
+ *                                         keywords. Mirrors the server-side
+ *                                         pre-filter used by
+ *                                         `queryFederalJuryBrief`.
+ *   - `pjiInAnyCircuitMatchingCharge`  — (W1) same title filter, no circuit
+ *                                         restriction. When zero, the
+ *                                         charge has no PJI in our corpus
+ *                                         at all and the banner is upgraded
+ *                                         to "no match anywhere".
  *
  * Inputs:
  *   - `circuit` accepts "1".."11" or "DC". When blank or unrecognized, falls
  *     back to STATE_TO_CIRCUIT (same map the resolver consumes).
  *   - `state` is the 2-letter postal code (uppercased) used for the cascade.
+ *   - `federalCharge` is the charge slug (key of `FEDERAL_CHARGES`). When
+ *     absent, the charge-specific counts are skipped — caller pays only for
+ *     what it asked for.
  */
 export async function checkFJIBCoverage(
   circuit: string | null,
   state: string,
+  federalCharge?: string | null,
 ): Promise<CoverageResult> {
   const supabase = createAdminClient();
 
@@ -458,17 +478,68 @@ export async function checkFJIBCoverage(
   const supported =
     Number.isFinite(numericCircuit) && PJI_COVERED_CIRCUITS.has(numericCircuit);
 
-  // Two parallel COUNT queries: total verified inventory + rows for the
-  // resolved circuit. `head: true` keeps payload empty.
-  const [totalRes, circuitRes] = await Promise.all([
-    supabase.from("v_pji_public").select("id", { count: "exact", head: true }),
-    supported && Number.isFinite(numericCircuit)
-      ? supabase
-          .from("v_pji_public")
-          .select("id", { count: "exact", head: true })
-          .eq("circuit", numericCircuit)
-      : Promise.resolve({ count: 0 } as { count: number | null }),
-  ]);
+  // W1 (PR #171 review): when the caller supplies a federal charge, derive
+  // the same title-keyword pre-filter that `queryFederalJuryBrief` uses
+  // server-side. Strip regex syntax noise, drop short/punctuation-only
+  // signals, and join into a PostgREST `or` ILIKE. Empty signal list means
+  // we skip the charge-specific counts (treat as "unknown — fall back to
+  // circuit-only banner").
+  const chargeDef =
+    federalCharge && Object.prototype.hasOwnProperty.call(FEDERAL_CHARGES, federalCharge)
+      ? FEDERAL_CHARGES[federalCharge]
+      : null;
+  let chargeOrClause: string | null = null;
+  if (chargeDef) {
+    const titleKwSignals = chargeDef.titleKeywords
+      .map((re) => re.source.replace(/\\b/g, "").replace(/\\s\+/g, " "))
+      .map((s) => s.replace(/[()|]/g, "").trim())
+      .filter((s) => s.length >= 3 && /^[A-Za-z0-9. \-/&§]+$/.test(s));
+    if (titleKwSignals.length > 0) {
+      chargeOrClause = titleKwSignals
+        .map((s) => `title.ilike.%${s.replace(/%/g, "")}%`)
+        .join(",");
+    }
+  }
+
+  // Up to four parallel COUNT queries: total verified inventory + rows for
+  // the resolved circuit + (when charge supplied) charge-specific counts.
+  // `head: true` keeps payload empty. Empty-shape `Promise.resolve` matches
+  // the Supabase response tuple per S3 of the PR #171 review.
+  const [totalRes, circuitRes, chargeAnyRes, chargeCircuitRes] =
+    await Promise.all([
+      supabase.from("v_pji_public").select("id", { count: "exact", head: true }),
+      supported && Number.isFinite(numericCircuit)
+        ? supabase
+            .from("v_pji_public")
+            .select("id", { count: "exact", head: true })
+            .eq("circuit", numericCircuit)
+        : Promise.resolve({
+            count: 0,
+            data: null,
+            error: null,
+          } as { count: number | null; data: null; error: null }),
+      chargeOrClause
+        ? supabase
+            .from("v_pji_public")
+            .select("id", { count: "exact", head: true })
+            .or(chargeOrClause)
+        : Promise.resolve({
+            count: null,
+            data: null,
+            error: null,
+          } as { count: number | null; data: null; error: null }),
+      chargeOrClause && supported && Number.isFinite(numericCircuit)
+        ? supabase
+            .from("v_pji_public")
+            .select("id", { count: "exact", head: true })
+            .or(chargeOrClause)
+            .eq("circuit", numericCircuit)
+        : Promise.resolve({
+            count: null,
+            data: null,
+            error: null,
+          } as { count: number | null; data: null; error: null }),
+    ]);
 
   const pjiTotal = totalRes.count ?? 0;
   const pjiInCircuit = circuitRes.count ?? 0;
@@ -479,9 +550,17 @@ export async function checkFJIBCoverage(
     supported: supported ? 1 : 0,
   };
 
+  // Only emit the charge-specific keys when we actually queried for them.
+  // Surfacing 0 unconditionally would force the AvailabilityChecker to
+  // distinguish "not asked" from "asked and zero", which is fragile.
+  if (chargeOrClause) {
+    coverage.pjiInAnyCircuitMatchingCharge = chargeAnyRes.count ?? 0;
+    coverage.pjiInCircuitMatchingCharge = chargeCircuitRes.count ?? 0;
+  }
+
   // `available: true` always — the resolver guarantees a closest-sibling
-  // fallback. The banner (powered by pjiInCircuit === 0) is the customer-
-  // facing signal.
+  // fallback. The banner (powered by pjiInCircuit === 0 OR the charge-
+  // specific counts) is the customer-facing signal.
   return {
     available: true,
     coverage,

--- a/src/lib/tier9-reports/federal-jury-instruction-brief.ts
+++ b/src/lib/tier9-reports/federal-jury-instruction-brief.ts
@@ -353,13 +353,18 @@ export const CIRCUIT_NAMES: Record<string, string> = {
   DC: "D.C. Circuit",
 };
 
-// Circuits with at least one PJI row in our corpus as of 2026-04-23.
-// Verified live: 1, 3, 5, 6, 7, 8, 9, 10. Circuits 2, 4, 11, DC have
-// no published pattern instructions OR are not yet ingested — these
-// resolve to an empty PJI match + limitation note, and the brief
-// falls back to the closest-sibling circuit's variant so delivery is
-// not blocked.
-export const PJI_COVERED_CIRCUITS = new Set([1, 3, 5, 6, 7, 8, 9, 10]);
+// Circuits with at least one PJI row in our corpus.
+// Verified live 2026-04-26 against `v_pji_public`:
+//   circuit 1: 72 rows / 3: 285 / 5: 251 / 6: 140 / 7: 67 / 8: 141 / 9: 44
+//   total: 1,772 rows across 7 circuits
+// Circuits 2, 4, 10, 11, DC have zero rows (not yet ingested OR no
+// published pattern instructions). For those, `queryFederalJuryBrief`
+// resolves to the closest-sibling circuit + adds a limitation note so
+// delivery is not blocked. Pre-purchase, the AvailabilityChecker yellow
+// banner discloses the fallback before the customer commits.
+// Earlier list incorrectly included `10` despite zero rows; corrected
+// 2026-04-26 D5 PR to match the live data shape.
+export const PJI_COVERED_CIRCUITS = new Set([1, 3, 5, 6, 7, 8, 9]);
 
 const VALID_CIRCUITS = new Set(Object.keys(CIRCUIT_NAMES));
 
@@ -554,7 +559,7 @@ export async function queryFederalJuryBrief(
       attackAuthorities: [],
       circuitVariants: [],
       limitations: [
-        `No pattern jury instruction in our corpus matches ${def.label}. Our coverage spans First, Third, Fifth, Sixth, Seventh, Eighth, Ninth, and Tenth Circuits as of 2026-04-23.`,
+        `No pattern jury instruction in our corpus matches ${def.label}. Our coverage spans First, Third, Fifth, Sixth, Seventh, Eighth, and Ninth Circuits as of 2026-04-26.`,
       ],
       federalOnly: false,
       isEmpty: true,
@@ -565,7 +570,10 @@ export async function queryFederalJuryBrief(
   //   1. prefer a match on the user's resolved circuit
   //   2. else prefer 9th Circuit (largest corpus), then 1st, then 8th
   //   3. else any match
-  const circuitPref = circuit ? [Number(circuit), 9, 1, 8, 10, 6, 7, 3, 5] : [9, 1, 8, 10, 6, 7, 3, 5];
+  // Closest-sibling preference: when the user's circuit has no PJI rows,
+  // prefer high-volume circuits (3, 5, 8) then mid-volume (6, 9, 1, 7).
+  // Drops circuit 10 — verified zero rows in v_pji_public 2026-04-26.
+  const circuitPref = circuit ? [Number(circuit), 3, 5, 8, 6, 9, 1, 7] : [3, 5, 8, 6, 9, 1, 7];
   let primary: PjiMatch | null = null;
   for (const c of circuitPref) {
     const m = candidates.find((x) => x.circuit === c);

--- a/src/lib/tier9-reports/fjib-charges.ts
+++ b/src/lib/tier9-reports/fjib-charges.ts
@@ -1,0 +1,109 @@
+/**
+ * FJIB charge slug + label list — client-safe extract.
+ *
+ * The full `FEDERAL_CHARGES` map lives in
+ * `./federal-jury-instruction-brief.ts`, which also exports
+ * `queryFederalJuryBrief` and pulls `@/lib/supabase/admin`. We do not want
+ * the client bundle to follow that chain. This module mirrors the slug
+ * keys + display labels so the AvailabilityChecker (client) can render
+ * the SELECT options without paying the server-side import cost.
+ *
+ * The companion test in `__tests__/fjib-coverage.test.ts` asserts that
+ * `FJB_CHARGE_SLUGS` matches `Object.keys(FEDERAL_CHARGES)` byte-for-byte
+ * (S1 of the 2026-04-26 PR #171 review). Drift trips the test on the next
+ * edit.
+ *
+ * If you add or remove a federal charge, update TWO sites in lockstep:
+ *   1. `FEDERAL_CHARGES` in `federal-jury-instruction-brief.ts`
+ *   2. `FJB_CHARGES` here (slug + label)
+ * The S1 test will fail loudly if (1) and (2) drift. The route layer
+ * re-validates the slug against `FEDERAL_CHARGES` regardless, so this list
+ * cannot grant access to any charge the server does not also support.
+ */
+
+export const FJB_CHARGES: { value: string; label: string }[] = [
+  { value: "wire-fraud", label: "Wire Fraud (18 U.S.C. § 1343)" },
+  { value: "mail-fraud", label: "Mail Fraud (18 U.S.C. § 1341)" },
+  { value: "conspiracy-general", label: "Conspiracy (18 U.S.C. § 371)" },
+  { value: "drug-conspiracy", label: "Drug Conspiracy (21 U.S.C. § 846)" },
+  {
+    value: "drug-distribution",
+    label: "Distribution of a Controlled Substance (21 U.S.C. § 841(a)(1))",
+  },
+  {
+    value: "drug-possession-intent",
+    label: "Possession with Intent to Distribute (21 U.S.C. § 841(a)(1))",
+  },
+  {
+    value: "drug-manufacture",
+    label: "Manufacture of a Controlled Substance (21 U.S.C. § 841(a)(1))",
+  },
+  {
+    value: "felon-in-possession",
+    label: "Felon in Possession of Firearm (18 U.S.C. § 922(g))",
+  },
+  {
+    value: "firearm-during-drug-crime",
+    label:
+      "Using/Carrying a Firearm During a Drug Trafficking Crime (18 U.S.C. § 924(c))",
+  },
+  { value: "bank-robbery", label: "Bank Robbery (18 U.S.C. § 2113)" },
+  {
+    value: "hobbs-act",
+    label: "Hobbs Act Robbery/Extortion (18 U.S.C. § 1951)",
+  },
+  {
+    value: "money-laundering",
+    label: "Money Laundering (18 U.S.C. §§ 1956, 1957)",
+  },
+  { value: "tax-evasion", label: "Tax Evasion (26 U.S.C. § 7201)" },
+  {
+    value: "false-statement-agency",
+    label: "False Statement to a Federal Agency (18 U.S.C. § 1001)",
+  },
+  {
+    value: "aggravated-identity-theft",
+    label: "Aggravated Identity Theft (18 U.S.C. § 1028A)",
+  },
+  {
+    value: "bribery-public-official",
+    label: "Bribery of a Public Official (18 U.S.C. § 201)",
+  },
+  {
+    value: "obstruction-justice",
+    label: "Obstruction of Justice (18 U.S.C. § 1503 / § 1512)",
+  },
+  { value: "perjury", label: "Perjury (18 U.S.C. § 1621)" },
+  { value: "rico", label: "RICO — Racketeering (18 U.S.C. § 1962)" },
+  {
+    value: "child-pornography-possession",
+    label: "Possession of Child Pornography (18 U.S.C. § 2252 / § 2252A)",
+  },
+  {
+    value: "illegal-reentry",
+    label: "Illegal Re-entry After Deportation (8 U.S.C. § 1326)",
+  },
+  {
+    value: "immigration-fraud",
+    label:
+      "Immigration Fraud (18 U.S.C. § 1546 / 8 U.S.C. § 1325(c))",
+  },
+  {
+    value: "kidnapping-federal",
+    label: "Federal Kidnapping (18 U.S.C. § 1201)",
+  },
+  {
+    value: "healthcare-fraud",
+    label: "Health Care Fraud (18 U.S.C. § 1347)",
+  },
+  {
+    value: "aiding-abetting",
+    label: "Aiding and Abetting (18 U.S.C. § 2)",
+  },
+];
+
+export const FJB_CHARGE_SLUGS: readonly string[] = FJB_CHARGES.map(
+  (c) => c.value,
+);
+
+export type FjbChargeSlug = (typeof FJB_CHARGE_SLUGS)[number];

--- a/src/lib/tiers.ts
+++ b/src/lib/tiers.ts
@@ -371,7 +371,13 @@ export const TIER_CORE = {
     priorityPrice: null,
     priorityDelivery: null,
     includesTiers: [] as readonly string[],
-    live: false as boolean, // test mode, flip after E2E validation
+    // 2026-04-26 D5 PR — circuit-coverage gating + transparent fallback
+    // disclosure satisfies $97 pricing without backfilling 6 missing
+    // circuits. Resolver already falls back to closest-sibling circuit;
+    // pre-purchase yellow banner (AvailabilityChecker) discloses the
+    // fallback before payment. 1,772 verified rows across 7 circuits
+    // (1, 3, 5, 6, 7, 8, 9).
+    live: true as boolean,
   },
   "precedent-watchlist": {
     name: "Precedent Watchlist",


### PR DESCRIPTION
## Summary

D5 from `docs/handoff/2026-04-26-product-audit-deferred.md`. Audit said: "$97 dark. v_pji_public empty for circuits 2, 4, 10, 11, DC, FC. Backfill before flipping live."

This PR ships the code-only path: keep ingestion deferred, but flip live with **transparent pre-purchase disclosure** when the user's circuit has zero PJI rows. Mirrors the D2 (similar-cases) and D3 (officer-bg-check) yellow-banner pattern.

- `v_pji_public` verified live 2026-04-26: **1,772 rows across 7 circuits** (1: 72, 3: 285, 5: 251, 6: 140, 7: 67, 8: 141, 9: 44). Circuits 2, 4, 10, 11, DC are zero.
- Existing resolver already falls back to closest-sibling circuit + adds a `limitations` line. Now the **AvailabilityChecker** discloses the fallback BEFORE payment.
- Side fix: `PJI_COVERED_CIRCUITS` previously claimed circuit 10 had rows; live data shows zero. Constant + limitation copy + circuit-preference selector all corrected.
- $97 price unchanged. URL slug unchanged. Stripe price ID unchanged. Resolver post-purchase behavior unchanged.

## Files changed

- `src/lib/tier9-reports/federal-jury-instruction-brief.ts` — `PJI_COVERED_CIRCUITS` corrected to `{1, 3, 5, 6, 7, 8, 9}`; limitation copy + circuit preference list aligned
- `src/lib/tier9-reports/coverage.ts` — new `checkFJIBCoverage(circuit, state)` helper
- `src/app/api/check-availability/[slug]/route.ts` — adds `federal-jury-instruction-brief` switch case (federalCharge required, circuit optional, cascades from state)
- `src/components/tier9/AvailabilityChecker.tsx` — new federal-charge + circuit `<select>` inputs, yellow banner when `pjiInCircuit === 0`, FJIB checkout-URL params
- `src/lib/tiers.ts` — `live: true`
- `src/lib/products.ts` — `isActive: true`; deliveryDetail row count corrected (1,808 → 1,772 verified)
- `src/app/api/intake/standalone/[slug]/route.ts` — VALID_FJB_CIRCUITS comment refreshed
- `src/lib/tier9-reports/__tests__/fjib-coverage.test.ts` — new test suite (PJI_COVERED_CIRCUITS sanity, supported/unsupported circuit paths, state cascade, edge inputs)
- `docs/plans/2026-04-26-d5-fjib-circuit-coverage.md` — plan

## Test plan

- [x] `npx tsc --noEmit --skipLibCheck` → 0 errors (clear `.next/types` first)
- [x] `npx vitest run src/lib/tier9-reports/__tests__/` → 137/137 passing across 10 files
- [x] Existing `federal-jury-instruction-brief.test.ts` still green
- [x] New `fjib-coverage.test.ts` covers supported circuit, unsupported circuit, state cascade, DC edge case, blank inputs
- [ ] Post-merge smoke: `POST /api/check-availability/federal-jury-instruction-brief` with `{state: "CA", federalCharge: "wire-fraud"}` → 200 with `coverage.pjiInCircuit > 0`
- [ ] Post-merge smoke: same with `{state: "VA", federalCharge: "wire-fraud"}` → 200 with `coverage.pjiInCircuit === 0` (banner-trigger)
- [ ] Post-merge smoke: `/services/federal-jury-instruction-brief` returns 200 (was 404 with `isActive: false`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)