### PR TITLE
fix(tier-core): backfill federal-sentencing-distribution + restore 10th homepage card

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -754,12 +754,11 @@ export default function Home() {
                 href: "/similar-cases-analyzer",
                 blurb: "Sentencing cohort: cases that look like yours and what actually happened to those defendants.",
               },
-              // federal-sentencing-distribution intentionally omitted: it lives
-              // in STANDALONE_PRODUCTS but not TIER_CORE, so the TIER_CORE
-              // lookup below would return undefined and crash the homepage at
-              // runtime (incident 2026-04-27, PR #203 → 500). Add to TIER_CORE
-              // alongside similar-cases-analyzer to re-include here. Followup:
-              // docs/plans/2026-04-27-fsd-tier-core-followup.md
+              {
+                slug: "federal-sentencing-distribution",
+                href: "/federal-sentencing-distribution",
+                blurb: "District-level federal sentencing percentiles (p10/p25/p50/p75/p90), departure rates, and Monte Carlo simulation for your charge and criminal-history category.",
+              },
             ].map((item) => {
               const tier = TIER_CORE[item.slug as keyof typeof TIER_CORE];
               return (

--- a/src/lib/CONTEXT.md
+++ b/src/lib/CONTEXT.md
@@ -190,12 +190,13 @@ No passwords. Flow: `POST /api/customer/magic-link` → token stored in `magic_l
 | X-Ray | $2,497, priority $497 (5 days) | `tiers.ts:197-212` |
 | War Room | $4,997, priority $997 (20 days) | `tiers.ts:213-228` |
 | Situation Room | $9,997 | `tiers.ts:229-244` |
-| District / Courthouse Intelligence | $147, `live: true` | `tiers.ts:308-326` |
-| Motion Success Report | $197, `live: true` | `tiers.ts:327-342` |
-| Federal Jury Instruction Brief | $97, `live: true` | `tiers.ts:359-380` |
-| Precedent Watchlist | $47 + 30d drip, `live: true` | `tiers.ts:381-397` |
-| Charge Authority Pack | $97, `live: true` | `tiers.ts:398-415` |
-| Witness Pack | $297 add-on | `tiers.ts:416-431` |
+| Federal Sentencing Distribution | $297, `live: true` | `tiers.ts:308-325` |
+| District / Courthouse Intelligence | $147, `live: true` | `tiers.ts:326-344` |
+| Motion Success Report | $197, `live: true` | `tiers.ts:345-360` |
+| Federal Jury Instruction Brief | $97, `live: true` | `tiers.ts:377-398` |
+| Precedent Watchlist | $47 + 30d drip, `live: true` | `tiers.ts:399-415` |
+| Charge Authority Pack | $97, `live: true` | `tiers.ts:416-433` |
+| Witness Pack | $297 add-on | `tiers.ts:434-449` |
 | **Scoring** | | |
 | Base score | 50 (neutral midpoint) | `score.ts:103` |
 | Score bands | Critical 0-30, Concerning 31-50, Average 51-70, Adequate 71-85, Excellent 86-100 | `score.ts:332-336` |

--- a/src/lib/tiers.ts
+++ b/src/lib/tiers.ts
@@ -305,6 +305,24 @@ export const TIER_CORE = {
     includesTiers: [] as readonly string[],
     live: true as boolean, // LIVE, 2026-04-11 (availability gate deployed)
   },
+  "federal-sentencing-distribution": {
+    name: "Federal Sentencing Distribution Report",
+    price: 29700,
+    priceDisplay: "$297",
+    delivery: "Instant",
+    deliveryDetail: "Your Federal Sentencing Distribution Report is generated on demand from 13,131 district-level buckets within 60 seconds.",
+    requiresDiscovery: false,
+    isAddon: false,
+    isDigitalProduct: true,
+    requiresWarRoom: false,
+    priorityPrice: null,
+    priorityDelivery: null,
+    includesTiers: [] as readonly string[],
+    // 2026-04-27: backfilled into TIER_CORE to match the dual-definition
+    // convention used by the other 9 Tier 9 SKUs. Closes the homepage 500
+    // incident root cause (see hotfix PR #206 + smoke-test doc).
+    live: true as boolean,
+  },
   "district-court-intelligence": {
     // Slug retained for URL compatibility; upgraded 2026-04-23 from the
     // $97 test-mode "District Court Intelligence" SKU to the $147


### PR DESCRIPTION
## Summary

- Adds `federal-sentencing-distribution` to `TIER_CORE` in `src/lib/tiers.ts` (mirrors `similar-cases-analyzer` shape — $297, instant-digital, live).
- Re-adds the FSD card to the homepage Tier 9 router array. Homepage now lists all 10 Tier 9 SKUs (was 9/10 after hotfix #206).
- Updates `src/lib/CONTEXT.md` tier table: new row + bumped line ranges for the 6 SKUs below the insert.

Closes the followup left by hotfix #206 (homepage 500 incident, 2026-04-27).

## Why this is safe

The other 9 Tier 9 SKUs already follow the dual-definition convention (TIER_CORE + STANDALONE_PRODUCTS). FSD was the only one missing it — adding it brings FSD into the same well-tested code path. No new shape, no new code.

## Verification

- [x] `node docs/verify-architecture.js` → 0 DRIFT, 369 verified
- [x] `npx tsc --noEmit --skipLibCheck` → 0 errors
- [x] Pre-commit price-check → 49 anchors valid, 0 mismatches
- [ ] Vercel preview build green
- [ ] Post-merge: homepage returns 200 + 10 SKU slug occurrences in HTML

🤖 Generated with [Claude Code](https://claude.com/claude-code)