### PR TITLE
fix(apex-3): IB defensive moat copy — Dunford differentiated value (final ship)

### DIFF
--- a/src/app/federal-sentencing-distribution/page.tsx
+++ b/src/app/federal-sentencing-distribution/page.tsx
@@ -24,7 +24,7 @@ import { FadeInUp } from "@/components/motion/FadeInUp";
 import AvailabilityChecker from "@/components/tier9/AvailabilityChecker";
 
 const PRODUCT = STANDALONE_PRODUCTS["federal-sentencing-distribution"];
-const PRICE_DISPLAY = PRODUCT?.priceDisplay ?? "$297";
+const PRICE_DISPLAY = PRODUCT?.priceDisplay ?? "$297"; // layer3-prose-stakes: defensive fallback when STANDALONE_PRODUCTS lookup misses; canonical price still flows from products.ts
 const PRODUCT_NAME = PRODUCT?.name ?? "Federal Sentencing Distribution Report";
 
 export function generateMetadata(): Metadata {
@@ -109,7 +109,7 @@ const FAQ_ITEMS = [
   {
     question: "How is this different from the X-Ray?",
     answer:
-      "The Federal Sentencing Distribution Report tells you the range — what month-counts cluster where for your charge in your district. The X-Ray ($2,497) inherits this district sentencing intelligence AND tells you where YOU fit inside it via full discovery analysis. Different scope, different price step.",
+      "The Federal Sentencing Distribution Report tells you the range — what month-counts cluster where for your charge in your district. The X-Ray ($2,497) inherits this district sentencing intelligence AND tells you where YOU fit inside it via full discovery analysis. Different scope, different price step.", // layer3-prose-stakes: cross-tier reference to X-Ray price in FAQ prose
   },
 ] as const;
 

--- a/src/app/services/page.tsx
+++ b/src/app/services/page.tsx
@@ -767,7 +767,20 @@ export default function ServicesPage() {
                       {tier.price}
                     </span>
                   </div>
-                  <p className="mt-2 flex-1 text-sm text-zinc-400">{tier.desc}</p>
+                  <p className="mt-2 text-sm text-zinc-400">{tier.desc}</p>
+                  {"capabilities" in tier && Array.isArray((tier as { capabilities?: string[] }).capabilities) && (
+                    <ul className="mt-3 flex-1 list-disc space-y-1 pl-5 text-xs text-zinc-400">
+                      {(tier as { capabilities: string[] }).capabilities.map((cap) => (
+                        <li key={cap}>{cap}</li>
+                      ))}
+                    </ul>
+                  )}
+                  {tier.slug === "intelligence-brief" && (
+                    <div className="mt-3 rounded-lg border border-amber-500/20 bg-amber-500/5 p-3 text-xs text-zinc-300">
+                      <p className="mb-1 font-semibold text-amber-400">What this does that the instant reports don&apos;t</p>
+                      <p>The instant Tier 9 reports (Judge Question Brief, Motion Success, Officer Background, Similar Cases) each return one signal in isolation. The Intelligence Brief synthesizes those signals against your specific charge, state, circuit, sentencing exposure, and case stage, then an operator reviews the output before delivery. Tier 9 is instant and aggregate. Intelligence Brief is calibrated and synthesized into 15-25 case-specific questions.</p>
+                    </div>
+                  )}
                   <TierBundleValue tierSlug={tier.slug} className="mt-4" />
                   <Link
                     href={`/checkout?tier=${tier.slug}`}

--- a/src/lib/drip-emails.ts
+++ b/src/lib/drip-emails.ts
@@ -1061,6 +1061,7 @@ export const POST_PURCHASE_EMAILS: DripEmail[] = [
     html: `
       <h1 style="color: #F59E0B;">Your Questions Are Good, But There's Context They're Missing</h1>
       <p>Your Case Decoder gave you 15 questions built from what you told us. The Intelligence Brief adds what you <em>can't</em> tell us, your jurisdiction's actual patterns, your prosecutor's track record, and jurisdiction-specific leverage points.</p>
+      <p>This is what separates the Intelligence Brief from instant single-signal reports: it synthesizes judge sentencing patterns, prosecutor track record, motion grant rates, and similar-cases distribution against your specific charge, state, circuit, and case stage, then an operator reviews the output before delivery. Single-signal reports give you one piece. The Intelligence Brief calibrates all of them to your case and produces 15-25 case-specific questions.</p>
       <p><strong style="color: white;">You have already paid ${TIER_CORE["case-decoder"].priceDisplay}. The Intelligence Brief costs ${upgradeCostBetween("case-decoder", "intelligence-brief")}, credit applies within 12 months.</strong></p>
       ${cta("Get the Intelligence Brief", "/checkout?tier=intelligence-brief")}
     `,
@@ -1108,6 +1109,7 @@ export const POST_PURCHASE_EMAILS: DripEmail[] = [
     html: `
       <h1 style="color: #F59E0B;">There Are Questions Your Case Decoder Can't Answer</h1>
       <p>Your report identified areas that need your jurisdiction's actual patterns and your prosecutor's track record to answer properly. Your Case Decoder can't provide that, it was built from what you told us, not from jurisdiction data.</p>
+      <p>You could buy single-signal reports separately, judge data alone, motion grants alone, similar-cases alone, but each one gives you one slice in isolation. The Intelligence Brief synthesizes them against your specific charge, state, circuit, and sentencing exposure, then an operator reviews the output before it reaches you. That synthesis is what produces the 15-25 calibrated questions. Single-signal reports cannot do this on their own.</p>
       <p><strong style="color: white;">You have already paid ${TIER_CORE["case-decoder"].priceDisplay}. The Intelligence Brief costs ${upgradeCostBetween("case-decoder", "intelligence-brief")}, credit applies within 12 months.</strong></p>
       ${cta("Get the Intelligence Brief", "/checkout?tier=intelligence-brief")}
       <p style="margin-top: 16px; color: #A1A1AA;">Motion deadlines, evidence preservation windows, and plea negotiation leverage all erode with time.</p>

--- a/src/lib/products.ts
+++ b/src/lib/products.ts
@@ -1163,7 +1163,7 @@ export const STANDALONE_PRODUCTS: Record<string, StandaloneProduct> = {
     // tier means buyer perceives no Dream Outcome lift.
     upsellTier: "intelligence-brief",
     upsellText:
-      "Your judge is one piece. The Intelligence Brief inherits your judge data and adds full jurisdiction prosecution patterns, accountability research, and 15-25 questions calibrated to your case. $997.",
+      "Your judge is one signal in isolation. The Intelligence Brief synthesizes judge sentencing with prosecutor patterns, motion grant rates, and similar-cases distribution against YOUR specific charge, state, and circuit, then an operator reviews before delivery. Tier 9 is instant and aggregate. IB is calibrated and synthesized into 15-25 case-specific questions. $997.",
     isActive: true,
   },
   "officer-background-check": {
@@ -1184,7 +1184,7 @@ export const STANDALONE_PRODUCTS: Record<string, StandaloneProduct> = {
     // intel; lateral upsell was a Hormozi value-step violation.
     upsellTier: "x-ray",
     upsellText:
-      "Officer reliability is one angle. The X-Ray inherits this cross-case officer history AND adds full discovery analysis with 35-50 calibrated questions. $2,497.",
+      "Officer reliability is one signal in isolation. The X-Ray reads every page of your discovery and tests where this officer's cross-case credibility pattern shows up in YOUR police reports, body-cam logs, and chain-of-custody records — synthesis Tier 9 cannot do, because Tier 9 doesn't read your documents. $2,497.",
     isActive: true,
   },
   "similar-cases-analyzer": {
@@ -1208,7 +1208,7 @@ export const STANDALONE_PRODUCTS: Record<string, StandaloneProduct> = {
     // Hormozi cannibalization violation (negative value step).
     upsellTier: "x-ray",
     upsellText:
-      "Similar cases set expectations. The X-Ray inherits this cohort intelligence AND adds full discovery analysis showing where YOU fit in the distribution. $2,497.",
+      "Similar cases tell you the cohort range. The X-Ray reads every page of YOUR discovery and identifies the specific contradictions, missing evidence, and constitutional issues that move you within that distribution — synthesis the cohort report cannot do alone, because it doesn't read your documents. $2,497.",
     isActive: true,
   },
   "federal-sentencing-distribution": {
@@ -1256,7 +1256,7 @@ export const STANDALONE_PRODUCTS: Record<string, StandaloneProduct> = {
     // Case Decoder ($197 — same price tier) failed Hormozi value-step rule.
     upsellTier: "intelligence-brief",
     upsellText:
-      "A motion map shows what gets granted. The Intelligence Brief inherits this circuit grant-rate data AND tells you which motions apply to YOUR case via full prosecution pattern analysis. $997.",
+      "A motion map shows what gets granted in aggregate. The Intelligence Brief synthesizes this circuit grant-rate data with judge sentencing patterns, prosecutor track record, and similar-cases distribution against YOUR specific charge, state, and circuit, then an operator reviews before delivery. Tier 9 is instant and aggregate. IB is calibrated and synthesized into 15-25 case-specific questions. $997.",
     // 2026-04-26: flipped live — D4 verified schema + resolver e2e (audit P3#13 closed)
     isActive: true,
   },


### PR DESCRIPTION
## Summary

- /services IB tier card now carries the moat callout: **"What this does that the instant reports don't"** — names synthesis + calibration + operator review as differentiators against the $788 Tier 9 stack
- 4 Tier 9 upsellText entries rewritten (JRC, MSR -> IB; OBC, SCA -> X-Ray) with single-signal-vs-synthesis framing
- 2 post-purchase drip emails get the moat paragraph (post_case_decoder_discovery_question + post_case_decoder_upsell)

## Context

Apex catalog audit (parent plan `docs/plans/2026-04-26-apex-catalog-health-pass.md` Fix #3) found Tier 9 stack reproduces ~80% of IB's perceived value with instant delivery. April Dunford's differentiated-value test: if alternatives deliver ~80% of value at ~80% of price with faster delivery, the higher-priced product has no moat. IB had no copy explaining what it does that Tier 9 stack does NOT.

Two prior agent attempts hit usage cap before commit. Work was captured in `stash@{2}`. This PR extracts only the Fix #3-specific files (services/page.tsx moat callout + 4 upsellText entries + 2 drip-email paragraphs) onto a clean branch off master. Fix #1 work in the same stash had already merged via PR #193 — explicitly skipped.

## Files Changed

| File | Change |
|------|--------|
| `src/app/services/page.tsx` | +13 lines: capability list rendering parity (Track A) + amber-bordered moat callout for IB tier card |
| `src/lib/products.ts` | 4 upsellText replacements (JRC, OBC, SCA, MSR) |
| `src/lib/drip-emails.ts` | 2 paragraph additions in post_case_decoder_discovery_question + post_case_decoder_upsell |
| `src/app/federal-sentencing-distribution/page.tsx` | +2 layer3-prose-stakes marker comments (unblocks pre-commit price-check hook on $297 fallback const + $2,497 X-Ray FAQ reference — pre-existing master state, semantics unchanged) |

## Hard Constraints (all honored)

- IB price unchanged: $997 (verified `src/lib/tiers.ts:184`)
- IB delivery unchanged: 72 hours (verified `src/lib/tiers.ts:186`)
- Stripe price IDs / URL slugs / DB tier_slug unchanged (no tiers.ts edits)
- Tone: clinical + defendant-empathetic
- No banned UPL phrases introduced (pre-existing "ask your attorney" copy in playbook descriptions outside Fix #3 lines)
- Tier 9 not disparaged — framed as "instant + aggregate" vs "calibrated + synthesized" tradeoff

## Cited Expert

April Dunford, *Obviously Awesome* (cached `~/.claude/experts/april-dunford.md`) — differentiated-value test.

## Test plan

- [x] `git diff master --stat` shows only the 4 files (3 Fix #3 + 1 hook-unblocker)
- [x] `node node_modules/typescript/bin/tsc --noEmit --skipLibCheck` after `rm -rf .next/types` — 0 errors
- [x] Moat statement in services/page.tsx matches plan verbatim (line 781)
- [x] No banned UPL phrases introduced in modified regions
- [x] Pre-commit price-check passes (49 anchors, 0 mismatches)
- [ ] Vercel preview build clean (commit used SKIP_TSC=1 + push used SKIP_BUILD=1 because system `npx tsc` and `next` shims are broken on this machine — direct `node node_modules/typescript/bin/tsc` ran clean before commit; Vercel will run a real build)
- [ ] Visual QA on /services preview — IB tier card moat callout renders amber-bordered

## Stash disposition

`stash@{3}` (the original Fix #3 stash, was `stash@{2}` before this session bumped indices) will be dropped after this PR merges. `stash@{0}-{2}` are sibling-session work — leaving alone per instructions.

Plan: `docs/plans/2026-04-26-apex-fix3-ib-moat.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)