### PR TITLE
hotfix: homepage 500 — drop federal-sentencing-distribution card

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -754,11 +754,12 @@ export default function Home() {
                 href: "/similar-cases-analyzer",
                 blurb: "Sentencing cohort: cases that look like yours and what actually happened to those defendants.",
               },
-              {
-                slug: "federal-sentencing-distribution",
-                href: "/federal-sentencing-distribution",
-                blurb: "District-level federal sentencing percentiles (p10/p25/p50/p75/p90), departure rates, and Monte Carlo simulation for your charge and criminal-history category.",
-              },
+              // federal-sentencing-distribution intentionally omitted: it lives
+              // in STANDALONE_PRODUCTS but not TIER_CORE, so the TIER_CORE
+              // lookup below would return undefined and crash the homepage at
+              // runtime (incident 2026-04-27, PR #203 → 500). Add to TIER_CORE
+              // alongside similar-cases-analyzer to re-include here. Followup:
+              // docs/plans/2026-04-27-fsd-tier-core-followup.md
             ].map((item) => {
               const tier = TIER_CORE[item.slug as keyof typeof TIER_CORE];
               return (


### PR DESCRIPTION
## Summary

- **Production is 500ing on https://imnotanattorney.com/** as of 2026-04-27 17:23Z (verified via 3x curl probes after PR #203 merged + Vercel deployed at sha 355843f0).
- Root cause: PR #203 added a homepage Tier 9 router card for `federal-sentencing-distribution`, which is in `STANDALONE_PRODUCTS` but NOT in `TIER_CORE`. The router code does `TIER_CORE[item.slug as keyof typeof TIER_CORE]` — runtime lookup returns undefined, `tier.name` throws, server crashes.
- This PR removes only that one card. The other 2 newly-added cards (`precedent-watchlist`, `charge-authority-pack`) stay because both DO have `TIER_CORE` entries. Service goes from 7/10 → 9/10 → restored.

## Why a hotfix branch

Production is currently down. Forward-fixing is faster than reverting the merge.

## Followup (separate PR)

Add `federal-sentencing-distribution` to `src/lib/tiers.ts` (mirror the `similar-cases-analyzer` shape — same $297, same Tier 9 instant-digital pattern), then re-add the homepage card. Tracked in commit message.

## Test plan

- [ ] tsc --noEmit --skipLibCheck = 0 errors (verified locally)
- [ ] Vercel preview build green
- [ ] Vercel production deploy at merged sha returns HTTP 200 on `/`
- [ ] All 9 surviving Tier 9 cards still render on homepage

🤖 Generated with [Claude Code](https://claude.com/claude-code)