### PR TITLE
fix(d6): officer_external_intel status union (PR #164 sibling gap)

### DIFF
--- a/docs/plans/2026-04-26-d6-officer-external-intel-status.md
+++ b/docs/plans/2026-04-26-d6-officer-external-intel-status.md
@@ -1,0 +1,83 @@
+# D6 — officer_external_intel status union (PR #164 sibling gap)
+
+**Date:** 2026-04-26
+**Branch:** `fix/d6-officer-external-intel-status`
+**Class:** FEATURE (3 files: query.ts, render.ts, test file)
+
+## Worry verbatim (from `docs/handoff/2026-04-26-product-audit-deferred.md`, D6)
+
+> PR #164 hardened the agency_incidents resolver. Reviewer noted `officerResult.error`
+> in the same file (`src/lib/defense-intelligence/query.ts:506`) is also unhandled —
+> silent swallow if `officer_external_intel` errors.
+>
+> Apply the same status-union pattern to officer_external_intel queries.
+> Add officerStatus union ("ok" | "no_officers" | "data_unavailable").
+> Update arrest-survival-kit + officer-background-check renderers.
+> Add tests covering the table-missing case for officer_external_intel.
+
+## Reference pattern
+
+PR #164 introduced for agency_incidents:
+
+- `AgencyIncidentsStatus = "ok" | "no_incidents" | "data_unavailable"`
+- `PGRST_RELATION_NOT_FOUND = "PGRST200"` constant
+- Branch on `result.error` (with PGRST200 → console.warn, else console.error → all map to `data_unavailable`)
+- Branch on empty rows → `no_incidents`
+- Otherwise → `ok` + populated rows
+- Renderer renders three message variants
+- 5 unit tests cover the matrix
+
+This PR mirrors the same pattern byte-for-byte structurally, swapping `agency` → `officer`.
+
+## Files to modify
+
+### 1. `src/lib/defense-intelligence/query.ts`
+
+- Add type `OfficerStatsStatus = "ok" | "no_officers" | "data_unavailable"`.
+- Extend `ArrestSurvivalKitData.officerStats` to include `status: OfficerStatsStatus`.
+- In `queryArrestSurvivalKit` after `Promise.all`, mirror the agency_incidents handling for `officerResult`:
+  - PGRST200 → console.warn → `data_unavailable`
+  - other errors → console.error → `data_unavailable`
+  - empty rows → `no_officers` (officers stays `[]`)
+  - populated rows → `ok` + officers populated
+- Pass `status: officerStatsStatus` into the returned `officerStats` object alongside the existing aggregates (totalAgencies/totalOfficers/wanderingOfficerCount remain — they compute correctly from `[]` in `data_unavailable`/`no_officers` branches).
+
+### 2. `src/lib/tier9-reports/render.ts`
+
+- Update arrest-survival-kit "Officer Intelligence Coverage" block (currently renders only when `data.officerStats.totalOfficers > 0`) to handle the 3 status branches:
+  - `'data_unavailable'`: clinical message —
+    `Officer-data is not yet available for this jurisdiction. This section will be enriched when local data sources are ingested.`
+  - `'no_officers'`: clinical message —
+    `No officer reliability records found for this state's available agencies.`
+  - `'ok'`: existing render (totalAgencies, totalOfficers, wanderingOfficerCount)
+
+### 3. `src/lib/defense-intelligence/__tests__/query-arrest-survival-kit.test.ts`
+
+Append a second describe block `queryArrestSurvivalKit — officerStatsStatus` mirroring the agency tests:
+
+1. PGRST200 on officer_external_intel → `officerStatsStatus = 'data_unavailable'`, totalOfficers = 0
+2. Unexpected error (e.g., `code: "PGRST500"`) → `'data_unavailable'`
+3. Empty rows → `'no_officers'`, totalOfficers = 0
+4. Populated rows → `'ok'`, totalOfficers > 0, aggregates correct
+5. Independence: agency-error doesn't affect officer status (agency `data_unavailable` + officer `ok` co-exist)
+
+## Out of scope
+
+- The `officer-background-check` resolver (different file path; D3 already touched it under a separate PR).
+- Any data ingestion (D3 covers ingestion gaps).
+- Renaming/refactoring beyond what the status branch demands.
+
+## Success criteria
+
+- `tsc --noEmit --skipLibCheck` is clean (0 errors).
+- `vitest run src/lib/defense-intelligence/__tests__/` passes 100% (existing 5 + new 5).
+- `tests/lib/officer-render.test.ts` does not exist in repo (per Glob); skip — `.next/types` clear + tsc + vitest = sufficient.
+- PR description references PR #164 as the pattern source.
+
+## Cascade
+
+- us: same hardening pattern applied uniformly across both Promise.all branches; future regressions caught at edit-time.
+- defendants: when officer_external_intel ingestion lags, the report explains "not yet available" instead of silently rendering empty rows that look like "no problem officers found."
+- future-us: the type union becomes the precedent for similar Promise.all pairs in this file.
+- ecosystem: the status-union pattern publishable as the canonical PostgREST relation-missing handling.
+- No node loses.

--- a/src/lib/defense-intelligence/__tests__/query-arrest-survival-kit.test.ts
+++ b/src/lib/defense-intelligence/__tests__/query-arrest-survival-kit.test.ts
@@ -157,3 +157,105 @@ describe("queryArrestSurvivalKit — agencyIncidentsStatus", () => {
     expect(result.officerStats.wanderingOfficerCount).toBe(1);
   });
 });
+
+// ── officerStatsStatus tests (PR #164 sibling pattern, D6) ────────────────────
+
+describe("queryArrestSurvivalKit — officerStatsStatus", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const emptyAgencyResult: MockQueryResult = { data: [], error: null };
+
+  it("returns data_unavailable when officer_external_intel table is missing (PGRST200)", async () => {
+    const officerResult: MockQueryResult = {
+      data: null,
+      error: { code: "PGRST200", message: "Could not find the table officer_external_intel" },
+    };
+    mockCreateAdminClient.mockReturnValue(
+      buildMockSupabase(emptyAgencyResult, officerResult)
+    );
+
+    const result = await queryArrestSurvivalKit("FL");
+
+    expect(result.officerStats.status).toBe("data_unavailable");
+    expect(result.officerStats.totalOfficers).toBe(0);
+    expect(result.officerStats.totalAgencies).toBe(0);
+    expect(result.officerStats.wanderingOfficerCount).toBe(0);
+    // Report should still be delivered (rights checklist is universal)
+    expect(result.isEmpty).toBe(false);
+  });
+
+  it("returns data_unavailable for any unexpected officer query error", async () => {
+    const officerResult: MockQueryResult = {
+      data: null,
+      error: { code: "PGRST500", message: "Internal server error" },
+    };
+    mockCreateAdminClient.mockReturnValue(
+      buildMockSupabase(emptyAgencyResult, officerResult)
+    );
+
+    const result = await queryArrestSurvivalKit("TX");
+
+    expect(result.officerStats.status).toBe("data_unavailable");
+    expect(result.officerStats.totalOfficers).toBe(0);
+  });
+
+  it("returns no_officers when officer table exists but no rows for this state", async () => {
+    const officerResult: MockQueryResult = { data: [], error: null };
+    mockCreateAdminClient.mockReturnValue(
+      buildMockSupabase(emptyAgencyResult, officerResult)
+    );
+
+    const result = await queryArrestSurvivalKit("WY");
+
+    expect(result.officerStats.status).toBe("no_officers");
+    expect(result.officerStats.totalOfficers).toBe(0);
+    expect(result.officerStats.totalAgencies).toBe(0);
+  });
+
+  it("returns ok with populated officerStats when rows are present", async () => {
+    const officerResult: MockQueryResult = {
+      data: [
+        { agency: "LAPD", npi_is_wandering_officer: false },
+        { agency: "LAPD", npi_is_wandering_officer: true },
+        { agency: "Long Beach PD", npi_is_wandering_officer: false },
+      ],
+      error: null,
+    };
+    mockCreateAdminClient.mockReturnValue(
+      buildMockSupabase(emptyAgencyResult, officerResult)
+    );
+
+    const result = await queryArrestSurvivalKit("CA");
+
+    expect(result.officerStats.status).toBe("ok");
+    expect(result.officerStats.totalOfficers).toBe(3);
+    expect(result.officerStats.totalAgencies).toBe(2);
+    expect(result.officerStats.wanderingOfficerCount).toBe(1);
+  });
+
+  it("agency error does not affect officer status (independence)", async () => {
+    const agencyResult: MockQueryResult = {
+      data: null,
+      error: { code: "PGRST200", message: "Could not find the table agency_incidents" },
+    };
+    const officerResult: MockQueryResult = {
+      data: [
+        { agency: "NYPD", npi_is_wandering_officer: false },
+      ],
+      error: null,
+    };
+    mockCreateAdminClient.mockReturnValue(
+      buildMockSupabase(agencyResult, officerResult)
+    );
+
+    const result = await queryArrestSurvivalKit("NY");
+
+    // Agency table missing
+    expect(result.agencyIncidentsStatus).toBe("data_unavailable");
+    // Officer table fine — both statuses are independent
+    expect(result.officerStats.status).toBe("ok");
+    expect(result.officerStats.totalOfficers).toBe(1);
+  });
+});

--- a/src/lib/defense-intelligence/query.ts
+++ b/src/lib/defense-intelligence/query.ts
@@ -448,6 +448,16 @@ export async function queryDistrictCourtIntel(
  */
 export type AgencyIncidentsStatus = "ok" | "no_incidents" | "data_unavailable";
 
+/**
+ * Status of the officer_external_intel data fetch.
+ *
+ * - "ok"               — table exists and rows were returned
+ * - "no_officers"      — table exists but no rows for this jurisdiction
+ * - "data_unavailable" — table does not exist yet (not yet ingested) or
+ *                        an unexpected query error occurred
+ */
+export type OfficerStatsStatus = "ok" | "no_officers" | "data_unavailable";
+
 export interface ArrestSurvivalKitData {
   stateName: string;
   stateCode: string;
@@ -462,6 +472,8 @@ export interface ArrestSurvivalKitData {
     totalAgencies: number;
     totalOfficers: number;
     wanderingOfficerCount: number;
+    /** Explicit status so the renderer can show a sensible message instead of silence. */
+    status: OfficerStatsStatus;
   };
   isEmpty: boolean;
 }
@@ -531,11 +543,33 @@ export async function queryArrestSurvivalKit(
     agencyIncidentsStatus = "ok";
   }
 
-  const officers = officerResult.data ?? [];
+  // Resolve officer stats with explicit status rather than silently swallowing errors.
+  // Mirrors agency_incidents handling above (PR #164 pattern).
+  let officers: Array<Record<string, unknown>> = [];
+  let officerStatsStatus: OfficerStatsStatus;
 
-  // Aggregate officer stats
-  const agencies = new Set(officers.map((o: Record<string, unknown>) => o.agency as string).filter(Boolean));
-  const wanderingCount = officers.filter((o: Record<string, unknown>) => o.npi_is_wandering_officer === true).length;
+  if (officerResult.error) {
+    if (officerResult.error.code === PGRST_RELATION_NOT_FOUND) {
+      console.warn(
+        "[queryArrestSurvivalKit] officer_external_intel table not found — data not yet ingested"
+      );
+    } else {
+      console.error(
+        "[queryArrestSurvivalKit] unexpected error querying officer_external_intel:",
+        officerResult.error
+      );
+    }
+    officerStatsStatus = "data_unavailable";
+  } else if (!officerResult.data || officerResult.data.length === 0) {
+    officerStatsStatus = "no_officers";
+  } else {
+    officers = officerResult.data as Array<Record<string, unknown>>;
+    officerStatsStatus = "ok";
+  }
+
+  // Aggregate officer stats (safe to compute on [] for both error/empty branches)
+  const agencies = new Set(officers.map((o) => o.agency as string).filter(Boolean));
+  const wanderingCount = officers.filter((o) => o.npi_is_wandering_officer === true).length;
 
   return {
     stateName,
@@ -546,6 +580,7 @@ export async function queryArrestSurvivalKit(
       totalAgencies: agencies.size,
       totalOfficers: officers.length,
       wanderingOfficerCount: wanderingCount,
+      status: officerStatsStatus,
     },
     // Always available, rights checklist is universal
     isEmpty: false,

--- a/src/lib/tier9-reports/render.ts
+++ b/src/lib/tier9-reports/render.ts
@@ -2188,9 +2188,18 @@ export function renderArrestSurvivalKit(data: ArrestSurvivalKitData): string {
     }
   }
 
-  // Officer Stats Summary
-  if (data.officerStats.totalOfficers > 0) {
-    body += sectionHeader("Officer Intelligence Coverage");
+  // Officer Stats Summary — always render a section; content depends on data status.
+  body += sectionHeader("Officer Intelligence Coverage");
+  if (data.officerStats.status === "data_unavailable") {
+    body += `<p style="color: #A1A1AA; font-size: 13px; margin-bottom: 12px;">
+      Officer-data is not yet available for this jurisdiction.
+      This section will be enriched when local data sources are ingested.
+    </p>`;
+  } else if (data.officerStats.status === "no_officers") {
+    body += `<p style="color: #A1A1AA; font-size: 13px; margin-bottom: 12px;">
+      No officer reliability records found for this state's available agencies.
+    </p>`;
+  } else {
     body += `<table style="width: 100%; border-collapse: collapse; margin-bottom: 24px;">
       <tr><td style="padding: 8px 16px; color: #A1A1AA; border-bottom: 1px solid #1C1917;">Agencies with officer data</td>
           <td style="padding: 8px 16px; color: #FAFAF9; border-bottom: 1px solid #1C1917;">${data.officerStats.totalAgencies}</td></tr>


### PR DESCRIPTION
## Summary

D6 from `docs/handoff/2026-04-26-product-audit-deferred.md`. Reviewer on PR #164 noted that the same file (`src/lib/defense-intelligence/query.ts`) silent-swallows `officerResult.error` for the `officer_external_intel` query. This PR applies the same status-union pattern PR #164 introduced for `agency_incidents`.

- New type: `OfficerStatsStatus = "ok" | "no_officers" | "data_unavailable"`
- `queryArrestSurvivalKit` now branches on `officerResult.error` (PGRST200 → `console.warn`, other errors → `console.error`, both → `data_unavailable`), empty rows → `no_officers`, populated rows → `ok`.
- Renderer (`src/lib/tier9-reports/render.ts`) renders three message variants for the Officer Intelligence Coverage section instead of silently rendering nothing.
- 5 new unit tests mirror the agency-incidents test matrix structurally.

Plan: `docs/plans/2026-04-26-d6-officer-external-intel-status.md`

## Test plan
- [x] `tsc --noEmit --skipLibCheck` clean (0 errors after `.next/types` clear)
- [x] `npx vitest run src/lib/defense-intelligence/__tests__/` — 10 tests pass (5 existing + 5 new)
- [x] `next build --webpack --experimental-build-mode compile` succeeds (pre-push hook)
- [ ] Manual: render an arrest-survival-kit report against a state with `officer_external_intel` data and one without, confirm the renderer surfaces the "data not yet available" message rather than silently rendering nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)