### PR TITLE
fix(tier9): stop-the-bleed — revert 2 dark + canonical SLUGS + district gate

### DIFF
--- a/docs/plans/2026-04-26-tier9-stopbleed-c3-c4.md
+++ b/docs/plans/2026-04-26-tier9-stopbleed-c3-c4.md
@@ -1,0 +1,127 @@
+# Tier 9 Stop-the-Bleed: C3 + C4 (+ revert of C1, C2 + W1 copy refresh)
+
+**Date:** 2026-04-26
+**Branch:** `fix/tier9-stopbleed-c3-c4`
+**Plan source:** `docs/plans/2026-04-26-worry-tier9-flipped-live.md` (worry-to-pristine output)
+
+## Context
+
+The 2026-04-26 D-T1 through D-T4 wave flipped six Tier 9 SKUs to `live: true`
+and `isActive: true`. A worry-to-pristine sweep surfaced four CRITICAL
+findings against the just-flipped subset:
+
+| ID | Severity | Issue |
+|----|----------|-------|
+| C1 | CRITICAL | `charge-authority-pack` has no dedicated landing page; checkout reaches generic fallback. |
+| C2 | CRITICAL | `precedent-watchlist` has no dedicated landing page; AvailabilityChecker `Slug` union excludes it; same fallback risk. |
+| C3 | CRITICAL | `/api/check-availability/[slug]` ships a local drifted `TIER9_SLUGS` Set (six entries) — the canonical at `src/lib/tier9-reports/constants.ts` has ten. The two 2026-04-26 additions return 400 even when products are live. |
+| C4 | CRITICAL | `checkDistrictCoverage` queries `judge_demographics.district` ilike `%state name%` — that column stores numeric district codes such as `"30"`, `"40"`, `"73"`, `"90"`. Plus `outcome_benchmarks.jurisdiction_name` is national-only. Returns `available: false` for every state, so the district-court product is gated to zero customers. |
+| W1 | WARNING  | `/district-court-intelligence` page copy still describes the old $97 JUSTFAIR-only SKU. Product was upgraded to $147 Courthouse Intelligence Pack on 2026-04-23. |
+
+C1 and C2 require new dedicated landing pages — out of scope for this
+stop-the-bleed PR. They will land in a follow-up PR. This PR pulls C1 and C2
+dark via a revert and ships C3 and C4 and W1 together.
+
+## Cascade
+
+- us: stop the bleed without holding the fix on a four-hour landing-page build
+- direct counterparty (customers reaching old links to charge-authority-pack
+  or precedent-watchlist): see no broken checkout that forwards them to a
+  generic fallback page; the products are simply offline until landings ship
+- direct counterparty (customers in any state visiting district-court-
+  intelligence): the gate stops returning `available: false` for every state
+  the moment C4 lands, so checkout works
+- ecosystem (the canonical TIER9_SLUGS contract): one source of truth restored
+- future-us: drift between the route's local Set and `constants.ts` cannot
+  recur because the route now imports the canonical export
+- adjacent (Slug union in AvailabilityChecker): unchanged, still excludes the
+  two reverted slugs — coherent with `live: false`
+
+## Fixes
+
+### 1. Revert C1 plus C2 (immediate stop-the-bleed)
+
+**Files:** `src/lib/tiers.ts`, `src/lib/products.ts`
+
+- `charge-authority-pack`: `live: true` becomes `live: false`, and
+  `isActive: true` becomes `isActive: false`. Comment:
+  `2026-04-26 reverted dark — no dedicated landing page yet (C1 from worry-tier9-flipped-live audit)`
+- `precedent-watchlist`: `live: true` becomes `live: false`, and
+  `isActive: true` becomes `isActive: false`. Comment:
+  `2026-04-26 reverted dark — no dedicated landing + Slug union excludes (C2)`
+
+Both SKUs will be re-flipped in a follow-up PR after dedicated landings ship.
+
+### 2. C3 — Canonical TIER9_SLUGS import
+
+**File:** `src/app/api/check-availability/[slug]/route.ts`
+
+Replace the local `const TIER9_SLUGS = new Set(...)` (six entries) with
+`import { TIER9_SLUGS } from "@/lib/tier9-reports/constants"`. Switch and
+case branches in the same file already handle the slugs they need; the dark
+slugs just need `available: false` via the `isActive` boolean check
+downstream of this gate, and they should not 400 at this layer.
+
+### 3. C4 — District-Court coverage gate rewritten
+
+**File:** `src/lib/tier9-reports/coverage.ts`
+
+`checkDistrictCoverage(stateCode)` rewritten to mirror the post-purchase
+resolver in `src/lib/tier9-reports/courthouse-intelligence.ts`:
+
+1. Look up `ussc_districts` rows where `state_code === stateCode` to get a
+   list of `cl_court_id` and `circuit` values.
+2. Count `judge_disposition_profile` rows where `district_id` is IN the
+   collected `cl_court_id` set.
+3. Normalize circuit format (`"5th"` becomes `"5"`) and count
+   `motion_outcome_rates_by_circuit` rows where `circuit` matches and
+   `charge_type === "(all)"`.
+4. Return `{ available: districts > 0, coverage: { districts, judges, circuitMotions }, matchedName, matchedCourt }`.
+
+Banner-trip on the frontend remains keyed off `available: false`. Available
+flips truthy for any state with at least one indexed federal district —
+which is every state plus DC.
+
+### 4. W1 — District-Court page copy refresh
+
+**File:** `src/app/district-court-intelligence/page.tsx`
+
+Hero, subhead, `CHECK_ITEMS`, `SAMPLE_ROWS`, and FAQ rewritten to the upgraded
+$147 Courthouse Intelligence Pack scope per
+`src/lib/tier9-reports/courthouse-intelligence.ts` lines 1-37:
+
+- District-aggregate judge caseload (volume only — no predictive signals)
+- Circuit-wide motion grant rates with national baseline plus deviation
+- USSC FY14-23 sentencing aggregates per district
+- Prosecutors section deliberately suppressed
+- Hold the URL slug (`/district-court-intelligence`) and the price ($147)
+- No banned UPL phrases ("you should", "consult your attorney", "we recommend")
+
+## Verification
+
+1. `node node_modules/typescript/bin/tsc --noEmit --skipLibCheck` returns zero errors.
+2. Live Node script (temp, deleted after run): replicate the new
+   `checkDistrictCoverage` query path against FL, TX, CA, NY — assert each
+   returns `districts >= 1`.
+3. Vitest: `npx vitest run src/lib/tier9-reports/__tests__/ src/lib/defense-intelligence/__tests__/`
+4. New unit test `src/lib/tier9-reports/__tests__/district-coverage.test.ts`
+   with a mocked Supabase client; FL, TX, CA, NY each assert `districts >= 1`.
+
+## Out of scope
+
+- C1 dedicated landing page for `charge-authority-pack`.
+- C2 dedicated landing page for `precedent-watchlist` plus
+  `AvailabilityChecker` Slug union extension.
+- Re-flip of those two SKUs (follow-up PR after C1 plus C2 land).
+- arrest-survival-kit (already covered by D-T4 tests).
+- All other Tier 9 SKUs not listed above.
+
+## Hard constraints
+
+- Stripe price IDs unchanged.
+- URL slugs unchanged.
+- DB tier_slugs unchanged.
+- `arrest-survival-kit` unchanged.
+- `district-court-intelligence` stays `live: true` — it works once C4 lands.
+- `SKIP_TSC=1` and `SKIP_BUILD=1` permitted only if Windows tsc / next-build
+  PATH issue surfaces, and any usage documented in the PR body.

--- a/src/app/api/check-availability/[slug]/route.ts
+++ b/src/app/api/check-availability/[slug]/route.ts
@@ -21,15 +21,10 @@ import {
 } from "@/lib/tier9-reports/federal-jury-instruction-brief";
 import { checkRateLimit } from "@/lib/rate-limit";
 import { getClientIp } from "@/lib/request";
-
-const TIER9_SLUGS = new Set([
-  "judge-report-card",
-  "officer-background-check",
-  "similar-cases-analyzer",
-  "district-court-intelligence",
-  "arrest-survival-kit",
-  "federal-jury-instruction-brief",
-]);
+// C3 (2026-04-26 stop-the-bleed): canonical TIER9_SLUGS — was a local
+// drifted Set with 6 entries; canonical at constants.ts has 10. Dark slugs
+// return available:false via the isActive boolean check downstream, NOT 400.
+import { TIER9_SLUGS } from "@/lib/tier9-reports/constants";
 const VALID_STATES = new Set(["AL","AK","AZ","AR","CA","CO","CT","DE","FL","GA","HI","ID","IL","IN","IA","KS","KY","LA","ME","MD","MA","MI","MN","MS","MO","MT","NE","NV","NH","NJ","NM","NY","NC","ND","OH","OK","OR","PA","RI","SC","SD","TN","TX","UT","VT","VA","WA","WV","WI","WY","DC"]);
 
 export async function POST(

--- a/src/app/district-court-intelligence/page.tsx
+++ b/src/app/district-court-intelligence/page.tsx
@@ -1,9 +1,12 @@
 /**
- * District Court Intelligence landing page (/district-court-intelligence)
+ * Courthouse Intelligence Pack landing page (/district-court-intelligence)
  *
- * Standalone Tier 9 data product, $97, instant delivery.
- * Federal district-level sentencing intelligence from 595,851 JUSTFAIR records.
- * Server component, AvailabilityChecker is a client island.
+ * Standalone Tier 9 data product, $147, instant delivery. URL slug retained
+ * for SEO + Stripe + DB stability; product upgraded 2026-04-23 from the
+ * $97 District Court Intelligence test SKU. Scope + UPL gates live in
+ * src/lib/tier9-reports/courthouse-intelligence.ts:1-37.
+ *
+ * Server component; AvailabilityChecker is a client island.
  */
 import type { Metadata } from "next";
 import { SITE_URL } from "@/lib/site";
@@ -15,15 +18,15 @@ import AvailabilityChecker from "@/components/tier9/AvailabilityChecker";
 
 export function generateMetadata(): Metadata {
   return {
-    title: `District Court Intelligence, ${TIER_CORE["district-court-intelligence"].priceDisplay} | ImNotAnAttorney`,
+    title: `Courthouse Intelligence Pack, ${TIER_CORE["district-court-intelligence"].priceDisplay} | ImNotAnAttorney`,
     description:
-      "Federal district-level sentencing patterns, conviction rates, plea rates, motion outcomes, and judge demographics. 595,851 JUSTFAIR sentencing records with source URLs.",
+      "Aggregate caseload, circuit motion grant rates, and USSC FY14-23 sentencing aggregates for the federal districts in your state. Compiled from verified public court records.",
     alternates: { canonical: `${SITE_URL}/district-court-intelligence` },
     openGraph: {
       title:
-        "District Court Intelligence, Know Your Court Before Your First Hearing",
+        "Courthouse Intelligence Pack — Know Your Federal Courthouse Before Your First Hearing",
       description:
-        "Aggregate sentencing patterns, outcome benchmarks, prosecution patterns, and judge demographics for your federal district. Verified data with source URLs.",
+        "Federal district caseload aggregates, circuit motion grant rates with national baselines, and USSC FY14-23 sentencing aggregates. Aggregate data from verified public court records.",
       url: `${SITE_URL}/district-court-intelligence`,
     },
   };
@@ -34,68 +37,68 @@ export function generateMetadata(): Metadata {
 /* ------------------------------------------------------------------ */
 
 const CHECK_ITEMS = [
-  "Sentencing patterns from 595,851 federal cases in your district",
-  "Conviction, dismissal, and plea rates for your jurisdiction",
-  "Motion grant rates \u2014 how often defense motions succeed in your court",
-  "Judge demographic breakdown \u2014 who sits on your bench",
-  "District-level prosecution patterns",
-  "National benchmarks for comparison",
-  "Every data point linked to its source URL",
+  "Judge caseload aggregate \u2014 every federal judge in your district ranked by indexed case volume",
+  "Circuit motion grant rates \u2014 motion-by-motion appellate-direction grant rates with national baselines and deviation",
+  "USSC FY14-23 sentencing aggregates \u2014 median sentence, prison rate, downward-departure rate per district",
+  "Multi-district coverage when your state has more than one federal courthouse",
+  "Methodology and known-limitation notes spelled out on every section",
+  "Every aggregate sourced from verified public court records (CourtListener, FJC IDB, USSC datafiles)",
+  "Aggregate frequencies only \u2014 never a prediction about a specific defendant",
 ] as const;
 
 const SAMPLE_ROWS = [
   {
-    metric: "Conviction rate",
-    value: "89.3%",
-    source: "BJS",
+    metric: "Judges with indexed dockets (typical state)",
+    value: "20-90",
+    source: "CourtListener \u00d7 FJC IDB",
   },
   {
-    metric: "Plea rate",
-    value: "96.1%",
-    source: "USSC",
+    metric: "Circuit motion grant rate (Motion to Suppress, Circuit 5)",
+    value: "8.2%",
+    source: "motion_outcome_rates_by_circuit",
   },
   {
-    metric: "Median sentence (drug trafficking)",
-    value: "84.0 months",
-    source: "JUSTFAIR",
+    metric: "Median federal sentence (district aggregate)",
+    value: "24-60 months",
+    source: "USSC FY14-23",
   },
   {
-    metric: "Downward departure rate",
-    value: "28.7%",
-    source: "USSC",
+    metric: "Downward-departure rate (district aggregate)",
+    value: "12-22%",
+    source: "USSC FY14-23",
   },
 ] as const;
 
 const FAQ_ITEMS = [
   {
-    question: "What data is in the District Court Intelligence report?",
+    question: "What is in the Courthouse Intelligence Pack?",
     answer:
-      "Aggregate sentencing patterns for your federal district, conviction and dismissal rates, plea rates, defense motion success rates, judge demographics, prosecution tendencies, and national benchmarks for comparison. Every data point includes a source URL you can verify independently.",
+      "Three sections built from verified public court records: (1) judge caseload aggregate \u2014 every indexed federal judge in your district ranked by case volume; (2) circuit motion grant rates \u2014 motion-type-by-motion-type appellate grant rates with national baselines and per-circuit deviation; (3) USSC FY14-23 sentencing aggregates \u2014 median sentence, prison rate, and downward-departure rate per district. A prosecutors section is currently suppressed \u2014 the underlying attorney-role data is not yet indexed in the corpus, and we will not fabricate it.",
   },
   {
     question: "Where does the data come from?",
     answer:
-      "Federal sentencing data from JUSTFAIR (QSIDE Institute) covering 595,851 sentencing records, supplemented by Bureau of Justice Statistics (BJS) and U.S. Sentencing Commission (USSC) published data. We do not generate or estimate data \u2014 every metric traces to a specific public record.",
+      "Federal docket records from CourtListener cross-referenced against the FJC Integrated Database, motion outcome rates from our circuit-level appellate aggregation, and sentencing aggregates computed from the U.S. Sentencing Commission public datafiles for fiscal years 2014-2023. Every aggregate is computed from verified records \u2014 nothing is estimated or fabricated.",
   },
   {
     question: "Is this legal advice?",
     answer:
-      "No. This is legal INFORMATION \u2014 verified court data compiled into a structured report. Decisions about how to use this information stay with you.",
+      "No. This is legal INFORMATION \u2014 aggregate frequencies, counts, and medians from public court records. Nothing in the pack is a prediction about a specific case. Decisions about how to apply the data to your case stay with you and your attorney.",
   },
   {
     question: "How is it delivered?",
     answer:
-      "On purchase. The report is generated on demand from our verified database and sent to your inbox.",
+      "Instantly on purchase. The pack is generated on demand from the verified court-records corpus and rendered to your email.",
   },
   {
-    question: "What if my district isn\u2019t covered?",
+    question: "What if my federal district has thin coverage?",
     answer:
-      "If we don\u2019t have sufficient data for your federal district, you\u2019ll see that before checkout \u2014 we won\u2019t charge you for data we don\u2019t have. You can join our waitlist and we\u2019ll notify you when coverage is available.",
+      "Before checkout you will see how many judges and motions are indexed for your state. If a district has no indexed disposition profiles, the relevant section discloses the gap rather than fabricating numbers \u2014 methodology and known limitations are listed on every render.",
   },
   {
     question: "How is this different from the Judge Question Brief?",
     answer:
-      "The Judge Question Brief focuses on a specific judge \u2014 questions to ask your attorney about their individual sentencing patterns, prosecutor pairings, and direct quotes. District Court Intelligence gives you the big picture: how your entire district operates, so you understand the environment your case will be decided in. They complement each other.",
+      "The Judge Question Brief is judge-specific \u2014 questions to ask your attorney about a single named judge. The Courthouse Intelligence Pack is district-aggregate \u2014 caseload, circuit motion direction, and sentencing patterns across the whole courthouse. They complement each other: the pack gives the environment, the brief targets one judge inside it.",
   },
 ] as const;
 
@@ -116,7 +119,7 @@ const breadcrumbLd = {
     {
       "@type": "ListItem",
       position: 2,
-      name: "District Court Intelligence",
+      name: "Courthouse Intelligence Pack",
       item: `${SITE_URL}/district-court-intelligence`,
     },
   ],
@@ -169,28 +172,28 @@ export default function DistrictCourtIntelligencePage() {
       <FadeInUp>
         <section aria-labelledby="hero-heading" className="text-center">
           <p className="text-xs font-bold uppercase tracking-widest text-amber-400">
-            District Court Intelligence
+            Courthouse Intelligence Pack
           </p>
 
           <p className="mb-6 text-base leading-relaxed text-zinc-400">
-            Every federal district has patterns. The prosecutors who work there
-            every day know them by heart &mdash; conviction rates, sentencing
-            tendencies, which motions get granted and which get denied. You&rsquo;re
-            walking into their home court. Until now, you had no way to see what
-            they see.
+            Every federal courthouse has patterns. Which motions land on appeal in
+            this circuit. How sentences cluster across the district. Which judges
+            carry the bulk of the docket. Defendants who walk in cold get a
+            stranger&rsquo;s court; defendants who walk in prepared get the same
+            aggregate context the prosecutor sees.
           </p>
 
           <h1
             id="hero-heading"
             className="font-display mt-4 text-4xl font-extrabold leading-tight text-white sm:text-5xl"
           >
-            Know Your Court Before Your First Hearing
+            Know Your Federal Courthouse Before Your First Hearing
           </h1>
 
           <p className="mt-4 text-lg text-zinc-400">
-            Every federal district has patterns. Conviction rates. Sentencing
-            tendencies. Motion outcomes. The prosecutor knows them. Now you will
-            too.
+            District-aggregate caseload. Circuit motion grant rates with national
+            baselines. USSC FY14-23 sentencing aggregates. Compiled from verified
+            public court records &mdash; nothing predicted, nothing estimated.
           </p>
 
           <p className="mt-6 text-4xl font-extrabold text-amber-400">
@@ -198,18 +201,19 @@ export default function DistrictCourtIntelligencePage() {
           </p>
 
           <p className="mt-2 text-sm text-zinc-400">
-            Less than a court filing fee &mdash; for intelligence the prosecution
-            already has.
+            Aggregate court-record intelligence for your federal district &mdash;
+            generated on demand.
           </p>
 
           <p className="mt-2 text-sm text-zinc-300">
-            595,851 federal sentencing records with source URLs
+            Verified public sources: CourtListener &times; FJC IDB &times; USSC
+            FY14-23
           </p>
 
           <div className="mt-6">
             <AvailabilityChecker
               slug="district-court-intelligence"
-              productName="District Court Intelligence"
+              productName="Courthouse Intelligence Pack"
               priceDisplay={TIER_CORE["district-court-intelligence"].priceDisplay}
             />
           </div>
@@ -253,7 +257,7 @@ export default function DistrictCourtIntelligencePage() {
           <div className="mt-8 overflow-x-auto rounded-lg border border-zinc-700">
             <table className="w-full text-left text-sm">
               <caption className="sr-only">
-                Sample district data &mdash; Southern District of Florida
+                Sample courthouse aggregate ranges across federal districts
               </caption>
               <thead className="border-b border-zinc-700 bg-zinc-900">
                 <tr>
@@ -286,8 +290,9 @@ export default function DistrictCourtIntelligencePage() {
           </div>
 
           <p className="mt-3 text-xs text-zinc-400">
-            Sample data shown for illustration. Your report contains data specific
-            to your federal district.
+            Ranges shown to illustrate what aggregate cells look like across
+            federal districts. Your pack contains the actual aggregate values
+            for the federal district(s) in your state.
           </p>
         </section>
       </FadeInUp>
@@ -303,17 +308,20 @@ export default function DistrictCourtIntelligencePage() {
           </h2>
 
           <p className="mt-4 text-zinc-400">
-            Every metric in your District Court Intelligence report links directly
-            to its source &mdash; JUSTFAIR, USSC, or BJS. No summaries from unnamed
-            sources. No fabricated estimates. Every data point traces back to a
-            verified federal court record with a URL you can check yourself.
+            Every aggregate in the pack is computed from verified public court
+            records. No paraphrase from unnamed sources. No estimated cells. When
+            a section has thin coverage, it discloses the gap on the page rather
+            than fabricating a number.
           </p>
 
           <p className="mt-3 text-sm text-zinc-400">
-            District analysis built from JUSTFAIR&rsquo;s 595,851 federal
-            sentencing records (QSIDE Institute), U.S. Sentencing Commission
-            published data, and Bureau of Justice Statistics reports. Computed
-            from verified records &mdash; not estimated, not fabricated.
+            Caseload aggregates are derived from federal docket records indexed
+            via CourtListener and cross-referenced with the Federal Judicial
+            Center Integrated Database. Circuit motion grant rates aggregate
+            appellate-direction outcomes per circuit. Sentencing aggregates are
+            computed from the U.S. Sentencing Commission public datafiles for
+            fiscal years 2014 through 2023. Aggregate frequencies only &mdash;
+            never a prediction about a specific case or defendant.
           </p>
 
           <div className="mt-8">
@@ -343,31 +351,34 @@ export default function DistrictCourtIntelligencePage() {
             id="cta-heading"
             className="font-display text-2xl font-bold text-white"
           >
-            Get Your District Court Intelligence &mdash;{" "}
+            Get the Courthouse Intelligence Pack &mdash;{" "}
             <span className="text-amber-400">
               {TIER_CORE["district-court-intelligence"].priceDisplay}
             </span>
           </h2>
 
           <p className="mt-4 text-zinc-400">
-            Most defendants walk into court with no idea how the district
-            operates. Defendants who prepare walk in knowing the conviction
-            rates, the sentencing patterns, and the motion outcomes. The
-            prosecution already has this data &mdash; now you can have it too.
+            Most defendants walk into a federal courthouse cold. Defendants who
+            prepare walk in with the same aggregate context the prosecutor
+            already has &mdash; the caseload makeup, the circuit motion direction,
+            and the sentencing aggregates for the district. This pack compiles
+            that context from verified public records.
           </p>
 
           <div className="mt-6">
             <AvailabilityChecker
               slug="district-court-intelligence"
-              productName="District Court Intelligence"
+              productName="Courthouse Intelligence Pack"
               priceDisplay={TIER_CORE["district-court-intelligence"].priceDisplay}
             />
           </div>
 
           <p className="mt-4 text-xs text-zinc-400">
-            This is legal information, not legal advice. ImNotAnAttorney provides
-            verified court data to help you prepare for conversations with your
-            attorney. Decisions about how to use this information stay with you.
+            This is legal information, not legal advice. The pack compiles
+            aggregate data from verified public court records to give you context
+            for conversations about your case. Nothing here predicts a specific
+            outcome, and decisions about how to use the information stay with
+            you.
           </p>
 
           <p className="mt-3 text-sm text-zinc-400">
@@ -390,9 +401,9 @@ export default function DistrictCourtIntelligencePage() {
           __html: JSON.stringify({
             "@context": "https://schema.org",
             "@type": "Product",
-            name: "District Court Intelligence",
+            name: "Courthouse Intelligence Pack",
             description:
-              "Federal district-level sentencing patterns, conviction rates, plea rates, motion outcomes, and judge demographics from 595,851 JUSTFAIR sentencing records.",
+              "Aggregate caseload, circuit motion grant rates, and USSC FY14-23 sentencing aggregates for the federal districts in your state. Compiled from verified public court records.",
             url: `${SITE_URL}/district-court-intelligence`,
             brand: {
               "@type": "Organization",
@@ -400,7 +411,7 @@ export default function DistrictCourtIntelligencePage() {
             },
             offers: {
               "@type": "Offer",
-              price: "97.00",
+              price: "147.00",
               priceCurrency: "USD",
               availability: "https://schema.org/InStock",
               url: `${SITE_URL}/checkout?standaloneProduct=district-court-intelligence`,

--- a/src/lib/products.ts
+++ b/src/lib/products.ts
@@ -1300,8 +1300,8 @@ export const STANDALONE_PRODUCTS: Record<string, StandaloneProduct> = {
     upsellTier: "case-decoder",
     upsellText:
       "Authorities tell you what to cite. The Case Decoder maps how to apply those precedents to your specific facts.",
-    // 2026-04-26: flipped live — D-T2 verified e2e (audit deferred-tier closeout)
-    isActive: true,
+    // 2026-04-26 reverted dark — no dedicated landing page yet (C1 from worry-tier9-flipped-live audit)
+    isActive: false,
   },
   "arrest-survival-kit": {
     name: "Arrest Survival Kit",
@@ -1361,7 +1361,8 @@ export const STANDALONE_PRODUCTS: Record<string, StandaloneProduct> = {
     upsellTier: "case-decoder",
     upsellText:
       "Citation velocity tells you which precedents are trending. The Case Decoder maps your specific defense strategy around them.",
-    isActive: true, // 2026-04-26 D-T3: cron 7522215 weekly + e2e verified
+    // 2026-04-26 reverted dark — no dedicated landing + Slug union excludes (C2)
+    isActive: false,
   },
 
   // ─── PRIORITY B, Critical 7 Worker Standalone Products ─────

--- a/src/lib/tier9-reports/__tests__/district-coverage.test.ts
+++ b/src/lib/tier9-reports/__tests__/district-coverage.test.ts
@@ -1,0 +1,260 @@
+/**
+ * Unit tests for the rewritten District-Court coverage gate
+ * (C4 stop-the-bleed, 2026-04-26).
+ *
+ * Old behavior queried `judge_demographics.district ilike %stateName%` and
+ * `outcome_benchmarks.jurisdiction_name ilike %stateName%` — both wrong:
+ *   - judge_demographics.district stores numeric district codes ("30",
+ *     "40", "73", "90"), not state names. ILIKE returned zero rows.
+ *   - outcome_benchmarks.jurisdiction_name is national-only — no state rows.
+ * Net effect: every state returned `available: false`.
+ *
+ * New behavior mirrors the post-purchase resolver in
+ * `src/lib/tier9-reports/courthouse-intelligence.ts`:
+ *   1. ussc_districts → matched federal districts (cl_court_id, circuit).
+ *   2. judge_disposition_profile rows where district_id IN those cl_court_ids.
+ *   3. motion_outcome_rates_by_circuit rows for the normalized circuit
+ *      with charge_type='(all)'.
+ *
+ * test-isolation-na: read-only mock, no Supabase writes
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+interface QueryRecord {
+  table: string;
+  columns: string;
+  isCount: boolean;
+  filters: Array<{ kind: "eq" | "in"; col: string; val: unknown }>;
+}
+
+let queryLog: QueryRecord[] = [];
+
+interface ScriptedDistrict {
+  cl_court_id: string;
+  district_name: string;
+  circuit: string;
+}
+
+interface Scenario {
+  districts: ScriptedDistrict[];
+  judgeCount: number;
+  motionCount: number;
+}
+
+let scenarios: Map<string, Scenario> = new Map();
+
+function mockBuilder(table: string, columns: string, isCount: boolean) {
+  const filters: QueryRecord["filters"] = [];
+  const record: QueryRecord = { table, columns, isCount, filters };
+  queryLog.push(record);
+
+  const builder: Record<string, unknown> = {};
+  builder.eq = (col: string, val: unknown) => {
+    filters.push({ kind: "eq", col, val });
+    return builder;
+  };
+  builder.in = (col: string, val: unknown) => {
+    filters.push({ kind: "in", col, val });
+    return builder;
+  };
+  builder.then = (resolve: (val: unknown) => unknown) => {
+    if (table === "ussc_districts") {
+      const stateFilter = filters.find(
+        (f) => f.kind === "eq" && f.col === "state_code",
+      );
+      const state = stateFilter?.val as string | undefined;
+      const scenario = state ? scenarios.get(state) : undefined;
+      const data = scenario ? scenario.districts : [];
+      return Promise.resolve({ data, error: null }).then(resolve);
+    }
+    if (table === "judge_disposition_profile" && isCount) {
+      const inFilter = filters.find((f) => f.kind === "in");
+      const ids = (inFilter?.val as string[]) ?? [];
+      const matched = Array.from(scenarios.values()).find((s) =>
+        s.districts.some((d) => ids.includes(d.cl_court_id)),
+      );
+      return Promise.resolve({
+        count: matched?.judgeCount ?? 0,
+        data: null,
+        error: null,
+      }).then(resolve);
+    }
+    if (table === "motion_outcome_rates_by_circuit" && isCount) {
+      const circuit = filters.find(
+        (f) => f.kind === "eq" && f.col === "circuit",
+      )?.val as string | undefined;
+      const matched = Array.from(scenarios.values()).find(
+        (s) =>
+          s.districts.length > 0 &&
+          normalizeCircuit(s.districts[0].circuit) === circuit,
+      );
+      return Promise.resolve({
+        count: matched?.motionCount ?? 0,
+        data: null,
+        error: null,
+      }).then(resolve);
+    }
+    return Promise.resolve({ count: 0, data: null, error: null }).then(resolve);
+  };
+  return builder;
+}
+
+function normalizeCircuit(c: string): string {
+  const m = c.match(/^(\d+)(st|nd|rd|th)$/i);
+  return m ? m[1] : c;
+}
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: () => ({
+    from: (table: string) => ({
+      select: (columns: string, opts?: { count?: string; head?: boolean }) => {
+        const isCount = !!(opts && opts.count === "exact");
+        return mockBuilder(table, columns, isCount);
+      },
+    }),
+  }),
+}));
+
+import { checkDistrictCoverage } from "../coverage";
+
+beforeEach(() => {
+  queryLog = [];
+  scenarios = new Map();
+  scenarios.set("FL", {
+    districts: [
+      { cl_court_id: "flnd", district_name: "Northern District of Florida", circuit: "11th" },
+      { cl_court_id: "flmd", district_name: "Middle District of Florida", circuit: "11th" },
+      { cl_court_id: "flsd", district_name: "Southern District of Florida", circuit: "11th" },
+    ],
+    judgeCount: 56,
+    motionCount: 17,
+  });
+  scenarios.set("TX", {
+    districts: [
+      { cl_court_id: "txnd", district_name: "Northern District of Texas", circuit: "5th" },
+      { cl_court_id: "txed", district_name: "Eastern District of Texas", circuit: "5th" },
+      { cl_court_id: "txsd", district_name: "Southern District of Texas", circuit: "5th" },
+      { cl_court_id: "txwd", district_name: "Western District of Texas", circuit: "5th" },
+    ],
+    judgeCount: 79,
+    motionCount: 18,
+  });
+  scenarios.set("CA", {
+    districts: [
+      { cl_court_id: "cand", district_name: "Northern District of California", circuit: "9th" },
+      { cl_court_id: "caed", district_name: "Eastern District of California", circuit: "9th" },
+      { cl_court_id: "cacd", district_name: "Central District of California", circuit: "9th" },
+      { cl_court_id: "casd", district_name: "Southern District of California", circuit: "9th" },
+    ],
+    judgeCount: 85,
+    motionCount: 19,
+  });
+  scenarios.set("NY", {
+    districts: [
+      { cl_court_id: "nynd", district_name: "Northern District of New York", circuit: "2nd" },
+      { cl_court_id: "nyed", district_name: "Eastern District of New York", circuit: "2nd" },
+      { cl_court_id: "nysd", district_name: "Southern District of New York", circuit: "2nd" },
+      { cl_court_id: "nywd", district_name: "Western District of New York", circuit: "2nd" },
+    ],
+    judgeCount: 92,
+    motionCount: 19,
+  });
+});
+
+describe("checkDistrictCoverage — rewritten C4 stop-the-bleed gate", () => {
+  it("FL: matches 3 federal districts, gate flips truthy", async () => {
+    const result = await checkDistrictCoverage("FL");
+    expect(result.coverage.districts).toBe(3);
+    expect(result.coverage.districts).toBeGreaterThanOrEqual(1);
+    expect(result.coverage.judges).toBe(56);
+    expect(result.coverage.circuitMotions).toBe(17);
+    expect(result.available).toBe(true);
+    expect(result.matchedName).toBe("Florida");
+  });
+
+  it("TX: matches 4 federal districts, gate flips truthy", async () => {
+    const result = await checkDistrictCoverage("TX");
+    expect(result.coverage.districts).toBe(4);
+    expect(result.coverage.districts).toBeGreaterThanOrEqual(1);
+    expect(result.coverage.judges).toBe(79);
+    expect(result.coverage.circuitMotions).toBe(18);
+    expect(result.available).toBe(true);
+    expect(result.matchedName).toBe("Texas");
+  });
+
+  it("CA: matches 4 federal districts, gate flips truthy", async () => {
+    const result = await checkDistrictCoverage("CA");
+    expect(result.coverage.districts).toBe(4);
+    expect(result.coverage.districts).toBeGreaterThanOrEqual(1);
+    expect(result.coverage.judges).toBe(85);
+    expect(result.coverage.circuitMotions).toBe(19);
+    expect(result.available).toBe(true);
+    expect(result.matchedName).toBe("California");
+  });
+
+  it("NY: matches 4 federal districts, gate flips truthy", async () => {
+    const result = await checkDistrictCoverage("NY");
+    expect(result.coverage.districts).toBe(4);
+    expect(result.coverage.districts).toBeGreaterThanOrEqual(1);
+    expect(result.coverage.judges).toBe(92);
+    expect(result.coverage.circuitMotions).toBe(19);
+    expect(result.available).toBe(true);
+    expect(result.matchedName).toBe("New York");
+  });
+
+  it("uppercases lowercase state codes before query", async () => {
+    const result = await checkDistrictCoverage("fl");
+    expect(result.coverage.districts).toBe(3);
+    const usscQuery = queryLog.find((q) => q.table === "ussc_districts");
+    const stateFilter = usscQuery?.filters.find(
+      (f) => f.kind === "eq" && f.col === "state_code",
+    );
+    expect(stateFilter?.val).toBe("FL");
+  });
+
+  it("queries judge_disposition_profile via IN(cl_court_ids), not ilike(stateName)", async () => {
+    await checkDistrictCoverage("TX");
+    const judgeQuery = queryLog.find(
+      (q) => q.table === "judge_disposition_profile" && q.isCount,
+    );
+    expect(judgeQuery).toBeTruthy();
+    const inFilter = judgeQuery?.filters.find((f) => f.kind === "in");
+    expect(inFilter?.col).toBe("district_id");
+    expect(inFilter?.val).toEqual(["txnd", "txed", "txsd", "txwd"]);
+    // Negative: must NOT use the broken ilike-on-state-name pattern.
+    const ilikeFilters = judgeQuery?.filters.filter(
+      (f) => f.kind === "eq" && f.col === "district",
+    );
+    expect(ilikeFilters?.length ?? 0).toBe(0);
+  });
+
+  it("queries motion_outcome_rates_by_circuit with normalized circuit + charge_type='(all)'", async () => {
+    await checkDistrictCoverage("CA");
+    const motionQuery = queryLog.find(
+      (q) => q.table === "motion_outcome_rates_by_circuit" && q.isCount,
+    );
+    expect(motionQuery).toBeTruthy();
+    const circuitFilter = motionQuery?.filters.find(
+      (f) => f.kind === "eq" && f.col === "circuit",
+    );
+    const chargeFilter = motionQuery?.filters.find(
+      (f) => f.kind === "eq" && f.col === "charge_type",
+    );
+    expect(circuitFilter?.val).toBe("9");
+    expect(chargeFilter?.val).toBe("(all)");
+  });
+
+  it("does NOT query the broken outcome_benchmarks.jurisdiction_name path", async () => {
+    await checkDistrictCoverage("FL");
+    const benchQueries = queryLog.filter(
+      (q) => q.table === "outcome_benchmarks",
+    );
+    expect(benchQueries).toHaveLength(0);
+  });
+
+  it("zero-coverage state: no scenario seeded → districts=0, available:false", async () => {
+    const result = await checkDistrictCoverage("ZZ");
+    expect(result.coverage.districts).toBe(0);
+    expect(result.available).toBe(false);
+  });
+});

--- a/src/lib/tier9-reports/coverage.ts
+++ b/src/lib/tier9-reports/coverage.ts
@@ -280,32 +280,107 @@ export async function checkOfficerCoverage(
   };
 }
 
+/** Normalize circuit string from ussc_districts ("5th") to the format used
+ *  in motion_outcome_rates_by_circuit ("5"). DC stays "DC". Mirror of the
+ *  helper in courthouse-intelligence.ts so the pre-purchase gate matches the
+ *  post-purchase resolver byte-for-byte. */
+function normalizeUsscCircuit(usscCircuit: string): string {
+  const m = usscCircuit.match(/^(\d+)(st|nd|rd|th)$/i);
+  if (m) return m[1];
+  return usscCircuit;
+}
+
+/**
+ * District-Court coverage gate (rewritten 2026-04-26 — C4 stop-the-bleed).
+ *
+ * Old behavior queried `judge_demographics.district ilike %stateName%` and
+ * `outcome_benchmarks.jurisdiction_name ilike %stateName%`. Both wrong:
+ *   - `judge_demographics.district` stores numeric district codes ("30",
+ *     "40", "73", "90", etc.), not state names. ILIKE returned zero rows.
+ *   - `outcome_benchmarks.jurisdiction_name` is national-only — no state
+ *     rows by design.
+ * Net effect: every state returned `available: false`, gating the product
+ * to zero customers despite indexed coverage existing in
+ * `judge_disposition_profile` and `motion_outcome_rates_by_circuit`.
+ *
+ * New behavior mirrors the post-purchase resolver in
+ * `src/lib/tier9-reports/courthouse-intelligence.ts`:
+ *   1. `ussc_districts` lookup by `state_code` → list of `cl_court_id` and
+ *      circuit values (1 row per federal district in that state).
+ *   2. Count `judge_disposition_profile` rows where `district_id` is IN
+ *      the matched `cl_court_id` set.
+ *   3. Count `motion_outcome_rates_by_circuit` rows where `circuit` matches
+ *      the normalized circuit and `charge_type === "(all)"`.
+ *
+ * `available` flips truthy when at least one federal district is indexed
+ * for the state — which is every state plus DC, matching the post-purchase
+ * resolver's coverage envelope.
+ */
 export async function checkDistrictCoverage(
   stateCode: string
 ): Promise<CoverageResult> {
   const supabase = createAdminClient();
-  const safeState = escapeIlike(stateCode);
+  const upperState = stateCode.trim().toUpperCase();
+  const stateName = US_STATE_NAMES[upperState] ?? upperState;
 
-  // Map state code to state name for district ilike match (shared lookup
-  // lives in src/lib/states.ts so the federal-fallback caption layer reuses
-  // the same source of truth).
-  const stateName = US_STATE_NAMES[safeState.toUpperCase()] ?? safeState;
-  const safeStateName = escapeIlike(stateName).toLowerCase();
+  // Step 1: state → federal districts (cl_court_id + circuit).
+  const { data: districtRows } = await supabase
+    .from("ussc_districts")
+    .select("cl_court_id, district_name, circuit")
+    .eq("state_code", upperState);
 
-  const [judges, benchmarks] = await Promise.all([
-    supabase.from("judge_demographics").select("judge_name", { count: "exact", head: true })
-      .ilike("district", `%${safeStateName}%`),
-    supabase.from("outcome_benchmarks").select("id", { count: "exact", head: true })
-      .ilike("jurisdiction_name", `%${safeStateName}%`),
+  const districts = districtRows ?? [];
+  const districtCount = districts.length;
+  const clCourtIds = districts
+    .map((r) => r.cl_court_id as string | null)
+    .filter((v): v is string => typeof v === "string" && v.length > 0);
+  const usscCircuit =
+    typeof districts[0]?.circuit === "string"
+      ? (districts[0].circuit as string)
+      : null;
+  const normalizedCircuit = usscCircuit
+    ? normalizeUsscCircuit(usscCircuit)
+    : null;
+
+  // Step 2 + 3: counts in parallel. When no districts matched, both
+  // dependent queries short-circuit to zero so we don't issue empty IN ()
+  // or null-circuit eq() against PostgREST.
+  const judgeRowCount = clCourtIds.length;
+  const motionEligible =
+    normalizedCircuit !== null && normalizedCircuit.length > 0;
+
+  const [judgesRes, motionsRes] = await Promise.all([
+    judgeRowCount > 0
+      ? supabase
+          .from("judge_disposition_profile")
+          .select("judge_name", { count: "exact", head: true })
+          .in("district_id", clCourtIds)
+      : Promise.resolve({
+          count: 0,
+          data: null,
+          error: null,
+        } as { count: number | null; data: null; error: null }),
+    motionEligible
+      ? supabase
+          .from("motion_outcome_rates_by_circuit")
+          .select("motion_type", { count: "exact", head: true })
+          .eq("circuit", normalizedCircuit as string)
+          .eq("charge_type", "(all)")
+      : Promise.resolve({
+          count: 0,
+          data: null,
+          error: null,
+        } as { count: number | null; data: null; error: null }),
   ]);
 
-  const coverage = {
-    judges: judges.count ?? 0,
-    benchmarks: benchmarks.count ?? 0,
+  const coverage: Record<string, number> = {
+    districts: districtCount,
+    judges: judgesRes.count ?? 0,
+    circuitMotions: motionsRes.count ?? 0,
   };
 
   return {
-    available: coverage.judges >= 1 || coverage.benchmarks >= 1,
+    available: districtCount > 0,
     coverage,
     matchedName: stateName,
     matchedCourt: null,

--- a/src/lib/tiers.ts
+++ b/src/lib/tiers.ts
@@ -391,7 +391,8 @@ export const TIER_CORE = {
     priorityPrice: null,
     priorityDelivery: null,
     includesTiers: [] as readonly string[],
-    live: true as boolean, // 2026-04-26 D-T3: cron 7522215 weekly + e2e verified
+    // 2026-04-26 reverted dark — no dedicated landing + Slug union excludes (C2)
+    live: false as boolean,
   },
   "charge-authority-pack": {
     name: "Charge Authority Pack",
@@ -407,7 +408,8 @@ export const TIER_CORE = {
     priorityPrice: null,
     priorityDelivery: null,
     includesTiers: [] as readonly string[],
-    live: true as boolean, // 2026-04-26: flipped live — D-T2 verified e2e (audit deferred-tier closeout)
+    // 2026-04-26 reverted dark — no dedicated landing page yet (C1 from worry-tier9-flipped-live audit)
+    live: false as boolean,
   },
   "witness-pack": {
     name: "Standalone Witness Pack",


### PR DESCRIPTION
## Summary

Worry-to-pristine sweep on the 2026-04-26 Tier 9 just-flipped subset surfaced 4 CRITICALs against `charge-authority-pack`, `precedent-watchlist`, `district-court-intelligence`, and `motion-success-report`. This PR ships 3 of them — the live products that were broken for customers right now.

- **C3** — `/api/check-availability/[slug]` now imports canonical `TIER9_SLUGS` from `src/lib/tier9-reports/constants.ts`. The route had a local drifted Set with 6 entries; canonical has 10. Two 2026-04-26 slugs were 400-ing pre-purchase even when the products were live.
- **C4** — `checkDistrictCoverage` rewritten to mirror the post-purchase resolver in `src/lib/tier9-reports/courthouse-intelligence.ts`. Old gate ILIKE'd `judge_demographics.district` against state names but the column stores numeric district codes (`"30"`, `"40"`, `"73"`, `"90"`); also queried `outcome_benchmarks.jurisdiction_name` which is national-only. Both returned 0 → `available: false` for every state. New gate: `ussc_districts.state_code` lookup → `judge_disposition_profile.district_id IN (cl_court_ids)` + `motion_outcome_rates_by_circuit.circuit eq normalized + charge_type='(all)'`.
- **W1** — `/district-court-intelligence` page copy refreshed to the $147 Courthouse Intelligence Pack scope (was stale $97 JUSTFAIR-only framing). URL slug + price unchanged.

Reverts (re-flipped in a follow-up PR after dedicated landings ship):
- `charge-authority-pack` `live: true → false` (no dedicated landing page)
- `precedent-watchlist` `live: true → false` (no dedicated landing + AvailabilityChecker `Slug` union excludes it)

## Verification

- `node node_modules/typescript/bin/tsc --noEmit --skipLibCheck` → 0 errors
- Vitest: 13 files, 173 tests passing across `src/lib/tier9-reports/__tests__/` + `src/lib/defense-intelligence/__tests__/`
- New unit test `district-coverage.test.ts` — 9 cases covering FL/TX/CA/NY (all `districts ≥ 1`), uppercase normalization, IN(cl_court_ids) shape, normalized circuit + `charge_type='(all)'`, no broken `outcome_benchmarks` query, zero-coverage state path
- Live Node verification against prod Supabase (temp script, deleted after run):
  - FL: districts=3 judges=56 circuitMotions=17 (Circuit 11)
  - TX: districts=4 judges=79 circuitMotions=18 (Circuit 5)
  - CA: districts=4 judges=85 circuitMotions=19 (Circuit 9)
  - NY: districts=4 judges=92 circuitMotions=19 (Circuit 2)
  - WY: districts=1 judges=3  circuitMotions=19 (Circuit 10)

## Hook bypasses (Windows PATH)

`SKIP_TSC=1` on commit and `SKIP_BUILD=1` on push — pre-commit/pre-push hooks invoke `tsc` and `next` directly which aren't on the bash PATH on this workstation. Both gates were verified clean via `node node_modules/<bin>` invocations before bypass.

## Test plan
- [ ] CI green
- [ ] Visit `/district-court-intelligence` on preview → AvailabilityChecker returns `available: true` for FL/TX/CA/NY/WY
- [ ] Visit `/charge-authority-pack` and `/precedent-watchlist` — products show as inactive in Stripe checkout (confirms revert)
- [ ] FAQ + hero copy reads as Courthouse Intelligence Pack scope, not old District SKU
- [ ] No banned UPL phrases ("you should", "consult your attorney", "we recommend") in page copy

## Out of scope (follow-up PR)
- C1 dedicated landing page for `charge-authority-pack`
- C2 dedicated landing page for `precedent-watchlist` + extending AvailabilityChecker `Slug` union
- Re-flip of those two SKUs after landings ship

🤖 Generated with [Claude Code](https://claude.com/claude-code)