### PR TITLE
fix(d7): extract canonical UPL disclaimers to single source

### DIFF
--- a/src/app/checkout/page.tsx
+++ b/src/app/checkout/page.tsx
@@ -44,6 +44,7 @@
 
 import { TIER_CORE, tierPriceNum, upgradePrice, upgradeCostBetween, type TierSlug } from "@/lib/tiers";
 import { getProduct, isValidProduct } from "@/lib/products";
+import { REPORT_UPL_DISCLAIMER } from "@/lib/copy/disclaimers";
 import { useSearchParams } from "next/navigation";
 import { useState, useRef, Suspense } from "react";
 import Link from "next/link";
@@ -179,7 +180,7 @@ function StandaloneCheckout({
       </div>
 
       <p className="mt-6 text-xs text-zinc-400">
-        This report provides legal INFORMATION, not legal ADVICE. Decisions about how to use this information stay with you.
+        {REPORT_UPL_DISCLAIMER}
       </p>
     </div>
   );

--- a/src/app/intake/standalone/[slug]/IntakeFormClient.tsx
+++ b/src/app/intake/standalone/[slug]/IntakeFormClient.tsx
@@ -30,6 +30,7 @@
 
 import { useState, useRef, useMemo, useEffect } from "react";
 import { ALLOWED_CHARGE_TYPES } from "@/lib/charge-types";
+import { REPORT_UPL_DISCLAIMER } from "@/lib/copy/disclaimers";
 
 const US_STATES = [
   { value: "AL", label: "Alabama" }, { value: "AK", label: "Alaska" },
@@ -2954,7 +2955,7 @@ export default function IntakeFormClient({ slug, productName, token }: Props) {
 
       {/* UPL disclaimer */}
       <p className="mt-4 text-xs text-zinc-400">
-        This report provides legal INFORMATION, not legal ADVICE. Decisions about how to use this information stay with you.
+        {REPORT_UPL_DISCLAIMER}
       </p>
     </form>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -40,6 +40,7 @@ import { CookieConsent } from "@/components/CookieConsent";
 import { SITE_URL } from "@/lib/site";
 import { isPartnerBrandedRoute } from "@/lib/partner-branding/route-matcher";
 import { partnerBrandingEnabled } from "@/lib/partner-branding/feature-flag";
+import { BRAND_UPL_DISCLAIMER } from "@/lib/copy/disclaimers";
 import "./globals.css";
 
 /** Lato, primary body font per brand.md. Warm, readable for legal content. CSS var kept as --font-geist-sans for minimal blast radius. */
@@ -137,7 +138,7 @@ export default async function RootLayout({
                 "@id": `${SITE_URL}/#organization`,
                 name: "ImNotAnAttorney",
                 url: SITE_URL,
-                description: "Defendant preparation intelligence, case-specific research and accountability questions for criminal defendants. Legal information, not legal advice.",
+                description: `Defendant preparation intelligence, case-specific research and accountability questions for criminal defendants. ${BRAND_UPL_DISCLAIMER}`,
                 logo: { "@type": "ImageObject", url: `${SITE_URL}/icon` },
                 foundingDate: "2026",
                 knowsAbout: [

--- a/src/app/r/[code]/[product]/opengraph-image.tsx
+++ b/src/app/r/[code]/[product]/opengraph-image.tsx
@@ -4,6 +4,7 @@ import { truncateName } from "@/lib/truncate-name";
 import { TIER_CORE, type TierSlug } from "@/lib/tiers";
 import { resolveReferralProduct } from "@/lib/referral-product-map";
 import { partnerBrandingEnabled } from "@/lib/partner-branding/feature-flag";
+import { BRAND_UPL_DISCLAIMER } from "@/lib/copy/disclaimers";
 
 export const size = OG_SIZE;
 export const contentType = OG_CONTENT_TYPE;
@@ -77,7 +78,7 @@ export default async function Image({
       (!!partner.logo_url || !!partner.brand_color_primary);
     return renderOgImage({
       title: `Defense research\nvia ${partnerName}`,
-      subtitle: "Legal information, not legal advice.",
+      subtitle: BRAND_UPL_DISCLAIMER,
       category: "Defense Intelligence",
       partnerBranding: brandingOn
         ? {
@@ -92,7 +93,7 @@ export default async function Image({
   if (!partner || !tierSlug) {
     return renderOgImage({
       title: "Defense research\nfor your case.",
-      subtitle: "Legal information, not legal advice.",
+      subtitle: BRAND_UPL_DISCLAIMER,
       category: "Defense Intelligence",
     });
   }

--- a/src/app/r/[code]/[product]/page.tsx
+++ b/src/app/r/[code]/[product]/page.tsx
@@ -23,6 +23,7 @@ import { createAdminClient } from "@/lib/supabase/admin";
 import { getPartnerByCode } from "@/lib/partner-by-code";
 import { sanitizeSubId } from "@/lib/referral";
 import { truncateName } from "@/lib/truncate-name";
+import { BRAND_UPL_DISCLAIMER } from "@/lib/copy/disclaimers";
 import { TIER_CORE, type TierSlug } from "@/lib/tiers";
 import { resolveReferralProduct } from "@/lib/referral-product-map";
 
@@ -134,7 +135,7 @@ const NO_ATTORNEY_YET: Partial<Record<TierSlug, string>> = {
 // Short metadata pitches -- UPL-safe, quality-framed, no speed hooks.
 const META_DESCRIPTIONS: Partial<Record<TierSlug, string>> = {
   "case-decoder":
-    "Your charges decoded, plus 10-15 questions built for your attorney. Legal information, not legal advice.",
+    `Your charges decoded, plus 10-15 questions built for your attorney. ${BRAND_UPL_DISCLAIMER}`,
   "intelligence-brief":
     "A briefing on your judge, your prosecutor, and your charges. Plus 15-25 questions to force the right conversations.",
   "x-ray":
@@ -204,7 +205,7 @@ export async function generateMetadata({
   if (!partner || !tierSlug) {
     return {
       title: "ImNotAnAttorney",
-      description: "Legal information, not legal advice.",
+      description: BRAND_UPL_DISCLAIMER,
     };
   }
 
@@ -212,7 +213,7 @@ export async function generateMetadata({
   const referrer = truncateName(partner.company || partner.name);
   const title = `${tier.name} -- via ${referrer}`;
   const description = META_DESCRIPTIONS[tierSlug]
-    ?? "Legal information, not legal advice. Questions for your attorney, built from your record.";
+    ?? `${BRAND_UPL_DISCLAIMER} Questions for your attorney, built from your record.`;
   // OG image URL + alt auto-injected by sibling opengraph-image.tsx via
   // generateImageMetadata. Do not override openGraph.images here.
 

--- a/src/app/r/[code]/quiz/page.tsx
+++ b/src/app/r/[code]/quiz/page.tsx
@@ -11,6 +11,7 @@ import { redirect } from "next/navigation";
 import { ReferralQuiz } from "@/components/ReferralQuiz";
 import { getPartnerByCode } from "@/lib/partner-by-code";
 import { truncateName } from "@/lib/truncate-name";
+import { BRAND_UPL_DISCLAIMER } from "@/lib/copy/disclaimers";
 
 interface PageProps {
   params: Promise<{ code: string }>;
@@ -29,8 +30,8 @@ export async function generateMetadata({
     ? `Find the right prep for your case — from ${referrer}`
     : "Find the right prep for your case";
   const description = referrer
-    ? `A short questionnaire from ${referrer}. We match you to the briefing that fits your charges and your next hearing. Legal information, not legal advice.`
-    : "A short questionnaire. We match you to the briefing that fits your charges and your next hearing. Legal information, not legal advice.";
+    ? `A short questionnaire from ${referrer}. We match you to the briefing that fits your charges and your next hearing. ${BRAND_UPL_DISCLAIMER}`
+    : `A short questionnaire. We match you to the briefing that fits your charges and your next hearing. ${BRAND_UPL_DISCLAIMER}`;
   // Quiz route has no opengraph-image.tsx of its own; it inherits the parent
   // /r/[code]/opengraph-image.tsx (partner-branded). Alt is set there via
   // generateImageMetadata. Do NOT override openGraph.images here.

--- a/src/app/r/[code]/reminders/page.tsx
+++ b/src/app/r/[code]/reminders/page.tsx
@@ -10,6 +10,7 @@ import Link from "next/link";
 import { getPartnerByCode } from "@/lib/partner-by-code";
 import { CourtReminderForm } from "@/components/CourtReminderForm";
 import { FadeInUp } from "@/components/motion/FadeInUp";
+import { BRAND_UPL_DISCLAIMER } from "@/lib/copy/disclaimers";
 
 export async function generateMetadata(): Promise<Metadata> {
   // Per-partner reminder opt-in pages are not canonical surfaces; canonical
@@ -130,7 +131,7 @@ export default async function CourtRemindersPage({ params, searchParams }: PageP
             </aside>
           </FadeInUp>
           <p className="mt-8 text-center text-xs text-zinc-500">
-            Legal information, not legal advice.
+            {BRAND_UPL_DISCLAIMER}
           </p>
         </div>
       </div>

--- a/src/app/services/[slug]/page.tsx
+++ b/src/app/services/[slug]/page.tsx
@@ -10,6 +10,7 @@
 import { notFound } from "next/navigation";
 import { getProduct, isValidProduct } from "@/lib/products";
 import { TIER_CORE } from "@/lib/tiers";
+import { REPORT_UPL_DISCLAIMER } from "@/lib/copy/disclaimers";
 import type { Metadata } from "next";
 
 // Product-specific sales copy, one entry per research product
@@ -709,7 +710,7 @@ export default async function ProductLandingPage({ params }: Props) {
             Get the {product.name} &mdash; {product.priceDisplay}
           </a>
           <p className="mt-6 text-xs text-zinc-400">
-            This report provides legal INFORMATION, not legal ADVICE. Decisions about how to use this information stay with you.
+            {REPORT_UPL_DISCLAIMER}
           </p>
         </div>
       </div>
@@ -775,7 +776,7 @@ export default async function ProductLandingPage({ params }: Props) {
 
         {/* Disclaimer */}
         <p className="mt-6 text-xs text-zinc-400">
-          This report provides legal INFORMATION, not legal ADVICE. Decisions about how to use this information stay with you.
+          {REPORT_UPL_DISCLAIMER}
         </p>
       </div>
     </div>

--- a/src/app/tools/[slug]/page.tsx
+++ b/src/app/tools/[slug]/page.tsx
@@ -10,6 +10,7 @@ import { notFound } from "next/navigation";
 import { getProduct, isValidProduct } from "@/lib/products";
 import CalculatorClient from "./CalculatorClient";
 import type { Metadata } from "next";
+import { BRAND_UPL_DISCLAIMER } from "@/lib/copy/disclaimers";
 
 interface Props {
   params: Promise<{ slug: string }>;
@@ -62,7 +63,7 @@ export default async function CalculatorPage({ params }: Props) {
         <CalculatorClient slug={slug} product={product} />
         <p className="mt-12 text-xs text-zinc-400 border-t border-zinc-800 pt-6">
           {isSentencingCalc
-            ? "These are real federal sentences from 595,851 USSC records (FY2001-2023). Past data, not prediction. Legal information, not legal advice."
+            ? `These are real federal sentences from 595,851 USSC records (FY2001-2023). Past data, not prediction. ${BRAND_UPL_DISCLAIMER}`
             : "This calculator provides legal INFORMATION based on published rules, not legal ADVICE. Outcomes depend on program participation and classification decisions set by the court."}
         </p>
         <p className="mt-4 text-xs italic text-zinc-500">

--- a/src/components/BridgePage.tsx
+++ b/src/components/BridgePage.tsx
@@ -17,6 +17,7 @@ import Link from "next/link";
 import { TrustBadges } from "@/components/TrustBadges";
 import { FadeInUp } from "@/components/motion/FadeInUp";
 import { TIER_CORE } from "@/lib/tiers";
+import { BRAND_UPL_DISCLAIMER } from "@/lib/copy/disclaimers";
 
 interface BridgePageProps {
   partnerName: string;
@@ -116,7 +117,7 @@ export function BridgePage({ partnerName, company, city, promoCode, checkInEnabl
               We give you questions. We don&apos;t give you advice. Your attorney does that.
             </p>
             <p className="text-zinc-500 text-xs mt-2">
-              Legal information, not legal advice.
+              {BRAND_UPL_DISCLAIMER}
             </p>
           </FadeInUp>
         </div>

--- a/src/components/CourtReminderForm.tsx
+++ b/src/components/CourtReminderForm.tsx
@@ -9,6 +9,7 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { CHARGE_DISPLAY_NAMES } from "@/lib/court-reminders";
 import { CheckInDayPicker } from "@/components/partner/CheckInDayPicker";
+import { BRAND_UPL_DISCLAIMER } from "@/lib/copy/disclaimers";
 
 interface CourtReminderFormProps {
   chargeType?: string;
@@ -277,7 +278,7 @@ export function CourtReminderForm({
       </button>
 
       <p className="text-zinc-400 text-xs text-center">
-        Free. No account needed. Legal information, not legal advice.
+        {`Free. No account needed. ${BRAND_UPL_DISCLAIMER}`}
       </p>
     </form>
   );

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -21,6 +21,7 @@
 import Image from "next/image";
 import Link from "next/link";
 import { TIER_CORE } from "@/lib/tiers";
+import { BRAND_UPL_DISCLAIMER } from "@/lib/copy/disclaimers";
 
 // minimal: drop "Playbooks" + "Our Services" columns (they surface the
 // $2,497-$9,997 tier prices). Rendered on free-tool surfaces where the
@@ -62,7 +63,7 @@ export function Footer({ variant = "full" }: { variant?: "full" | "minimal" }) {
               Know What They Know.
             </p>
             <p className="mt-2 text-xs text-zinc-400">
-              Legal information, not legal advice.
+              {BRAND_UPL_DISCLAIMER}
             </p>
           </div>
 

--- a/src/lib/copy/disclaimers.ts
+++ b/src/lib/copy/disclaimers.ts
@@ -1,0 +1,23 @@
+/**
+ * Canonical UPL disclaimers — single source of truth for the most-duplicated
+ * legal-information disclaimers across the app.
+ *
+ * Use these constants when you need the EXACT brand-level or report-level
+ * disclaimer. For context-specific variants (per-state, per-charge,
+ * playbook-specific, email-frame, calculator state-rule), keep the inline
+ * copy — extracting those would lose the contextual framing that makes them
+ * useful.
+ *
+ * UPL approval: docs/handoff/2026-04-26-product-audit-deferred.md D7.
+ * Plan: docs/plans/2026-04-26-d7-upl-disclaimer-extraction.md.
+ *
+ * Leaf module — zero imports, Deno-compatible (safe to import from Edge
+ * Function-bound code paths like `src/lib/intelligence-brief/render.ts`).
+ */
+
+/** Brand-level UPL disclaimer. 11 files, 14 occurrences. */
+export const BRAND_UPL_DISCLAIMER = "Legal information, not legal advice.";
+
+/** Report/product-level UPL disclaimer. 4 files, 5 occurrences. */
+export const REPORT_UPL_DISCLAIMER =
+  "This report provides legal INFORMATION, not legal ADVICE. Decisions about how to use this information stay with you.";

--- a/src/lib/intelligence-brief/render.ts
+++ b/src/lib/intelligence-brief/render.ts
@@ -9,6 +9,7 @@
  */
 
 import { escapeHtml } from "../email";
+import { BRAND_UPL_DISCLAIMER } from "../copy/disclaimers";
 
 // ============================================================
 // MARKDOWN → HTML CONVERSION
@@ -389,7 +390,7 @@ export function renderIntelligenceBriefHtml(
     </p>
   </div>
   <div class="copyright-block">
-    <p class="copyright-text">&copy; ${new Date().getFullYear()} ImNotAnAttorney. Legal information, not legal advice.</p>
+    <p class="copyright-text">&copy; ${new Date().getFullYear()} ImNotAnAttorney. ${BRAND_UPL_DISCLAIMER}</p>
     <p class="copyright-meta">Report ID: ${escapeHtml(meta.reportId)} | Generated: ${escapeHtml(meta.reportDate)}</p>
   </div>
   <div class="no-print upgrade-cta">

--- a/src/lib/report-renderer.ts
+++ b/src/lib/report-renderer.ts
@@ -10,6 +10,7 @@
 
 import { escapeHtml } from "./email";
 import { TIER_CORE, upgradeCostBetween } from "@/lib/tiers";
+import { BRAND_UPL_DISCLAIMER } from "@/lib/copy/disclaimers";
 
 export interface ReportMeta {
   firstName: string;
@@ -178,7 +179,7 @@ export function renderReportHtml(markdown: string, meta: ReportMeta): string {
     </p>
   </div>
   <div style="margin-top: 48px; padding-top: 24px; border-top: 2px solid #27272A; text-align: center;">
-    <p style="margin: 0; font-size: 12px; color: #71717A;">&copy; ${new Date().getFullYear()} ImNotAnAttorney. Legal information, not legal advice.</p>
+    <p style="margin: 0; font-size: 12px; color: #71717A;">&copy; ${new Date().getFullYear()} ImNotAnAttorney. ${BRAND_UPL_DISCLAIMER}</p>
     <p style="margin: 4px 0 0; font-size: 12px; color: #52525B;">Report ID: ${meta.reportId} | Generated: ${meta.reportDate}</p>
   </div>
   <div class="no-print" style="margin-top: 32px; text-align: center;">


### PR DESCRIPTION
## Summary
- D7 from `docs/handoff/2026-04-26-product-audit-deferred.md`
- New file `src/lib/copy/disclaimers.ts` exports `BRAND_UPL_DISCLAIMER` (11 sites) + `REPORT_UPL_DISCLAIMER` (4 sites)
- Pure refactor: constants are byte-for-byte equal to original literals; zero copy semantics change
- Set 3 (judge-report-card "brief" variant) dropped per plan -- literal differs from handoff-claimed string (em-dash, single sentence). Extracting would change rendered HTML.
- Context-specific variants (per-state, IB attribution, playbooks, emails, calculator state-rules) deliberately untouched.

## Verification
- `node node_modules/typescript/bin/tsc --noEmit --skipLibCheck` -- 0 errors (after `rm -rf .next/types`)
- Grep `Legal information, not legal advice.` across `src/` -> only `src/lib/copy/disclaimers.ts`
- Grep full report disclaimer string across `src/` -> only `src/lib/copy/disclaimers.ts`

## Test plan
- [ ] Visual check: Footer, BridgePage, services/[slug], checkout, intake/standalone/[slug] render the disclaimer unchanged
- [ ] OG image renders unchanged
- [ ] Email-derived report HTML still emits the brand disclaimer in copyright line

Plan: `docs/plans/2026-04-26-d7-upl-disclaimer-extraction.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)