### PR TITLE
fix(apex-c1c2): build landings + re-flip live for charge-authority-pack + precedent-watchlist

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,12 +1,12 @@
 # Architecture, ImNotAnAttorney-web
 
-> Living document. Updated: 2026-04-23. Read this before making any change.
+> Living document. Updated: 2026-04-27. Read this before making any change.
 > Subsystem details live in `CONTEXT.md` files next to the code. This file is the system map.
 > For column-level DB schema: `supabase/SCHEMA.md`. For state machines: `supabase/CONTEXT.md`. For email sequences: `src/lib/CONTEXT.md`.
 
 ## System Overview
 
-Legal empowerment platform for criminal defendants. "We Research. You Ask." Combines a content funnel (60 MDX blog posts, free ungated resources, Plea Analyzer acquisition wedge) with e-commerce (8 playbooks at $127/$147, 5 service tiers at $197–$9,997, 49 standalone products, 35 paid $97–$497, 14 free, across 4 categories) and automated case processing (Claude AI report generation). Live at imnotanattorney.com.
+Legal empowerment platform for criminal defendants. "We Research. You Ask." Combines a content funnel (70 MDX blog posts as of 2026-04-27, free ungated resources, Plea Analyzer acquisition wedge) with e-commerce (8 playbooks at $127/$147, 5 service tiers at $197–$9,997, 49 standalone products, 35 paid $97–$497, 14 free, across 4 categories) and automated case processing (Claude AI report generation). Live at imnotanattorney.com.
 
 One of three repos in the INAA ecosystem: `ImNotAnAttorney` (business docs/templates), `ImNotAnAttorney-web` (this, customer-facing), `ImNotAnAttorney-engine` (background job workers). All three share the same Supabase database.
 
@@ -46,7 +46,7 @@ Properties that MUST hold system-wide. Violating any of these is a critical defe
 
 | Subsystem | What It Does | Details |
 |---------, |-------------|---------|
-| **Pages & Routes** | 80+ pages + 120+ API routes (App Router) — added /pji, /pji/[circuit], /pji/[circuit]/[instruction], /assault-defense[/state], /drug-possession-defense[/state], /domestic-violence-defense[/state], /admin/tier-generation, /tools/scotus-case-search, /research/defense-score-data, /district-court-intelligence | [`src/app/CONTEXT.md`](src/app/CONTEXT.md) |
+| **Pages & Routes** | 80+ pages + 120+ API routes (App Router) — added /pji, /pji/[circuit], /pji/[circuit]/[instruction], /assault-defense[/state], /drug-possession-defense[/state], /domestic-violence-defense[/state], /admin/tier-generation, /tools/scotus-case-search, /research/defense-score-data, /district-court-intelligence; Phase C 2026-04-27 added `/api/cron/quora-discovery` (scaffold returns 503 with runbook) + `/api/cron/gsc-query-discovery` (LIVE, weekly Mon 13:00 UTC, jobId 7533529, inlined GSC service-account JWT auth) | [`src/app/CONTEXT.md`](src/app/CONTEXT.md) |
 | **Core Business Logic** | Auth, payments, email, cron, reports, scoring, sanitization, **Phase 2 cite-tag transform + entity whitelist + badge renderer** | [`src/lib/CONTEXT.md`](src/lib/CONTEXT.md) |
 | **Standalone Products** | 49 active (59 total, 10 inactive): calculators (incl. Federal Sentencing Distribution $297 + SCOTUS Case Search), content guides, research reports, bundles | `src/lib/products.ts` + `src/lib/bundles.ts` |
 | **UI Components** | 80+ components + `ReportVerificationFooter` (live confidence-tier head count from `v_entity_confidence`) + `RelatedStateCharges` (pSEO cross-state linking) | [`src/components/CONTEXT.md`](src/components/CONTEXT.md) |

--- a/docs/plans/2026-04-27-apex-c1c2-dark-skus-landings.md
+++ b/docs/plans/2026-04-27-apex-c1c2-dark-skus-landings.md
@@ -1,0 +1,149 @@
+# Plan — Apex C1+C2 Dark-SKU Landings + Re-Flip Live
+
+Date: 2026-04-27
+Branch: `fix/apex-c1c2-dark-skus-landings`
+Repo: `C:/Users/email/projects/ImNotAnAttorney-web`
+Closes: `docs/plans/2026-04-26-worry-tier9-flipped-live.md` C1 + C2 + S1 (last
+two deferred items in the audit thread).
+
+## Summary
+
+PR #188 stop-the-bleed reverted `charge-authority-pack` ($97) and
+`precedent-watchlist` ($47) to `live: false / isActive: false` because both
+were live but had no dedicated landing route. Customers reaching them got the
+generic `/services/[slug]` fallback with no AvailabilityChecker — no way to
+collect `chargeType` (and optional `state`) pre-purchase, so the post-purchase
+intake was the only collection point. PR #188 was correct to dark them.
+
+This PR closes that loop:
+- Build dedicated `/charge-authority-pack` landing page mirroring the 8 prior
+  Tier 9 dedicated landings (most recent template:
+  `src/app/federal-jury-instruction-brief/page.tsx`).
+- Build dedicated `/precedent-watchlist` landing page in the same shape, with
+  drip explainer surfaced as part of the value prop (30-day, 4-email cadence).
+- Widen `AvailabilityChecker` `Slug` union to include both slugs and route
+  per-slug intake-payload branches in `handleCheck`, `handleWaitlist`,
+  `buildCheckoutUrl`.
+- Re-flip both `live: true` (`tiers.ts`) + `isActive: true` (`products.ts`).
+
+## Files to create
+
+1. `src/app/charge-authority-pack/page.tsx` — server component landing page,
+   mounts `<AvailabilityChecker slug="charge-authority-pack" .../>`. Mirrors
+   FJB landing structure (Metadata, FAQ, CHECK_ITEMS, JSON-LD Product +
+   BreadcrumbList, methodology disclaimer, mandatory gate line). Sample data
+   uses verified DUI / drug-trafficking / drug-possession-cocaine baseline
+   counts (the three CHARGE_TYPE_AUTHORITY_MAP keys with dense coverage per
+   audit W3).
+2. `src/app/precedent-watchlist/page.tsx` — same shape; surfaces the 30-day
+   drip cadence on the page. Sample data references the
+   `citation_velocity_criminal` 1.13M-row corpus + the rising/fading shape.
+
+## Files to modify
+
+3. `src/components/tier9/AvailabilityChecker.tsx`
+   - Extend `Slug` union to add `'charge-authority-pack'` and
+     `'precedent-watchlist'`.
+   - Per-slug intake-payload branches in `handleCheck` (POST body), in
+     `handleWaitlist` (waitlist payload), and in `buildCheckoutUrl` (URL
+     params): both pass `chargeType` (required) + optional `state`.
+   - Charge-type select condition (`slug === 'similar-cases-analyzer' || ...`)
+     extended to include both new slugs.
+   - "Check a different X" button label condition extended (X = "charge").
+   - Add a per-charge-authority-pack fallback transparency banner: when the
+     selected `chargeType` resolves to zero `charge_type_top_authorities`
+     rows but the criminal national fallback exists, display a yellow info
+     banner so the customer knows the report uses national authorities.
+     Mirrors the `pleaStateMissing` / `arrestKitThinState` D-T4 pattern.
+4. `src/lib/tier9-reports/coverage.ts` — append two helpers:
+   - `checkChargeAuthorityPackCoverage(chargeType, state)` — counts
+     `charge_type_top_authorities` rows for the bridged internal slugs (via
+     `CHARGE_TYPE_AUTHORITY_MAP`). Returns `{ available: true, coverage:
+     { authoritiesCharge, authoritiesNational }, ... }`. `available` always
+     true (national fallback is real data); banner condition lives in
+     AvailabilityChecker.
+   - `checkPrecedentWatchlistCoverage(chargeType, state)` — counts
+     `citation_velocity_criminal WHERE charge_type_slug = ANY(bridged) AND
+     rising_flag = true` plus a fading-flag count. Returns
+     `{ available: true, coverage: { risingPrecedents, fadingPrecedents }, ... }`.
+5. `src/app/api/check-availability/[slug]/route.ts` — add two `case`
+   branches calling the new helpers. Reuse the existing `chargeType`
+   validation (`isValidChargeType`).
+6. `src/components/tier9/AvailabilityChecker.tsx` `COVERAGE_LABELS` — add
+   labels for `authoritiesCharge`, `authoritiesNational`, `risingPrecedents`,
+   `fadingPrecedents`.
+7. `src/app/sitemap.ts` — extend `DEDICATED_ROUTE_SLUGS` set to include both
+   slugs (so `/services/<slug>` is deduped) and emit explicit
+   sitemap entries for the two new dedicated routes (priority 0.8).
+8. `src/lib/tiers.ts` — flip `charge-authority-pack.live` + `precedent-
+   watchlist.live` from `false` → `true`. Update inline comments to cite
+   2026-04-27 closure.
+9. `src/lib/products.ts` — flip both `isActive: false` → `true` with same
+   comment update.
+
+## Tests
+
+10. `src/lib/tier9-reports/__tests__/charge-authority-pack-coverage.test.ts` —
+    mock pattern from `arrest-kit-coverage.test.ts`. Asserts the helper
+    returns `available: true` and surfaces both `authoritiesCharge` (via
+    bridged internal slugs) and `authoritiesNational`.
+11. `src/lib/tier9-reports/__tests__/precedent-watchlist-coverage.test.ts` —
+    same pattern. Asserts rising + fading counters surface and `available:
+    true` even when zero rising rows (the resolver uses national fallback).
+12. `src/components/tier9/__tests__/availability-checker-slugs.test.ts` —
+    sync test asserting the AvailabilityChecker `Slug` union literally
+    contains all 9 slugs (the 7 active + 2 new). Mirror of the FJB-charges
+    sync test pattern.
+
+## Out of scope
+
+- Data ingestion / pipeline changes
+- Renderer copy refactors (charge-authority-pack.ts + precedent-watchlist.ts
+  resolvers untouched)
+- Stripe price ID changes (UNCHANGED — $97 / $47)
+- DB migrations
+- Cron route changes (the precedent-watchlist drip cron stays as-is)
+- `content/blog/`, `blog-pipeline/`, `scripts/blog-pipeline/` (sibling
+  session territory per branch protection)
+
+## Hard constraints
+
+- URL slugs UNCHANGED: `/charge-authority-pack`, `/precedent-watchlist`.
+- DB `tier_slug` UNCHANGED.
+- Stripe price IDs UNCHANGED.
+- Mandatory gate line per SKU rendered on the page:
+  - charge-authority-pack: "Top-cited authorities are aggregate frequencies.
+    Use them to ask sharper questions, not to predict your case."
+  - precedent-watchlist: "Citation velocity reflects which precedents are
+    gaining or fading. Use it as a starting point for research, not a
+    verdict."
+- No banned UPL phrases — `UPL_BANNED_PHRASES` from
+  `src/lib/charge-slug-maps.ts`.
+- Tone: clinical + defendant-empathetic.
+- Pattern parity: byte-for-byte structural mirror of FJB landing.
+
+## Verification
+
+- `rm -rf .next/types && node node_modules/typescript/bin/tsc --noEmit
+  --skipLibCheck` → 0 errors.
+- `npx vitest run src/lib/tier9-reports/__tests__ src/components/tier9/__tests__`
+  → all green.
+- Grep verify no banned UPL phrases in either new landing.
+- Grep verify mandatory gate line per SKU present on the new pages.
+- Grep verify `Slug` union literal includes both new slugs.
+
+## Cascade
+
+- us (Atlas): closes the audit loop; both SKUs sellable end-to-end.
+- direct counterparty (defendants): pre-purchase intake collects `chargeType`
+  + `state`, so the report (and the precedent-watchlist drip) seeds correctly
+  on day one — no fragile post-purchase fallback.
+- their downstream (defendants' families, attorneys): correctly-seeded report
+  is sharper context for the representation conversation.
+- ecosystem (Tier 9 catalog): all 10 Tier 9 slugs end up at parity — every
+  one has a dedicated route + intake. No silent fallback to `/services/<slug>`
+  for products that need slug-specific intake.
+- future-us (next Tier 9 SKU): the AvailabilityChecker Slug union expansion
+  is now in the canonical pattern; future SKUs follow the same recipe.
+
+No node loses. Cascade-positive.

--- a/src/app/api/check-availability/[slug]/route.ts
+++ b/src/app/api/check-availability/[slug]/route.ts
@@ -14,6 +14,8 @@ import {
   checkFJIBCoverage,
   checkMotionSuccessCoverage,
   checkFederalSentencingCoverage,
+  checkChargeAuthorityPackCoverage,
+  checkPrecedentWatchlistCoverage,
   type CoverageResult,
 } from "@/lib/tier9-reports/coverage";
 import { isValidChargeType } from "@/lib/charge-types";
@@ -204,6 +206,26 @@ export async function POST(
           return NextResponse.json({ error: "Valid charge type required" }, { status: 400 });
         }
         const result = await checkFederalSentencingCoverage(chargeType, state);
+        return handleWaitlist(result, chargeType, chargeType);
+      }
+
+      case "charge-authority-pack": {
+        // 2026-04-27 — closes C1 of worry-tier9-flipped-live audit.
+        const chargeType = typeof body.chargeType === "string" ? body.chargeType.trim() : "";
+        if (!chargeType || !isValidChargeType(chargeType)) {
+          return NextResponse.json({ error: "Valid charge type required" }, { status: 400 });
+        }
+        const result = await checkChargeAuthorityPackCoverage(chargeType, state);
+        return handleWaitlist(result, chargeType, chargeType);
+      }
+
+      case "precedent-watchlist": {
+        // 2026-04-27 — closes C2 of worry-tier9-flipped-live audit.
+        const chargeType = typeof body.chargeType === "string" ? body.chargeType.trim() : "";
+        if (!chargeType || !isValidChargeType(chargeType)) {
+          return NextResponse.json({ error: "Valid charge type required" }, { status: 400 });
+        }
+        const result = await checkPrecedentWatchlistCoverage(chargeType, state);
         return handleWaitlist(result, chargeType, chargeType);
       }
 

--- a/src/app/charge-authority-pack/page.tsx
+++ b/src/app/charge-authority-pack/page.tsx
@@ -1,0 +1,452 @@
+/**
+ * Charge Authority Pack landing page (/charge-authority-pack)
+ *
+ * Standalone Tier 9 data product, $97, instant delivery. Activates
+ * charge_type_top_authorities (548 rows), authority_quotes_criminal (254
+ * rows), citation_velocity_criminal (1.13M rows), and citation_authority_
+ * criminal (620k rows national fallback) — see
+ * src/lib/tier9-reports/charge-authority-pack.ts for resolver scope + UPL.
+ *
+ * Built 2026-04-27 to close C1 of docs/plans/2026-04-26-worry-tier9-flipped-
+ * live.md. PR #188 stop-the-bleed reverted this SKU to dark because no
+ * dedicated landing route existed — customers reaching the generic
+ * /services/<slug> fallback could not collect chargeType pre-purchase.
+ *
+ * Server component; AvailabilityChecker is a client island.
+ */
+import type { Metadata } from "next";
+import { SITE_URL } from "@/lib/site";
+import { TIER_CORE } from "@/lib/tiers";
+import { TrustBadges } from "@/components/TrustBadges";
+import { FAQAccordion } from "@/components/FAQAccordion";
+import { FadeInUp } from "@/components/motion/FadeInUp";
+import AvailabilityChecker from "@/components/tier9/AvailabilityChecker";
+
+export function generateMetadata(): Metadata {
+  return {
+    title: `Charge Authority Pack, ${TIER_CORE["charge-authority-pack"].priceDisplay} | ImNotAnAttorney`,
+    description:
+      "Top 10 must-cite defense authorities for your charge type — case name, citation, authority tier, pre-extracted canonical quote, and citation-velocity arrow. Every row links to CourtListener for independent verification.",
+    alternates: { canonical: `${SITE_URL}/charge-authority-pack` },
+    openGraph: {
+      title:
+        "Charge Authority Pack — The Top 10 Authorities Cited In Your Charge Type",
+      description:
+        "Top 10 must-cite defense authorities, pre-extracted canonical quotes, citation-velocity arrows, every row linked to CourtListener.",
+      url: `${SITE_URL}/charge-authority-pack`,
+    },
+  };
+}
+
+/* ------------------------------------------------------------------ */
+/*  Static data                                                        */
+/* ------------------------------------------------------------------ */
+
+const CHECK_ITEMS = [
+  "Top 10 must-cite defense authorities for your charge type — case name, citation, and authority tier",
+  "Pre-extracted canonical quote per authority — the exact sentence other defense filings have cited from each opinion",
+  "Citation-velocity arrow per row — rising, stable, or fading over the last 24 months",
+  "Every row links to the CourtListener opinion you can verify yourself — no row ships without a source URL",
+  "When the charge type has zero rows in the charge-specific table, the report falls back to the national criminal-authority pool with the fallback called out clearly",
+  "Methodology + UPL disclaimer on every section",
+  "Top-cited authorities are aggregate frequencies. Use them to ask sharper questions, not to predict your case.",
+] as const;
+
+const SAMPLE_ROWS = [
+  {
+    metric: "Indexed top-cited authorities (charge-specific)",
+    value: "548 rows",
+    source: "charge_type_top_authorities",
+  },
+  {
+    metric: "Pre-extracted canonical quotes",
+    value: "254 rows",
+    source: "authority_quotes_criminal",
+  },
+  {
+    metric: "Citation-velocity rows tracked",
+    value: "1,131,000+ rows",
+    source: "citation_velocity_criminal",
+  },
+  {
+    metric: "National criminal-authority fallback pool",
+    value: "620,000+ rows",
+    source: "citation_authority_criminal",
+  },
+  {
+    metric: "Charges with dense charge-specific coverage",
+    value: "DUI / Drug Trafficking / Cocaine Possession",
+    source: "CHARGE_TYPE_AUTHORITY_MAP",
+  },
+] as const;
+
+const FAQ_ITEMS = [
+  {
+    question: "What is in the Charge Authority Pack?",
+    answer:
+      "Three sections built from indexed criminal court records: (1) the top 10 must-cite defense authorities for your charge type, with case name, citation, and authority tier; (2) the pre-extracted canonical quote from each authority — the exact sentence defense filings have cited from that opinion; (3) a citation-velocity arrow per row showing whether the authority is rising, stable, or fading over the last 24 months. Every row links to CourtListener.",
+  },
+  {
+    question: "Where does the data come from?",
+    answer:
+      "Indexed criminal court records aggregated into charge_type_top_authorities (548 charge-specific rows), authority_quotes_criminal (254 pre-extracted canonical quotes), and citation_velocity_criminal (1.13M velocity rows). Rows without a CourtListener source URL are suppressed — every cited case carries a verifiable URL.",
+  },
+  {
+    question: "Is this legal advice?",
+    answer:
+      "No. This is legal INFORMATION — aggregate citation frequencies and verbatim quotes from public criminal-defense opinions. Top-cited authorities are aggregate frequencies. Use them to ask sharper questions, not to predict your case.",
+  },
+  {
+    question: "How is it delivered?",
+    answer:
+      "Instantly on purchase. The report is generated on demand from the verified authority corpus and rendered to your email within 60 seconds.",
+  },
+  {
+    question: "What if my charge type has thin charge-specific coverage?",
+    answer:
+      "Before checkout you will see how many charge-specific top-cited authorities back your charge type. When that count is zero, the report falls back to the 620,000-row national criminal-authority pool with the fallback called out on every section. The Availability Checker discloses the fallback before purchase so you can decide whether to buy or waitlist.",
+  },
+  {
+    question: "How is this different from the Intelligence Brief?",
+    answer:
+      `The Charge Authority Pack is one focused slice — the top 10 authorities for your charge type, with quotes and velocity arrows. The Intelligence Brief (${TIER_CORE["intelligence-brief"].priceDisplay}) synthesizes this authority data with judge sentencing patterns, prosecutor track record, and similar-cases distribution against YOUR specific charge, state, and circuit, then an operator reviews the output before delivery. Tier 9 is instant and aggregate. Intelligence Brief is calibrated and synthesized into 15-25 case-specific questions.`,
+  },
+] as const;
+
+/* ------------------------------------------------------------------ */
+/*  JSON-LD structured data                                            */
+/* ------------------------------------------------------------------ */
+
+const breadcrumbLd = {
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  itemListElement: [
+    {
+      "@type": "ListItem",
+      position: 1,
+      name: "Home",
+      item: SITE_URL,
+    },
+    {
+      "@type": "ListItem",
+      position: 2,
+      name: "Charge Authority Pack",
+      item: `${SITE_URL}/charge-authority-pack`,
+    },
+  ],
+};
+
+const faqLd = {
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  mainEntity: FAQ_ITEMS.map((faq) => ({
+    "@type": "Question",
+    name: faq.question,
+    acceptedAnswer: {
+      "@type": "Answer",
+      text: faq.answer,
+    },
+  })),
+};
+
+/* ------------------------------------------------------------------ */
+/*  Checkmark icon                                                     */
+/* ------------------------------------------------------------------ */
+
+function CheckIcon() {
+  return (
+    <svg
+      className="mt-0.5 h-5 w-5 shrink-0 text-amber-400"
+      aria-hidden="true"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      strokeWidth={2}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M5 13l4 4L19 7"
+      />
+    </svg>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Page                                                               */
+/* ------------------------------------------------------------------ */
+
+export default function ChargeAuthorityPackPage() {
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-16">
+      {/* ---------- HERO ---------- */}
+      <FadeInUp>
+        <section aria-labelledby="hero-heading" className="text-center">
+          <p className="text-xs font-bold uppercase tracking-widest text-amber-400">
+            Charge Authority Pack
+          </p>
+
+          <p className="mb-6 text-base leading-relaxed text-zinc-400">
+            In every criminal-defense filing on your charge type, the same
+            handful of opinions get cited over and over. The prosecutor knows
+            them. The judge has read them a hundred times. Most defendants
+            never see the list.
+          </p>
+
+          <h1
+            id="hero-heading"
+            className="font-display mt-4 text-4xl font-extrabold leading-tight text-white sm:text-5xl"
+          >
+            The Top 10 Authorities Cited In Your Charge Type
+          </h1>
+
+          <p className="mt-4 text-lg text-zinc-400">
+            Case name, citation, authority tier, pre-extracted canonical quote,
+            and a 24-month citation-velocity arrow per row. Every row links to
+            the CourtListener opinion you can verify yourself.
+          </p>
+
+          <p className="mt-6 text-base text-zinc-300 italic">
+            Top-cited authorities are aggregate frequencies. Use them to ask
+            sharper questions, not to predict your case.
+          </p>
+
+          <p className="mt-6 text-4xl font-extrabold text-amber-400">
+            {TIER_CORE["charge-authority-pack"].priceDisplay}
+          </p>
+
+          <p className="mt-2 text-sm text-zinc-400">
+            Generated on demand from indexed criminal court records &mdash;
+            delivered on purchase.
+          </p>
+
+          <p className="mt-2 text-sm text-zinc-300">
+            Verified public sources: CourtListener appellate authorities &times;
+            authority-quote extraction &times; 24-month citation-velocity
+            tracking
+          </p>
+
+          <div id="availability" className="mt-6 scroll-mt-24">
+            <AvailabilityChecker
+              slug="charge-authority-pack"
+              productName="Charge Authority Pack"
+              priceDisplay={
+                TIER_CORE["charge-authority-pack"].priceDisplay
+              }
+            />
+          </div>
+        </section>
+      </FadeInUp>
+
+      {/* ---------- WHAT YOU GET ---------- */}
+      <FadeInUp>
+        <section aria-labelledby="features-heading" className="mt-20">
+          <h2
+            id="features-heading"
+            className="font-display text-2xl font-bold text-white"
+          >
+            What You Get
+          </h2>
+
+          <ul className="mt-8 space-y-4">
+            {CHECK_ITEMS.map((item) => (
+              <li
+                key={item}
+                className="flex items-start gap-3 text-zinc-300"
+              >
+                <CheckIcon />
+                <span>{item}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      </FadeInUp>
+
+      {/* ---------- SAMPLE DATA ---------- */}
+      <FadeInUp>
+        <section aria-labelledby="sample-heading" className="mt-20">
+          <h2
+            id="sample-heading"
+            className="font-display text-2xl font-bold text-white"
+          >
+            Sample Pack Inventory
+          </h2>
+
+          <div className="mt-8 overflow-x-auto rounded-lg border border-zinc-700">
+            <table className="w-full text-left text-sm">
+              <caption className="sr-only">
+                Sample authority-pack corpus inventory
+              </caption>
+              <thead className="border-b border-zinc-700 bg-zinc-900">
+                <tr>
+                  <th scope="col" className="px-4 py-3 font-semibold text-zinc-200">
+                    Metric
+                  </th>
+                  <th scope="col" className="px-4 py-3 font-semibold text-zinc-200">
+                    Value
+                  </th>
+                  <th scope="col" className="px-4 py-3 font-semibold text-zinc-200">
+                    Source
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-zinc-800">
+                {SAMPLE_ROWS.map((row) => (
+                  <tr key={row.metric}>
+                    <th
+                      scope="row"
+                      className="whitespace-nowrap px-4 py-3 font-medium text-zinc-300"
+                    >
+                      {row.metric}
+                    </th>
+                    <td className="px-4 py-3 text-zinc-400">{row.value}</td>
+                    <td className="px-4 py-3 text-zinc-400">{row.source}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          <p className="mt-3 text-xs text-zinc-400">
+            Inventory shown to illustrate corpus shape. Your pack contains the
+            top 10 authorities scoped to the charge slug you select, each with
+            citation, pre-extracted quote, and a 24-month velocity arrow.
+          </p>
+        </section>
+      </FadeInUp>
+
+      {/* ---------- TRUST ---------- */}
+      <FadeInUp>
+        <section aria-labelledby="trust-heading" className="mt-20">
+          <h2
+            id="trust-heading"
+            className="font-display text-2xl font-bold text-white"
+          >
+            Why You Can Trust This Data
+          </h2>
+
+          <p className="mt-4 text-zinc-400">
+            Every authority in your pack carries a CourtListener URL you can
+            open and read in full. Pre-extracted quotes are verbatim from the
+            opinion text — same sentence other defense filings have cited.
+            Rows without a verifiable source URL are suppressed rather than
+            rendered.
+          </p>
+
+          <p className="mt-3 text-sm text-zinc-400">
+            Authority-tier labels and citation counts are aggregated from
+            charge_type_top_authorities (548 charge-specific rows) with a
+            citation_authority_criminal national fallback when the charge slug
+            has zero charge-specific rows. Citation-velocity arrows reflect a
+            24-month rolling window over the citation_velocity_criminal corpus.
+            The Availability Checker on this page discloses the fallback
+            before purchase when it applies.
+          </p>
+
+          <div className="mt-8">
+            <TrustBadges variant="pricing" />
+          </div>
+        </section>
+      </FadeInUp>
+
+      {/* ---------- FAQ ---------- */}
+      <section aria-labelledby="faq-heading" className="mt-20">
+        <h2
+          id="faq-heading"
+          className="font-display text-2xl font-bold text-white"
+        >
+          Frequently Asked Questions
+        </h2>
+
+        <div className="mt-8">
+          <FAQAccordion items={[...FAQ_ITEMS]} />
+        </div>
+      </section>
+
+      {/* ---------- FINAL CTA ---------- */}
+      <FadeInUp>
+        <section aria-labelledby="cta-heading" className="mt-20 text-center">
+          <h2
+            id="cta-heading"
+            className="font-display text-2xl font-bold text-white"
+          >
+            Get the Charge Authority Pack &mdash;{" "}
+            <span className="text-amber-400">
+              {TIER_CORE["charge-authority-pack"].priceDisplay}
+            </span>
+          </h2>
+
+          <p className="mt-4 text-zinc-400">
+            Most defendants walk into the courtroom unaware of which
+            authorities the prosecutor will reach for first. Defendants who
+            prepare walk in knowing the top 10, the canonical quotes, and
+            which precedents are gaining or losing weight in the last 24
+            months. Yours in 60 seconds.
+          </p>
+
+          <div className="mt-6">
+            <AvailabilityChecker
+              slug="charge-authority-pack"
+              productName="Charge Authority Pack"
+              priceDisplay={
+                TIER_CORE["charge-authority-pack"].priceDisplay
+              }
+            />
+          </div>
+
+          <p className="mt-4 text-xs text-zinc-400">
+            This is legal information, not legal advice. The pack reproduces
+            verifiable citations and verbatim quotes from public criminal-
+            defense opinions. Decisions about how to use the information stay
+            with you.
+          </p>
+
+          <p className="mt-3 text-sm text-zinc-400">
+            Questions before you buy?{" "}
+            <a
+              href="mailto:help@imnotanattorney.com"
+              className="text-amber-400 underline decoration-amber-400/50 hover:decoration-amber-400"
+            >
+              help@imnotanattorney.com
+            </a>
+            {" "}&mdash; a defendant-side researcher replies, not a bot.
+          </p>
+        </section>
+      </FadeInUp>
+
+      {/* ---------- JSON-LD: Product ---------- */}
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            "@context": "https://schema.org",
+            "@type": "Product",
+            name: "Charge Authority Pack",
+            description:
+              "Top 10 must-cite defense authorities for your charge type, with case name, citation, authority tier, pre-extracted canonical quote, and 24-month citation-velocity arrow. Every row linked to CourtListener.",
+            url: `${SITE_URL}/charge-authority-pack`,
+            brand: {
+              "@type": "Organization",
+              "@id": "https://imnotanattorney.com/#organization",
+            },
+            offers: {
+              "@type": "Offer",
+              price: "97.00",
+              priceCurrency: "USD",
+              availability: "https://schema.org/InStock",
+              url: `${SITE_URL}/checkout?standaloneProduct=charge-authority-pack`,
+            },
+          }),
+        }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbLd) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqLd) }}
+      />
+    </div>
+  );
+}

--- a/src/app/precedent-watchlist/page.tsx
+++ b/src/app/precedent-watchlist/page.tsx
@@ -1,0 +1,497 @@
+/**
+ * Precedent Watchlist landing page (/precedent-watchlist)
+ *
+ * Standalone Tier 9 data product, $47, instant + 30-day email drip.
+ * Activates citation_velocity_criminal (1.13M rows) — see
+ * src/lib/tier9-reports/precedent-watchlist.ts for resolver scope + UPL.
+ *
+ * Built 2026-04-27 to close C2 of docs/plans/2026-04-26-worry-tier9-flipped-
+ * live.md. PR #188 stop-the-bleed reverted this SKU to dark because no
+ * dedicated landing route existed — customers reaching the generic
+ * /services/<slug> fallback could not collect chargeType pre-purchase, so
+ * the 4-email drip seed (orders.watchlist_email_state JSONB) was fragile.
+ *
+ * Server component; AvailabilityChecker is a client island.
+ */
+import type { Metadata } from "next";
+import { SITE_URL } from "@/lib/site";
+import { TIER_CORE } from "@/lib/tiers";
+import { TrustBadges } from "@/components/TrustBadges";
+import { FAQAccordion } from "@/components/FAQAccordion";
+import { FadeInUp } from "@/components/motion/FadeInUp";
+import AvailabilityChecker from "@/components/tier9/AvailabilityChecker";
+
+export function generateMetadata(): Metadata {
+  return {
+    title: `Precedent Watchlist, ${TIER_CORE["precedent-watchlist"].priceDisplay} | ImNotAnAttorney`,
+    description:
+      "Top 10 fastest-rising and top 5 fastest-fading criminal-defense precedents for your charge type. Arrow-glyph velocity deltas over the last 24 months, every row linked to CourtListener, plus 4 weekly email updates over 30 days.",
+    alternates: { canonical: `${SITE_URL}/precedent-watchlist` },
+    openGraph: {
+      title:
+        "Precedent Watchlist — Which Precedents Are Gaining And Fading For Your Charge",
+      description:
+        "Top 10 rising and top 5 fading criminal-defense precedents for your charge, plus 4 weekly email updates over 30 days. Sourced from 1.13M citation-velocity rows.",
+      url: `${SITE_URL}/precedent-watchlist`,
+    },
+  };
+}
+
+/* ------------------------------------------------------------------ */
+/*  Static data                                                        */
+/* ------------------------------------------------------------------ */
+
+const CHECK_ITEMS = [
+  "Top 10 fastest-rising criminal-defense precedents for your charge type — case name, citation, authority tier, citation-velocity arrow, and CourtListener URL",
+  "Top 5 fastest-fading precedents for your charge — what defense filings used to lean on but increasingly don't",
+  "24-month rolling citation-velocity window — same delta the derivation pipeline computes quarterly across 1.13M citation rows",
+  "Every row links to the CourtListener opinion you can verify yourself — no row ships without a source URL",
+  "30-day email drip: 4 weekly updates surfacing the latest velocity-rank shifts for your charge",
+  "When the charge type has zero rising rows, the report falls back to the national criminal rising-precedent pool with the fallback called out clearly",
+  "Citation velocity reflects which precedents are gaining or fading. Use it as a starting point for research, not a verdict.",
+] as const;
+
+const SAMPLE_ROWS = [
+  {
+    metric: "Citation-velocity rows tracked",
+    value: "1,131,000+ rows",
+    source: "citation_velocity_criminal",
+  },
+  {
+    metric: "Rolling window per row",
+    value: "24 months",
+    source: "VELOCITY_WINDOW_MONTHS",
+  },
+  {
+    metric: "Rising-precedent rows surfaced per pack",
+    value: "Top 10",
+    source: "rising_flag = true",
+  },
+  {
+    metric: "Fading-precedent rows surfaced per pack",
+    value: "Top 5",
+    source: "velocity_tier = fading",
+  },
+  {
+    metric: "Email cadence after purchase",
+    value: "4 weekly updates over 30 days",
+    source: "/api/cron/precedent-watchlist-emails",
+  },
+] as const;
+
+const FAQ_ITEMS = [
+  {
+    question: "What is in the Precedent Watchlist?",
+    answer:
+      "Three sections built from the citation-velocity corpus: (1) the top 10 fastest-rising criminal-defense precedents for your charge type — case name, citation, authority tier, velocity arrow, and CourtListener URL; (2) the top 5 fastest-fading precedents — what defense filings used to cite but increasingly don't; (3) methodology and a UPL disclaimer. Every row links to CourtListener.",
+  },
+  {
+    question: "What about the 30-day email drip?",
+    answer:
+      "After purchase you receive up to 4 weekly emails over 30 days. Each email surfaces the latest rank shifts in the rising and fading lists for your charge type — when a precedent climbs into the top 10 or drops out, you see it. The drip seed is set at purchase from the chargeType you selected; no further intake required. You can unsubscribe at any time.",
+  },
+  {
+    question: "Where does the data come from?",
+    answer:
+      "Indexed criminal court records aggregated into citation_velocity_criminal (1.13M velocity rows, 24-month rolling window, computed quarterly by the derivation pipeline). Rising-precedent rows are flagged when the velocity slope crosses the rising threshold; fading rows when the velocity tier drops to fading. Every cited case carries a CourtListener URL.",
+  },
+  {
+    question: "Is this legal advice?",
+    answer:
+      "No. This is legal INFORMATION — aggregate citation-velocity deltas across public criminal-defense opinions. Citation velocity reflects which precedents are gaining or fading. Use it as a starting point for research, not a verdict.",
+  },
+  {
+    question: "What if my charge type has thin rising-precedent coverage?",
+    answer:
+      "Before checkout you will see how many rising and fading precedents back your charge type. When the charge-specific rising count is zero, the report falls back to the national criminal rising-precedent pool with the fallback called out on every section. The Availability Checker discloses the fallback before purchase so you can decide whether to buy or waitlist.",
+  },
+  {
+    question: "How is this different from the Charge Authority Pack?",
+    answer:
+      `The Precedent Watchlist tracks which precedents are GAINING or FADING citation weight for your charge over the last 24 months — a directional signal. The Charge Authority Pack (${TIER_CORE["charge-authority-pack"].priceDisplay}) gives you the current top 10 must-cite authorities with pre-extracted canonical quotes — a snapshot. Watchlist also includes the 30-day email drip; the Pack is single-delivery.`,
+  },
+] as const;
+
+/* ------------------------------------------------------------------ */
+/*  JSON-LD structured data                                            */
+/* ------------------------------------------------------------------ */
+
+const breadcrumbLd = {
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  itemListElement: [
+    {
+      "@type": "ListItem",
+      position: 1,
+      name: "Home",
+      item: SITE_URL,
+    },
+    {
+      "@type": "ListItem",
+      position: 2,
+      name: "Precedent Watchlist",
+      item: `${SITE_URL}/precedent-watchlist`,
+    },
+  ],
+};
+
+const faqLd = {
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  mainEntity: FAQ_ITEMS.map((faq) => ({
+    "@type": "Question",
+    name: faq.question,
+    acceptedAnswer: {
+      "@type": "Answer",
+      text: faq.answer,
+    },
+  })),
+};
+
+/* ------------------------------------------------------------------ */
+/*  Checkmark icon                                                     */
+/* ------------------------------------------------------------------ */
+
+function CheckIcon() {
+  return (
+    <svg
+      className="mt-0.5 h-5 w-5 shrink-0 text-amber-400"
+      aria-hidden="true"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      strokeWidth={2}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M5 13l4 4L19 7"
+      />
+    </svg>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Page                                                               */
+/* ------------------------------------------------------------------ */
+
+export default function PrecedentWatchlistPage() {
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-16">
+      {/* ---------- HERO ---------- */}
+      <FadeInUp>
+        <section aria-labelledby="hero-heading" className="text-center">
+          <p className="text-xs font-bold uppercase tracking-widest text-amber-400">
+            Precedent Watchlist
+          </p>
+
+          <p className="mb-6 text-base leading-relaxed text-zinc-400">
+            Defense precedent isn't static. Some opinions get cited more every
+            quarter. Others quietly fall out of rotation. Most defendants
+            never see the trajectory — they just see whatever the brief
+            template was last refreshed with.
+          </p>
+
+          <h1
+            id="hero-heading"
+            className="font-display mt-4 text-4xl font-extrabold leading-tight text-white sm:text-5xl"
+          >
+            Which Precedents Are Gaining And Fading For Your Charge
+          </h1>
+
+          <p className="mt-4 text-lg text-zinc-400">
+            Top 10 rising and top 5 fading criminal-defense precedents for your
+            charge type, 24-month velocity arrows on every row, every row
+            linked to CourtListener &mdash; plus 4 weekly email updates over
+            the next 30 days.
+          </p>
+
+          <p className="mt-6 text-base text-zinc-300 italic">
+            Citation velocity reflects which precedents are gaining or fading.
+            Use it as a starting point for research, not a verdict.
+          </p>
+
+          <p className="mt-6 text-4xl font-extrabold text-amber-400">
+            {TIER_CORE["precedent-watchlist"].priceDisplay}
+          </p>
+
+          <p className="mt-2 text-sm text-zinc-400">
+            Generated instantly &mdash; followed by 4 weekly email updates over
+            30 days.
+          </p>
+
+          <p className="mt-2 text-sm text-zinc-300">
+            Verified public sources: CourtListener appellate authorities &times;
+            24-month citation-velocity tracking &times; quarterly REPLACE-mode
+            derivation
+          </p>
+
+          <div id="availability" className="mt-6 scroll-mt-24">
+            <AvailabilityChecker
+              slug="precedent-watchlist"
+              productName="Precedent Watchlist"
+              priceDisplay={
+                TIER_CORE["precedent-watchlist"].priceDisplay
+              }
+            />
+          </div>
+        </section>
+      </FadeInUp>
+
+      {/* ---------- WHAT YOU GET ---------- */}
+      <FadeInUp>
+        <section aria-labelledby="features-heading" className="mt-20">
+          <h2
+            id="features-heading"
+            className="font-display text-2xl font-bold text-white"
+          >
+            What You Get
+          </h2>
+
+          <ul className="mt-8 space-y-4">
+            {CHECK_ITEMS.map((item) => (
+              <li
+                key={item}
+                className="flex items-start gap-3 text-zinc-300"
+              >
+                <CheckIcon />
+                <span>{item}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      </FadeInUp>
+
+      {/* ---------- DRIP EXPLAINER ---------- */}
+      <FadeInUp>
+        <section aria-labelledby="drip-heading" className="mt-20">
+          <h2
+            id="drip-heading"
+            className="font-display text-2xl font-bold text-white"
+          >
+            The 30-Day Email Drip
+          </h2>
+
+          <p className="mt-4 text-zinc-400">
+            Citation velocity moves quarterly. A single snapshot tells you
+            where the lists stand the day you buy. The drip tells you when
+            the lists shift while your case is still active.
+          </p>
+
+          <ul className="mt-6 space-y-3 text-zinc-300">
+            <li className="flex items-start gap-3">
+              <CheckIcon />
+              <span>
+                <strong className="text-white">Day 0:</strong> instant report
+                with the current top 10 rising and top 5 fading precedents for
+                your charge type.
+              </span>
+            </li>
+            <li className="flex items-start gap-3">
+              <CheckIcon />
+              <span>
+                <strong className="text-white">Days 7, 14, 21, 28:</strong>{" "}
+                up to 4 weekly emails surfacing rank shifts &mdash; new
+                entrants into the top 10, drops out of the list, fading-tier
+                additions.
+              </span>
+            </li>
+            <li className="flex items-start gap-3">
+              <CheckIcon />
+              <span>
+                <strong className="text-white">Drip seed:</strong> set at
+                purchase from the charge type you select. No further intake
+                required. Unsubscribe at any time.
+              </span>
+            </li>
+          </ul>
+        </section>
+      </FadeInUp>
+
+      {/* ---------- SAMPLE DATA ---------- */}
+      <FadeInUp>
+        <section aria-labelledby="sample-heading" className="mt-20">
+          <h2
+            id="sample-heading"
+            className="font-display text-2xl font-bold text-white"
+          >
+            Sample Watchlist Inventory
+          </h2>
+
+          <div className="mt-8 overflow-x-auto rounded-lg border border-zinc-700">
+            <table className="w-full text-left text-sm">
+              <caption className="sr-only">
+                Sample precedent-watchlist corpus inventory
+              </caption>
+              <thead className="border-b border-zinc-700 bg-zinc-900">
+                <tr>
+                  <th scope="col" className="px-4 py-3 font-semibold text-zinc-200">
+                    Metric
+                  </th>
+                  <th scope="col" className="px-4 py-3 font-semibold text-zinc-200">
+                    Value
+                  </th>
+                  <th scope="col" className="px-4 py-3 font-semibold text-zinc-200">
+                    Source
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-zinc-800">
+                {SAMPLE_ROWS.map((row) => (
+                  <tr key={row.metric}>
+                    <th
+                      scope="row"
+                      className="whitespace-nowrap px-4 py-3 font-medium text-zinc-300"
+                    >
+                      {row.metric}
+                    </th>
+                    <td className="px-4 py-3 text-zinc-400">{row.value}</td>
+                    <td className="px-4 py-3 text-zinc-400">{row.source}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          <p className="mt-3 text-xs text-zinc-400">
+            Inventory shown to illustrate corpus shape. Your watchlist contains
+            the top 10 rising and top 5 fading precedents scoped to the charge
+            slug you select, each with citation, velocity arrow, and a
+            CourtListener URL.
+          </p>
+        </section>
+      </FadeInUp>
+
+      {/* ---------- TRUST ---------- */}
+      <FadeInUp>
+        <section aria-labelledby="trust-heading" className="mt-20">
+          <h2
+            id="trust-heading"
+            className="font-display text-2xl font-bold text-white"
+          >
+            Why You Can Trust This Data
+          </h2>
+
+          <p className="mt-4 text-zinc-400">
+            Velocity arrows reflect a 24-month rolling window over the
+            citation_velocity_criminal corpus &mdash; the same derivation the
+            quarterly REPLACE-mode pipeline computes. Rows without a
+            CourtListener source URL are suppressed rather than rendered.
+          </p>
+
+          <p className="mt-3 text-sm text-zinc-400">
+            Rising and fading rows are scoped to the internal charge slugs
+            bridged from your selected user-facing charge. When the bridge
+            returns zero rising rows, the report falls back to the national
+            criminal rising-precedent pool and the fallback is called out on
+            every section. The Availability Checker on this page discloses
+            the fallback before purchase when it applies.
+          </p>
+
+          <div className="mt-8">
+            <TrustBadges variant="pricing" />
+          </div>
+        </section>
+      </FadeInUp>
+
+      {/* ---------- FAQ ---------- */}
+      <section aria-labelledby="faq-heading" className="mt-20">
+        <h2
+          id="faq-heading"
+          className="font-display text-2xl font-bold text-white"
+        >
+          Frequently Asked Questions
+        </h2>
+
+        <div className="mt-8">
+          <FAQAccordion items={[...FAQ_ITEMS]} />
+        </div>
+      </section>
+
+      {/* ---------- FINAL CTA ---------- */}
+      <FadeInUp>
+        <section aria-labelledby="cta-heading" className="mt-20 text-center">
+          <h2
+            id="cta-heading"
+            className="font-display text-2xl font-bold text-white"
+          >
+            Get the Precedent Watchlist &mdash;{" "}
+            <span className="text-amber-400">
+              {TIER_CORE["precedent-watchlist"].priceDisplay}
+            </span>
+          </h2>
+
+          <p className="mt-4 text-zinc-400">
+            Most defendants find out their go-to precedent has been quietly
+            losing weight only when the prosecutor cites a newer, sharper case
+            in the same line. Defendants who prepare watch the velocity month
+            over month and adjust before the courtroom does. Yours in 60
+            seconds, plus 4 weekly updates over the next 30 days.
+          </p>
+
+          <div className="mt-6">
+            <AvailabilityChecker
+              slug="precedent-watchlist"
+              productName="Precedent Watchlist"
+              priceDisplay={
+                TIER_CORE["precedent-watchlist"].priceDisplay
+              }
+            />
+          </div>
+
+          <p className="mt-4 text-xs text-zinc-400">
+            This is legal information, not legal advice. The watchlist
+            reproduces verifiable citations and aggregate citation-velocity
+            deltas from public criminal-defense opinions. Decisions about
+            how to use the information stay with you.
+          </p>
+
+          <p className="mt-3 text-sm text-zinc-400">
+            Questions before you buy?{" "}
+            <a
+              href="mailto:help@imnotanattorney.com"
+              className="text-amber-400 underline decoration-amber-400/50 hover:decoration-amber-400"
+            >
+              help@imnotanattorney.com
+            </a>
+            {" "}&mdash; a defendant-side researcher replies, not a bot.
+          </p>
+        </section>
+      </FadeInUp>
+
+      {/* ---------- JSON-LD: Product ---------- */}
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            "@context": "https://schema.org",
+            "@type": "Product",
+            name: "Precedent Watchlist",
+            description:
+              "Top 10 fastest-rising and top 5 fastest-fading criminal-defense precedents for your charge type, with 24-month citation-velocity arrows, every row linked to CourtListener, plus 4 weekly email updates over 30 days.",
+            url: `${SITE_URL}/precedent-watchlist`,
+            brand: {
+              "@type": "Organization",
+              "@id": "https://imnotanattorney.com/#organization",
+            },
+            offers: {
+              "@type": "Offer",
+              price: "47.00",
+              priceCurrency: "USD",
+              availability: "https://schema.org/InStock",
+              url: `${SITE_URL}/checkout?standaloneProduct=precedent-watchlist`,
+            },
+          }),
+        }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbLd) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqLd) }}
+      />
+    </div>
+  );
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -76,6 +76,10 @@ export default function sitemap(): MetadataRoute.Sitemap {
     "motion-success-report",
     "federal-jury-instruction-brief",
     "federal-sentencing-distribution",
+    // 2026-04-27 — closes C1+C2 of worry-tier9-flipped-live audit. Two
+    // newly-built dedicated landings; dedupe `/services/<slug>` entries.
+    "charge-authority-pack",
+    "precedent-watchlist",
   ]);
   const serviceProductEntries: MetadataRoute.Sitemap = (
     [
@@ -307,6 +311,19 @@ export default function sitemap(): MetadataRoute.Sitemap {
     {
       url: `${SITE_URL}/federal-sentencing-distribution`,
       lastModified: new Date("2026-04-26"),
+      changeFrequency: "monthly" as const,
+      priority: 0.8,
+    },
+    // 2026-04-27 — closes C1+C2 of worry-tier9-flipped-live audit.
+    {
+      url: `${SITE_URL}/charge-authority-pack`,
+      lastModified: new Date("2026-04-27"),
+      changeFrequency: "monthly" as const,
+      priority: 0.8,
+    },
+    {
+      url: `${SITE_URL}/precedent-watchlist`,
+      lastModified: new Date("2026-04-27"),
       changeFrequency: "monthly" as const,
       priority: 0.8,
     },

--- a/src/components/tier9/AvailabilityChecker.tsx
+++ b/src/components/tier9/AvailabilityChecker.tsx
@@ -166,6 +166,12 @@ const COVERAGE_LABELS: Record<string, string> = {
   // federal-sentencing-distribution coverage gating (Apex Fix #1, 2026-04-26)
   distributionsAtAll: 'federal sentencing buckets for this offense',
   federallyMappable: 'mapped to a USSC sentencing guideline',
+  // charge-authority-pack + precedent-watchlist coverage gating
+  // (2026-04-27, closes worry-tier9-flipped-live C1+C2)
+  authoritiesCharge: 'charge-specific top-cited authorities',
+  authoritiesNational: 'national criminal authorities (fallback)',
+  risingPrecedents: 'rising precedents for this charge',
+  fadingPrecedents: 'fading precedents for this charge',
 };
 
 /* Federal Jury Instruction Brief — intake options now come from the
@@ -219,7 +225,9 @@ type Slug =
   | 'arrest-survival-kit'
   | 'federal-jury-instruction-brief'
   | 'motion-success-report'
-  | 'federal-sentencing-distribution';
+  | 'federal-sentencing-distribution'
+  | 'charge-authority-pack'
+  | 'precedent-watchlist';
 
 interface AvailabilityCheckerProps {
   slug: Slug;
@@ -266,6 +274,20 @@ export default function AvailabilityChecker({ slug, productName, priceDisplay }:
   const isOfficerBgCheck = slug === 'officer-background-check';
   const isFjib = slug === 'federal-jury-instruction-brief';
   const isArrestKit = slug === 'arrest-survival-kit';
+  // 2026-04-27 (closes worry-tier9-flipped-live C1+C2): hoist the two new
+  // slug booleans alongside the existing four, mirroring the same pattern.
+  const isChargeAuthorityPack = slug === 'charge-authority-pack';
+  const isPrecedentWatchlist = slug === 'precedent-watchlist';
+  // Slugs that gate on a charge-type picker (intent: chargeType + state).
+  const usesChargePicker =
+    isSimilarCases ||
+    slug === 'motion-success-report' ||
+    slug === 'federal-sentencing-distribution' ||
+    isChargeAuthorityPack ||
+    isPrecedentWatchlist;
+  // Slugs that gate on state-only.
+  const usesStateOnly =
+    slug === 'district-court-intelligence' || isArrestKit;
 
   const [componentState, setComponentState] = useState<ComponentState>('idle');
   const [errorMsg, setErrorMsg] = useState('');
@@ -344,6 +366,11 @@ export default function AvailabilityChecker({ slug, productName, priceDisplay }:
     else if (slug === 'federal-sentencing-distribution') {
       payload.chargeType = chargeType;
     }
+    else if (slug === 'charge-authority-pack' || slug === 'precedent-watchlist') {
+      // 2026-04-27 — both SKUs gate on chargeType + state (state is already
+      // in the base payload). Closes C1+C2 of worry-tier9-flipped-live.
+      payload.chargeType = chargeType;
+    }
     // arrest-survival-kit: state-only (already in base payload)
 
     try {
@@ -366,7 +393,7 @@ export default function AvailabilityChecker({ slug, productName, priceDisplay }:
       setErrorMsg(err instanceof Error ? err.message : 'Something went wrong. Please try again.');
       setComponentState('error');
     }
-  }, [slug, name, state, chargeType, federalCharge, circuit]);
+  }, [slug, name, state, chargeType, federalCharge, circuit, componentState]);
 
   /* ── Waitlist submit ── */
 
@@ -389,6 +416,10 @@ export default function AvailabilityChecker({ slug, productName, priceDisplay }:
       if (name) payload.judgeName = name;
     }
     else if (slug === 'federal-sentencing-distribution') {
+      payload.chargeType = chargeType;
+    }
+    else if (slug === 'charge-authority-pack' || slug === 'precedent-watchlist') {
+      // 2026-04-27 — waitlist payload mirrors handleCheck; closes C1+C2.
       payload.chargeType = chargeType;
     }
     // arrest-survival-kit: state-only (already in base payload)
@@ -449,11 +480,24 @@ export default function AvailabilityChecker({ slug, productName, priceDisplay }:
     if (slug === 'federal-sentencing-distribution') {
       params.set('chargeType', chargeType);
     }
+    if (slug === 'charge-authority-pack' || slug === 'precedent-watchlist') {
+      // 2026-04-27 — closes C1+C2. chargeType is the only intake-required
+      // field; state is set above for every slug.
+      params.set('chargeType', chargeType);
+    }
     return `/checkout?${params.toString()}`;
   }
 
   /* ── ID prefix for unique htmlFor bindings ── */
   const id = `ac-${slug}`;
+
+  /* "Check a different X" button label — single derivation reused by both
+     the available-state and waitlisted-state retry buttons. */
+  const retryNoun = usesChargePicker
+    ? 'charge'
+    : usesStateOnly
+      ? 'state'
+      : 'name';
 
   /* ──────────────────────── RENDER ──────────────────────── */
 
@@ -522,6 +566,38 @@ export default function AvailabilityChecker({ slug, productName, priceDisplay }:
       (coverage.agencyIncidentsState ?? 0) as number;
     const arrestKitThinState =
       isArrestKit && arrestKitAgencyCount < 50;
+
+    /* Charge-authority-pack thin-charge derivation (2026-04-27, closes C1
+       of worry-tier9-flipped-live + audit W3). `authoritiesCharge` is the
+       charge-specific count from charge_type_top_authorities; when zero
+       the resolver falls through to citation_authority_criminal national
+       fallback. Disclosure is pre-purchase banner only — buy button stays
+       so the customer can decide. Mirrors D3 / D-T4 transparency pattern. */
+    const capAuthoritiesCharge =
+      (coverage.authoritiesCharge ?? 0) as number;
+    const capAuthoritiesNational =
+      (coverage.authoritiesNational ?? 0) as number;
+    const capChargeFallback =
+      isChargeAuthorityPack &&
+      capAuthoritiesCharge === 0 &&
+      capAuthoritiesNational > 0;
+    /* Precedent-watchlist thin-charge derivation (2026-04-27, closes C2).
+       When the bridged internal slugs have zero rising rows, the
+       precedent-watchlist resolver still ships a list via the national
+       fallback pool — banner discloses the fallback. */
+    const pwlRisingCount =
+      (coverage.risingPrecedents ?? 0) as number;
+    const pwlChargeFallback =
+      isPrecedentWatchlist && pwlRisingCount === 0;
+    /* Display label for the user-selected charge slug, looked up in
+       CHARGE_GROUPS. Used for both new banners. */
+    const chargeLabel = (() => {
+      for (const g of CHARGE_GROUPS) {
+        const m = g.options.find((o) => o.value === chargeType);
+        if (m) return m.label;
+      }
+      return chargeType;
+    })();
 
     /* FJIB circuit-coverage derivation (D5 plan, 2026-04-26; extended
        2026-04-26 PR #171 review W1).
@@ -656,6 +732,29 @@ export default function AvailabilityChecker({ slug, productName, priceDisplay }:
           we have.
         </p>
       );
+    } else if (capChargeFallback) {
+      /* 2026-04-27 — charge-specific top-cited authorities are not yet
+         ingested for the selected charge slug. The report falls back to
+         the national criminal-authority pool with a limitation note. */
+      fallbackBanner = (
+        <p className="text-amber-200 text-sm">
+          <strong>Heads up:</strong> Charge-specific top-cited authorities are
+          not yet ingested for {chargeLabel}. The report will use the national
+          criminal-authority fallback as the closest available reference.
+        </p>
+      );
+    } else if (pwlChargeFallback) {
+      /* 2026-04-27 — no rising precedents for the selected charge slug.
+         The report falls back to the national criminal rising-precedent
+         pool with a limitation note. */
+      fallbackBanner = (
+        <p className="text-amber-200 text-sm">
+          <strong>Heads up:</strong> No rising-precedent rows are yet ingested
+          for {chargeLabel}. The report will use the national criminal
+          rising-precedent pool as the closest available reference, with the
+          fallback called out on every section.
+        </p>
+      );
     }
 
     /* dl filter (W3): drop fallback-only metrics that this customer's
@@ -733,7 +832,7 @@ export default function AvailabilityChecker({ slug, productName, priceDisplay }:
           onClick={handleRetry}
           className="w-full text-center text-sm text-zinc-400 hover:text-zinc-200 transition-colors mt-3 h-10 focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2 focus:ring-offset-zinc-950 rounded-lg"
         >
-          Check a different {slug === 'similar-cases-analyzer' || slug === 'federal-jury-instruction-brief' || slug === 'motion-success-report' || slug === 'federal-sentencing-distribution' ? 'charge' : (slug === 'district-court-intelligence' || slug === 'arrest-survival-kit') ? 'state' : 'name'}
+          Check a different {retryNoun}
         </button>
       </div>
     );
@@ -763,7 +862,7 @@ export default function AvailabilityChecker({ slug, productName, priceDisplay }:
           onClick={handleRetry}
           className="text-sm text-zinc-400 hover:text-zinc-200 transition-colors mt-4 h-10 focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2 focus:ring-offset-zinc-950 rounded-lg"
         >
-          Check a different {slug === 'similar-cases-analyzer' || slug === 'federal-jury-instruction-brief' || slug === 'motion-success-report' || slug === 'federal-sentencing-distribution' ? 'charge' : (slug === 'district-court-intelligence' || slug === 'arrest-survival-kit') ? 'state' : 'name'}
+          Check a different {retryNoun}
         </button>
       </div>
     );
@@ -930,11 +1029,16 @@ export default function AvailabilityChecker({ slug, productName, priceDisplay }:
       )}
 
       {/* Charge type select — similar-cases-analyzer / motion-success-report /
-          federal-sentencing-distribution all gate on a user-facing charge slug
-          (ALLOWED_CHARGE_TYPES). Same picker, different downstream resolvers. */}
+          federal-sentencing-distribution / charge-authority-pack /
+          precedent-watchlist all gate on a user-facing charge slug
+          (ALLOWED_CHARGE_TYPES). Same picker, different downstream resolvers.
+          (charge-authority-pack + precedent-watchlist added 2026-04-27 to
+          close C1+C2 of the worry-tier9-flipped-live audit.) */}
       {(slug === 'similar-cases-analyzer' ||
         slug === 'motion-success-report' ||
-        slug === 'federal-sentencing-distribution') && (
+        slug === 'federal-sentencing-distribution' ||
+        isChargeAuthorityPack ||
+        isPrecedentWatchlist) && (
         <div>
           <label htmlFor={`${id}-charge`} className={labelClass}>
             Charge type{' '}

--- a/src/components/tier9/__tests__/availability-checker-slugs.test.ts
+++ b/src/components/tier9/__tests__/availability-checker-slugs.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Sync test: AvailabilityChecker `Slug` union literal matches the canonical
+ * TIER9_SLUGS set (2026-04-27, closes S1 of worry-tier9-flipped-live audit).
+ *
+ * The AvailabilityChecker ships only for slugs whose dedicated landing page
+ * mounts the component. When TIER9_SLUGS expands, the union must expand too
+ * or the new slug fails to typecheck on the page that mounts it.
+ *
+ * This test reads the AvailabilityChecker source and asserts the literal
+ * type union contains every slug we've shipped a dedicated landing for.
+ *
+ * test-isolation-na: read-only fs check, no Supabase access.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve as pathResolve } from "path";
+
+// The set of slugs that MUST be in the AvailabilityChecker Slug union.
+// Mirrors the dedicated-landing pattern: each entry corresponds to a
+// `src/app/<slug>/page.tsx` that mounts AvailabilityChecker.
+const REQUIRED_SLUGS = [
+  "judge-report-card",
+  "officer-background-check",
+  "similar-cases-analyzer",
+  "district-court-intelligence",
+  "arrest-survival-kit",
+  "federal-jury-instruction-brief",
+  "motion-success-report",
+  "federal-sentencing-distribution",
+  "charge-authority-pack",
+  "precedent-watchlist",
+] as const;
+
+describe("AvailabilityChecker Slug union — sync with shipped landings", () => {
+  const source = readFileSync(
+    pathResolve(__dirname, "..", "AvailabilityChecker.tsx"),
+    "utf8",
+  );
+
+  it.each(REQUIRED_SLUGS)("Slug union contains '%s'", (slug) => {
+    // Match the literal slug string within the type Slug = '...' | '...' block.
+    // Anchor on the quoted form so a substring match (e.g. 'dui' inside
+    // 'dui-first') can't false-positive.
+    const literal = `'${slug}'`;
+    expect(source).toContain(literal);
+  });
+
+  it("Slug union has the right cardinality (10 entries — 2026-04-27)", () => {
+    // Extract the type Slug = ... ; block and count `|` separators + 1.
+    const m = source.match(/type\s+Slug\s*=\s*([\s\S]*?);/);
+    expect(m).not.toBeNull();
+    const body = m![1];
+    // Count quoted-string literals in the union body.
+    const literals = body.match(/'[a-z][a-z0-9-]+'/g) ?? [];
+    expect(literals.length).toBe(REQUIRED_SLUGS.length);
+  });
+});

--- a/src/lib/products.ts
+++ b/src/lib/products.ts
@@ -1300,8 +1300,9 @@ export const STANDALONE_PRODUCTS: Record<string, StandaloneProduct> = {
     upsellTier: "case-decoder",
     upsellText:
       "Authorities tell you what to cite. The Case Decoder maps how to apply those precedents to your specific facts.",
-    // 2026-04-26 reverted dark — no dedicated landing page yet (C1 from worry-tier9-flipped-live audit)
-    isActive: false,
+    // 2026-04-27 re-flipped active — C1 dedicated landing shipped
+    // (audit worry-tier9-flipped-live closed)
+    isActive: true,
   },
   "arrest-survival-kit": {
     name: "Arrest Survival Kit",
@@ -1361,8 +1362,9 @@ export const STANDALONE_PRODUCTS: Record<string, StandaloneProduct> = {
     upsellTier: "case-decoder",
     upsellText:
       "Citation velocity tells you which precedents are trending. The Case Decoder maps your specific defense strategy around them.",
-    // 2026-04-26 reverted dark — no dedicated landing + Slug union excludes (C2)
-    isActive: false,
+    // 2026-04-27 re-flipped active — C2 dedicated landing + Slug union widened
+    // (audit worry-tier9-flipped-live closed)
+    isActive: true,
   },
 
   // ─── PRIORITY B, Critical 7 Worker Standalone Products ─────

--- a/src/lib/tier9-reports/__tests__/charge-authority-pack-coverage.test.ts
+++ b/src/lib/tier9-reports/__tests__/charge-authority-pack-coverage.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Unit tests for the charge-authority-pack coverage gate (2026-04-27,
+ * closes C1 of worry-tier9-flipped-live audit).
+ *
+ * Focus:
+ *   - checkChargeAuthorityPackCoverage exposes authoritiesCharge + authoritiesNational
+ *   - Bridged charge slugs (CHARGE_TYPE_AUTHORITY_MAP) hit charge_type_top_authorities
+ *   - Empty bridge ("federal", "self-defense") returns 0 charge-specific
+ *     but always-positive national fallback
+ *   - `available: true` regardless (resolver always has national fallback)
+ *
+ * test-isolation-na: read-only mock, no Supabase writes
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+interface QueryRecord {
+  table: string;
+  filters: Array<{ col: string; val: unknown }>;
+  inFilter: { col: string; val: unknown[] } | null;
+  isCount: boolean;
+}
+
+let queryLog: QueryRecord[] = [];
+let scriptedCounts: Map<string, number> = new Map();
+
+function key(table: string, inJoined?: string): string {
+  return inJoined === undefined ? table : `${table}|in:${inJoined}`;
+}
+
+function mockBuilder(table: string, isCount: boolean) {
+  const filters: Array<{ col: string; val: unknown }> = [];
+  let inFilter: { col: string; val: unknown[] } | null = null;
+  const record: QueryRecord = { table, filters, inFilter, isCount };
+  queryLog.push(record);
+
+  const builder: Record<string, unknown> = {};
+  builder.eq = (col: string, val: unknown) => {
+    filters.push({ col, val });
+    return builder;
+  };
+  builder.in = (col: string, vals: unknown[]) => {
+    inFilter = { col, val: vals };
+    record.inFilter = inFilter;
+    return builder;
+  };
+  builder.then = (resolve: (val: unknown) => unknown) => {
+    let lookupKey: string;
+    if (inFilter) {
+      const joined = (inFilter.val as string[]).slice().sort().join(",");
+      lookupKey = key(table, joined);
+    } else {
+      lookupKey = key(table);
+    }
+    const explicit = scriptedCounts.get(lookupKey) ?? scriptedCounts.get(key(table));
+    if (isCount) {
+      return Promise.resolve({ count: explicit ?? 0, data: null, error: null }).then(
+        resolve,
+      );
+    }
+    return Promise.resolve({ data: [], error: null }).then(resolve);
+  };
+  return builder;
+}
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: () => ({
+    from: (table: string) => ({
+      select: (_cols: string, opts?: { count?: string; head?: boolean }) => {
+        const isCount = !!(opts && opts.count === "exact");
+        return mockBuilder(table, isCount);
+      },
+    }),
+  }),
+}));
+
+import { checkChargeAuthorityPackCoverage } from "../coverage";
+import { CHARGE_TYPE_AUTHORITY_MAP } from "@/lib/charge-slug-maps";
+
+beforeEach(() => {
+  queryLog = [];
+  scriptedCounts = new Map();
+});
+
+describe("checkChargeAuthorityPackCoverage — charge + national exposure", () => {
+  it("dense charge (DUI): authoritiesCharge > 0 and authoritiesNational > 0", async () => {
+    // CHARGE_TYPE_AUTHORITY_MAP['dui'] = ['dui-dwi', 'dui-drugs',
+    // 'dui-felony-injury', 'refusing-breath-test']
+    const duiBridge = CHARGE_TYPE_AUTHORITY_MAP["dui"]!.slice().sort().join(",");
+    scriptedCounts.set(`charge_type_top_authorities|in:${duiBridge}`, 84);
+    scriptedCounts.set("citation_authority_criminal", 620000);
+
+    const result = await checkChargeAuthorityPackCoverage("dui", "FL");
+
+    expect(result.coverage.authoritiesCharge).toBe(84);
+    expect(result.coverage.authoritiesNational).toBe(620000);
+    expect(result.available).toBe(true);
+  });
+
+  it("empty-bridge charge (federal): authoritiesCharge=0 but authoritiesNational > 0", async () => {
+    // CHARGE_TYPE_AUTHORITY_MAP['federal'] = []
+    expect(CHARGE_TYPE_AUTHORITY_MAP["federal"]).toEqual([]);
+    scriptedCounts.set("citation_authority_criminal", 620000);
+
+    const result = await checkChargeAuthorityPackCoverage("federal", "TX");
+
+    expect(result.coverage.authoritiesCharge).toBe(0);
+    expect(result.coverage.authoritiesNational).toBe(620000);
+    // Resolver always has national fallback — banner discloses, buy stays.
+    expect(result.available).toBe(true);
+  });
+
+  it("unmapped charge slug: authoritiesCharge=0 still safe (no .in([])) and national still surfaces", async () => {
+    scriptedCounts.set("citation_authority_criminal", 620000);
+
+    const result = await checkChargeAuthorityPackCoverage(
+      "made-up-not-in-map",
+      "CA",
+    );
+
+    expect(result.coverage.authoritiesCharge).toBe(0);
+    expect(result.coverage.authoritiesNational).toBe(620000);
+    expect(result.available).toBe(true);
+    // Verify no IN query was issued against the empty bridge.
+    const inQueries = queryLog.filter(
+      (q) => q.table === "charge_type_top_authorities" && q.inFilter !== null,
+    );
+    expect(inQueries.length).toBe(0);
+  });
+
+  it("queries charge_type_top_authorities with the bridged internal slugs", async () => {
+    const trafficBridge = CHARGE_TYPE_AUTHORITY_MAP["drug-trafficking"]!;
+    scriptedCounts.set(
+      `charge_type_top_authorities|in:${trafficBridge.slice().sort().join(",")}`,
+      37,
+    );
+    scriptedCounts.set("citation_authority_criminal", 620000);
+
+    await checkChargeAuthorityPackCoverage("drug-trafficking", "NV");
+
+    const ctaQueries = queryLog.filter(
+      (q) => q.table === "charge_type_top_authorities" && q.isCount,
+    );
+    expect(ctaQueries).toHaveLength(1);
+    expect(ctaQueries[0].inFilter?.col).toBe("charge_type");
+    expect(ctaQueries[0].inFilter?.val).toEqual(trafficBridge);
+  });
+});

--- a/src/lib/tier9-reports/__tests__/precedent-watchlist-coverage.test.ts
+++ b/src/lib/tier9-reports/__tests__/precedent-watchlist-coverage.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Unit tests for the precedent-watchlist coverage gate (2026-04-27,
+ * closes C2 of worry-tier9-flipped-live audit).
+ *
+ * Focus:
+ *   - checkPrecedentWatchlistCoverage exposes risingPrecedents + fadingPrecedents
+ *   - Bridged charge slugs (CHARGE_TYPE_AUTHORITY_MAP) hit citation_velocity_criminal
+ *   - Empty bridge ("federal", "self-defense") returns 0 rising AND 0 fading
+ *   - `available: true` always (resolver has national fallback in renderer)
+ *
+ * test-isolation-na: read-only mock, no Supabase writes
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+interface QueryRecord {
+  table: string;
+  filters: Array<{ col: string; val: unknown }>;
+  inFilter: { col: string; val: unknown[] } | null;
+  isCount: boolean;
+}
+
+let queryLog: QueryRecord[] = [];
+let scriptedCounts: Map<string, number> = new Map();
+
+function makeKey(
+  table: string,
+  inJoined: string | null,
+  filters: Array<{ col: string; val: unknown }>,
+): string {
+  const f = filters
+    .map((x) => `${x.col}=${String(x.val)}`)
+    .sort()
+    .join(";");
+  if (inJoined === null) return `${table}|${f}`;
+  return `${table}|in:${inJoined}|${f}`;
+}
+
+function mockBuilder(table: string, isCount: boolean) {
+  const filters: Array<{ col: string; val: unknown }> = [];
+  let inFilter: { col: string; val: unknown[] } | null = null;
+  const record: QueryRecord = { table, filters, inFilter, isCount };
+  queryLog.push(record);
+
+  const builder: Record<string, unknown> = {};
+  builder.eq = (col: string, val: unknown) => {
+    filters.push({ col, val });
+    return builder;
+  };
+  builder.in = (col: string, vals: unknown[]) => {
+    inFilter = { col, val: vals };
+    record.inFilter = inFilter;
+    return builder;
+  };
+  builder.then = (resolve: (val: unknown) => unknown) => {
+    const inJoined = inFilter
+      ? (inFilter.val as string[]).slice().sort().join(",")
+      : null;
+    const lookupKey = makeKey(table, inJoined, filters);
+    const explicit =
+      scriptedCounts.get(lookupKey) ?? scriptedCounts.get(table) ?? 0;
+    if (isCount) {
+      return Promise.resolve({ count: explicit, data: null, error: null }).then(
+        resolve,
+      );
+    }
+    return Promise.resolve({ data: [], error: null }).then(resolve);
+  };
+  return builder;
+}
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: () => ({
+    from: (table: string) => ({
+      select: (_cols: string, opts?: { count?: string; head?: boolean }) => {
+        const isCount = !!(opts && opts.count === "exact");
+        return mockBuilder(table, isCount);
+      },
+    }),
+  }),
+}));
+
+import { checkPrecedentWatchlistCoverage } from "../coverage";
+import { CHARGE_TYPE_AUTHORITY_MAP } from "@/lib/charge-slug-maps";
+
+beforeEach(() => {
+  queryLog = [];
+  scriptedCounts = new Map();
+});
+
+describe("checkPrecedentWatchlistCoverage — rising + fading exposure", () => {
+  it("dense charge (DUI): risingPrecedents > 0 and fadingPrecedents >= 0", async () => {
+    const duiBridge = CHARGE_TYPE_AUTHORITY_MAP["dui"]!.slice().sort().join(",");
+    scriptedCounts.set(
+      `citation_velocity_criminal|in:${duiBridge}|rising_flag=true`,
+      127,
+    );
+    scriptedCounts.set(
+      `citation_velocity_criminal|in:${duiBridge}|velocity_tier=fading`,
+      24,
+    );
+
+    const result = await checkPrecedentWatchlistCoverage("dui", "FL");
+
+    expect(result.coverage.risingPrecedents).toBe(127);
+    expect(result.coverage.fadingPrecedents).toBe(24);
+    expect(result.available).toBe(true);
+  });
+
+  it("empty-bridge charge (federal): both counters zero, available stays true", async () => {
+    expect(CHARGE_TYPE_AUTHORITY_MAP["federal"]).toEqual([]);
+
+    const result = await checkPrecedentWatchlistCoverage("federal", "TX");
+
+    expect(result.coverage.risingPrecedents).toBe(0);
+    expect(result.coverage.fadingPrecedents).toBe(0);
+    // Resolver always has national fallback for the watchlist — banner
+    // discloses, buy stays.
+    expect(result.available).toBe(true);
+  });
+
+  it("unmapped charge slug: skips IN query against citation_velocity_criminal", async () => {
+    const result = await checkPrecedentWatchlistCoverage(
+      "made-up-not-in-map",
+      "CA",
+    );
+
+    expect(result.coverage.risingPrecedents).toBe(0);
+    expect(result.coverage.fadingPrecedents).toBe(0);
+    expect(result.available).toBe(true);
+    const cvcInQueries = queryLog.filter(
+      (q) => q.table === "citation_velocity_criminal" && q.inFilter !== null,
+    );
+    expect(cvcInQueries.length).toBe(0);
+  });
+
+  it("queries citation_velocity_criminal with rising_flag=true AND velocity_tier=fading separately", async () => {
+    const robberyBridge = CHARGE_TYPE_AUTHORITY_MAP["robbery"]!;
+    scriptedCounts.set(
+      `citation_velocity_criminal|in:${robberyBridge.slice().sort().join(",")}|rising_flag=true`,
+      42,
+    );
+    scriptedCounts.set(
+      `citation_velocity_criminal|in:${robberyBridge.slice().sort().join(",")}|velocity_tier=fading`,
+      11,
+    );
+
+    await checkPrecedentWatchlistCoverage("robbery", "NY");
+
+    const cvcQueries = queryLog.filter(
+      (q) => q.table === "citation_velocity_criminal" && q.isCount,
+    );
+    // Two parallel queries — one rising, one fading.
+    expect(cvcQueries).toHaveLength(2);
+    const risingQ = cvcQueries.find((q) =>
+      q.filters.some((f) => f.col === "rising_flag" && f.val === true),
+    );
+    const fadingQ = cvcQueries.find((q) =>
+      q.filters.some(
+        (f) => f.col === "velocity_tier" && f.val === "fading",
+      ),
+    );
+    expect(risingQ).toBeDefined();
+    expect(fadingQ).toBeDefined();
+    expect(risingQ!.inFilter?.col).toBe("charge_type");
+    expect(fadingQ!.inFilter?.col).toBe("charge_type");
+  });
+});

--- a/src/lib/tier9-reports/coverage.ts
+++ b/src/lib/tier9-reports/coverage.ts
@@ -20,7 +20,10 @@ import {
   CIRCUIT_NAMES,
   FEDERAL_CHARGES,
 } from "./federal-jury-instruction-brief";
-import { CHARGE_TYPE_MOR_MAP } from "@/lib/charge-slug-maps";
+import {
+  CHARGE_TYPE_MOR_MAP,
+  CHARGE_TYPE_AUTHORITY_MAP,
+} from "@/lib/charge-slug-maps";
 import {
   STATE_TO_CIRCUIT as MSR_STATE_TO_CIRCUIT,
   CIRCUIT_NAMES as MSR_CIRCUIT_NAMES,
@@ -805,6 +808,145 @@ export async function checkFederalSentencingCoverage(
     coverage: {
       distributionsAtAll,
       federallyMappable: 1,
+    },
+    matchedName: null,
+    matchedCourt: null,
+  };
+}
+
+/**
+ * Charge Authority Pack coverage gate (2026-04-27, closes C1 of
+ * worry-tier9-flipped-live audit).
+ *
+ * Inputs: chargeType (required user-facing slug from ALLOWED_CHARGE_TYPES),
+ * state (required for AvailabilityChecker — display context only; the
+ * authority list itself is national precedent).
+ *
+ * Surfaces two coverage counters so AvailabilityChecker can show the
+ * customer how many charge-specific top-cited authorities back the report
+ * vs. how many national criminal authorities are available as fallback.
+ *
+ * Bridge: ALLOWED_CHARGE_TYPES user-facing slug → array of internal slugs
+ * via CHARGE_TYPE_AUTHORITY_MAP. Slugs with empty arrays (e.g. arson,
+ * domestic-violence, federal, self-defense) fall through to the national
+ * fallback by design — the resolver in `charge-authority-pack.ts` handles
+ * that path and renders a `data_scope: "criminal_fallback"` row marker.
+ *
+ * `available: true` always — the resolver guarantees a non-empty list via
+ * the citation_authority_criminal national fallback. Banner condition
+ * (charge-specific < threshold) lives in the AvailabilityChecker, mirroring
+ * the D-T4 arrest-kit + D2 similar-cases pattern.
+ *
+ * Coverage shape:
+ *   - `authoritiesCharge`    — rows in charge_type_top_authorities for the
+ *                              bridged internal slugs (zero for unmapped or
+ *                              empty-bridge charges)
+ *   - `authoritiesNational`  — rows in citation_authority_criminal national
+ *                              fallback (always > 0 — 620k-row table)
+ */
+export async function checkChargeAuthorityPackCoverage(
+  chargeType: string,
+  _state: string,
+): Promise<CoverageResult> {
+  const supabase = createAdminClient();
+  const internalCharges = CHARGE_TYPE_AUTHORITY_MAP[chargeType] ?? [];
+
+  const [chargeRes, nationalRes] = await Promise.all([
+    internalCharges.length > 0
+      ? supabase
+          .from("charge_type_top_authorities")
+          .select("cited_opinion_id", { count: "exact", head: true })
+          .in("charge_type", internalCharges)
+      : Promise.resolve({
+          count: 0,
+          data: null,
+          error: null,
+        } as { count: number | null; data: null; error: null }),
+    supabase
+      .from("citation_authority_criminal")
+      .select("cited_opinion_id", { count: "exact", head: true }),
+  ]);
+
+  const authoritiesCharge = chargeRes.count ?? 0;
+  const authoritiesNational = nationalRes.count ?? 0;
+
+  return {
+    available: true,
+    coverage: {
+      authoritiesCharge,
+      authoritiesNational,
+    },
+    matchedName: null,
+    matchedCourt: null,
+  };
+}
+
+/**
+ * Precedent Watchlist coverage gate (2026-04-27, closes C2 of
+ * worry-tier9-flipped-live audit).
+ *
+ * Inputs: chargeType (required user-facing slug from ALLOWED_CHARGE_TYPES),
+ * state (required for AvailabilityChecker — display context only; citation
+ * velocity is not circuit-partitioned in the derivation pipeline).
+ *
+ * Surfaces two counters so AvailabilityChecker can show the customer how
+ * many rising and fading precedents back the report for their charge.
+ *
+ * Bridge: same CHARGE_TYPE_AUTHORITY_MAP used for charge-authority-pack —
+ * citation_velocity_criminal joins on the SAME internal charge slugs as
+ * charge_type_top_authorities (verified against derivation pipeline). When
+ * the bridge is empty for a slug, the resolver falls back to the
+ * national-criminal top-N pool with a limitation note.
+ *
+ * `available: true` always — the resolver guarantees a non-empty list via
+ * the national-criminal fallback (1.13M citation_velocity_criminal rows).
+ *
+ * Coverage shape:
+ *   - `risingPrecedents` — rows where rising_flag=true for the bridged
+ *                          internal charge slugs (charge-scoped subset)
+ *   - `fadingPrecedents` — rows where velocity_tier='fading' for the same
+ *                          bridged internal charge slugs
+ */
+export async function checkPrecedentWatchlistCoverage(
+  chargeType: string,
+  _state: string,
+): Promise<CoverageResult> {
+  const supabase = createAdminClient();
+  const internalCharges = CHARGE_TYPE_AUTHORITY_MAP[chargeType] ?? [];
+
+  const [risingRes, fadingRes] = await Promise.all([
+    internalCharges.length > 0
+      ? supabase
+          .from("citation_velocity_criminal")
+          .select("cited_opinion_id", { count: "exact", head: true })
+          .in("charge_type", internalCharges)
+          .eq("rising_flag", true)
+      : Promise.resolve({
+          count: 0,
+          data: null,
+          error: null,
+        } as { count: number | null; data: null; error: null }),
+    internalCharges.length > 0
+      ? supabase
+          .from("citation_velocity_criminal")
+          .select("cited_opinion_id", { count: "exact", head: true })
+          .in("charge_type", internalCharges)
+          .eq("velocity_tier", "fading")
+      : Promise.resolve({
+          count: 0,
+          data: null,
+          error: null,
+        } as { count: number | null; data: null; error: null }),
+  ]);
+
+  const risingPrecedents = risingRes.count ?? 0;
+  const fadingPrecedents = fadingRes.count ?? 0;
+
+  return {
+    available: true,
+    coverage: {
+      risingPrecedents,
+      fadingPrecedents,
     },
     matchedName: null,
     matchedCourt: null,

--- a/src/lib/tiers.ts
+++ b/src/lib/tiers.ts
@@ -391,8 +391,9 @@ export const TIER_CORE = {
     priorityPrice: null,
     priorityDelivery: null,
     includesTiers: [] as readonly string[],
-    // 2026-04-26 reverted dark — no dedicated landing + Slug union excludes (C2)
-    live: false as boolean,
+    // 2026-04-27 re-flipped live — C2 dedicated landing + Slug union widened
+    // (audit worry-tier9-flipped-live closed)
+    live: true as boolean,
   },
   "charge-authority-pack": {
     name: "Charge Authority Pack",
@@ -408,8 +409,9 @@ export const TIER_CORE = {
     priorityPrice: null,
     priorityDelivery: null,
     includesTiers: [] as readonly string[],
-    // 2026-04-26 reverted dark — no dedicated landing page yet (C1 from worry-tier9-flipped-live audit)
-    live: false as boolean,
+    // 2026-04-27 re-flipped live — C1 dedicated landing shipped
+    // (audit worry-tier9-flipped-live closed)
+    live: true as boolean,
   },
   "witness-pack": {
     name: "Standalone Witness Pack",


### PR DESCRIPTION
## Summary

Closes the last 2 deferred items from `docs/plans/2026-04-26-worry-tier9-flipped-live.md` (C1 + C2). PR #188 stop-the-bleed reverted both SKUs to dark because no dedicated landing routes existed — customers reaching the generic `/services/<slug>` fallback could not collect `chargeType` pre-purchase, so the post-purchase intake was the only path. Both reverted to `live: false` + `isActive: false` while landings shipped.

This PR builds the landings, widens the AvailabilityChecker `Slug` union, ships the coverage helpers, and re-flips both SKUs back to `live: true` + `isActive: true`.

- `/charge-authority-pack` landing page ($97) — Top 10 must-cite defense authorities, pre-extracted canonical quotes, citation-velocity arrows, every row CourtListener-linked. Mandatory gate line: "Top-cited authorities are aggregate frequencies. Use them to ask sharper questions, not to predict your case."
- `/precedent-watchlist` landing page ($47) — Top 10 rising + top 5 fading precedents, 30-day email drip explainer surfaced as part of the value prop. Mandatory gate line: "Citation velocity reflects which precedents are gaining or fading. Use it as a starting point for research, not a verdict."
- AvailabilityChecker `Slug` union widened from 8 → 10. Per-slug intake-payload branches in `handleCheck` / `handleWaitlist` / `buildCheckoutUrl`. Hoisted `isChargeAuthorityPack` + `isPrecedentWatchlist` booleans alongside the existing four. Charge-type select + retry-button noun derivation factored to a single helper.
- Two charge-fallback transparency banners in the available-state render block — surface when the charge-specific count is 0 but national fallback exists. Mirrors the D2 `pleaStateMissing` / D3 `officerThinState` / D-T4 `arrestKitThinState` pattern.
- `coverage.ts` adds `checkChargeAuthorityPackCoverage` (counts `charge_type_top_authorities` via `CHARGE_TYPE_AUTHORITY_MAP` bridge + national `citation_authority_criminal` baseline) and `checkPrecedentWatchlistCoverage` (counts `citation_velocity_criminal` rising_flag=true + velocity_tier=fading via the same bridge).
- `/api/check-availability/[slug]/route.ts` adds two `case` branches — already imports canonical `TIER9_SLUGS` from `constants.ts` (PR #188), so the slugs were valid in the slug-set; the missing piece was the per-slug switch arm.
- `sitemap.ts` extends `DEDICATED_ROUTE_SLUGS` (so `/services/<slug>` dedupes) and emits priority-0.8 entries for the two new dedicated routes.
- 3 new test files: 11 vitest tests covering the two coverage helpers + AvailabilityChecker `Slug`-union sync test (asserts all 10 expected slugs literal in the union, with cardinality assertion to catch silent drift).

## Hard constraints honored

- URL slugs UNCHANGED (`/charge-authority-pack`, `/precedent-watchlist`)
- DB `tier_slug` UNCHANGED
- Stripe price IDs UNCHANGED ($97 / $47)
- No banned UPL phrases (grep clean against the canonical 11-phrase blocklist in `charge-slug-maps.ts`)
- Mandatory gate line per SKU rendered on the page

## Test plan

- [x] `node node_modules/typescript/bin/tsc --noEmit --skipLibCheck` after `rm -rf .next/types` → 0 errors
- [x] `node node_modules/vitest/vitest.mjs run src/lib/tier9-reports/__tests__ src/components/tier9/__tests__` → 15 suites / 181 tests passing
- [x] Grep verify zero banned UPL phrases on both new landings
- [x] Grep verify mandatory gate line present per SKU
- [x] Grep verify `Slug` union literal includes all 10 expected slugs
- [ ] Post-merge: smoke `curl https://imnotanattorney.com/charge-authority-pack` (expect 200) + same for `/precedent-watchlist`
- [ ] Post-merge: smoke `POST /api/check-availability/charge-authority-pack` with `{state:'FL', chargeType:'dui'}` (expect `available:true`, `coverage.authoritiesCharge>0`, `coverage.authoritiesNational>0`)
- [ ] Post-merge: smoke `POST /api/check-availability/precedent-watchlist` with `{state:'FL', chargeType:'dui'}` (expect `available:true`, `coverage.risingPrecedents>=0`)

## Hook bypass disclosure

- `SKIP_TSC=1` on commit: pre-commit hook calls global `tsc` shim which errors on this machine ("not the tsc you're looking for"). Verified locally with `node node_modules/typescript/bin/tsc --noEmit --skipLibCheck` → clean.
- `SKIP_BUILD=1` on push: pre-push hook calls global `next` shim with same shim issue. Tsc + 181 tests pass; Vercel will run the real next build on PR CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)