### PR TITLE
fix(post-purchase-ux): substitute {email} placeholder + suppress redundant Delivery line

### DIFF
--- a/src/app/checkout/success/page.tsx
+++ b/src/app/checkout/success/page.tsx
@@ -622,13 +622,20 @@ function SuccessContent() {
               </div>
             ) : (
               <>
-                <p className="mt-4 text-zinc-400">{info.action}</p>
+                <p className="mt-4 text-zinc-400">
+                  {info.action.replace(/\{email\}/g, customerEmail || 'your email')}
+                </p>
                 {priorityDelivery && tier && TIER_CORE[tier as keyof typeof TIER_CORE]?.priorityDelivery ? (
                   <div className="mt-3 rounded-lg border border-amber-500/30 bg-amber-500/10 px-4 py-2">
                     <p className="text-sm font-semibold text-amber-400">
                       Priority Delivery: {TIER_CORE[tier as keyof typeof TIER_CORE].priorityDelivery}
                     </p>
                   </div>
+                ) : info.isInstantStandalone ? (
+                  // Tier 9 instant standalone — action string already states delivery
+                  // ("Typical delivery: 60 seconds"). Suppress the redundant "Delivery:"
+                  // line that repeats info.delivery verbatim.
+                  null
                 ) : (
                   <p className="mt-2 text-sm text-zinc-400">
                     Delivery: {info.delivery}


### PR DESCRIPTION
## Summary

Live arrest-survival-kit test on prod (post PR #213 deploy) surfaced two copy bugs in the \`info\` branch (\`?tier=\` success path) that the earlier swarm missed:

1. **\`{email}\` rendered literally.** The 10 new Tier 9 entries' action strings contain a \`{email}\` token meant for runtime substitution. The \`info\` branch passed it through unchanged → customer saw \"We'll email a link to {email}\".
2. **Redundant \"Delivery: ...\" line.** Below the action string, \`info.delivery\` was repeated verbatim. Tier 9 instant action strings already state \"Typical delivery: 60 seconds\" — the second line was clutter.

Both bugs only fire on the \`?tier=\` path. The \`?product=\` (standaloneProduct) branch was already correct because PR #213's A2 wired \`customerEmail\` directly there.

## Fix

\`src/app/checkout/success/page.tsx\` (line ~625):
- Substitute \`{email}\` → \`customerEmail || 'your email'\` at render time
- Gate the \"Delivery:\" line off when \`info.isInstantStandalone\` is true

## Verification

- [x] \`npx tsc --noEmit --skipLibCheck\` → 0 errors
- [x] \`npx vitest run src/__tests__\` → 37/37 pass (35 from PR #213 regression suite + 2 from middleware-x-pathname)
- [ ] Vercel preview build green
- [ ] Post-merge manual check: visit \`/api/qa-checkout?key=KEY&tier=arrest-survival-kit\` → success page shows real email, no literal \`{email}\`, no \"Delivery: ...\" repeat below the action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)