### PR TITLE
feat(bar-disc): SD/ND/AK/DC/VT/WY scrapers (G1c batch 8) — 943 events live

### DIFF
--- a/scripts/ingest/__tests__/scrape-akbar-discipline.test.mjs
+++ b/scripts/ingest/__tests__/scrape-akbar-discipline.test.mjs
@@ -1,0 +1,140 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  parseCaseName,
+  normalizeAkDocket,
+  isAkDocket,
+  buildRecordFromClResult,
+  ALLOWED_DISCIPLINE_TYPES,
+} from '../scrape-akbar-discipline.mjs';
+
+test('parseCaseName accepts canonical AK caption', () => {
+  assert.equal(
+    parseCaseName('In the Disciplinary Matter Involving Joshua M. Kindred').fullName,
+    'Joshua M. Kindred',
+  );
+  assert.equal(
+    parseCaseName('In the Disciplinary Matter Involving Nathan R. Michalski').fullName,
+    'Nathan R. Michalski',
+  );
+});
+
+test('parseCaseName strips trailing ", Attorney."', () => {
+  assert.equal(
+    parseCaseName('In the Disciplinary Matter Involving Ward M. Merdes, Attorney.').fullName,
+    'Ward M. Merdes',
+  );
+});
+
+test('parseCaseName strips leading "Attorney " in name', () => {
+  assert.equal(
+    parseCaseName('In the Disciplinary Matter Involving Attorney Gayle Brown').fullName,
+    'Gayle Brown',
+  );
+  assert.equal(
+    parseCaseName('In the Disciplinary Matter Involving Attorney Paul D. Stockler').fullName,
+    'Paul D. Stockler',
+  );
+});
+
+test('parseCaseName REJECTS judicial-discipline (Honorable / Judge / Magistrate)', () => {
+  assert.equal(
+    parseCaseName('In the Disciplinary Matter Involving Honorable Martin C. Fallon, District Court Judge').fullName,
+    null,
+  );
+  assert.equal(
+    parseCaseName('In the Disciplinary Matter Involving Hon. Mary Smith').fullName,
+    null,
+  );
+  assert.equal(
+    parseCaseName('In the Disciplinary Matter Involving Magistrate John Doe').fullName,
+    null,
+  );
+});
+
+test('parseCaseName REJECTS reinstatement petitions', () => {
+  assert.equal(
+    parseCaseName('In the Matter of the Petition for Reinstatement of Erin Pohland').fullName,
+    null,
+  );
+});
+
+test('parseCaseName accepts legacy "In re <Name>" form', () => {
+  assert.equal(parseCaseName('In re Albertsen').fullName, 'Albertsen');
+  assert.equal(parseCaseName('In re Vance').fullName, 'Vance');
+});
+
+test('parseCaseName REJECTS civil v. captions', () => {
+  assert.equal(
+    parseCaseName('Leroy Oenga, Jr. v. Maria M. Givens').fullName,
+    null,
+  );
+});
+
+test('normalizeAkDocket accepts modern "S19587"', () => {
+  assert.equal(normalizeAkDocket('S19587'), 'S19587');
+  assert.equal(normalizeAkDocket('S18006'), 'S18006');
+});
+
+test('normalizeAkDocket accepts legacy "Supreme Court No. S-NNNNN"', () => {
+  assert.equal(normalizeAkDocket('Supreme Court No. S-17026'), 'S17026');
+  assert.equal(normalizeAkDocket('Supreme Court No. S-16858'), 'S16858');
+});
+
+test('normalizeAkDocket accepts "S-17026" hyphen form', () => {
+  assert.equal(normalizeAkDocket('S-17026'), 'S17026');
+});
+
+test('normalizeAkDocket rejects malformed', () => {
+  assert.equal(normalizeAkDocket('A12345'), null);
+  assert.equal(normalizeAkDocket(''), null);
+});
+
+test('isAkDocket boolean wrapper', () => {
+  assert.equal(isAkDocket('S19587'), true);
+  assert.equal(isAkDocket('Supreme Court No. S-17026'), true);
+  assert.equal(isAkDocket('A12345'), false);
+});
+
+test('buildRecordFromClResult uses normalized docket in bar_number', () => {
+  const r = {
+    caseName: 'In the Disciplinary Matter Involving Joshua M. Kindred',
+    docketNumber: 'S19587',
+    dateFiled: '2025-11-07',
+    absolute_url: '/opinion/10734996/in-the-disciplinary-matter-involving-joshua-m-kindred/',
+    opinions: [{ snippet: 'suspended for two years.' }],
+  };
+  const rec = buildRecordFromClResult(r, 'suspension');
+  assert.equal(rec.bar_number, 'AK:S19587');
+  assert.equal(rec.full_name, 'Joshua M. Kindred');
+});
+
+test('buildRecordFromClResult uses normalized legacy docket', () => {
+  const r = {
+    caseName: 'In re Albertsen',
+    docketNumber: 'Supreme Court No. S-17026',
+    dateFiled: '2018-04-13',
+    absolute_url: '/opinion/9999/in-re-albertsen/',
+    opinions: [{ snippet: 'suspension' }],
+  };
+  const rec = buildRecordFromClResult(r, 'suspension');
+  assert.equal(rec.bar_number, 'AK:S17026');
+  assert.equal(rec.full_name, 'Albertsen');
+});
+
+test('buildRecordFromClResult REJECTS judicial discipline (Judge in name)', () => {
+  const r = {
+    caseName: 'In the Disciplinary Matter Involving Honorable Martin C. Fallon',
+    docketNumber: 'S18873',
+    dateFiled: '2024-03-08',
+    absolute_url: '/opinion/x/x/',
+    opinions: [{ snippet: 'judicial discipline' }],
+  };
+  assert.equal(buildRecordFromClResult(r, 'suspension'), null);
+});
+
+test('ALLOWED_DISCIPLINE_TYPES contains expected enum', () => {
+  assert.equal(ALLOWED_DISCIPLINE_TYPES.has('disbarment'), true);
+  assert.equal(ALLOWED_DISCIPLINE_TYPES.has('suspension'), true);
+});

--- a/scripts/ingest/__tests__/scrape-dcbar-discipline.test.mjs
+++ b/scripts/ingest/__tests__/scrape-dcbar-discipline.test.mjs
@@ -1,0 +1,82 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  parseCaseName,
+  isDcDocket,
+  buildRecordFromClResult,
+  ALLOWED_DISCIPLINE_TYPES,
+} from '../scrape-dcbar-discipline.mjs';
+
+test('parseCaseName accepts canonical "In re <Name>"', () => {
+  assert.equal(parseCaseName('In re Brammer').fullName, 'Brammer');
+  assert.equal(parseCaseName('In re Payne').fullName, 'Payne');
+  assert.equal(parseCaseName('In re Larson-Jackson').fullName, 'Larson-Jackson');
+});
+
+test('parseCaseName strips trailing III', () => {
+  assert.equal(parseCaseName('In re Lopatto, III').fullName, 'Lopatto');
+});
+
+test('parseCaseName preserves "IV" if attached without comma', () => {
+  // "Crane IV" has IV as part of the literal name presentation.
+  // Per spec we strip ", IV" only with comma — bare "Crane IV" stays.
+  assert.equal(parseCaseName('In re Crane IV').fullName, 'Crane IV');
+});
+
+test('parseCaseName REJECTS "In re Estate of"', () => {
+  assert.equal(parseCaseName('In re Estate of Smith').fullName, null);
+});
+
+test('parseCaseName REJECTS "In re Sealed Case"', () => {
+  assert.equal(parseCaseName('In re Sealed Case').fullName, null);
+});
+
+test('parseCaseName REJECTS "In re Petition of <X>"', () => {
+  assert.equal(parseCaseName('In re Petition of Doe').fullName, null);
+});
+
+test('parseCaseName REJECTS corporate captions', () => {
+  assert.equal(parseCaseName('In re Smith LLC').fullName, null);
+});
+
+test('isDcDocket accepts NN-BG-NNNN', () => {
+  assert.equal(isDcDocket('26-BG-0127'), true);
+  assert.equal(isDcDocket('25-BG-0333'), true);
+  assert.equal(isDcDocket('22-BG-0565'), true);
+});
+
+test('isDcDocket REJECTS non-BG dockets', () => {
+  assert.equal(isDcDocket('26-CA-0127'), false);
+  assert.equal(isDcDocket('20250115'), false);
+  assert.equal(isDcDocket(''), false);
+});
+
+test('buildRecordFromClResult builds canonical event', () => {
+  const r = {
+    caseName: 'In re Brammer',
+    docketNumber: '26-BG-0127',
+    dateFiled: '2026-04-23',
+    absolute_url: '/opinion/abc/in-re-brammer/',
+    opinions: [{ snippet: 'disbarred from the Bar of the District of Columbia.' }],
+  };
+  const rec = buildRecordFromClResult(r, 'disbarment');
+  assert.equal(rec.bar_number, 'DC:26-BG-0127');
+  assert.equal(rec.full_name, 'Brammer');
+  assert.equal(rec.discipline_type, 'disbarment');
+});
+
+test('buildRecordFromClResult REJECTS non-BG dockets', () => {
+  const r = {
+    caseName: 'In re Smith',
+    docketNumber: '26-CA-0127',
+    dateFiled: '2026-01-01',
+    absolute_url: '/x/',
+    opinions: [{ snippet: 'civil' }],
+  };
+  assert.equal(buildRecordFromClResult(r, 'disbarment'), null);
+});
+
+test('ALLOWED_DISCIPLINE_TYPES contains expected enum', () => {
+  assert.equal(ALLOWED_DISCIPLINE_TYPES.has('disbarment'), true);
+});

--- a/scripts/ingest/__tests__/scrape-ndbar-discipline.test.mjs
+++ b/scripts/ingest/__tests__/scrape-ndbar-discipline.test.mjs
@@ -1,0 +1,108 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  parseCaseName,
+  normalizeNdDocket,
+  isNdDocket,
+  buildRecordFromClResult,
+  ALLOWED_DISCIPLINE_TYPES,
+} from '../scrape-ndbar-discipline.mjs';
+
+test('parseCaseName accepts "Disciplinary Board v. <Name>"', () => {
+  assert.equal(parseCaseName('Disciplinary Board v. Merkens').fullName, 'Merkens');
+  assert.equal(parseCaseName('Disciplinary Board v. Spencer').fullName, 'Spencer');
+});
+
+test('parseCaseName strips parenthetical stage labels', () => {
+  assert.equal(
+    parseCaseName('Disciplinary Board v. Spencer (Interim Suspension)').fullName,
+    'Spencer',
+  );
+});
+
+test('parseCaseName strips trailing ND citation', () => {
+  assert.equal(
+    parseCaseName('Disciplinary Board v. Spencer 2024 ND 28').fullName,
+    'Spencer',
+  );
+  assert.equal(
+    parseCaseName('Disciplinary Board v. Daniel 2024 ND 191').fullName,
+    'Daniel',
+  );
+});
+
+test('parseCaseName accepts "Reciprocal Discipline of <Name>"', () => {
+  assert.equal(parseCaseName('Reciprocal Discipline of Odegaard').fullName, 'Odegaard');
+  assert.equal(
+    parseCaseName('Reciprocal Discipline of Odegaard 2025 ND 118').fullName,
+    'Odegaard',
+  );
+});
+
+test('parseCaseName rejects criminal/civil captions', () => {
+  assert.equal(parseCaseName('State v. Cooper').fullName, null);
+  assert.equal(parseCaseName('Bauer v. Adam').fullName, null);
+});
+
+test('parseCaseName strips <mark> highlights', () => {
+  assert.equal(
+    parseCaseName('<mark>Disciplinary Board</mark> v. Merkens').fullName,
+    'Merkens',
+  );
+});
+
+test('normalizeNdDocket accepts 8-digit numeric with No. prefix', () => {
+  assert.equal(normalizeNdDocket('No. 20250115'), '20250115');
+  assert.equal(normalizeNdDocket('20240339'), '20240339');
+});
+
+test('normalizeNdDocket accepts multi-docket range and returns first', () => {
+  assert.equal(normalizeNdDocket('Nos. 20250300-20250302'), '20250300');
+});
+
+test('normalizeNdDocket strips <mark> highlights', () => {
+  assert.equal(normalizeNdDocket('<mark>No.</mark> 20240182'), '20240182');
+});
+
+test('normalizeNdDocket rejects malformed', () => {
+  assert.equal(normalizeNdDocket('XYZ'), null);
+  assert.equal(normalizeNdDocket(''), null);
+  assert.equal(normalizeNdDocket(null), null);
+});
+
+test('isNdDocket boolean wrapper', () => {
+  assert.equal(isNdDocket('No. 20250115'), true);
+  assert.equal(isNdDocket('XYZ'), false);
+});
+
+test('buildRecordFromClResult builds from canonical result', () => {
+  const r = {
+    caseName: 'Disciplinary Board v. Merkens',
+    docketNumber: 'Nos. 20250300-20250302',
+    dateFiled: '2025-09-22',
+    absolute_url: '/opinion/10675457/disciplinary-board-v-merkens/',
+    opinions: [{ snippet: 'Disciplinary Board notified. SUSPENSION ORDERED.' }],
+  };
+  const rec = buildRecordFromClResult(r, 'suspension');
+  assert.equal(rec.bar_number, 'ND:20250300');
+  assert.equal(rec.full_name, 'Merkens');
+  assert.equal(rec.discipline_type, 'suspension');
+});
+
+test('buildRecordFromClResult returns null without absolute_url', () => {
+  const r = {
+    caseName: 'Disciplinary Board v. X',
+    docketNumber: 'No. 20240001',
+    dateFiled: '2024-01-01',
+    absolute_url: null,
+    opinions: [{ snippet: 'x' }],
+  };
+  assert.equal(buildRecordFromClResult(r, 'suspension'), null);
+});
+
+test('ALLOWED_DISCIPLINE_TYPES contains all enum values', () => {
+  for (const t of ['disbarment', 'suspension', 'reciprocal_discipline']) {
+    assert.equal(ALLOWED_DISCIPLINE_TYPES.has(t), true);
+  }
+});

--- a/scripts/ingest/__tests__/scrape-sdbar-discipline.test.mjs
+++ b/scripts/ingest/__tests__/scrape-sdbar-discipline.test.mjs
@@ -1,0 +1,115 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  parseCaseName,
+  isSdDocket,
+  buildRecordFromClResult,
+  ALLOWED_DISCIPLINE_TYPES,
+  normalizeDiscipline,
+} from '../scrape-sdbar-discipline.mjs';
+
+test('parseCaseName accepts canonical "Discipline of <Name>"', () => {
+  assert.equal(parseCaseName('Discipline of Volesky').fullName, 'Volesky');
+  assert.equal(parseCaseName('Discipline of Ravnsborg').fullName, 'Ravnsborg');
+});
+
+test('parseCaseName accepts "Reciprocal Discipline of <Name>"', () => {
+  assert.equal(parseCaseName('Reciprocal Discipline of Smith').fullName, 'Smith');
+});
+
+test('parseCaseName accepts legacy "In Re the Discipline of <Name>"', () => {
+  assert.equal(parseCaseName('In Re the Discipline of Tornow').fullName, 'Tornow');
+});
+
+test('parseCaseName accepts "Matter of Discipline of <Name>"', () => {
+  assert.equal(parseCaseName('Matter of Discipline of Russell').fullName, 'Russell');
+});
+
+test('parseCaseName rejects criminal "State v. <Name>"', () => {
+  assert.equal(parseCaseName('State v. Klager').fullName, null);
+});
+
+test('parseCaseName rejects probate "Estate of <Name>"', () => {
+  assert.equal(parseCaseName('Estate of Mack').fullName, null);
+});
+
+test('parseCaseName rejects corporate dissolution', () => {
+  assert.equal(parseCaseName('Dissolution of Healy Ranch, Inc.').fullName, null);
+});
+
+test('parseCaseName strips trailing Jr./Sr./II suffixes', () => {
+  assert.equal(parseCaseName('Discipline of Smith, Jr.').fullName, 'Smith');
+  assert.equal(parseCaseName('Discipline of Smith, III').fullName, 'Smith');
+});
+
+test('parseCaseName strips <mark> highlights', () => {
+  assert.equal(parseCaseName('Discipline of <mark>Volesky</mark>').fullName, 'Volesky');
+});
+
+test('isSdDocket accepts 4-6 digit numeric', () => {
+  assert.equal(isSdDocket('30736'), true);
+  assert.equal(isSdDocket('29156'), true);
+  assert.equal(isSdDocket('25490'), true);
+  assert.equal(isSdDocket('1234'), true);
+});
+
+test('isSdDocket rejects non-numeric', () => {
+  assert.equal(isSdDocket('S19587'), false);
+  assert.equal(isSdDocket('25-BG-0264'), false);
+  assert.equal(isSdDocket(''), false);
+  assert.equal(isSdDocket(null), false);
+});
+
+test('buildRecordFromClResult builds from valid CL result', () => {
+  const r = {
+    caseName: 'Discipline of Volesky',
+    docketNumber: '30736',
+    dateFiled: '2025-11-12',
+    absolute_url: '/opinion/10739463/discipline-of-volesky/',
+    opinions: [{ snippet: 'Attorneys for Disciplinary Board. Suspended for two years.' }],
+  };
+  const rec = buildRecordFromClResult(r, 'suspension');
+  assert.equal(rec.bar_number, 'SD:30736');
+  assert.equal(rec.full_name, 'Volesky');
+  assert.equal(rec.discipline_type, 'suspension');
+  assert.equal(rec.order_date, '2025-11-12');
+  assert.equal(rec.source_url, 'https://www.courtlistener.com/opinion/10739463/discipline-of-volesky/');
+});
+
+test('buildRecordFromClResult returns null for non-discipline caption', () => {
+  const r = {
+    caseName: 'State v. Klager',
+    docketNumber: '25609',
+    dateFiled: '2020-01-01',
+    absolute_url: '/opinion/9/state-v-klager/',
+    opinions: [{ snippet: 'criminal' }],
+  };
+  assert.equal(buildRecordFromClResult(r, 'suspension'), null);
+});
+
+test('buildRecordFromClResult returns null without absolute_url (never fabricate)', () => {
+  const r = {
+    caseName: 'Discipline of X',
+    docketNumber: '30000',
+    dateFiled: '2025-01-01',
+    absolute_url: null,
+    opinions: [{ snippet: 'x' }],
+  };
+  assert.equal(buildRecordFromClResult(r, 'suspension'), null);
+});
+
+test('ALLOWED_DISCIPLINE_TYPES contains the expected enum values', () => {
+  for (const t of ['disbarment', 'suspension', 'interim_suspension', 'probation',
+    'public_reprimand', 'resignation_with_charges', 'censure',
+    'admonition', 'reciprocal_discipline', 'disability_inactive']) {
+    assert.equal(ALLOWED_DISCIPLINE_TYPES.has(t), true, t);
+  }
+});
+
+test('normalizeDiscipline matches expected sanction', () => {
+  assert.equal(normalizeDiscipline('order of disbarment').type, 'disbarment');
+  assert.equal(normalizeDiscipline('suspended for two years').type, 'suspension');
+  assert.equal(normalizeDiscipline('publicly reprimanded').type, 'public_reprimand');
+  assert.equal(normalizeDiscipline('').type, 'unknown');
+});

--- a/scripts/ingest/__tests__/scrape-vtbar-discipline.test.mjs
+++ b/scripts/ingest/__tests__/scrape-vtbar-discipline.test.mjs
@@ -1,0 +1,112 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  parseCaseName,
+  normalizeVtDocket,
+  isVtDocket,
+  buildRecordFromClResult,
+  ALLOWED_DISCIPLINE_TYPES,
+} from '../scrape-vtbar-discipline.mjs';
+
+test('parseCaseName accepts "In Re <Name> (Office of Disciplinary Counsel)"', () => {
+  assert.equal(
+    parseCaseName('In Re Matthew Ragaller (Office of Disciplinary Counsel, Appellant)').fullName,
+    'Matthew Ragaller',
+  );
+  assert.equal(
+    parseCaseName('In Re Norman E. Watts, Esq. (Office of Disciplinary Counsel)').fullName,
+    'Norman E. Watts',
+  );
+});
+
+test('parseCaseName accepts multi-caption form', () => {
+  assert.equal(
+    parseCaseName('In re Theodore Studdert-Kennedy / In re PRB-021-2022 (Office of Disciplinary Counsel)').fullName,
+    'Theodore Studdert-Kennedy',
+  );
+});
+
+test('parseCaseName accepts "In Re <Name>, Esq." (no parenthetical)', () => {
+  assert.equal(
+    parseCaseName('In Re C. Robert Manby, Jr., Esq.').fullName,
+    'C. Robert Manby',
+  );
+  assert.equal(
+    parseCaseName('In Re Melvin Fink, Esq.').fullName,
+    'Melvin Fink',
+  );
+});
+
+test('parseCaseName accepts bare "In Re <Name>" (PRB-context anchored at search level)', () => {
+  // VT/PRB has many bare-caption discipline orders; the search anchor is
+  // the gatekeeper, parser shouldn't reject these.
+  assert.equal(parseCaseName('In Re George Henry Spangler').fullName, 'George Henry Spangler');
+});
+
+test('parseCaseName REJECTS corporate "In Re <Co> LLC"', () => {
+  assert.equal(parseCaseName('In Re Holland Cannabis, LLC').fullName, null);
+});
+
+test('parseCaseName REJECTS "In Re Estate of"', () => {
+  assert.equal(parseCaseName('In Re Estate of Smith').fullName, null);
+});
+
+test('parseCaseName REJECTS PRB-only refs', () => {
+  assert.equal(parseCaseName('In re PRB-021-2022').fullName, null);
+});
+
+test('normalizeVtDocket accepts modern NN-AP-NNN', () => {
+  assert.equal(normalizeVtDocket('25-AP-019'), '25-AP-019');
+  assert.equal(normalizeVtDocket('22-AP-265'), '22-AP-265');
+});
+
+test('normalizeVtDocket accepts multi-docket and returns first', () => {
+  assert.equal(normalizeVtDocket('23-AP-263, 23-AP-264'), '23-AP-263');
+});
+
+test('normalizeVtDocket accepts legacy YYYY-NNN', () => {
+  assert.equal(normalizeVtDocket('2021-080'), '2021-080');
+});
+
+test('normalizeVtDocket rejects malformed', () => {
+  assert.equal(normalizeVtDocket('XYZ'), null);
+  assert.equal(normalizeVtDocket(''), null);
+});
+
+test('isVtDocket boolean wrapper', () => {
+  assert.equal(isVtDocket('25-AP-019'), true);
+  assert.equal(isVtDocket('2021-080'), true);
+  assert.equal(isVtDocket('XYZ'), false);
+});
+
+test('buildRecordFromClResult builds canonical event', () => {
+  const r = {
+    caseName: 'In Re Matthew Ragaller (Office of Disciplinary Counsel, Appellant)',
+    docketNumber: '25-AP-019',
+    dateFiled: '2025-03-14',
+    absolute_url: '/opinion/10356508/in-re-matthew-ragaller-office-of-disciplinary-counsel-appellant/',
+    opinions: [{ snippet: 'suspended from the practice of law for two years.' }],
+  };
+  const rec = buildRecordFromClResult(r, 'suspension');
+  assert.equal(rec.bar_number, 'VT:25-AP-019');
+  assert.equal(rec.full_name, 'Matthew Ragaller');
+  assert.equal(rec.discipline_type, 'suspension');
+});
+
+test('buildRecordFromClResult uses legacy docket', () => {
+  const r = {
+    caseName: 'In re William Tracy Carris, Esq. (Office of Disciplinary Counsel)',
+    docketNumber: '2021-080',
+    dateFiled: '2022-01-01',
+    absolute_url: '/opinion/x/in-re-carris/',
+    opinions: [{ snippet: 'suspension' }],
+  };
+  const rec = buildRecordFromClResult(r, 'suspension');
+  assert.equal(rec.bar_number, 'VT:2021-080');
+  assert.equal(rec.full_name, 'William Tracy Carris');
+});
+
+test('ALLOWED_DISCIPLINE_TYPES contains expected enum', () => {
+  assert.equal(ALLOWED_DISCIPLINE_TYPES.has('disbarment'), true);
+});

--- a/scripts/ingest/__tests__/scrape-wybar-discipline.test.mjs
+++ b/scripts/ingest/__tests__/scrape-wybar-discipline.test.mjs
@@ -1,0 +1,107 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  parseCaseName,
+  isWyDocket,
+  buildRecordFromClResult,
+  ALLOWED_DISCIPLINE_TYPES,
+} from '../scrape-wybar-discipline.mjs';
+
+test('parseCaseName accepts canonical caption with WSB number', () => {
+  const r = parseCaseName(
+    'Board of Professional Responsibility, Wyoming State Bar v. Kent C. Cobb, Wsb 8-6998',
+  );
+  assert.equal(r.fullName, 'Kent C. Cobb');
+  assert.equal(r.wsb, '8-6998');
+});
+
+test('parseCaseName accepts caption without WSB number', () => {
+  const r = parseCaseName(
+    'Board of Professional Responsibility, Wyoming State Bar v. Jane Smith',
+  );
+  assert.equal(r.fullName, 'Jane Smith');
+  assert.equal(r.wsb, null);
+});
+
+test('parseCaseName extracts WSB-formatted variants', () => {
+  const r = parseCaseName(
+    'Board of Professional Responsibility, Wyoming State Bar v. Vaughn H. Neubauer, WSB 6-3443',
+  );
+  assert.equal(r.fullName, 'Vaughn H. Neubauer');
+  assert.equal(r.wsb, '6-3443');
+});
+
+test('parseCaseName REJECTS criminal/civil captions', () => {
+  assert.equal(
+    parseCaseName('Aaron R. Maki v. The State of Wyoming').fullName,
+    null,
+  );
+  assert.equal(
+    parseCaseName('In the Matter of the Estate of Lloyd Haack, Deceased').fullName,
+    null,
+  );
+});
+
+test('parseCaseName strips <mark> highlights', () => {
+  const r = parseCaseName(
+    '<mark>Board of Professional Responsibility</mark>, <mark>Wyoming State Bar</mark> v. John Doe, Wsb 1-1234',
+  );
+  assert.equal(r.fullName, 'John Doe');
+  assert.equal(r.wsb, '1-1234');
+});
+
+test('isWyDocket accepts D-NN-NNNN', () => {
+  assert.equal(isWyDocket('D-26-0001'), true);
+  assert.equal(isWyDocket('D-22-0004'), true);
+  assert.equal(isWyDocket('D-19-0001'), true);
+});
+
+test('isWyDocket rejects non-discipline (S-) docket', () => {
+  assert.equal(isWyDocket('S-25-0166'), false);
+});
+
+test('isWyDocket rejects malformed', () => {
+  assert.equal(isWyDocket(''), false);
+  assert.equal(isWyDocket(null), false);
+});
+
+test('buildRecordFromClResult prefers WSB-derived bar_number', () => {
+  const r = {
+    caseName: 'Board of Professional Responsibility, Wyoming State Bar v. Kent C. Cobb, Wsb 8-6998',
+    docketNumber: 'D-26-0001',
+    dateFiled: '2026-04-08',
+    absolute_url: '/opinion/x/board-of-professional-responsibility-wyoming-state-bar-v-kent-c-cobb/',
+    opinions: [{ snippet: 'order of disbarment.' }],
+  };
+  const rec = buildRecordFromClResult(r, 'disbarment');
+  assert.equal(rec.bar_number, 'WY:WSB-8-6998');
+  assert.equal(rec.full_name, 'Kent C. Cobb');
+});
+
+test('buildRecordFromClResult falls back to docket-based bar_number when WSB absent', () => {
+  const r = {
+    caseName: 'Board of Professional Responsibility, Wyoming State Bar v. Jane Smith',
+    docketNumber: 'D-25-0010',
+    dateFiled: '2025-06-01',
+    absolute_url: '/opinion/x/x/',
+    opinions: [{ snippet: 'suspension' }],
+  };
+  const rec = buildRecordFromClResult(r, 'suspension');
+  assert.equal(rec.bar_number, 'WY:D-25-0010');
+});
+
+test('buildRecordFromClResult REJECTS non-discipline docket', () => {
+  const r = {
+    caseName: 'Board of Professional Responsibility, Wyoming State Bar v. X',
+    docketNumber: 'S-25-0001',
+    dateFiled: '2025-01-01',
+    absolute_url: '/x/',
+    opinions: [{ snippet: 'x' }],
+  };
+  assert.equal(buildRecordFromClResult(r, 'suspension'), null);
+});
+
+test('ALLOWED_DISCIPLINE_TYPES contains expected enum', () => {
+  assert.equal(ALLOWED_DISCIPLINE_TYPES.has('disbarment'), true);
+});

--- a/scripts/ingest/scrape-akbar-discipline.mjs
+++ b/scripts/ingest/scrape-akbar-discipline.mjs
@@ -1,0 +1,450 @@
+// csv-bulk-checked: none-exists — CourtListener search API used for per-sanction filtering of Alaska Supreme Court bar discipline opinions. CL has 96+ "Bar Counsel/Disciplinary Board" opinions on court=alaska (probed 2026-04-27). alaskabar.org publishes Decisions and Sanctions but the listing is paginated HTML without a structured archive endpoint; AK SC opinions on CL are the bulk-tractable surface (PR #185 OK/OR/CT pattern).
+// Template: scripts/ingest/scrape-nmbar-discipline.mjs
+// Pattern: cl-bulk-data-defensive #18 (COPY FROM STDIN via bulkCopyRows)
+//
+// Alaska Supreme Court bar discipline scraper.
+//
+// Source discovery (probed 2026-04-27):
+//   Primary: CourtListener search API — court=alaska + per-sanction queries
+//
+// AK caption shapes (verified live):
+//   "In the Disciplinary Matter Involving Joshua M. Kindred"        → discipline (canonical)
+//   "In the Disciplinary Matter Involving Nathan R. Michalski"      → discipline
+//   "In the Disciplinary Matter Involving Benjamin Crittenden"      → discipline
+//   "In the Disciplinary Matter Involving Ward M. Merdes, Attorney." → discipline
+//   "In the Disciplinary Matter Involving Honorable <X>, District Court Judge"
+//                                                                    → JUDICIAL discipline; SKIP
+//   "In the Matter of the Petition for Reinstatement of <Name>"     → SKIP (reinstatement)
+//   "Leroy Oenga, Jr. v. Maria M. Givens"                           → SKIP (civil — citation only)
+//
+// Filter requires:
+//   1. caseName starts with "In the Disciplinary Matter Involving"
+//   2. AFTER stripping prefix, name does NOT contain "Honorable", "Judge",
+//      "Magistrate", "Justice" (judicial, not bar discipline)
+//
+// AK docket: "S" + 5 digits (e.g. "S19587", "S19315", "S18814", "S18006").
+//
+// Discipline label mapping (AK SC → internal enum) — same as NM/NE.
+//
+// bar_number = "AK:<docketNumber>" — deterministic, idempotent.
+//
+// Polite scraping: 800-1600 ms randomized delay between CL page requests.
+
+import fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { setTimeout as sleep } from 'node:timers/promises';
+
+import { createBulkClient, bulkCopyRows } from '../lib/pg-bulk-defaults.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+
+// ── Env loader (inline) ─────────────────────────────────────────────────────
+{
+  const ENV_PATH = 'C:/Users/email/projects/ImNotAnAttorney-web/.env.local';
+  const VALID_KEY_RX = /^[A-Z_][A-Z0-9_]*$/;
+  if (fs.existsSync(ENV_PATH)) {
+    const txt = fs.readFileSync(ENV_PATH, 'utf-8');
+    for (const rawLine of txt.split('\n')) {
+      let line = rawLine.endsWith('\r') ? rawLine.slice(0, -1) : rawLine;
+      line = line.trim();
+      if (!line || line[0] === '#') continue;
+      const eq = line.indexOf('=');
+      if (eq <= 0) continue;
+      const key = line.slice(0, eq).trim();
+      let val = line.slice(eq + 1).trim();
+      if (val.length >= 2 && ((val[0] === '"' && val[val.length - 1] === '"') ||
+          (val[0] === "'" && val[val.length - 1] === "'"))) {
+        val = val.slice(1, -1);
+      }
+      if (!VALID_KEY_RX.test(key)) continue;
+      if (!process.env[key]) process.env[key] = val;
+    }
+  }
+}
+
+const JURISDICTION = 'AK';
+const USER_AGENT =
+  'INAA-Crawler/1.0 (+https://imnotanattorney.com; contact: noreply-legal@inaa.com)';
+const CL_SEARCH_BASE =
+  'https://www.courtlistener.com/api/rest/v4/search/' +
+  '?type=o&court=alaska&format=json&order_by=dateFiled+desc&highlight=on';
+
+const SANCTION_QUERIES = [
+  ['"reciprocal discipline"', 'reciprocal_discipline'],
+  ['"disability inactive"', 'disability_inactive'],
+  ['disbarred OR disbarment', 'disbarment'],
+  ['"resignation" OR "resigned"', 'resignation_with_charges'],
+  ['"interim suspension" OR "temporary suspension"', 'interim_suspension'],
+  ['suspended OR suspension', 'suspension'],
+  ['probation', 'probation'],
+  ['censured OR censure', 'censure'],
+  ['"public reprimand" OR "publicly reprimanded"', 'public_reprimand'],
+  ['"private reprimand" OR admonition', 'admonition'],
+];
+
+const CL_OPINION_BASE = 'https://www.courtlistener.com';
+
+const DISCIPLINE_PATTERNS = [
+  [/\breciprocal\s+disciplin/i, 'reciprocal_discipline'],
+  [/\bdisability\s+inactiv/i, 'disability_inactive'],
+  [/\bdisbar(red|ment|ring)/i, 'disbarment'],
+  [/\bresign(ation|ed)/i, 'resignation_with_charges'],
+  [/\binterim\s+suspen/i, 'interim_suspension'],
+  [/\btemporary\s+suspen/i, 'interim_suspension'],
+  [/\bsuspen(d|ded|sion)/i, 'suspension'],
+  [/\bprobation\b/i, 'probation'],
+  [/\bcensur(ed|e)\b/i, 'censure'],
+  [/\bpublic(ly)?\s+reprimand/i, 'public_reprimand'],
+  [/\bprivate\s+reprimand/i, 'admonition'],
+  [/\badmoni(tion|shed)/i, 'admonition'],
+  [/\breprimand(ed)?\b/i, 'public_reprimand'],
+];
+
+export const ALLOWED_DISCIPLINE_TYPES = new Set([
+  'disbarment', 'suspension', 'interim_suspension', 'probation',
+  'public_reprimand', 'resignation_with_charges', 'censure',
+  'admonition', 'reciprocal_discipline', 'disability_inactive',
+]);
+
+export function normalizeDiscipline(text) {
+  if (!text) return { type: 'unknown', raw: null };
+  for (const [re, type] of DISCIPLINE_PATTERNS) {
+    if (re.test(text)) return { type, raw: text.slice(0, 500) };
+  }
+  return { type: 'unknown', raw: text.slice(0, 500) };
+}
+
+function parseArgs(argv) {
+  const args = argv.slice(2);
+  const out = {
+    apply: false, startRow: 0, limit: Infinity,
+    startDate: '1990-01-01', endDate: null, maxPages: Infinity,
+  };
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === '--apply') out.apply = true;
+    else if (a === '--start-row') out.startRow = parseInt(args[++i], 10);
+    else if (a === '--limit') out.limit = parseInt(args[++i], 10);
+    else if (a === '--start-date') out.startDate = args[++i];
+    else if (a === '--end-date') out.endDate = args[++i];
+    else if (a === '--max-pages') out.maxPages = parseInt(args[++i], 10);
+    else if (a === '--help' || a === '-h') {
+      const header = fs.readFileSync(__filename, 'utf8').split('\n').slice(0, 50).join('\n');
+      console.log(header);
+      process.exit(0);
+    }
+  }
+  return out;
+}
+
+const OPTS = parseArgs(process.argv);
+
+function politeDelay() {
+  const ms = 800 + Math.floor(Math.random() * 800);
+  return sleep(ms);
+}
+
+async function fetchJson(url, attempt = 1) {
+  const headers = { 'User-Agent': USER_AGENT, 'Accept': 'application/json' };
+  if (process.env.COURTLISTENER_TOKEN) {
+    headers['Authorization'] = `Token ${process.env.COURTLISTENER_TOKEN}`;
+  }
+  const resp = await fetch(url, { headers });
+  if (resp.status === 429 || resp.status === 503 || resp.status === 502) {
+    if (attempt > 8) throw new Error(`HTTP ${resp.status} after ${attempt} retries — ${url}`);
+    const baseMs = Math.min(60000, 3000 * Math.pow(2, attempt - 1));
+    const ms = baseMs + Math.floor(Math.random() * 2000);
+    console.error(`[ak] HTTP ${resp.status} attempt ${attempt}, backing off ${ms}ms`);
+    await sleep(ms);
+    return fetchJson(url, attempt + 1);
+  }
+  if (!resp.ok) throw new Error(`HTTP ${resp.status} ${resp.statusText} — ${url}`);
+  return resp.json();
+}
+
+// ── Caption parsing ─────────────────────────────────────────────────────────
+
+// AK discipline captions:
+//   "In the Disciplinary Matter Involving Joshua M. Kindred"
+//   "In the Disciplinary Matter Involving Nathan R. Michalski"
+//   "In the Disciplinary Matter Involving Ward M. Merdes, Attorney."
+// REJECT: "Honorable", "Judge", "Magistrate", "Justice" — those are
+// judicial-discipline matters under the same caption form.
+// REJECT: "Petition for Reinstatement" — those are not discipline orders.
+export function parseCaseName(rawCaption) {
+  if (!rawCaption) return { fullName: null };
+  const caption = rawCaption.replace(/<\/?mark>/g, '').replace(/\s+/g, ' ').trim();
+
+  // Reject reinstatement petitions and other side matters
+  if (/\b(petition\s+for\s+reinstatement|petition\s+of)\b/i.test(caption)) {
+    return { fullName: null };
+  }
+
+  // Match canonical AK caption — prefix can include trailing colon.
+  // Also accept legacy "In re <Name>" form when search is already
+  // discipline-context-anchored (snippet contains "Disciplinary Matter
+  // Involving" — which CL highlighted-search does match against this).
+  let m = caption.match(/^in\s+the\s+disciplinary\s+matter\s+involving[:\s]\s*(.+?)\s*$/i);
+  if (!m) {
+    m = caption.match(/^in\s+re\s+(.+?)\s*$/i);
+  }
+  if (!m) return { fullName: null };
+
+  let name = m[1].trim();
+  // Strip leading "Attorney " (some AK captions read "Involving Attorney <Name>")
+  name = name.replace(/^Attorney\s+/i, '').trim();
+  // Strip trailing role suffix: ", Attorney.", ", Esq.", ", Esquire"
+  name = name.replace(/,?\s*(Attorney\.?|Esq\.?|Esquire)\s*$/i, '').trim();
+  // Strip series suffix
+  name = name.replace(/\s*\((?:[IVX]+|\d+)\)\s*$/i, '').trim();
+  // Strip ", Jr.", ", Sr.", ", III"
+  name = name.replace(/,\s*(II|III|IV|V|Jr\.?|Sr\.?)\s*$/i, '').trim();
+  name = name.replace(/[.,]+$/, '').trim();
+
+  if (name.length < 2 || name.length > 150) return { fullName: null };
+
+  // Critical filter: judicial-discipline rejection (Judge Fallon etc.)
+  if (/\b(honorable|hon\.?|judge|magistrate|justice|district\s+court\s+judge|superior\s+court\s+judge)\b/i.test(name)) {
+    return { fullName: null };
+  }
+
+  if (/\b(LLC|Inc\.?|Corp\.?|Ltd\.?|Co\.?|Bank|Trust|Commission|Department|Board\b)\b/i.test(name)) {
+    return { fullName: null };
+  }
+
+  return { fullName: name };
+}
+
+// AK docket: "S" + 4-5 digits (e.g. "S19587", "S18006") — modern form
+//            OR "Supreme Court No. S-NNNNN" — older form (returned by some
+//            CL records for 2010-2017 cases)
+// Returns the normalized docket string ("S<digits>") on success, null otherwise.
+export function normalizeAkDocket(docketRaw) {
+  if (typeof docketRaw !== 'string') return null;
+  const stripped = docketRaw
+    .replace(/<\/?mark>/g, '')
+    .replace(/^Case Number:\s*/i, '')
+    .replace(/\.$/, '')
+    .trim();
+  // Modern form: S19587
+  let m = stripped.match(/^S(\d{4,5})$/i);
+  if (m) return `S${m[1]}`;
+  // Legacy form: "Supreme Court No. S-17026" / "Supreme Court No. S17026"
+  m = stripped.match(/^Supreme\s+Court\s+(?:No\.?|Number)?\s*S-?(\d{4,5})$/i);
+  if (m) return `S${m[1]}`;
+  // Older alternative: "S-17026" (with hyphen)
+  m = stripped.match(/^S-(\d{4,5})$/i);
+  if (m) return `S${m[1]}`;
+  return null;
+}
+
+export function isAkDocket(docketRaw) {
+  return normalizeAkDocket(docketRaw) !== null;
+}
+
+async function discoverViaCl() {
+  const byKey = new Map();
+
+  for (const [qFragment, sanctionType] of SANCTION_QUERIES) {
+    // Anchor on "Disciplinary Matter Involving" — the Alaska SC's canonical
+    // attorney-discipline caption form. This excludes incidental citations
+    // in unrelated opinions.
+    const baseQ = `"Disciplinary Matter Involving" AND (${qFragment})`;
+    let url =
+      CL_SEARCH_BASE +
+      `&q=${encodeURIComponent(baseQ)}` +
+      `&filed_after=${encodeURIComponent(OPTS.startDate)}` +
+      (OPTS.endDate ? `&filed_before=${encodeURIComponent(OPTS.endDate)}` : '');
+
+    let page = 0;
+    let pageSanctionAccepted = 0;
+    while (url && page < OPTS.maxPages) {
+      page++;
+      console.error(`[cl:${sanctionType}] page ${page} — fetching`);
+      const json = await fetchJson(url);
+      if (!Array.isArray(json.results)) {
+        console.error(`[cl:${sanctionType}] unexpected response shape — keys: ${Object.keys(json).join(', ')}`);
+        break;
+      }
+      for (const r of json.results) {
+        const record = buildRecordFromClResult(r, sanctionType);
+        if (!record) continue;
+        const dedupKey = `${record.bar_number}|${record.order_date || ''}`;
+        if (!byKey.has(dedupKey)) {
+          byKey.set(dedupKey, record);
+          pageSanctionAccepted++;
+        }
+      }
+      console.error(`[cl:${sanctionType}] page ${page}: ${json.results.length} results, total kept: ${byKey.size}`);
+      url = json.next || null;
+      if (url) await politeDelay();
+    }
+    console.error(`[cl:${sanctionType}] complete — accepted ${pageSanctionAccepted} new events`);
+  }
+  return [...byKey.values()];
+}
+
+async function load(records) {
+  const { client, cleanup } = await createBulkClient();
+  try {
+    await client.query(`SET statement_timeout = '30min'`);
+    await client.query(`SET idle_in_transaction_session_timeout = '5min'`);
+    await client.query(`DROP TABLE IF EXISTS public._stg_attorneys_ak`);
+    await client.query(`DROP TABLE IF EXISTS public._stg_discipline_ak`);
+    await client.query(`
+      CREATE UNLOGGED TABLE public._stg_attorneys_ak (
+        jurisdiction char(2), bar_number text, full_name text,
+        first_name text, last_name text, admission_date date,
+        current_status text, city text, source_url text
+      );
+      CREATE UNLOGGED TABLE public._stg_discipline_ak (
+        jurisdiction char(2), bar_number text, full_name text,
+        order_date date, effective_date date,
+        discipline_type text, discipline_raw text, violation_summary text,
+        order_url text, source_url text
+      );
+    `);
+
+    const byBar = new Map();
+    for (const r of records) {
+      if (!byBar.has(r.bar_number)) {
+        const clean = r.full_name.replace(/\s+/g, ' ').trim();
+        const parts = clean.split(' ');
+        const first = parts.length > 1 ? parts.slice(0, -1).join(' ') : null;
+        const last = parts[parts.length - 1];
+        byBar.set(r.bar_number, {
+          jurisdiction: JURISDICTION, bar_number: r.bar_number,
+          full_name: r.full_name, first_name: first, last_name: last,
+          admission_date: null, current_status: null, city: null,
+          source_url: r.source_url,
+        });
+      }
+    }
+
+    await bulkCopyRows(
+      client, '_stg_attorneys_ak',
+      ['jurisdiction', 'bar_number', 'full_name', 'first_name', 'last_name',
+       'admission_date', 'current_status', 'city', 'source_url'],
+      [...byBar.values()].map((a) => [
+        a.jurisdiction, a.bar_number, a.full_name, a.first_name, a.last_name,
+        a.admission_date, a.current_status, a.city, a.source_url,
+      ]),
+    );
+    await bulkCopyRows(
+      client, '_stg_discipline_ak',
+      ['jurisdiction', 'bar_number', 'full_name', 'order_date', 'effective_date',
+       'discipline_type', 'discipline_raw', 'violation_summary', 'order_url', 'source_url'],
+      records.map((r) => [
+        JURISDICTION, r.bar_number, r.full_name,
+        r.order_date, r.effective_date,
+        r.discipline_type, r.discipline_raw, r.violation_summary,
+        r.order_url, r.source_url,
+      ]),
+    );
+
+    const upsertAttorneys = await client.query(`
+      INSERT INTO public.attorneys
+        (jurisdiction, bar_number, full_name, first_name, last_name,
+         admission_date, current_status, city, source_url, last_seen_at)
+      SELECT jurisdiction, bar_number, full_name, first_name, last_name,
+             admission_date, current_status, city, source_url, NOW()
+      FROM _stg_attorneys_ak
+      ON CONFLICT (jurisdiction, bar_number) DO UPDATE SET
+        full_name      = EXCLUDED.full_name,
+        first_name     = COALESCE(EXCLUDED.first_name, public.attorneys.first_name),
+        last_name      = COALESCE(EXCLUDED.last_name, public.attorneys.last_name),
+        admission_date = COALESCE(EXCLUDED.admission_date, public.attorneys.admission_date),
+        city           = COALESCE(EXCLUDED.city, public.attorneys.city),
+        source_url     = COALESCE(EXCLUDED.source_url, public.attorneys.source_url),
+        last_seen_at   = NOW()
+      RETURNING id, bar_number;
+    `);
+    console.error(`[db] attorneys upserted: ${upsertAttorneys.rowCount}`);
+
+    const insertEvents = await client.query(`
+      INSERT INTO public.attorney_discipline_events
+        (attorney_id, jurisdiction, bar_number, full_name, order_date, effective_date,
+         discipline_type, discipline_raw, violation_summary, order_url, source_url)
+      SELECT a.id, s.jurisdiction, s.bar_number, s.full_name,
+             s.order_date, s.effective_date,
+             s.discipline_type, s.discipline_raw,
+             s.violation_summary, s.order_url, s.source_url
+      FROM _stg_discipline_ak s
+      JOIN public.attorneys a
+        ON a.jurisdiction = s.jurisdiction AND a.bar_number = s.bar_number
+      ON CONFLICT (jurisdiction, bar_number, order_date, discipline_type) DO NOTHING;
+    `);
+    console.error(`[db] discipline events inserted: ${insertEvents.rowCount}`);
+
+    await client.query(`DROP TABLE IF EXISTS public._stg_attorneys_ak, public._stg_discipline_ak`);
+  } finally {
+    await cleanup();
+  }
+}
+
+export function buildRecordFromClResult(r, assertedSanctionType) {
+  const docket = normalizeAkDocket(r.docketNumber || '');
+  if (!docket) return null;
+
+  const { fullName } = parseCaseName(r.caseName || '');
+  if (!fullName) return null;
+
+  if (!ALLOWED_DISCIPLINE_TYPES.has(assertedSanctionType)) return null;
+
+  const opinionSnippet = (r.opinions && r.opinions[0] && r.opinions[0].snippet) || '';
+  const cleanSnippet = opinionSnippet.replace(/<\/?mark>/g, '').replace(/&#x27;/g, "'").replace(/\s+/g, ' ').trim();
+
+  const orderDate = r.dateFiled || null;
+  const sourceUrl = r.absolute_url ? `${CL_OPINION_BASE}${r.absolute_url}` : null;
+  if (!sourceUrl) return null;
+
+  const barNumber = `AK:${docket.toUpperCase()}`;
+  const summary = cleanSnippet.slice(0, 2000);
+  return {
+    bar_number: barNumber, full_name: fullName,
+    order_date: orderDate, effective_date: null,
+    discipline_type: assertedSanctionType,
+    discipline_raw: cleanSnippet ? cleanSnippet.slice(0, 500) : null,
+    violation_summary: summary,
+    order_url: sourceUrl, source_url: sourceUrl,
+  };
+}
+
+async function main() {
+  console.error(
+    `[akbar] start — apply=${OPTS.apply} startDate=${OPTS.startDate}` +
+    (OPTS.endDate ? ` endDate=${OPTS.endDate}` : '') +
+    ` limit=${OPTS.limit} startRow=${OPTS.startRow}`
+  );
+
+  let records = await discoverViaCl();
+  if (OPTS.startRow > 0) records = records.slice(OPTS.startRow);
+  if (Number.isFinite(OPTS.limit)) records = records.slice(0, OPTS.limit);
+
+  console.error(`[akbar] collected ${records.length} discipline rows`);
+
+  const preview = records.slice(0, 3);
+  console.error('[akbar] first 3 rows:');
+  for (const r of preview) {
+    console.error(
+      `  · [${r.bar_number}] ${r.full_name} — ${r.discipline_type}` +
+      ` (order_date=${r.order_date || '?'}) — ${r.source_url}`
+    );
+  }
+
+  if (!OPTS.apply) {
+    console.error('[akbar] dry-run — pass --apply to write to DB');
+    return;
+  }
+  if (records.length === 0) {
+    console.error('[akbar] no records — nothing to load');
+    return;
+  }
+  await load(records);
+  console.error('[akbar] done');
+}
+
+if (import.meta.url === `file://${process.argv[1].replace(/\\/g, '/')}` ||
+    import.meta.url === `file:///${process.argv[1].replace(/\\/g, '/').replace(/^\//, '')}`) {
+  main().catch((err) => { console.error(err); process.exit(1); });
+}

--- a/scripts/ingest/scrape-dcbar-discipline.mjs
+++ b/scripts/ingest/scrape-dcbar-discipline.mjs
@@ -1,0 +1,405 @@
+// csv-bulk-checked: none-exists — CourtListener search API used for per-sanction filtering of D.C. Court of Appeals bar discipline opinions. CL has 1,651 "Office of Disciplinary Counsel/Board on Professional Responsibility" opinions on court=dc and 2,605 disbarment/suspension matches (probed 2026-04-27). dcbar.org/discipline publishes ODC orders but the listing requires JS-rendered pagination + per-attorney drill-down; D.C. Court of Appeals opinions on CL are the bulk-tractable surface (PR #185 OK/OR/CT pattern).
+// Template: scripts/ingest/scrape-nmbar-discipline.mjs
+// Pattern: cl-bulk-data-defensive #18 (COPY FROM STDIN via bulkCopyRows)
+//
+// District of Columbia Court of Appeals bar discipline scraper.
+//
+// Source discovery (probed 2026-04-27):
+//   Primary: CourtListener search API — court=dc + per-sanction queries
+//
+// DC caption shapes (verified live):
+//   "In re Brammer"                  → discipline (canonical)
+//   "In re Payne"                    → discipline
+//   "In re Robinson"                 → discipline
+//   "In re John A. Doe, Jr., Esquire" → discipline (formal full-name form)
+//
+// Filter: caseName must match "In re <Name>" or "In Re <Name>". DC's docket
+// number is the strong signal — the "BG" (Bar Grievance) suffix uniquely
+// identifies bar-discipline matters.
+//
+// DC docket: "NN-BG-NNNN" (e.g. "26-BG-0127", "26-BG-0209", "25-BG-0333").
+// "BG" = Bar Grievance. We ALSO accept the older "BG.NNN" form when present.
+//
+// REJECT dockets without BG suffix — DC also handles criminal appeals and
+// civil matters with "In re <Name>" caption (e.g. "In re Sealed Case",
+// "In re Estate of <Name>"). The BG docket gate is the noise filter.
+//
+// Discipline label mapping (DC CA → internal enum) — same as NM/NE.
+//
+// bar_number = "DC:<docketNumber>" — deterministic, idempotent.
+
+import fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { setTimeout as sleep } from 'node:timers/promises';
+
+import { createBulkClient, bulkCopyRows } from '../lib/pg-bulk-defaults.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+
+{
+  const ENV_PATH = 'C:/Users/email/projects/ImNotAnAttorney-web/.env.local';
+  const VALID_KEY_RX = /^[A-Z_][A-Z0-9_]*$/;
+  if (fs.existsSync(ENV_PATH)) {
+    const txt = fs.readFileSync(ENV_PATH, 'utf-8');
+    for (const rawLine of txt.split('\n')) {
+      let line = rawLine.endsWith('\r') ? rawLine.slice(0, -1) : rawLine;
+      line = line.trim();
+      if (!line || line[0] === '#') continue;
+      const eq = line.indexOf('=');
+      if (eq <= 0) continue;
+      const key = line.slice(0, eq).trim();
+      let val = line.slice(eq + 1).trim();
+      if (val.length >= 2 && ((val[0] === '"' && val[val.length - 1] === '"') ||
+          (val[0] === "'" && val[val.length - 1] === "'"))) {
+        val = val.slice(1, -1);
+      }
+      if (!VALID_KEY_RX.test(key)) continue;
+      if (!process.env[key]) process.env[key] = val;
+    }
+  }
+}
+
+const JURISDICTION = 'DC';
+const USER_AGENT =
+  'INAA-Crawler/1.0 (+https://imnotanattorney.com; contact: noreply-legal@inaa.com)';
+const CL_SEARCH_BASE =
+  'https://www.courtlistener.com/api/rest/v4/search/' +
+  '?type=o&court=dc&format=json&order_by=dateFiled+desc&highlight=on';
+
+const SANCTION_QUERIES = [
+  ['"reciprocal discipline"', 'reciprocal_discipline'],
+  ['"disability inactive"', 'disability_inactive'],
+  ['disbarred OR disbarment', 'disbarment'],
+  ['"resignation" OR "resigned"', 'resignation_with_charges'],
+  ['"interim suspension" OR "temporary suspension"', 'interim_suspension'],
+  ['suspended OR suspension', 'suspension'],
+  ['probation', 'probation'],
+  ['censured OR censure', 'censure'],
+  ['"public reprimand" OR "publicly reprimanded"', 'public_reprimand'],
+  ['"private reprimand" OR admonition OR admonishment', 'admonition'],
+];
+
+const CL_OPINION_BASE = 'https://www.courtlistener.com';
+
+const DISCIPLINE_PATTERNS = [
+  [/\breciprocal\s+disciplin/i, 'reciprocal_discipline'],
+  [/\bdisability\s+inactiv/i, 'disability_inactive'],
+  [/\bdisbar(red|ment|ring)/i, 'disbarment'],
+  [/\bresign(ation|ed)/i, 'resignation_with_charges'],
+  [/\binterim\s+suspen/i, 'interim_suspension'],
+  [/\btemporary\s+suspen/i, 'interim_suspension'],
+  [/\bsuspen(d|ded|sion)/i, 'suspension'],
+  [/\bprobation\b/i, 'probation'],
+  [/\bcensur(ed|e)\b/i, 'censure'],
+  [/\bpublic(ly)?\s+reprimand/i, 'public_reprimand'],
+  [/\bprivate\s+reprimand/i, 'admonition'],
+  [/\badmoni(tion|shed|shment)/i, 'admonition'],
+  [/\breprimand(ed)?\b/i, 'public_reprimand'],
+];
+
+export const ALLOWED_DISCIPLINE_TYPES = new Set([
+  'disbarment', 'suspension', 'interim_suspension', 'probation',
+  'public_reprimand', 'resignation_with_charges', 'censure',
+  'admonition', 'reciprocal_discipline', 'disability_inactive',
+]);
+
+export function normalizeDiscipline(text) {
+  if (!text) return { type: 'unknown', raw: null };
+  for (const [re, type] of DISCIPLINE_PATTERNS) {
+    if (re.test(text)) return { type, raw: text.slice(0, 500) };
+  }
+  return { type: 'unknown', raw: text.slice(0, 500) };
+}
+
+function parseArgs(argv) {
+  const args = argv.slice(2);
+  const out = {
+    apply: false, startRow: 0, limit: Infinity,
+    startDate: '1990-01-01', endDate: null, maxPages: Infinity,
+  };
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === '--apply') out.apply = true;
+    else if (a === '--start-row') out.startRow = parseInt(args[++i], 10);
+    else if (a === '--limit') out.limit = parseInt(args[++i], 10);
+    else if (a === '--start-date') out.startDate = args[++i];
+    else if (a === '--end-date') out.endDate = args[++i];
+    else if (a === '--max-pages') out.maxPages = parseInt(args[++i], 10);
+    else if (a === '--help' || a === '-h') {
+      const header = fs.readFileSync(__filename, 'utf8').split('\n').slice(0, 50).join('\n');
+      console.log(header);
+      process.exit(0);
+    }
+  }
+  return out;
+}
+
+const OPTS = parseArgs(process.argv);
+
+function politeDelay() {
+  const ms = 800 + Math.floor(Math.random() * 800);
+  return sleep(ms);
+}
+
+async function fetchJson(url, attempt = 1) {
+  const headers = { 'User-Agent': USER_AGENT, 'Accept': 'application/json' };
+  if (process.env.COURTLISTENER_TOKEN) {
+    headers['Authorization'] = `Token ${process.env.COURTLISTENER_TOKEN}`;
+  }
+  const resp = await fetch(url, { headers });
+  if (resp.status === 429 || resp.status === 503 || resp.status === 502) {
+    if (attempt > 8) throw new Error(`HTTP ${resp.status} after ${attempt} retries — ${url}`);
+    const baseMs = Math.min(60000, 3000 * Math.pow(2, attempt - 1));
+    const ms = baseMs + Math.floor(Math.random() * 2000);
+    console.error(`[dc] HTTP ${resp.status} attempt ${attempt}, backing off ${ms}ms`);
+    await sleep(ms);
+    return fetchJson(url, attempt + 1);
+  }
+  if (!resp.ok) throw new Error(`HTTP ${resp.status} ${resp.statusText} — ${url}`);
+  return resp.json();
+}
+
+// DC discipline caption: "In re <Name>" / "In Re <Name>"
+// REJECT: "In re Estate of <Name>", "In re Sealed Case", "In re Petition of"
+export function parseCaseName(rawCaption) {
+  if (!rawCaption) return { fullName: null };
+  const caption = rawCaption.replace(/<\/?mark>/g, '').replace(/\s+/g, ' ').trim();
+
+  // Reject estate/sealed/special-matter captions
+  if (/\bin\s+re\s+(estate|sealed|petition|application|matter|appeal|grand\s+jury)\b/i.test(caption)) {
+    return { fullName: null };
+  }
+
+  const m = caption.match(/^in\s+re\s+(.+?)\s*$/i);
+  if (!m) return { fullName: null };
+
+  let name = m[1].trim();
+  name = name.replace(/\s*\((?:[IVX]+|\d+)\)\s*$/i, '').trim();
+  name = name.replace(/,\s*(II|III|IV|V|Jr\.?|Sr\.?|Esq\.?|Esquire)\s*$/i, '').trim();
+  name = name.replace(/[.,]+$/, '').trim();
+
+  if (name.length < 2 || name.length > 150) return { fullName: null };
+
+  if (/\b(LLC|Inc\.?|Corp\.?|Ltd\.?|Co\.?|Bank|Trust|Estate|Commission)\b/i.test(name)) {
+    return { fullName: null };
+  }
+  return { fullName: name };
+}
+
+// DC docket: "NN-BG-NNNN" (Bar Grievance docket suffix is the noise filter)
+export function isDcDocket(docket) {
+  if (typeof docket !== 'string') return false;
+  const d = docket.trim().replace(/\.$/, '');
+  return /^\d{2}-BG-\d{2,5}$/i.test(d);
+}
+
+async function discoverViaCl() {
+  const byKey = new Map();
+
+  for (const [qFragment, sanctionType] of SANCTION_QUERIES) {
+    // Anchor on Office of Disciplinary Counsel / Board on Professional
+    // Responsibility — the strongest DC discipline-context anchor.
+    const baseQ = `("Office of Disciplinary Counsel" OR "Board on Professional Responsibility") AND (${qFragment})`;
+    let url =
+      CL_SEARCH_BASE +
+      `&q=${encodeURIComponent(baseQ)}` +
+      `&filed_after=${encodeURIComponent(OPTS.startDate)}` +
+      (OPTS.endDate ? `&filed_before=${encodeURIComponent(OPTS.endDate)}` : '');
+
+    let page = 0;
+    let pageSanctionAccepted = 0;
+    while (url && page < OPTS.maxPages) {
+      page++;
+      console.error(`[cl:${sanctionType}] page ${page} — fetching`);
+      const json = await fetchJson(url);
+      if (!Array.isArray(json.results)) {
+        console.error(`[cl:${sanctionType}] unexpected response shape — keys: ${Object.keys(json).join(', ')}`);
+        break;
+      }
+      for (const r of json.results) {
+        const record = buildRecordFromClResult(r, sanctionType);
+        if (!record) continue;
+        const dedupKey = `${record.bar_number}|${record.order_date || ''}`;
+        if (!byKey.has(dedupKey)) {
+          byKey.set(dedupKey, record);
+          pageSanctionAccepted++;
+        }
+      }
+      console.error(`[cl:${sanctionType}] page ${page}: ${json.results.length} results, total kept: ${byKey.size}`);
+      url = json.next || null;
+      if (url) await politeDelay();
+    }
+    console.error(`[cl:${sanctionType}] complete — accepted ${pageSanctionAccepted} new events`);
+  }
+  return [...byKey.values()];
+}
+
+async function load(records) {
+  const { client, cleanup } = await createBulkClient();
+  try {
+    await client.query(`SET statement_timeout = '30min'`);
+    await client.query(`SET idle_in_transaction_session_timeout = '5min'`);
+    await client.query(`DROP TABLE IF EXISTS public._stg_attorneys_dc`);
+    await client.query(`DROP TABLE IF EXISTS public._stg_discipline_dc`);
+    await client.query(`
+      CREATE UNLOGGED TABLE public._stg_attorneys_dc (
+        jurisdiction char(2), bar_number text, full_name text,
+        first_name text, last_name text, admission_date date,
+        current_status text, city text, source_url text
+      );
+      CREATE UNLOGGED TABLE public._stg_discipline_dc (
+        jurisdiction char(2), bar_number text, full_name text,
+        order_date date, effective_date date,
+        discipline_type text, discipline_raw text, violation_summary text,
+        order_url text, source_url text
+      );
+    `);
+
+    const byBar = new Map();
+    for (const r of records) {
+      if (!byBar.has(r.bar_number)) {
+        const clean = r.full_name.replace(/\s+/g, ' ').trim();
+        const parts = clean.split(' ');
+        const first = parts.length > 1 ? parts.slice(0, -1).join(' ') : null;
+        const last = parts[parts.length - 1];
+        byBar.set(r.bar_number, {
+          jurisdiction: JURISDICTION, bar_number: r.bar_number,
+          full_name: r.full_name, first_name: first, last_name: last,
+          admission_date: null, current_status: null, city: null,
+          source_url: r.source_url,
+        });
+      }
+    }
+
+    await bulkCopyRows(
+      client, '_stg_attorneys_dc',
+      ['jurisdiction', 'bar_number', 'full_name', 'first_name', 'last_name',
+       'admission_date', 'current_status', 'city', 'source_url'],
+      [...byBar.values()].map((a) => [
+        a.jurisdiction, a.bar_number, a.full_name, a.first_name, a.last_name,
+        a.admission_date, a.current_status, a.city, a.source_url,
+      ]),
+    );
+    await bulkCopyRows(
+      client, '_stg_discipline_dc',
+      ['jurisdiction', 'bar_number', 'full_name', 'order_date', 'effective_date',
+       'discipline_type', 'discipline_raw', 'violation_summary', 'order_url', 'source_url'],
+      records.map((r) => [
+        JURISDICTION, r.bar_number, r.full_name,
+        r.order_date, r.effective_date,
+        r.discipline_type, r.discipline_raw, r.violation_summary,
+        r.order_url, r.source_url,
+      ]),
+    );
+
+    const upsertAttorneys = await client.query(`
+      INSERT INTO public.attorneys
+        (jurisdiction, bar_number, full_name, first_name, last_name,
+         admission_date, current_status, city, source_url, last_seen_at)
+      SELECT jurisdiction, bar_number, full_name, first_name, last_name,
+             admission_date, current_status, city, source_url, NOW()
+      FROM _stg_attorneys_dc
+      ON CONFLICT (jurisdiction, bar_number) DO UPDATE SET
+        full_name      = EXCLUDED.full_name,
+        first_name     = COALESCE(EXCLUDED.first_name, public.attorneys.first_name),
+        last_name      = COALESCE(EXCLUDED.last_name, public.attorneys.last_name),
+        admission_date = COALESCE(EXCLUDED.admission_date, public.attorneys.admission_date),
+        city           = COALESCE(EXCLUDED.city, public.attorneys.city),
+        source_url     = COALESCE(EXCLUDED.source_url, public.attorneys.source_url),
+        last_seen_at   = NOW()
+      RETURNING id, bar_number;
+    `);
+    console.error(`[db] attorneys upserted: ${upsertAttorneys.rowCount}`);
+
+    const insertEvents = await client.query(`
+      INSERT INTO public.attorney_discipline_events
+        (attorney_id, jurisdiction, bar_number, full_name, order_date, effective_date,
+         discipline_type, discipline_raw, violation_summary, order_url, source_url)
+      SELECT a.id, s.jurisdiction, s.bar_number, s.full_name,
+             s.order_date, s.effective_date,
+             s.discipline_type, s.discipline_raw,
+             s.violation_summary, s.order_url, s.source_url
+      FROM _stg_discipline_dc s
+      JOIN public.attorneys a
+        ON a.jurisdiction = s.jurisdiction AND a.bar_number = s.bar_number
+      ON CONFLICT (jurisdiction, bar_number, order_date, discipline_type) DO NOTHING;
+    `);
+    console.error(`[db] discipline events inserted: ${insertEvents.rowCount}`);
+
+    await client.query(`DROP TABLE IF EXISTS public._stg_attorneys_dc, public._stg_discipline_dc`);
+  } finally {
+    await cleanup();
+  }
+}
+
+export function buildRecordFromClResult(r, assertedSanctionType) {
+  const docket = (r.docketNumber || '')
+    .replace(/<\/?mark>/g, '')
+    .replace(/^Case Number:\s*/i, '')
+    .replace(/\.$/, '')
+    .trim();
+
+  if (!isDcDocket(docket)) return null;
+
+  const { fullName } = parseCaseName(r.caseName || '');
+  if (!fullName) return null;
+
+  if (!ALLOWED_DISCIPLINE_TYPES.has(assertedSanctionType)) return null;
+
+  const opinionSnippet = (r.opinions && r.opinions[0] && r.opinions[0].snippet) || '';
+  const cleanSnippet = opinionSnippet.replace(/<\/?mark>/g, '').replace(/&#x27;/g, "'").replace(/\s+/g, ' ').trim();
+
+  const orderDate = r.dateFiled || null;
+  const sourceUrl = r.absolute_url ? `${CL_OPINION_BASE}${r.absolute_url}` : null;
+  if (!sourceUrl) return null;
+
+  const barNumber = `DC:${docket.toUpperCase()}`;
+  const summary = cleanSnippet.slice(0, 2000);
+  return {
+    bar_number: barNumber, full_name: fullName,
+    order_date: orderDate, effective_date: null,
+    discipline_type: assertedSanctionType,
+    discipline_raw: cleanSnippet ? cleanSnippet.slice(0, 500) : null,
+    violation_summary: summary,
+    order_url: sourceUrl, source_url: sourceUrl,
+  };
+}
+
+async function main() {
+  console.error(
+    `[dcbar] start — apply=${OPTS.apply} startDate=${OPTS.startDate}` +
+    (OPTS.endDate ? ` endDate=${OPTS.endDate}` : '') +
+    ` limit=${OPTS.limit} startRow=${OPTS.startRow}`
+  );
+
+  let records = await discoverViaCl();
+  if (OPTS.startRow > 0) records = records.slice(OPTS.startRow);
+  if (Number.isFinite(OPTS.limit)) records = records.slice(0, OPTS.limit);
+
+  console.error(`[dcbar] collected ${records.length} discipline rows`);
+
+  const preview = records.slice(0, 3);
+  console.error('[dcbar] first 3 rows:');
+  for (const r of preview) {
+    console.error(
+      `  · [${r.bar_number}] ${r.full_name} — ${r.discipline_type}` +
+      ` (order_date=${r.order_date || '?'}) — ${r.source_url}`
+    );
+  }
+
+  if (!OPTS.apply) {
+    console.error('[dcbar] dry-run — pass --apply to write to DB');
+    return;
+  }
+  if (records.length === 0) {
+    console.error('[dcbar] no records — nothing to load');
+    return;
+  }
+  await load(records);
+  console.error('[dcbar] done');
+}
+
+if (import.meta.url === `file://${process.argv[1].replace(/\\/g, '/')}` ||
+    import.meta.url === `file:///${process.argv[1].replace(/\\/g, '/').replace(/^\//, '')}`) {
+  main().catch((err) => { console.error(err); process.exit(1); });
+}

--- a/scripts/ingest/scrape-ndbar-discipline.mjs
+++ b/scripts/ingest/scrape-ndbar-discipline.mjs
@@ -1,0 +1,443 @@
+// csv-bulk-checked: none-exists — CourtListener search API used for per-sanction filtering of North Dakota Supreme Court bar discipline opinions. CL has 568+ "Disciplinary Board" opinions on court=nd (probed 2026-04-27). ndcourts.gov publishes Disciplinary Action releases but the public archive is HTML across multiple pages without a structured listing endpoint; ND SC opinions on CL are the bulk-tractable surface (PR #185 OK/OR/CT pattern).
+// Template: scripts/ingest/scrape-nmbar-discipline.mjs
+// Pattern: cl-bulk-data-defensive #18 (COPY FROM STDIN via bulkCopyRows)
+//
+// North Dakota Supreme Court bar discipline scraper.
+//
+// Source discovery (probed 2026-04-27):
+//   Primary: CourtListener search API — court=nd + per-sanction queries
+//
+// ND caption shapes (verified live):
+//   "Disciplinary Board v. Merkens"               → discipline (canonical)
+//   "Disciplinary Board v. Spencer"               → discipline
+//   "Disciplinary Board v. Spencer (Interim Suspension)" → discipline (parenthetical)
+//   "Disciplinary Board v. Spencer 2024 ND 28"    → discipline (citation suffix)
+//   "Disciplinary Board v. Daniel 2024 ND 191"    → discipline
+//   "Reciprocal Discipline of Odegaard"           → reciprocal
+//   "Reciprocal Discipline of Odegaard 2025 ND 118" → reciprocal (citation suffix)
+//   "State v. Cooper"                             → SKIP (criminal)
+//   "Bauer v. Adam"                               → SKIP (civil)
+//
+// Filter: caseName must match "Disciplinary Board v. <Name>" or
+// "Reciprocal Discipline of <Name>". Strip trailing citation suffix
+// (e.g. "2025 ND 118") and parenthetical stage labels.
+//
+// ND docket: 8-digit numeric with optional "No." prefix (e.g. "No. 20250115",
+// "No. 20240339"). Multi-docket strings ("Nos. 20250300-20250302") are also
+// valid — normalize to first docket in range.
+//
+// Discipline label mapping (ND SC → internal enum) — same as NM/NE.
+//
+// bar_number = "ND:<docketNumber>" — deterministic, idempotent.
+//
+// Polite scraping: 800-1600 ms randomized delay between CL page requests.
+
+import fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { setTimeout as sleep } from 'node:timers/promises';
+
+import { createBulkClient, bulkCopyRows } from '../lib/pg-bulk-defaults.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+
+// ── Env loader (inline) ─────────────────────────────────────────────────────
+{
+  const ENV_PATH = 'C:/Users/email/projects/ImNotAnAttorney-web/.env.local';
+  const VALID_KEY_RX = /^[A-Z_][A-Z0-9_]*$/;
+  if (fs.existsSync(ENV_PATH)) {
+    const txt = fs.readFileSync(ENV_PATH, 'utf-8');
+    for (const rawLine of txt.split('\n')) {
+      let line = rawLine.endsWith('\r') ? rawLine.slice(0, -1) : rawLine;
+      line = line.trim();
+      if (!line || line[0] === '#') continue;
+      const eq = line.indexOf('=');
+      if (eq <= 0) continue;
+      const key = line.slice(0, eq).trim();
+      let val = line.slice(eq + 1).trim();
+      if (val.length >= 2 && ((val[0] === '"' && val[val.length - 1] === '"') ||
+          (val[0] === "'" && val[val.length - 1] === "'"))) {
+        val = val.slice(1, -1);
+      }
+      if (!VALID_KEY_RX.test(key)) continue;
+      if (!process.env[key]) process.env[key] = val;
+    }
+  }
+}
+
+const JURISDICTION = 'ND';
+const USER_AGENT =
+  'INAA-Crawler/1.0 (+https://imnotanattorney.com; contact: noreply-legal@inaa.com)';
+const CL_SEARCH_BASE =
+  'https://www.courtlistener.com/api/rest/v4/search/' +
+  '?type=o&court=nd&format=json&order_by=dateFiled+desc&highlight=on';
+
+const SANCTION_QUERIES = [
+  ['"reciprocal discipline"', 'reciprocal_discipline'],
+  ['"disability inactive"', 'disability_inactive'],
+  ['disbarred OR disbarment', 'disbarment'],
+  ['"resignation" OR "resigned"', 'resignation_with_charges'],
+  ['"interim suspension" OR "temporary suspension"', 'interim_suspension'],
+  ['suspended OR suspension', 'suspension'],
+  ['probation', 'probation'],
+  ['censured OR censure', 'censure'],
+  ['"public reprimand" OR "publicly reprimanded"', 'public_reprimand'],
+  ['"private reprimand" OR admonition', 'admonition'],
+];
+
+const CL_OPINION_BASE = 'https://www.courtlistener.com';
+
+const DISCIPLINE_PATTERNS = [
+  [/\breciprocal\s+disciplin/i, 'reciprocal_discipline'],
+  [/\bdisability\s+inactiv/i, 'disability_inactive'],
+  [/\bdisbar(red|ment|ring)/i, 'disbarment'],
+  [/\bresign(ation|ed)/i, 'resignation_with_charges'],
+  [/\binterim\s+suspen/i, 'interim_suspension'],
+  [/\btemporary\s+suspen/i, 'interim_suspension'],
+  [/\bsuspen(d|ded|sion)/i, 'suspension'],
+  [/\bprobation\b/i, 'probation'],
+  [/\bcensur(ed|e)\b/i, 'censure'],
+  [/\bpublic(ly)?\s+reprimand/i, 'public_reprimand'],
+  [/\bprivate\s+reprimand/i, 'admonition'],
+  [/\badmoni(tion|shed)/i, 'admonition'],
+  [/\breprimand(ed)?\b/i, 'public_reprimand'],
+];
+
+export const ALLOWED_DISCIPLINE_TYPES = new Set([
+  'disbarment', 'suspension', 'interim_suspension', 'probation',
+  'public_reprimand', 'resignation_with_charges', 'censure',
+  'admonition', 'reciprocal_discipline', 'disability_inactive',
+]);
+
+export function normalizeDiscipline(text) {
+  if (!text) return { type: 'unknown', raw: null };
+  for (const [re, type] of DISCIPLINE_PATTERNS) {
+    if (re.test(text)) return { type, raw: text.slice(0, 500) };
+  }
+  return { type: 'unknown', raw: text.slice(0, 500) };
+}
+
+// ── CLI ─────────────────────────────────────────────────────────────────────
+
+function parseArgs(argv) {
+  const args = argv.slice(2);
+  const out = {
+    apply: false, startRow: 0, limit: Infinity,
+    startDate: '1990-01-01', endDate: null, maxPages: Infinity,
+  };
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === '--apply') out.apply = true;
+    else if (a === '--start-row') out.startRow = parseInt(args[++i], 10);
+    else if (a === '--limit') out.limit = parseInt(args[++i], 10);
+    else if (a === '--start-date') out.startDate = args[++i];
+    else if (a === '--end-date') out.endDate = args[++i];
+    else if (a === '--max-pages') out.maxPages = parseInt(args[++i], 10);
+    else if (a === '--help' || a === '-h') {
+      const header = fs.readFileSync(__filename, 'utf8').split('\n').slice(0, 50).join('\n');
+      console.log(header);
+      process.exit(0);
+    }
+  }
+  return out;
+}
+
+const OPTS = parseArgs(process.argv);
+
+function politeDelay() {
+  const ms = 800 + Math.floor(Math.random() * 800);
+  return sleep(ms);
+}
+
+async function fetchJson(url, attempt = 1) {
+  const headers = { 'User-Agent': USER_AGENT, 'Accept': 'application/json' };
+  if (process.env.COURTLISTENER_TOKEN) {
+    headers['Authorization'] = `Token ${process.env.COURTLISTENER_TOKEN}`;
+  }
+  const resp = await fetch(url, { headers });
+  if (resp.status === 429 || resp.status === 503 || resp.status === 502) {
+    if (attempt > 8) throw new Error(`HTTP ${resp.status} after ${attempt} retries — ${url}`);
+    const baseMs = Math.min(60000, 3000 * Math.pow(2, attempt - 1));
+    const ms = baseMs + Math.floor(Math.random() * 2000);
+    console.error(`[nd] HTTP ${resp.status} attempt ${attempt}, backing off ${ms}ms`);
+    await sleep(ms);
+    return fetchJson(url, attempt + 1);
+  }
+  if (!resp.ok) throw new Error(`HTTP ${resp.status} ${resp.statusText} — ${url}`);
+  return resp.json();
+}
+
+// ── Caption parsing ─────────────────────────────────────────────────────────
+
+// Strip trailing ND-citation suffix " 2024 ND 28" etc.
+function stripCitation(s) {
+  return s.replace(/\s+\d{4}\s+ND\s+\d+\s*$/i, '').trim();
+}
+
+// ND discipline captions:
+//   "Disciplinary Board v. Merkens"
+//   "Disciplinary Board v. Spencer (Interim Suspension)"
+//   "Disciplinary Board v. Spencer 2024 ND 28"  → strip citation
+//   "Reciprocal Discipline of Odegaard"
+//   "Reciprocal Discipline of Odegaard 2025 ND 118"
+export function parseCaseName(rawCaption) {
+  if (!rawCaption) return { fullName: null };
+  let caption = rawCaption.replace(/<\/?mark>/g, '').replace(/\s+/g, ' ').trim();
+  caption = stripCitation(caption);
+
+  // Try "Disciplinary Board v. <Name>"
+  let m = caption.match(/^disciplinary\s+board\s+v\.?\s+(.+?)\s*$/i);
+  if (!m) {
+    // Try "Reciprocal Discipline of <Name>"
+    m = caption.match(/^reciprocal\s+discipline\s+of\s+(.+?)\s*$/i);
+  }
+  if (!m) return { fullName: null };
+
+  let name = m[1].trim();
+  // Strip parenthetical stage labels: "(Interim Suspension)", "(II)"
+  name = name.replace(/\s*\([^)]*\)\s*$/i, '').trim();
+  // Strip ", Jr.", ", Sr.", ", III", ", Esq."
+  name = name.replace(/,\s*(II|III|IV|V|Jr\.?|Sr\.?|Esq\.?)\s*$/i, '').trim();
+  // Strip trailing periods/commas
+  name = name.replace(/[.,]+$/, '').trim();
+
+  if (name.length < 2 || name.length > 150) return { fullName: null };
+
+  if (/\b(LLC|Inc\.?|Corp\.?|Ltd\.?|Co\.?|Bank|Trust)\b/i.test(name)) {
+    return { fullName: null };
+  }
+  return { fullName: name };
+}
+
+// ND docket: "No. NNNNNNNN" (8 digits) or "Nos. NNNNNNNN-NNNNNNNN" (range).
+// Normalize to first 8-digit number.
+export function normalizeNdDocket(docketRaw) {
+  if (typeof docketRaw !== 'string') return null;
+  const stripped = docketRaw
+    .replace(/<\/?mark>/g, '')
+    .replace(/^Case Number:\s*/i, '')
+    .replace(/^Nos?\.?\s*/i, '')
+    .trim();
+  const m = stripped.match(/^(\d{8})(?:[-,\s]|$)/);
+  if (!m) return null;
+  return m[1];
+}
+
+export function isNdDocket(docketRaw) {
+  return normalizeNdDocket(docketRaw) !== null;
+}
+
+// ── CL discovery ──────────────────────────────────────────────────────────
+
+async function discoverViaCl() {
+  const byKey = new Map();
+
+  for (const [qFragment, sanctionType] of SANCTION_QUERIES) {
+    const baseQ = `("Disciplinary Board" OR "Disciplinary Counsel") AND (${qFragment})`;
+    let url =
+      CL_SEARCH_BASE +
+      `&q=${encodeURIComponent(baseQ)}` +
+      `&filed_after=${encodeURIComponent(OPTS.startDate)}` +
+      (OPTS.endDate ? `&filed_before=${encodeURIComponent(OPTS.endDate)}` : '');
+
+    let page = 0;
+    let pageSanctionAccepted = 0;
+    while (url && page < OPTS.maxPages) {
+      page++;
+      console.error(`[cl:${sanctionType}] page ${page} — fetching`);
+      const json = await fetchJson(url);
+      if (!Array.isArray(json.results)) {
+        console.error(`[cl:${sanctionType}] unexpected response shape — keys: ${Object.keys(json).join(', ')}`);
+        break;
+      }
+      for (const r of json.results) {
+        const record = buildRecordFromClResult(r, sanctionType);
+        if (!record) continue;
+        const dedupKey = `${record.bar_number}|${record.order_date || ''}`;
+        if (!byKey.has(dedupKey)) {
+          byKey.set(dedupKey, record);
+          pageSanctionAccepted++;
+        }
+      }
+      console.error(`[cl:${sanctionType}] page ${page}: ${json.results.length} results, total kept: ${byKey.size}`);
+      url = json.next || null;
+      if (url) await politeDelay();
+    }
+    console.error(`[cl:${sanctionType}] complete — accepted ${pageSanctionAccepted} new events`);
+  }
+  return [...byKey.values()];
+}
+
+// ── Load ─────────────────────────────────────────────────────────────────────
+
+async function load(records) {
+  const { client, cleanup } = await createBulkClient();
+  try {
+    await client.query(`SET statement_timeout = '30min'`);
+    await client.query(`SET idle_in_transaction_session_timeout = '5min'`);
+    await client.query(`DROP TABLE IF EXISTS public._stg_attorneys_nd`);
+    await client.query(`DROP TABLE IF EXISTS public._stg_discipline_nd`);
+    await client.query(`
+      CREATE UNLOGGED TABLE public._stg_attorneys_nd (
+        jurisdiction char(2), bar_number text, full_name text,
+        first_name text, last_name text, admission_date date,
+        current_status text, city text, source_url text
+      );
+      CREATE UNLOGGED TABLE public._stg_discipline_nd (
+        jurisdiction char(2), bar_number text, full_name text,
+        order_date date, effective_date date,
+        discipline_type text, discipline_raw text, violation_summary text,
+        order_url text, source_url text
+      );
+    `);
+
+    const byBar = new Map();
+    for (const r of records) {
+      if (!byBar.has(r.bar_number)) {
+        const clean = r.full_name.replace(/\s+/g, ' ').trim();
+        const parts = clean.split(' ');
+        const first = parts.length > 1 ? parts.slice(0, -1).join(' ') : null;
+        const last = parts[parts.length - 1];
+        byBar.set(r.bar_number, {
+          jurisdiction: JURISDICTION,
+          bar_number: r.bar_number,
+          full_name: r.full_name,
+          first_name: first, last_name: last,
+          admission_date: null, current_status: null, city: null,
+          source_url: r.source_url,
+        });
+      }
+    }
+
+    await bulkCopyRows(
+      client, '_stg_attorneys_nd',
+      ['jurisdiction', 'bar_number', 'full_name', 'first_name', 'last_name',
+       'admission_date', 'current_status', 'city', 'source_url'],
+      [...byBar.values()].map((a) => [
+        a.jurisdiction, a.bar_number, a.full_name, a.first_name, a.last_name,
+        a.admission_date, a.current_status, a.city, a.source_url,
+      ]),
+    );
+    await bulkCopyRows(
+      client, '_stg_discipline_nd',
+      ['jurisdiction', 'bar_number', 'full_name', 'order_date', 'effective_date',
+       'discipline_type', 'discipline_raw', 'violation_summary', 'order_url', 'source_url'],
+      records.map((r) => [
+        JURISDICTION, r.bar_number, r.full_name,
+        r.order_date, r.effective_date,
+        r.discipline_type, r.discipline_raw, r.violation_summary,
+        r.order_url, r.source_url,
+      ]),
+    );
+
+    const upsertAttorneys = await client.query(`
+      INSERT INTO public.attorneys
+        (jurisdiction, bar_number, full_name, first_name, last_name,
+         admission_date, current_status, city, source_url, last_seen_at)
+      SELECT jurisdiction, bar_number, full_name, first_name, last_name,
+             admission_date, current_status, city, source_url, NOW()
+      FROM _stg_attorneys_nd
+      ON CONFLICT (jurisdiction, bar_number) DO UPDATE SET
+        full_name      = EXCLUDED.full_name,
+        first_name     = COALESCE(EXCLUDED.first_name, public.attorneys.first_name),
+        last_name      = COALESCE(EXCLUDED.last_name, public.attorneys.last_name),
+        admission_date = COALESCE(EXCLUDED.admission_date, public.attorneys.admission_date),
+        city           = COALESCE(EXCLUDED.city, public.attorneys.city),
+        source_url     = COALESCE(EXCLUDED.source_url, public.attorneys.source_url),
+        last_seen_at   = NOW()
+      RETURNING id, bar_number;
+    `);
+    console.error(`[db] attorneys upserted: ${upsertAttorneys.rowCount}`);
+
+    const insertEvents = await client.query(`
+      INSERT INTO public.attorney_discipline_events
+        (attorney_id, jurisdiction, bar_number, full_name, order_date, effective_date,
+         discipline_type, discipline_raw, violation_summary, order_url, source_url)
+      SELECT a.id, s.jurisdiction, s.bar_number, s.full_name,
+             s.order_date, s.effective_date,
+             s.discipline_type, s.discipline_raw,
+             s.violation_summary, s.order_url, s.source_url
+      FROM _stg_discipline_nd s
+      JOIN public.attorneys a
+        ON a.jurisdiction = s.jurisdiction AND a.bar_number = s.bar_number
+      ON CONFLICT (jurisdiction, bar_number, order_date, discipline_type) DO NOTHING;
+    `);
+    console.error(`[db] discipline events inserted: ${insertEvents.rowCount}`);
+
+    await client.query(`DROP TABLE IF EXISTS public._stg_attorneys_nd, public._stg_discipline_nd`);
+  } finally {
+    await cleanup();
+  }
+}
+
+// ── buildRecordFromClResult ──────────────────────────────────────────────────
+
+export function buildRecordFromClResult(r, assertedSanctionType) {
+  const docketRaw = r.docketNumber || '';
+  const docket = normalizeNdDocket(docketRaw);
+  if (!docket) return null;
+
+  const { fullName } = parseCaseName(r.caseName || '');
+  if (!fullName) return null;
+
+  if (!ALLOWED_DISCIPLINE_TYPES.has(assertedSanctionType)) return null;
+
+  const opinionSnippet = (r.opinions && r.opinions[0] && r.opinions[0].snippet) || '';
+  const cleanSnippet = opinionSnippet.replace(/<\/?mark>/g, '').replace(/&#x27;/g, "'").replace(/\s+/g, ' ').trim();
+
+  const orderDate = r.dateFiled || null;
+  const sourceUrl = r.absolute_url ? `${CL_OPINION_BASE}${r.absolute_url}` : null;
+  if (!sourceUrl) return null;
+
+  const barNumber = `ND:${docket}`;
+  const summary = cleanSnippet.slice(0, 2000);
+  return {
+    bar_number: barNumber, full_name: fullName,
+    order_date: orderDate, effective_date: null,
+    discipline_type: assertedSanctionType,
+    discipline_raw: cleanSnippet ? cleanSnippet.slice(0, 500) : null,
+    violation_summary: summary,
+    order_url: sourceUrl, source_url: sourceUrl,
+  };
+}
+
+// ── Main ─────────────────────────────────────────────────────────────────────
+
+async function main() {
+  console.error(
+    `[ndbar] start — apply=${OPTS.apply} startDate=${OPTS.startDate}` +
+    (OPTS.endDate ? ` endDate=${OPTS.endDate}` : '') +
+    ` limit=${OPTS.limit} startRow=${OPTS.startRow}`
+  );
+
+  let records = await discoverViaCl();
+  if (OPTS.startRow > 0) records = records.slice(OPTS.startRow);
+  if (Number.isFinite(OPTS.limit)) records = records.slice(0, OPTS.limit);
+
+  console.error(`[ndbar] collected ${records.length} discipline rows`);
+
+  const preview = records.slice(0, 3);
+  console.error('[ndbar] first 3 rows:');
+  for (const r of preview) {
+    console.error(
+      `  · [${r.bar_number}] ${r.full_name} — ${r.discipline_type}` +
+      ` (order_date=${r.order_date || '?'}) — ${r.source_url}`
+    );
+  }
+
+  if (!OPTS.apply) {
+    console.error('[ndbar] dry-run — pass --apply to write to DB');
+    return;
+  }
+  if (records.length === 0) {
+    console.error('[ndbar] no records — nothing to load');
+    return;
+  }
+
+  await load(records);
+  console.error('[ndbar] done');
+}
+
+if (import.meta.url === `file://${process.argv[1].replace(/\\/g, '/')}` ||
+    import.meta.url === `file:///${process.argv[1].replace(/\\/g, '/').replace(/^\//, '')}`) {
+  main().catch((err) => { console.error(err); process.exit(1); });
+}

--- a/scripts/ingest/scrape-sdbar-discipline.mjs
+++ b/scripts/ingest/scrape-sdbar-discipline.mjs
@@ -1,0 +1,514 @@
+// csv-bulk-checked: none-exists — CourtListener search API used for per-sanction filtering of South Dakota Supreme Court bar discipline opinions. CL has 95 anchored opinions and 58 "In re Discipline" matches on court=sd (probed 2026-04-27). statebarofsouthdakota.com publishes Discipline reports as PDFs but the listing page lacks a structured archive; SD SC opinions on CL are the authoritative scrape surface (PR #185 OK/OR/CT pattern).
+// Template: scripts/ingest/scrape-nmbar-discipline.mjs
+// Pattern: cl-bulk-data-defensive #18 (COPY FROM STDIN via bulkCopyRows)
+//
+// South Dakota Supreme Court bar discipline scraper.
+//
+// Source discovery (probed 2026-04-27):
+//   Primary: CourtListener search API — court=sd + per-sanction queries
+//     https://www.courtlistener.com/api/rest/v4/search/?type=o&court=sd&q=...
+//
+// SD caption shapes (verified live):
+//   "Discipline of Volesky"            → discipline (canonical)
+//   "Discipline of Ravnsborg"          → discipline
+//   "Discipline of Frauenshuh"         → discipline
+//   "Discipline of Swier"              → discipline (multi-stage same docket OK)
+//   "Reciprocal Discipline of <Name>"  → discipline (reciprocal)
+//   "Estate of Mack"                   → SKIP (probate)
+//   "State v. Cooper"                  → SKIP (criminal)
+//   "Dissolution of Healy Ranch, Inc." → SKIP (corporate)
+//
+// Filter: caseName must match "Discipline of <Name>" or
+// "Reciprocal Discipline of <Name>". The "of <Name>" anchor is the noise gate
+// against probate ("Estate of <Name>") and corporate dissolution.
+//
+// SD docket: 5-digit numeric, no prefix (e.g. "30736", "29156", "30354").
+//
+// Discipline label mapping (SD SC → internal enum):
+//   "disbarred" / "disbarment"            → disbarment
+//   "suspended" / "suspension"             → suspension
+//   "interim suspension" / "temporary"     → interim_suspension
+//   "censured" / "censure"                 → censure
+//   "publicly reprimanded" / "public reprimand" → public_reprimand
+//   "private reprimand" / "admonition"     → admonition
+//   "probation"                            → probation
+//   "resignation" / "resigned"             → resignation_with_charges
+//   "reciprocal discipline"                → reciprocal_discipline
+//   "disability inactive"                  → disability_inactive
+//
+// bar_number = "SD:<docketNumber>" — deterministic, idempotent (NM/NE/MS/KS
+// pattern). Same-docket multi-stage cases (e.g. Swier 29156 across years)
+// share bar_number; UNIQUE on (jurisdiction, bar_number, order_date,
+// discipline_type) admits each stage as a distinct event.
+//
+// Polite scraping: 800-1600 ms randomized delay between CL page requests.
+//
+// Usage:
+//   node scripts/ingest/scrape-sdbar-discipline.mjs                # dry-run
+//   node scripts/ingest/scrape-sdbar-discipline.mjs --apply        # write
+//   node scripts/ingest/scrape-sdbar-discipline.mjs --start-date 2010-01-01 --apply
+
+import fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { setTimeout as sleep } from 'node:timers/promises';
+
+import { createBulkClient, bulkCopyRows } from '../lib/pg-bulk-defaults.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+
+// ── Env loader (inline) ─────────────────────────────────────────────────────
+{
+  const ENV_PATH = 'C:/Users/email/projects/ImNotAnAttorney-web/.env.local';
+  const VALID_KEY_RX = /^[A-Z_][A-Z0-9_]*$/;
+  if (fs.existsSync(ENV_PATH)) {
+    const txt = fs.readFileSync(ENV_PATH, 'utf-8');
+    for (const rawLine of txt.split('\n')) {
+      let line = rawLine.endsWith('\r') ? rawLine.slice(0, -1) : rawLine;
+      line = line.trim();
+      if (!line || line[0] === '#') continue;
+      const eq = line.indexOf('=');
+      if (eq <= 0) continue;
+      const key = line.slice(0, eq).trim();
+      let val = line.slice(eq + 1).trim();
+      if (val.length >= 2 && ((val[0] === '"' && val[val.length - 1] === '"') ||
+          (val[0] === "'" && val[val.length - 1] === "'"))) {
+        val = val.slice(1, -1);
+      }
+      if (!VALID_KEY_RX.test(key)) continue;
+      if (!process.env[key]) process.env[key] = val;
+    }
+  }
+}
+
+const JURISDICTION = 'SD';
+const USER_AGENT =
+  'INAA-Crawler/1.0 (+https://imnotanattorney.com; contact: noreply-legal@inaa.com)';
+const CL_SEARCH_BASE =
+  'https://www.courtlistener.com/api/rest/v4/search/' +
+  '?type=o&court=sd&format=json&order_by=dateFiled+desc&highlight=on';
+
+const SANCTION_QUERIES = [
+  ['"reciprocal discipline"', 'reciprocal_discipline'],
+  ['"disability inactive"', 'disability_inactive'],
+  ['disbarred OR disbarment', 'disbarment'],
+  ['"resignation" OR "resigned"', 'resignation_with_charges'],
+  ['"interim suspension" OR "temporary suspension"', 'interim_suspension'],
+  ['suspended OR suspension', 'suspension'],
+  ['probation', 'probation'],
+  ['censured OR censure', 'censure'],
+  ['"public reprimand" OR "publicly reprimanded"', 'public_reprimand'],
+  ['"private reprimand" OR admonition', 'admonition'],
+];
+
+const CL_OPINION_BASE = 'https://www.courtlistener.com';
+
+const DISCIPLINE_PATTERNS = [
+  [/\breciprocal\s+disciplin/i, 'reciprocal_discipline'],
+  [/\bdisability\s+inactiv/i, 'disability_inactive'],
+  [/\bdisbar(red|ment|ring)/i, 'disbarment'],
+  [/\bresign(ation|ed)/i, 'resignation_with_charges'],
+  [/\binterim\s+suspen/i, 'interim_suspension'],
+  [/\btemporary\s+suspen/i, 'interim_suspension'],
+  [/\bsuspen(d|ded|sion)/i, 'suspension'],
+  [/\bprobation\b/i, 'probation'],
+  [/\bcensur(ed|e)\b/i, 'censure'],
+  [/\bpublic(ly)?\s+reprimand/i, 'public_reprimand'],
+  [/\bprivate\s+reprimand/i, 'admonition'],
+  [/\badmoni(tion|shed)/i, 'admonition'],
+  [/\breprimand(ed)?\b/i, 'public_reprimand'],
+];
+
+export const ALLOWED_DISCIPLINE_TYPES = new Set([
+  'disbarment', 'suspension', 'interim_suspension', 'probation',
+  'public_reprimand', 'resignation_with_charges', 'censure',
+  'admonition', 'reciprocal_discipline', 'disability_inactive',
+]);
+
+export function normalizeDiscipline(text) {
+  if (!text) return { type: 'unknown', raw: null };
+  for (const [re, type] of DISCIPLINE_PATTERNS) {
+    if (re.test(text)) return { type, raw: text.slice(0, 500) };
+  }
+  return { type: 'unknown', raw: text.slice(0, 500) };
+}
+
+// ── CLI ─────────────────────────────────────────────────────────────────────
+
+function parseArgs(argv) {
+  const args = argv.slice(2);
+  const out = {
+    apply: false,
+    startRow: 0,
+    limit: Infinity,
+    startDate: '1990-01-01',
+    endDate: null,
+    maxPages: Infinity,
+  };
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === '--apply') out.apply = true;
+    else if (a === '--start-row') out.startRow = parseInt(args[++i], 10);
+    else if (a === '--limit') out.limit = parseInt(args[++i], 10);
+    else if (a === '--start-date') out.startDate = args[++i];
+    else if (a === '--end-date') out.endDate = args[++i];
+    else if (a === '--max-pages') out.maxPages = parseInt(args[++i], 10);
+    else if (a === '--help' || a === '-h') {
+      const header = fs.readFileSync(__filename, 'utf8').split('\n').slice(0, 60).join('\n');
+      console.log(header);
+      process.exit(0);
+    }
+  }
+  return out;
+}
+
+const OPTS = parseArgs(process.argv);
+
+// ── HTTP ────────────────────────────────────────────────────────────────────
+
+function politeDelay() {
+  const ms = 800 + Math.floor(Math.random() * 800);
+  return sleep(ms);
+}
+
+async function fetchJson(url, attempt = 1) {
+  const headers = { 'User-Agent': USER_AGENT, 'Accept': 'application/json' };
+  if (process.env.COURTLISTENER_TOKEN) {
+    headers['Authorization'] = `Token ${process.env.COURTLISTENER_TOKEN}`;
+  }
+  const resp = await fetch(url, { headers });
+  if (resp.status === 429 || resp.status === 503 || resp.status === 502) {
+    if (attempt > 8) throw new Error(`HTTP ${resp.status} after ${attempt} retries — ${url}`);
+    const baseMs = Math.min(60000, 3000 * Math.pow(2, attempt - 1));
+    const ms = baseMs + Math.floor(Math.random() * 2000);
+    console.error(`[sd] HTTP ${resp.status} attempt ${attempt}, backing off ${ms}ms`);
+    await sleep(ms);
+    return fetchJson(url, attempt + 1);
+  }
+  if (!resp.ok) throw new Error(`HTTP ${resp.status} ${resp.statusText} — ${url}`);
+  return resp.json();
+}
+
+// ── Caption parsing ─────────────────────────────────────────────────────────
+
+// SD discipline captions:
+//   "Discipline of Volesky"
+//   "Reciprocal Discipline of <Name>"
+//   "Discipline of Marcus J. Aurelius, Jr."
+// Returns { fullName } or { fullName: null } on reject.
+export function parseCaseName(rawCaption) {
+  if (!rawCaption) return { fullName: null };
+  const caption = rawCaption.replace(/<\/?mark>/g, '').replace(/\s+/g, ' ').trim();
+
+  // Reject obvious non-discipline captions early
+  if (/^(state|estate|in\s+the\s+matter\s+of\s+the\s+estate|dissolution\s+of)\b/i.test(caption)) {
+    return { fullName: null };
+  }
+  if (/\bv\.\s/i.test(caption)) {
+    // Captions with "v." are adversarial proceedings, not "Discipline of <Name>"
+    return { fullName: null };
+  }
+
+  // Match SD discipline captions in any of these shapes:
+  //   "Discipline of <Name>"
+  //   "Reciprocal Discipline of <Name>"
+  //   "In Re the Discipline of <Name>"   (older form)
+  //   "Matter of Discipline of <Name>"   (older form)
+  let m = caption.match(/^(?:reciprocal\s+)?discipline\s+of\s+(.+?)\s*$/i);
+  if (!m) {
+    m = caption.match(/^in\s+re\s+(?:the\s+)?(?:reciprocal\s+)?discipline\s+of\s+(.+?)\s*$/i);
+  }
+  if (!m) {
+    m = caption.match(/^(?:in\s+the\s+)?matter\s+of\s+(?:the\s+)?(?:reciprocal\s+)?discipline\s+of\s+(.+?)\s*$/i);
+  }
+  if (!m) return { fullName: null };
+
+  let name = m[1].trim();
+  // Strip series suffix "(II)", "(2)", etc.
+  name = name.replace(/\s*\((?:[IVX]+|\d+)\)\s*$/i, '').trim();
+  // Strip ", Jr.", ", Sr.", ", III", ", Esq."
+  name = name.replace(/,\s*(II|III|IV|V|Jr\.?|Sr\.?|Esq\.?)\s*$/i, '').trim();
+  // Strip trailing periods/commas
+  name = name.replace(/[.,]+$/, '').trim();
+
+  if (name.length < 2 || name.length > 150) return { fullName: null };
+
+  // Reject corporate-styled (defense in depth — SD captions don't usually include
+  // these for discipline, but Inc./LLC/Corp. would only appear in dissolution captions)
+  if (/\b(LLC|Inc\.?|Corp\.?|Ltd\.?|Co\.?|Bank|Trust|Ranch|Estate)\b/i.test(name)) {
+    return { fullName: null };
+  }
+
+  return { fullName: name };
+}
+
+// SD docket: 5-digit numeric, no prefix (e.g. "30736", "29156", "30354")
+export function isSdDocket(docket) {
+  if (typeof docket !== 'string') return false;
+  const d = docket.trim().replace(/\.$/, '');
+  return /^\d{4,6}$/.test(d);
+}
+
+// ── CourtListener discovery ──────────────────────────────────────────────────
+
+async function discoverViaCl() {
+  const byKey = new Map();
+
+  for (const [qFragment, sanctionType] of SANCTION_QUERIES) {
+    // Anchor on "Disciplinary Board" — South Dakota Supreme Court attorney-
+    // discipline opinions all reference the State Bar Disciplinary Board.
+    const baseQ = `"Disciplinary Board" AND (${qFragment})`;
+    let url =
+      CL_SEARCH_BASE +
+      `&q=${encodeURIComponent(baseQ)}` +
+      `&filed_after=${encodeURIComponent(OPTS.startDate)}` +
+      (OPTS.endDate ? `&filed_before=${encodeURIComponent(OPTS.endDate)}` : '');
+
+    let page = 0;
+    let pageSanctionAccepted = 0;
+    while (url && page < OPTS.maxPages) {
+      page++;
+      console.error(`[cl:${sanctionType}] page ${page} — fetching`);
+
+      const json = await fetchJson(url);
+
+      if (!Array.isArray(json.results)) {
+        console.error(`[cl:${sanctionType}] unexpected response shape — keys: ${Object.keys(json).join(', ')}`);
+        break;
+      }
+
+      for (const r of json.results) {
+        const record = buildRecordFromClResult(r, sanctionType);
+        if (!record) continue;
+        // Multi-stage same-docket cases (e.g. Swier 29156) get distinct events
+        // per (bar_number, order_date) pair — already enforced by table UNIQUE.
+        const dedupKey = `${record.bar_number}|${record.order_date || ''}`;
+        if (!byKey.has(dedupKey)) {
+          byKey.set(dedupKey, record);
+          pageSanctionAccepted++;
+        }
+      }
+
+      console.error(
+        `[cl:${sanctionType}] page ${page}: ${json.results.length} results, total kept: ${byKey.size}`
+      );
+
+      url = json.next || null;
+      if (url) await politeDelay();
+    }
+
+    console.error(`[cl:${sanctionType}] complete — accepted ${pageSanctionAccepted} new events`);
+  }
+
+  return [...byKey.values()];
+}
+
+// ── Load ─────────────────────────────────────────────────────────────────────
+
+async function load(records) {
+  const { client, cleanup } = await createBulkClient();
+  try {
+    await client.query(`SET statement_timeout = '30min'`);
+    await client.query(`SET idle_in_transaction_session_timeout = '5min'`);
+
+    await client.query(`DROP TABLE IF EXISTS public._stg_attorneys_sd`);
+    await client.query(`DROP TABLE IF EXISTS public._stg_discipline_sd`);
+    await client.query(`
+      CREATE UNLOGGED TABLE public._stg_attorneys_sd (
+        jurisdiction    char(2),
+        bar_number      text,
+        full_name       text,
+        first_name      text,
+        last_name       text,
+        admission_date  date,
+        current_status  text,
+        city            text,
+        source_url      text
+      );
+      CREATE UNLOGGED TABLE public._stg_discipline_sd (
+        jurisdiction      char(2),
+        bar_number        text,
+        full_name         text,
+        order_date        date,
+        effective_date    date,
+        discipline_type   text,
+        discipline_raw    text,
+        violation_summary text,
+        order_url         text,
+        source_url        text
+      );
+    `);
+
+    const byBar = new Map();
+    for (const r of records) {
+      if (!byBar.has(r.bar_number)) {
+        const clean = r.full_name.replace(/\s+/g, ' ').trim();
+        const parts = clean.split(' ');
+        const first = parts.length > 1 ? parts.slice(0, -1).join(' ') : null;
+        const last = parts[parts.length - 1];
+        byBar.set(r.bar_number, {
+          jurisdiction: JURISDICTION,
+          bar_number: r.bar_number,
+          full_name: r.full_name,
+          first_name: first,
+          last_name: last,
+          admission_date: null,
+          current_status: null,
+          city: null,
+          source_url: r.source_url,
+        });
+      }
+    }
+
+    const attorneyRows = [...byBar.values()].map((a) => [
+      a.jurisdiction, a.bar_number, a.full_name, a.first_name, a.last_name,
+      a.admission_date, a.current_status, a.city, a.source_url,
+    ]);
+
+    await bulkCopyRows(
+      client,
+      '_stg_attorneys_sd',
+      ['jurisdiction', 'bar_number', 'full_name', 'first_name', 'last_name',
+       'admission_date', 'current_status', 'city', 'source_url'],
+      attorneyRows,
+    );
+
+    const disciplineRows = records.map((r) => [
+      JURISDICTION, r.bar_number, r.full_name,
+      r.order_date, r.effective_date,
+      r.discipline_type, r.discipline_raw,
+      r.violation_summary, r.order_url, r.source_url,
+    ]);
+
+    await bulkCopyRows(
+      client,
+      '_stg_discipline_sd',
+      ['jurisdiction', 'bar_number', 'full_name', 'order_date', 'effective_date',
+       'discipline_type', 'discipline_raw', 'violation_summary', 'order_url', 'source_url'],
+      disciplineRows,
+    );
+
+    const upsertAttorneys = await client.query(`
+      INSERT INTO public.attorneys
+        (jurisdiction, bar_number, full_name, first_name, last_name,
+         admission_date, current_status, city, source_url, last_seen_at)
+      SELECT jurisdiction, bar_number, full_name, first_name, last_name,
+             admission_date, current_status, city, source_url, NOW()
+      FROM _stg_attorneys_sd
+      ON CONFLICT (jurisdiction, bar_number) DO UPDATE SET
+        full_name      = EXCLUDED.full_name,
+        first_name     = COALESCE(EXCLUDED.first_name, public.attorneys.first_name),
+        last_name      = COALESCE(EXCLUDED.last_name, public.attorneys.last_name),
+        admission_date = COALESCE(EXCLUDED.admission_date, public.attorneys.admission_date),
+        city           = COALESCE(EXCLUDED.city, public.attorneys.city),
+        source_url     = COALESCE(EXCLUDED.source_url, public.attorneys.source_url),
+        last_seen_at   = NOW()
+      RETURNING id, bar_number;
+    `);
+    console.error(`[db] attorneys upserted: ${upsertAttorneys.rowCount}`);
+
+    const insertEvents = await client.query(`
+      INSERT INTO public.attorney_discipline_events
+        (attorney_id, jurisdiction, bar_number, full_name, order_date, effective_date,
+         discipline_type, discipline_raw, violation_summary, order_url, source_url)
+      SELECT a.id, s.jurisdiction, s.bar_number, s.full_name,
+             s.order_date, s.effective_date,
+             s.discipline_type, s.discipline_raw,
+             s.violation_summary, s.order_url, s.source_url
+      FROM _stg_discipline_sd s
+      JOIN public.attorneys a
+        ON a.jurisdiction = s.jurisdiction AND a.bar_number = s.bar_number
+      ON CONFLICT (jurisdiction, bar_number, order_date, discipline_type) DO NOTHING;
+    `);
+    console.error(`[db] discipline events inserted: ${insertEvents.rowCount}`);
+
+    await client.query(`DROP TABLE IF EXISTS public._stg_attorneys_sd, public._stg_discipline_sd`);
+  } finally {
+    await cleanup();
+  }
+}
+
+// ── buildRecordFromClResult (exported for tests) ─────────────────────────────
+
+export function buildRecordFromClResult(r, assertedSanctionType) {
+  const docket = (r.docketNumber || '')
+    .replace(/<\/?mark>/g, '')
+    .replace(/^Case Number:\s*/i, '')
+    .replace(/\.$/, '')
+    .trim();
+
+  if (!isSdDocket(docket)) return null;
+
+  const { fullName } = parseCaseName(r.caseName || '');
+  if (!fullName) return null;
+
+  if (!ALLOWED_DISCIPLINE_TYPES.has(assertedSanctionType)) return null;
+
+  const opinionSnippet = (r.opinions && r.opinions[0] && r.opinions[0].snippet) || '';
+  const cleanSnippet = opinionSnippet.replace(/<\/?mark>/g, '').replace(/&#x27;/g, "'").replace(/\s+/g, ' ').trim();
+
+  const orderDate = r.dateFiled || null;
+  const sourceUrl = r.absolute_url ? `${CL_OPINION_BASE}${r.absolute_url}` : null;
+  if (!sourceUrl) return null; // NEVER fabricate source_url
+
+  const barNumber = `SD:${docket}`;
+  const summary = cleanSnippet.slice(0, 2000);
+
+  return {
+    bar_number: barNumber,
+    full_name: fullName,
+    order_date: orderDate,
+    effective_date: null,
+    discipline_type: assertedSanctionType,
+    discipline_raw: cleanSnippet ? cleanSnippet.slice(0, 500) : null,
+    violation_summary: summary,
+    order_url: sourceUrl,
+    source_url: sourceUrl,
+  };
+}
+
+// ── Main ─────────────────────────────────────────────────────────────────────
+
+async function main() {
+  console.error(
+    `[sdbar] start — apply=${OPTS.apply} startDate=${OPTS.startDate}` +
+    (OPTS.endDate ? ` endDate=${OPTS.endDate}` : '') +
+    ` limit=${OPTS.limit} startRow=${OPTS.startRow}`
+  );
+
+  let records = await discoverViaCl();
+
+  if (OPTS.startRow > 0) records = records.slice(OPTS.startRow);
+  if (Number.isFinite(OPTS.limit)) records = records.slice(0, OPTS.limit);
+
+  console.error(`[sdbar] collected ${records.length} discipline rows`);
+
+  const preview = records.slice(0, 3);
+  console.error('[sdbar] first 3 rows:');
+  for (const r of preview) {
+    console.error(
+      `  · [${r.bar_number}] ${r.full_name} — ${r.discipline_type}` +
+      ` (order_date=${r.order_date || '?'}) — ${r.source_url}`
+    );
+  }
+
+  if (!OPTS.apply) {
+    console.error('[sdbar] dry-run — pass --apply to write to DB');
+    return;
+  }
+
+  if (records.length === 0) {
+    console.error('[sdbar] no records — nothing to load');
+    return;
+  }
+
+  await load(records);
+  console.error('[sdbar] done');
+}
+
+if (import.meta.url === `file://${process.argv[1].replace(/\\/g, '/')}` ||
+    import.meta.url === `file:///${process.argv[1].replace(/\\/g, '/').replace(/^\//, '')}`) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/scripts/ingest/scrape-vtbar-discipline.mjs
+++ b/scripts/ingest/scrape-vtbar-discipline.mjs
@@ -1,0 +1,438 @@
+// csv-bulk-checked: none-exists — CourtListener search API used for per-sanction filtering of Vermont Supreme Court bar discipline opinions. CL has 105 "Office of Disciplinary Counsel/Professional Responsibility Board" opinions on court=vt (probed 2026-04-27). vermontjudiciary.org publishes PRB decisions but the listing is split across multiple HTML index pages without a structured archive endpoint; VT SC opinions on CL are the bulk-tractable surface (PR #185 OK/OR/CT pattern).
+// Template: scripts/ingest/scrape-nmbar-discipline.mjs
+// Pattern: cl-bulk-data-defensive #18 (COPY FROM STDIN via bulkCopyRows)
+//
+// Vermont Supreme Court bar discipline scraper.
+//
+// Source discovery (probed 2026-04-27):
+//   Primary: CourtListener search API — court=vt + per-sanction queries
+//
+// VT caption shapes (verified live):
+//   "In Re Matthew Ragaller (Office of Disciplinary Counsel, Appellant)" → discipline
+//   "In Re Norman E. Watts, Esq. (Office of Disciplinary Counsel)"        → discipline
+//   "In re Theodore Studdert-Kennedy / In re PRB-021-2022 (Office of Disciplinary Counsel)" → discipline
+//   "In re Eva P. Vekos, Esq. (Office of Disciplinary Counsel)"           → discipline
+//   "In Re C. Robert Manby, Jr., Esq."                                    → discipline (no parenthetical, but PRB context)
+//   "In Re Lisa Wellman-Ally, Esq. (Office of Disciplinary Counsel)"      → discipline
+//   "In Re Holland Cannabis, LLC"                                         → SKIP (corporate)
+//
+// Filter requires:
+//   1. caseName starts with "In Re" / "In re"
+//   2. caseName contains "(Office of Disciplinary Counsel)" parenthetical
+//      OR "Esq." suffix (PRB attorney form)
+//
+// VT docket: "NN-AP-NNN" (e.g. "25-AP-019", "23-AP-302", "24-AP-070").
+// Multi-docket "23-AP-263, 23-AP-264" — normalize to first.
+//
+// Discipline label mapping (VT SC → internal enum) — same as NM/NE.
+//
+// bar_number = "VT:<docketNumber>" — deterministic, idempotent.
+
+import fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { setTimeout as sleep } from 'node:timers/promises';
+
+import { createBulkClient, bulkCopyRows } from '../lib/pg-bulk-defaults.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+
+{
+  const ENV_PATH = 'C:/Users/email/projects/ImNotAnAttorney-web/.env.local';
+  const VALID_KEY_RX = /^[A-Z_][A-Z0-9_]*$/;
+  if (fs.existsSync(ENV_PATH)) {
+    const txt = fs.readFileSync(ENV_PATH, 'utf-8');
+    for (const rawLine of txt.split('\n')) {
+      let line = rawLine.endsWith('\r') ? rawLine.slice(0, -1) : rawLine;
+      line = line.trim();
+      if (!line || line[0] === '#') continue;
+      const eq = line.indexOf('=');
+      if (eq <= 0) continue;
+      const key = line.slice(0, eq).trim();
+      let val = line.slice(eq + 1).trim();
+      if (val.length >= 2 && ((val[0] === '"' && val[val.length - 1] === '"') ||
+          (val[0] === "'" && val[val.length - 1] === "'"))) {
+        val = val.slice(1, -1);
+      }
+      if (!VALID_KEY_RX.test(key)) continue;
+      if (!process.env[key]) process.env[key] = val;
+    }
+  }
+}
+
+const JURISDICTION = 'VT';
+const USER_AGENT =
+  'INAA-Crawler/1.0 (+https://imnotanattorney.com; contact: noreply-legal@inaa.com)';
+const CL_SEARCH_BASE =
+  'https://www.courtlistener.com/api/rest/v4/search/' +
+  '?type=o&court=vt&format=json&order_by=dateFiled+desc&highlight=on';
+
+const SANCTION_QUERIES = [
+  ['"reciprocal discipline"', 'reciprocal_discipline'],
+  ['"disability inactive"', 'disability_inactive'],
+  ['disbarred OR disbarment', 'disbarment'],
+  ['"resignation" OR "resigned"', 'resignation_with_charges'],
+  ['"interim suspension" OR "temporary suspension"', 'interim_suspension'],
+  ['suspended OR suspension', 'suspension'],
+  ['probation', 'probation'],
+  ['censured OR censure', 'censure'],
+  ['"public reprimand" OR "publicly reprimanded"', 'public_reprimand'],
+  ['"private reprimand" OR admonition OR admonishment', 'admonition'],
+];
+
+const CL_OPINION_BASE = 'https://www.courtlistener.com';
+
+const DISCIPLINE_PATTERNS = [
+  [/\breciprocal\s+disciplin/i, 'reciprocal_discipline'],
+  [/\bdisability\s+inactiv/i, 'disability_inactive'],
+  [/\bdisbar(red|ment|ring)/i, 'disbarment'],
+  [/\bresign(ation|ed)/i, 'resignation_with_charges'],
+  [/\binterim\s+suspen/i, 'interim_suspension'],
+  [/\btemporary\s+suspen/i, 'interim_suspension'],
+  [/\bsuspen(d|ded|sion)/i, 'suspension'],
+  [/\bprobation\b/i, 'probation'],
+  [/\bcensur(ed|e)\b/i, 'censure'],
+  [/\bpublic(ly)?\s+reprimand/i, 'public_reprimand'],
+  [/\bprivate\s+reprimand/i, 'admonition'],
+  [/\badmoni(tion|shed|shment)/i, 'admonition'],
+  [/\breprimand(ed)?\b/i, 'public_reprimand'],
+];
+
+export const ALLOWED_DISCIPLINE_TYPES = new Set([
+  'disbarment', 'suspension', 'interim_suspension', 'probation',
+  'public_reprimand', 'resignation_with_charges', 'censure',
+  'admonition', 'reciprocal_discipline', 'disability_inactive',
+]);
+
+export function normalizeDiscipline(text) {
+  if (!text) return { type: 'unknown', raw: null };
+  for (const [re, type] of DISCIPLINE_PATTERNS) {
+    if (re.test(text)) return { type, raw: text.slice(0, 500) };
+  }
+  return { type: 'unknown', raw: text.slice(0, 500) };
+}
+
+function parseArgs(argv) {
+  const args = argv.slice(2);
+  const out = {
+    apply: false, startRow: 0, limit: Infinity,
+    startDate: '1990-01-01', endDate: null, maxPages: Infinity,
+  };
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === '--apply') out.apply = true;
+    else if (a === '--start-row') out.startRow = parseInt(args[++i], 10);
+    else if (a === '--limit') out.limit = parseInt(args[++i], 10);
+    else if (a === '--start-date') out.startDate = args[++i];
+    else if (a === '--end-date') out.endDate = args[++i];
+    else if (a === '--max-pages') out.maxPages = parseInt(args[++i], 10);
+    else if (a === '--help' || a === '-h') {
+      const header = fs.readFileSync(__filename, 'utf8').split('\n').slice(0, 50).join('\n');
+      console.log(header);
+      process.exit(0);
+    }
+  }
+  return out;
+}
+
+const OPTS = parseArgs(process.argv);
+
+function politeDelay() {
+  const ms = 800 + Math.floor(Math.random() * 800);
+  return sleep(ms);
+}
+
+async function fetchJson(url, attempt = 1) {
+  const headers = { 'User-Agent': USER_AGENT, 'Accept': 'application/json' };
+  if (process.env.COURTLISTENER_TOKEN) {
+    headers['Authorization'] = `Token ${process.env.COURTLISTENER_TOKEN}`;
+  }
+  const resp = await fetch(url, { headers });
+  if (resp.status === 429 || resp.status === 503 || resp.status === 502) {
+    if (attempt > 8) throw new Error(`HTTP ${resp.status} after ${attempt} retries — ${url}`);
+    const baseMs = Math.min(60000, 3000 * Math.pow(2, attempt - 1));
+    const ms = baseMs + Math.floor(Math.random() * 2000);
+    console.error(`[vt] HTTP ${resp.status} attempt ${attempt}, backing off ${ms}ms`);
+    await sleep(ms);
+    return fetchJson(url, attempt + 1);
+  }
+  if (!resp.ok) throw new Error(`HTTP ${resp.status} ${resp.statusText} — ${url}`);
+  return resp.json();
+}
+
+// VT discipline: "In Re <Name> (Office of Disciplinary Counsel...)"
+//                "In Re <Name>, Esq. (Office of Disciplinary Counsel)"
+//                "In Re <Name>, Esq." (PRB form, no parenthetical)
+//                "In re <Name> / In re PRB-NNN-YYYY (Office of Disciplinary Counsel)" (multi-caption)
+export function parseCaseName(rawCaption) {
+  if (!rawCaption) return { fullName: null };
+  const caption = rawCaption.replace(/<\/?mark>/g, '').replace(/\s+/g, ' ').trim();
+
+  // The PRB-context anchor lives in the CL search (anchored on
+  // "Office of Disciplinary Counsel" OR "Professional Responsibility Board").
+  // Caption-level filtering only needs to gate against obvious non-attorney
+  // matters (corporate, statutory, regulatory). Many older PRB cases appear
+  // on CL with the bare "In Re <Name>" caption (no parenthetical, no Esq.) —
+  // those are still discipline orders and must NOT be rejected.
+
+  // Reject corporate / non-attorney
+  if (/\b(LLC|Inc\.?|Corp\.?|Cannabis|Holding|Trust\b)\b/i.test(caption)) {
+    return { fullName: null };
+  }
+  // Reject estate/sealed/special-matter
+  if (/\bin\s+re\s+(estate|sealed|petition|application|grand\s+jury|appeal\s+of)\b/i.test(caption)) {
+    return { fullName: null };
+  }
+
+  // Match leading "In Re" / "In re"
+  const m = caption.match(/^in\s+re\s+(.+?)\s*$/i);
+  if (!m) return { fullName: null };
+
+  let body = m[1].trim();
+
+  // Multi-caption: "Theodore Studdert-Kennedy / In re PRB-021-2022 (Office...)"
+  // Take the first segment (the named attorney).
+  if (body.includes(' / ')) body = body.split(' / ')[0].trim();
+
+  // Strip parenthetical at end: "(Office of Disciplinary Counsel...)"
+  body = body.replace(/\s*\([^)]*\)\s*$/i, '').trim();
+
+  // Strip ", Esq.", ", Esquire"
+  let name = body.replace(/,\s*(Esq\.?|Esquire)\s*$/i, '').trim();
+  // Strip ", Jr." etc.
+  name = name.replace(/,\s*(II|III|IV|V|Jr\.?|Sr\.?)\s*$/i, '').trim();
+  name = name.replace(/[.,]+$/, '').trim();
+
+  if (name.length < 2 || name.length > 150) return { fullName: null };
+
+  // Reject PRB-only references (no human name)
+  if (/^PRB[-\s]/i.test(name)) return { fullName: null };
+
+  return { fullName: name };
+}
+
+// VT docket: modern "NN-AP-NNN" (multi-docket "23-AP-263, 23-AP-264" → first)
+//            OR legacy "YYYY-NNN" (4-digit year + 3-digit serial)
+//            OR "NN-NNN" (2-digit year + 3-digit serial, very old)
+export function normalizeVtDocket(docketRaw) {
+  if (typeof docketRaw !== 'string') return null;
+  const stripped = docketRaw
+    .replace(/<\/?mark>/g, '')
+    .replace(/^Case Number:\s*/i, '')
+    .trim();
+  // Modern: 25-AP-019
+  let m = stripped.match(/^(\d{2}-AP-\d{2,4})(?:[,\s]|$)/i);
+  if (m) return m[1].toUpperCase();
+  // Legacy: 2021-080 (4-digit year + 3-digit serial)
+  m = stripped.match(/^(\d{4}-\d{3,4})(?:[,\s]|$)/);
+  if (m) return m[1];
+  return null;
+}
+
+export function isVtDocket(docketRaw) {
+  return normalizeVtDocket(docketRaw) !== null;
+}
+
+async function discoverViaCl() {
+  const byKey = new Map();
+
+  for (const [qFragment, sanctionType] of SANCTION_QUERIES) {
+    const baseQ = `("Office of Disciplinary Counsel" OR "Professional Responsibility Board") AND (${qFragment})`;
+    let url =
+      CL_SEARCH_BASE +
+      `&q=${encodeURIComponent(baseQ)}` +
+      `&filed_after=${encodeURIComponent(OPTS.startDate)}` +
+      (OPTS.endDate ? `&filed_before=${encodeURIComponent(OPTS.endDate)}` : '');
+
+    let page = 0;
+    let pageSanctionAccepted = 0;
+    while (url && page < OPTS.maxPages) {
+      page++;
+      console.error(`[cl:${sanctionType}] page ${page} — fetching`);
+      const json = await fetchJson(url);
+      if (!Array.isArray(json.results)) {
+        console.error(`[cl:${sanctionType}] unexpected response shape — keys: ${Object.keys(json).join(', ')}`);
+        break;
+      }
+      for (const r of json.results) {
+        const record = buildRecordFromClResult(r, sanctionType);
+        if (!record) continue;
+        const dedupKey = `${record.bar_number}|${record.order_date || ''}`;
+        if (!byKey.has(dedupKey)) {
+          byKey.set(dedupKey, record);
+          pageSanctionAccepted++;
+        }
+      }
+      console.error(`[cl:${sanctionType}] page ${page}: ${json.results.length} results, total kept: ${byKey.size}`);
+      url = json.next || null;
+      if (url) await politeDelay();
+    }
+    console.error(`[cl:${sanctionType}] complete — accepted ${pageSanctionAccepted} new events`);
+  }
+  return [...byKey.values()];
+}
+
+async function load(records) {
+  const { client, cleanup } = await createBulkClient();
+  try {
+    await client.query(`SET statement_timeout = '30min'`);
+    await client.query(`SET idle_in_transaction_session_timeout = '5min'`);
+    await client.query(`DROP TABLE IF EXISTS public._stg_attorneys_vt`);
+    await client.query(`DROP TABLE IF EXISTS public._stg_discipline_vt`);
+    await client.query(`
+      CREATE UNLOGGED TABLE public._stg_attorneys_vt (
+        jurisdiction char(2), bar_number text, full_name text,
+        first_name text, last_name text, admission_date date,
+        current_status text, city text, source_url text
+      );
+      CREATE UNLOGGED TABLE public._stg_discipline_vt (
+        jurisdiction char(2), bar_number text, full_name text,
+        order_date date, effective_date date,
+        discipline_type text, discipline_raw text, violation_summary text,
+        order_url text, source_url text
+      );
+    `);
+
+    const byBar = new Map();
+    for (const r of records) {
+      if (!byBar.has(r.bar_number)) {
+        const clean = r.full_name.replace(/\s+/g, ' ').trim();
+        const parts = clean.split(' ');
+        const first = parts.length > 1 ? parts.slice(0, -1).join(' ') : null;
+        const last = parts[parts.length - 1];
+        byBar.set(r.bar_number, {
+          jurisdiction: JURISDICTION, bar_number: r.bar_number,
+          full_name: r.full_name, first_name: first, last_name: last,
+          admission_date: null, current_status: null, city: null,
+          source_url: r.source_url,
+        });
+      }
+    }
+
+    await bulkCopyRows(
+      client, '_stg_attorneys_vt',
+      ['jurisdiction', 'bar_number', 'full_name', 'first_name', 'last_name',
+       'admission_date', 'current_status', 'city', 'source_url'],
+      [...byBar.values()].map((a) => [
+        a.jurisdiction, a.bar_number, a.full_name, a.first_name, a.last_name,
+        a.admission_date, a.current_status, a.city, a.source_url,
+      ]),
+    );
+    await bulkCopyRows(
+      client, '_stg_discipline_vt',
+      ['jurisdiction', 'bar_number', 'full_name', 'order_date', 'effective_date',
+       'discipline_type', 'discipline_raw', 'violation_summary', 'order_url', 'source_url'],
+      records.map((r) => [
+        JURISDICTION, r.bar_number, r.full_name,
+        r.order_date, r.effective_date,
+        r.discipline_type, r.discipline_raw, r.violation_summary,
+        r.order_url, r.source_url,
+      ]),
+    );
+
+    const upsertAttorneys = await client.query(`
+      INSERT INTO public.attorneys
+        (jurisdiction, bar_number, full_name, first_name, last_name,
+         admission_date, current_status, city, source_url, last_seen_at)
+      SELECT jurisdiction, bar_number, full_name, first_name, last_name,
+             admission_date, current_status, city, source_url, NOW()
+      FROM _stg_attorneys_vt
+      ON CONFLICT (jurisdiction, bar_number) DO UPDATE SET
+        full_name      = EXCLUDED.full_name,
+        first_name     = COALESCE(EXCLUDED.first_name, public.attorneys.first_name),
+        last_name      = COALESCE(EXCLUDED.last_name, public.attorneys.last_name),
+        admission_date = COALESCE(EXCLUDED.admission_date, public.attorneys.admission_date),
+        city           = COALESCE(EXCLUDED.city, public.attorneys.city),
+        source_url     = COALESCE(EXCLUDED.source_url, public.attorneys.source_url),
+        last_seen_at   = NOW()
+      RETURNING id, bar_number;
+    `);
+    console.error(`[db] attorneys upserted: ${upsertAttorneys.rowCount}`);
+
+    const insertEvents = await client.query(`
+      INSERT INTO public.attorney_discipline_events
+        (attorney_id, jurisdiction, bar_number, full_name, order_date, effective_date,
+         discipline_type, discipline_raw, violation_summary, order_url, source_url)
+      SELECT a.id, s.jurisdiction, s.bar_number, s.full_name,
+             s.order_date, s.effective_date,
+             s.discipline_type, s.discipline_raw,
+             s.violation_summary, s.order_url, s.source_url
+      FROM _stg_discipline_vt s
+      JOIN public.attorneys a
+        ON a.jurisdiction = s.jurisdiction AND a.bar_number = s.bar_number
+      ON CONFLICT (jurisdiction, bar_number, order_date, discipline_type) DO NOTHING;
+    `);
+    console.error(`[db] discipline events inserted: ${insertEvents.rowCount}`);
+
+    await client.query(`DROP TABLE IF EXISTS public._stg_attorneys_vt, public._stg_discipline_vt`);
+  } finally {
+    await cleanup();
+  }
+}
+
+export function buildRecordFromClResult(r, assertedSanctionType) {
+  const docketRaw = r.docketNumber || '';
+  const docket = normalizeVtDocket(docketRaw);
+  if (!docket) return null;
+
+  const { fullName } = parseCaseName(r.caseName || '');
+  if (!fullName) return null;
+
+  if (!ALLOWED_DISCIPLINE_TYPES.has(assertedSanctionType)) return null;
+
+  const opinionSnippet = (r.opinions && r.opinions[0] && r.opinions[0].snippet) || '';
+  const cleanSnippet = opinionSnippet.replace(/<\/?mark>/g, '').replace(/&#x27;/g, "'").replace(/\s+/g, ' ').trim();
+
+  const orderDate = r.dateFiled || null;
+  const sourceUrl = r.absolute_url ? `${CL_OPINION_BASE}${r.absolute_url}` : null;
+  if (!sourceUrl) return null;
+
+  const barNumber = `VT:${docket}`;
+  const summary = cleanSnippet.slice(0, 2000);
+  return {
+    bar_number: barNumber, full_name: fullName,
+    order_date: orderDate, effective_date: null,
+    discipline_type: assertedSanctionType,
+    discipline_raw: cleanSnippet ? cleanSnippet.slice(0, 500) : null,
+    violation_summary: summary,
+    order_url: sourceUrl, source_url: sourceUrl,
+  };
+}
+
+async function main() {
+  console.error(
+    `[vtbar] start — apply=${OPTS.apply} startDate=${OPTS.startDate}` +
+    (OPTS.endDate ? ` endDate=${OPTS.endDate}` : '') +
+    ` limit=${OPTS.limit} startRow=${OPTS.startRow}`
+  );
+
+  let records = await discoverViaCl();
+  if (OPTS.startRow > 0) records = records.slice(OPTS.startRow);
+  if (Number.isFinite(OPTS.limit)) records = records.slice(0, OPTS.limit);
+
+  console.error(`[vtbar] collected ${records.length} discipline rows`);
+
+  const preview = records.slice(0, 3);
+  console.error('[vtbar] first 3 rows:');
+  for (const r of preview) {
+    console.error(
+      `  · [${r.bar_number}] ${r.full_name} — ${r.discipline_type}` +
+      ` (order_date=${r.order_date || '?'}) — ${r.source_url}`
+    );
+  }
+
+  if (!OPTS.apply) {
+    console.error('[vtbar] dry-run — pass --apply to write to DB');
+    return;
+  }
+  if (records.length === 0) {
+    console.error('[vtbar] no records — nothing to load');
+    return;
+  }
+  await load(records);
+  console.error('[vtbar] done');
+}
+
+if (import.meta.url === `file://${process.argv[1].replace(/\\/g, '/')}` ||
+    import.meta.url === `file:///${process.argv[1].replace(/\\/g, '/').replace(/^\//, '')}`) {
+  main().catch((err) => { console.error(err); process.exit(1); });
+}

--- a/scripts/ingest/scrape-wybar-discipline.mjs
+++ b/scripts/ingest/scrape-wybar-discipline.mjs
@@ -1,0 +1,412 @@
+// csv-bulk-checked: none-exists — CourtListener search API used for per-sanction filtering of Wyoming Supreme Court bar discipline opinions. CL has 234 "Board of Professional Responsibility/Bar Counsel" opinions on court=wyo and 285 "Wyoming State Bar" opinions (probed 2026-04-27). wyomingbar.org publishes Disciplinary Reports as PDFs but the listing is paginated HTML without a structured archive endpoint; WY SC opinions on CL are the bulk-tractable surface (PR #185 OK/OR/CT pattern).
+// Template: scripts/ingest/scrape-nmbar-discipline.mjs
+// Pattern: cl-bulk-data-defensive #18 (COPY FROM STDIN via bulkCopyRows)
+//
+// Wyoming Supreme Court bar discipline scraper.
+//
+// Source discovery (probed 2026-04-27):
+//   Primary: CourtListener search API — court=wyo + per-sanction queries
+//
+// WY caption shapes (verified live):
+//   "Board of Professional Responsibility, Wyoming State Bar v. Kent C. Cobb, Wsb 8-6998" → discipline
+//   "Board of Professional Responsibility, Wyoming State Bar v. Cody M. Jerabek, Wsb 7-5758" → discipline
+//   "Board of Professional Responsibility, Wyoming State Bar v. Vaughn H. Neubauer, Wsb 6-3443" → discipline
+//   "Aaron R. Maki v. The State of Wyoming"  → SKIP (criminal appeal)
+//   "In the Matter of the Estate of Lloyd Haack"  → SKIP (probate)
+//
+// Filter requires:
+//   1. caseName starts with "Board of Professional Responsibility, Wyoming State Bar v."
+//   2. Trailing "Wsb N-NNNN" suffix (WSB number) optional but common
+//
+// WY docket: "D-NN-NNNN" (e.g. "D-26-0001", "D-22-0004", "D-25-0003").
+// "D-" prefix = Disciplinary case (vs "S-" for criminal/civil).
+//
+// Discipline label mapping (WY SC → internal enum) — same as NM/NE.
+//
+// bar_number = "WY:<wsbNumber>" preferred (real bar number), fall back to
+//              "WY:D-<docket>" if WSB unavailable.
+
+import fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { setTimeout as sleep } from 'node:timers/promises';
+
+import { createBulkClient, bulkCopyRows } from '../lib/pg-bulk-defaults.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+
+{
+  const ENV_PATH = 'C:/Users/email/projects/ImNotAnAttorney-web/.env.local';
+  const VALID_KEY_RX = /^[A-Z_][A-Z0-9_]*$/;
+  if (fs.existsSync(ENV_PATH)) {
+    const txt = fs.readFileSync(ENV_PATH, 'utf-8');
+    for (const rawLine of txt.split('\n')) {
+      let line = rawLine.endsWith('\r') ? rawLine.slice(0, -1) : rawLine;
+      line = line.trim();
+      if (!line || line[0] === '#') continue;
+      const eq = line.indexOf('=');
+      if (eq <= 0) continue;
+      const key = line.slice(0, eq).trim();
+      let val = line.slice(eq + 1).trim();
+      if (val.length >= 2 && ((val[0] === '"' && val[val.length - 1] === '"') ||
+          (val[0] === "'" && val[val.length - 1] === "'"))) {
+        val = val.slice(1, -1);
+      }
+      if (!VALID_KEY_RX.test(key)) continue;
+      if (!process.env[key]) process.env[key] = val;
+    }
+  }
+}
+
+const JURISDICTION = 'WY';
+const USER_AGENT =
+  'INAA-Crawler/1.0 (+https://imnotanattorney.com; contact: noreply-legal@inaa.com)';
+const CL_SEARCH_BASE =
+  'https://www.courtlistener.com/api/rest/v4/search/' +
+  '?type=o&court=wyo&format=json&order_by=dateFiled+desc&highlight=on';
+
+const SANCTION_QUERIES = [
+  ['"reciprocal discipline"', 'reciprocal_discipline'],
+  ['"disability inactive"', 'disability_inactive'],
+  ['disbarred OR disbarment', 'disbarment'],
+  ['"resignation" OR "resigned"', 'resignation_with_charges'],
+  ['"interim suspension" OR "temporary suspension"', 'interim_suspension'],
+  ['suspended OR suspension', 'suspension'],
+  ['probation', 'probation'],
+  ['censured OR censure', 'censure'],
+  ['"public reprimand" OR "publicly reprimanded"', 'public_reprimand'],
+  ['"private reprimand" OR admonition', 'admonition'],
+];
+
+const CL_OPINION_BASE = 'https://www.courtlistener.com';
+
+const DISCIPLINE_PATTERNS = [
+  [/\breciprocal\s+disciplin/i, 'reciprocal_discipline'],
+  [/\bdisability\s+inactiv/i, 'disability_inactive'],
+  [/\bdisbar(red|ment|ring)/i, 'disbarment'],
+  [/\bresign(ation|ed)/i, 'resignation_with_charges'],
+  [/\binterim\s+suspen/i, 'interim_suspension'],
+  [/\btemporary\s+suspen/i, 'interim_suspension'],
+  [/\bsuspen(d|ded|sion)/i, 'suspension'],
+  [/\bprobation\b/i, 'probation'],
+  [/\bcensur(ed|e)\b/i, 'censure'],
+  [/\bpublic(ly)?\s+reprimand/i, 'public_reprimand'],
+  [/\bprivate\s+reprimand/i, 'admonition'],
+  [/\badmoni(tion|shed)/i, 'admonition'],
+  [/\breprimand(ed)?\b/i, 'public_reprimand'],
+];
+
+export const ALLOWED_DISCIPLINE_TYPES = new Set([
+  'disbarment', 'suspension', 'interim_suspension', 'probation',
+  'public_reprimand', 'resignation_with_charges', 'censure',
+  'admonition', 'reciprocal_discipline', 'disability_inactive',
+]);
+
+export function normalizeDiscipline(text) {
+  if (!text) return { type: 'unknown', raw: null };
+  for (const [re, type] of DISCIPLINE_PATTERNS) {
+    if (re.test(text)) return { type, raw: text.slice(0, 500) };
+  }
+  return { type: 'unknown', raw: text.slice(0, 500) };
+}
+
+function parseArgs(argv) {
+  const args = argv.slice(2);
+  const out = {
+    apply: false, startRow: 0, limit: Infinity,
+    startDate: '1990-01-01', endDate: null, maxPages: Infinity,
+  };
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === '--apply') out.apply = true;
+    else if (a === '--start-row') out.startRow = parseInt(args[++i], 10);
+    else if (a === '--limit') out.limit = parseInt(args[++i], 10);
+    else if (a === '--start-date') out.startDate = args[++i];
+    else if (a === '--end-date') out.endDate = args[++i];
+    else if (a === '--max-pages') out.maxPages = parseInt(args[++i], 10);
+    else if (a === '--help' || a === '-h') {
+      const header = fs.readFileSync(__filename, 'utf8').split('\n').slice(0, 50).join('\n');
+      console.log(header);
+      process.exit(0);
+    }
+  }
+  return out;
+}
+
+const OPTS = parseArgs(process.argv);
+
+function politeDelay() {
+  const ms = 800 + Math.floor(Math.random() * 800);
+  return sleep(ms);
+}
+
+async function fetchJson(url, attempt = 1) {
+  const headers = { 'User-Agent': USER_AGENT, 'Accept': 'application/json' };
+  if (process.env.COURTLISTENER_TOKEN) {
+    headers['Authorization'] = `Token ${process.env.COURTLISTENER_TOKEN}`;
+  }
+  const resp = await fetch(url, { headers });
+  if (resp.status === 429 || resp.status === 503 || resp.status === 502) {
+    if (attempt > 8) throw new Error(`HTTP ${resp.status} after ${attempt} retries — ${url}`);
+    const baseMs = Math.min(60000, 3000 * Math.pow(2, attempt - 1));
+    const ms = baseMs + Math.floor(Math.random() * 2000);
+    console.error(`[wy] HTTP ${resp.status} attempt ${attempt}, backing off ${ms}ms`);
+    await sleep(ms);
+    return fetchJson(url, attempt + 1);
+  }
+  if (!resp.ok) throw new Error(`HTTP ${resp.status} ${resp.statusText} — ${url}`);
+  return resp.json();
+}
+
+// WY canonical caption:
+//   "Board of Professional Responsibility, Wyoming State Bar v. <Name>, Wsb N-NNNN"
+// Returns { fullName, wsb } or { fullName: null }
+export function parseCaseName(rawCaption) {
+  if (!rawCaption) return { fullName: null, wsb: null };
+  const caption = rawCaption.replace(/<\/?mark>/g, '').replace(/\s+/g, ' ').trim();
+
+  const m = caption.match(
+    /^board\s+of\s+professional\s+responsibility\s*,?\s*wyoming\s+state\s+bar\s+v\.?\s+(.+?)\s*$/i
+  );
+  if (!m) return { fullName: null, wsb: null };
+
+  let body = m[1].trim();
+
+  // Extract trailing WSB number suffix if present:
+  // ", Wsb 8-6998" / ", WSB 6-3443" / ", Wsb 7-5758"
+  let wsb = null;
+  const wsbMatch = body.match(/,\s*WSB\s+(\d+[-]\d+)\s*$/i);
+  if (wsbMatch) {
+    wsb = wsbMatch[1];
+    body = body.slice(0, wsbMatch.index).trim();
+  }
+
+  // Strip trailing comma and period, ", Jr.", ", Sr.", ", Esq."
+  let name = body.replace(/[.,]+$/, '').trim();
+  name = name.replace(/,\s*(II|III|IV|V|Jr\.?|Sr\.?|Esq\.?|Esquire)\s*$/i, '').trim();
+  name = name.replace(/[.,]+$/, '').trim();
+
+  if (name.length < 2 || name.length > 150) return { fullName: null, wsb: null };
+
+  if (/\b(LLC|Inc\.?|Corp\.?|Ltd\.?|Co\.?|Bank|Trust|Estate)\b/i.test(name)) {
+    return { fullName: null, wsb: null };
+  }
+
+  return { fullName: name, wsb };
+}
+
+// WY discipline docket: "D-NN-NNNN"
+export function isWyDocket(docket) {
+  if (typeof docket !== 'string') return false;
+  const d = docket.trim().replace(/\.$/, '');
+  return /^D-\d{2}-\d{4}$/i.test(d);
+}
+
+async function discoverViaCl() {
+  const byKey = new Map();
+
+  for (const [qFragment, sanctionType] of SANCTION_QUERIES) {
+    const baseQ = `("Board of Professional Responsibility" AND "Wyoming State Bar") AND (${qFragment})`;
+    let url =
+      CL_SEARCH_BASE +
+      `&q=${encodeURIComponent(baseQ)}` +
+      `&filed_after=${encodeURIComponent(OPTS.startDate)}` +
+      (OPTS.endDate ? `&filed_before=${encodeURIComponent(OPTS.endDate)}` : '');
+
+    let page = 0;
+    let pageSanctionAccepted = 0;
+    while (url && page < OPTS.maxPages) {
+      page++;
+      console.error(`[cl:${sanctionType}] page ${page} — fetching`);
+      const json = await fetchJson(url);
+      if (!Array.isArray(json.results)) {
+        console.error(`[cl:${sanctionType}] unexpected response shape — keys: ${Object.keys(json).join(', ')}`);
+        break;
+      }
+      for (const r of json.results) {
+        const record = buildRecordFromClResult(r, sanctionType);
+        if (!record) continue;
+        const dedupKey = `${record.bar_number}|${record.order_date || ''}`;
+        if (!byKey.has(dedupKey)) {
+          byKey.set(dedupKey, record);
+          pageSanctionAccepted++;
+        }
+      }
+      console.error(`[cl:${sanctionType}] page ${page}: ${json.results.length} results, total kept: ${byKey.size}`);
+      url = json.next || null;
+      if (url) await politeDelay();
+    }
+    console.error(`[cl:${sanctionType}] complete — accepted ${pageSanctionAccepted} new events`);
+  }
+  return [...byKey.values()];
+}
+
+async function load(records) {
+  const { client, cleanup } = await createBulkClient();
+  try {
+    await client.query(`SET statement_timeout = '30min'`);
+    await client.query(`SET idle_in_transaction_session_timeout = '5min'`);
+    await client.query(`DROP TABLE IF EXISTS public._stg_attorneys_wy`);
+    await client.query(`DROP TABLE IF EXISTS public._stg_discipline_wy`);
+    await client.query(`
+      CREATE UNLOGGED TABLE public._stg_attorneys_wy (
+        jurisdiction char(2), bar_number text, full_name text,
+        first_name text, last_name text, admission_date date,
+        current_status text, city text, source_url text
+      );
+      CREATE UNLOGGED TABLE public._stg_discipline_wy (
+        jurisdiction char(2), bar_number text, full_name text,
+        order_date date, effective_date date,
+        discipline_type text, discipline_raw text, violation_summary text,
+        order_url text, source_url text
+      );
+    `);
+
+    const byBar = new Map();
+    for (const r of records) {
+      if (!byBar.has(r.bar_number)) {
+        const clean = r.full_name.replace(/\s+/g, ' ').trim();
+        const parts = clean.split(' ');
+        const first = parts.length > 1 ? parts.slice(0, -1).join(' ') : null;
+        const last = parts[parts.length - 1];
+        byBar.set(r.bar_number, {
+          jurisdiction: JURISDICTION, bar_number: r.bar_number,
+          full_name: r.full_name, first_name: first, last_name: last,
+          admission_date: null, current_status: null, city: null,
+          source_url: r.source_url,
+        });
+      }
+    }
+
+    await bulkCopyRows(
+      client, '_stg_attorneys_wy',
+      ['jurisdiction', 'bar_number', 'full_name', 'first_name', 'last_name',
+       'admission_date', 'current_status', 'city', 'source_url'],
+      [...byBar.values()].map((a) => [
+        a.jurisdiction, a.bar_number, a.full_name, a.first_name, a.last_name,
+        a.admission_date, a.current_status, a.city, a.source_url,
+      ]),
+    );
+    await bulkCopyRows(
+      client, '_stg_discipline_wy',
+      ['jurisdiction', 'bar_number', 'full_name', 'order_date', 'effective_date',
+       'discipline_type', 'discipline_raw', 'violation_summary', 'order_url', 'source_url'],
+      records.map((r) => [
+        JURISDICTION, r.bar_number, r.full_name,
+        r.order_date, r.effective_date,
+        r.discipline_type, r.discipline_raw, r.violation_summary,
+        r.order_url, r.source_url,
+      ]),
+    );
+
+    const upsertAttorneys = await client.query(`
+      INSERT INTO public.attorneys
+        (jurisdiction, bar_number, full_name, first_name, last_name,
+         admission_date, current_status, city, source_url, last_seen_at)
+      SELECT jurisdiction, bar_number, full_name, first_name, last_name,
+             admission_date, current_status, city, source_url, NOW()
+      FROM _stg_attorneys_wy
+      ON CONFLICT (jurisdiction, bar_number) DO UPDATE SET
+        full_name      = EXCLUDED.full_name,
+        first_name     = COALESCE(EXCLUDED.first_name, public.attorneys.first_name),
+        last_name      = COALESCE(EXCLUDED.last_name, public.attorneys.last_name),
+        admission_date = COALESCE(EXCLUDED.admission_date, public.attorneys.admission_date),
+        city           = COALESCE(EXCLUDED.city, public.attorneys.city),
+        source_url     = COALESCE(EXCLUDED.source_url, public.attorneys.source_url),
+        last_seen_at   = NOW()
+      RETURNING id, bar_number;
+    `);
+    console.error(`[db] attorneys upserted: ${upsertAttorneys.rowCount}`);
+
+    const insertEvents = await client.query(`
+      INSERT INTO public.attorney_discipline_events
+        (attorney_id, jurisdiction, bar_number, full_name, order_date, effective_date,
+         discipline_type, discipline_raw, violation_summary, order_url, source_url)
+      SELECT a.id, s.jurisdiction, s.bar_number, s.full_name,
+             s.order_date, s.effective_date,
+             s.discipline_type, s.discipline_raw,
+             s.violation_summary, s.order_url, s.source_url
+      FROM _stg_discipline_wy s
+      JOIN public.attorneys a
+        ON a.jurisdiction = s.jurisdiction AND a.bar_number = s.bar_number
+      ON CONFLICT (jurisdiction, bar_number, order_date, discipline_type) DO NOTHING;
+    `);
+    console.error(`[db] discipline events inserted: ${insertEvents.rowCount}`);
+
+    await client.query(`DROP TABLE IF EXISTS public._stg_attorneys_wy, public._stg_discipline_wy`);
+  } finally {
+    await cleanup();
+  }
+}
+
+export function buildRecordFromClResult(r, assertedSanctionType) {
+  const docket = (r.docketNumber || '')
+    .replace(/<\/?mark>/g, '')
+    .replace(/^Case Number:\s*/i, '')
+    .replace(/\.$/, '')
+    .trim();
+
+  if (!isWyDocket(docket)) return null;
+
+  const { fullName, wsb } = parseCaseName(r.caseName || '');
+  if (!fullName) return null;
+
+  if (!ALLOWED_DISCIPLINE_TYPES.has(assertedSanctionType)) return null;
+
+  const opinionSnippet = (r.opinions && r.opinions[0] && r.opinions[0].snippet) || '';
+  const cleanSnippet = opinionSnippet.replace(/<\/?mark>/g, '').replace(/&#x27;/g, "'").replace(/\s+/g, ' ').trim();
+
+  const orderDate = r.dateFiled || null;
+  const sourceUrl = r.absolute_url ? `${CL_OPINION_BASE}${r.absolute_url}` : null;
+  if (!sourceUrl) return null;
+
+  // Prefer real WSB number when available, else use docket-derived ID.
+  const barNumber = wsb ? `WY:WSB-${wsb}` : `WY:${docket.toUpperCase()}`;
+  const summary = cleanSnippet.slice(0, 2000);
+  return {
+    bar_number: barNumber, full_name: fullName,
+    order_date: orderDate, effective_date: null,
+    discipline_type: assertedSanctionType,
+    discipline_raw: cleanSnippet ? cleanSnippet.slice(0, 500) : null,
+    violation_summary: summary,
+    order_url: sourceUrl, source_url: sourceUrl,
+  };
+}
+
+async function main() {
+  console.error(
+    `[wybar] start — apply=${OPTS.apply} startDate=${OPTS.startDate}` +
+    (OPTS.endDate ? ` endDate=${OPTS.endDate}` : '') +
+    ` limit=${OPTS.limit} startRow=${OPTS.startRow}`
+  );
+
+  let records = await discoverViaCl();
+  if (OPTS.startRow > 0) records = records.slice(OPTS.startRow);
+  if (Number.isFinite(OPTS.limit)) records = records.slice(0, OPTS.limit);
+
+  console.error(`[wybar] collected ${records.length} discipline rows`);
+
+  const preview = records.slice(0, 3);
+  console.error('[wybar] first 3 rows:');
+  for (const r of preview) {
+    console.error(
+      `  · [${r.bar_number}] ${r.full_name} — ${r.discipline_type}` +
+      ` (order_date=${r.order_date || '?'}) — ${r.source_url}`
+    );
+  }
+
+  if (!OPTS.apply) {
+    console.error('[wybar] dry-run — pass --apply to write to DB');
+    return;
+  }
+  if (records.length === 0) {
+    console.error('[wybar] no records — nothing to load');
+    return;
+  }
+  await load(records);
+  console.error('[wybar] done');
+}
+
+if (import.meta.url === `file://${process.argv[1].replace(/\\/g, '/')}` ||
+    import.meta.url === `file:///${process.argv[1].replace(/\\/g, '/').replace(/^\//, '')}`) {
+  main().catch((err) => { console.error(err); process.exit(1); });
+}


### PR DESCRIPTION
## Summary

G1c batch 8 — six new bar-discipline scrapers built on the CourtListener-anchored template (NM/NE pattern from PR #191). Per-sanction CL queries + caption + docket validation + cross-validation harness BEFORE --apply. 943 events / 891 attorneys live in prod, all with HTTPS source_url.

## Live counts

| Jurisdiction | Events | Attorneys | Date range |
|---|---|---|---|
| SD | 28 | 25 | 1990-05-09 → 2025-11-12 |
| ND | 34 | 33 | 2002-01-15 → 2025-09-22 |
| AK | 27 | 27 | 1991-01-25 → 2025-11-07 |
| DC | 730 | 711 | 1994-02-03 → 2026-04-23 |
| VT | 36 | 31 | 2009-12-24 → 2025-03-14 |
| WY | 88 | 64 | 2007-06-20 → 2026-04-08 |
| **Total** | **943** | **891** | |

## Anti-hallucination audit

- 100% HTTPS `source_url` coverage on all 943 events
- 0 NULL/non-HTTPS rows for SD/ND/AK/DC/VT/WY
- Full table now 30,320 events with 0 NULL `source_url`

## Per-state caption + docket patterns

- **SD** — `Discipline of <Name>` / `In Re the Discipline of <Name>` / `Matter of Discipline of <Name>`; 4-6 digit numeric docket
- **ND** — `Disciplinary Board v. <Name>` / `Reciprocal Discipline of <Name>`; 8-digit `No. NNNNNNNN` (multi-docket range normalized to first)
- **AK** — `In the Disciplinary Matter Involving <Name>` + legacy `In re <Name>`; rejects judicial-discipline (Honorable/Judge/Magistrate); accepts both modern `S19587` and legacy `Supreme Court No. S-NNNNN` docket forms
- **DC** — `In re <Name>` with `NN-BG-NNNN` docket suffix as noise filter (BG = Bar Grievance, distinct from CA = criminal appeal)
- **VT** — `In Re <Name> (Office of Disciplinary Counsel)` + bare `In Re <Name>` (PRB-context anchored at search level); accepts modern `NN-AP-NNN` and legacy `YYYY-NNN` docket forms
- **WY** — `Board of Professional Responsibility, Wyoming State Bar v. <Name>`; prefers WSB number from caption (`Wsb 8-6998`) for bar_number, falls back to `D-NN-NNNN` docket. `S-` prefix dockets are non-discipline (rejected).

## Cross-validation harness caught 5 parser bugs before --apply

Anti-TN-bug pattern: live CL fixtures + per-result accept/reject inspection BEFORE any `--apply`. Caught:

1. SD legacy `In Re the Discipline of` + `Matter of Discipline of` forms initially rejected → widened regex
2. AK legacy `In re <Name>` + legacy docket `Supreme Court No. S-NNNNN` forms initially rejected → added `normalizeAkDocket` helper
3. AK leading `Attorney ` in name (e.g. "Attorney Gayle Brown") was kept as part of name → stripped
4. VT Esq/ODC parenthetical requirement was overly strict; bare `In Re <Name>` forms now accepted (PRB-context-anchored at search level)
5. VT legacy `YYYY-NNN` docket form initially rejected → `normalizeVtDocket` accepts both forms

## Test plan

- [x] `node --test scripts/ingest/__tests__/scrape-{sd,nd,ak,dc,vt,wy}bar-discipline.test.mjs` — 85/85 pass
- [x] `node node_modules/typescript/bin/tsc --noEmit --skipLibCheck` — clean
- [x] Live cross-validation against current CL — parsers validated, 5 bugs caught + fixed
- [x] `--apply` ran against prod — INSERT counts confirmed
- [x] Anti-hallucination audit: 0 NULL/non-HTTPS rows
- [x] HEAD-check one source URL per state — all return CL standard 202
- [ ] CV (`node ~/projects/continuous-verification/verify.mjs --project inna --probe-only --no-trends`) — recommended after merge

## References

- Memory: `~/.claude/agent-memory/general-purpose/inaa-bar-scrapers.md` (CL-anchored template + per-sanction-query + `<mark>` gotcha + `main()` guard)
- Pattern: cl-bulk-data-defensive #18 (COPY FROM STDIN via bulkCopyRows)
- Rule: `~/.claude/rules/no-hallucinated-legal-data.md` (HTTPS source_url required for every event; never fabricate)
- Predecessor: PR #191 (MS/KS/NM/NE batch 5)