### PR TITLE
docs(CLAUDE.md): add deploy-scope callout under ecosystem table

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,8 @@ Part of INAA (ImNotAnAttorney) ecosystem. Freely read files from sibling repos:
 
 **Default boundary**: Do NOT read files from projects outside this table unless Rahim explicitly directs.
 
+**⚠ DEPLOY SCOPE — read before any app-code change:** As of 2026-04-28 cutover, Vercel project `imnotanattorney` (prj_zqxNgG9xcM235bnKRoEgP5kBOEEr) deploys from `ImNotAnAttorney/apps/web/` (monorepo), NOT this repo. Pushing app-code fixes to `ImNotAnAttorney-web/master` MERGES BUT DOES NOT SHIP. For any change that must reach prod (`/src/`, `/supabase/functions/`, `/scripts/` runtime artifacts, `/content/`, `/public/`), work in `C:\Users\email\projects\ImNotAnAttorney\apps\web\`. This repo is now read-only-for-deploys (still useful for blog drafts, Twitter queue, scripts/cron registration, docs). Mirror landing site changes in BOTH repos until -web is fully retired. Verify link state any time: `curl https://api.vercel.com/v9/projects/prj_zqxNgG9xcM235bnKRoEgP5kBOEEr -H "Authorization: Bearer $VERCEL_TOKEN" | jq '{link, rootDirectory}'`. See memory `gotcha-vercel-project-cutover-silent-abandon.md`.
+
 **How repos connect:**
 - **This repo → Engine:** Stripe webhook creates `cases` + `processing_jobs` rows. Engine polls `processing_jobs` via cron-job.org every 5min. Discovery tiers ($2,497+) processed by engine workers.
 - **This repo → Parent:** Reads `system/EVALUATION-TEAM.md` for audit criteria. Engine reads `system/templates/` for prompt templates at runtime.

--- a/docs/plans/2026-04-28-claude-md-deploy-scope-callout.md
+++ b/docs/plans/2026-04-28-claude-md-deploy-scope-callout.md
@@ -1,0 +1,45 @@
+# Plan: CLAUDE.md Deploy-Scope Callout (-web Ecosystem Section)
+
+**Date:** 2026-04-28
+**Author:** Atlas (continuation of `docs/handoffs/2026-04-28-archetype-validation-followups.md`)
+**Triage:** FEATURE (auto-upgraded from QUICK_FIX after edit count crossed 2)
+**Approval:** Rahim said "do it" in chat re: recommendation #1 ("CLAUDE.md ecosystem fix").
+
+## Why
+
+Today's PR #219 silently shipped to nowhere because Vercel's `imnotanattorney` project was relinked to `ImNotAnAttorney/apps/web/` during cutover, but `-web/CLAUDE.md`'s ecosystem table still presents `-web` as "Next.js customer-facing site (THIS REPO)" with no annotation that it's read-only-for-deploys. A future session reading just the ecosystem table will assume "this repo deploys" and merge a fix to nowhere again.
+
+Cascade test:
+- Us / future-us: prevents repeat of today's silent-deploy class across every session.
+- Rahim: zero re-debug overhead next time.
+- Sibling sessions: see the deploy reality immediately.
+- Ecosystem (other Claude Code teams running monorepo cutovers): publishable pattern.
+- No node loses.
+
+## Files to modify
+
+| Path | Change |
+|---|---|
+| `C:\Users\email\projects\ImNotAnAttorney-web\CLAUDE.md` | Insert one paragraph between the "Default boundary" line and "How repos connect:" — calls out: (a) Vercel project ID + monorepo `apps/web` rootDirectory, (b) what STILL belongs in -web (blog drafts, Twitter queue, cron registration, docs), (c) verify-link-state curl command, (d) memory pointer to `gotcha-vercel-project-cutover-silent-abandon.md`. |
+
+## Files to create
+
+None.
+
+## Tasks
+
+1. Edit `-web/CLAUDE.md` insertion point per the file table above. Use the bold `⚠ DEPLOY SCOPE` callout text already drafted in the chat exchange immediately preceding this plan.
+2. Verify the insertion lands (file diff readable, no other lines drift).
+
+## Out of scope
+
+- Mirroring the callout into `ImNotAnAttorney/CLAUDE.md` and `ImNotAnAttorney/apps/web/CLAUDE.md` — those already document the deploy reality clearly (lines 9, 33, 64-66 of root; lines 44, 70-74 of apps/web). Adding here would be duplicate noise.
+- Writing a hook to enforce "don't push to -web/master" — the gotcha memory + this CLAUDE.md callout cover the human path. A hook is over-engineering for a one-time cutover whose end-state is "-web fully retired".
+- Retiring `-web` entirely — separate, larger decision.
+
+## Verification
+
+After edit:
+- `git diff CLAUDE.md` shows ONE inserted block, zero unrelated changes.
+- The ecosystem table renders unchanged.
+- The new paragraph appears between the "Default boundary" line and "How repos connect:".


### PR DESCRIPTION
## Summary
- Add prominent **⚠ DEPLOY SCOPE** paragraph between "Default boundary" and "How repos connect:" in `-web/CLAUDE.md`.
- Names: Vercel project + ID, monorepo `apps/web/` rootDirectory, what still belongs in -web (blog drafts, Twitter queue, scripts/cron registration, docs), the Vercel-API check command.

## Why
PR #219 (the Tier 9 after()-wrap fix) merged here on 2026-04-28T11:51Z and never reached prod — Vercel had been silently relinked to the monorepo during cutover. The ecosystem table still presented this repo as "the customer-facing site", giving zero signal that `-web/master` is read-only-for-deploys. Callout closes that loop. Future sessions reading just the ecosystem table now see the deploy reality immediately.

## Plan
`docs/plans/2026-04-28-claude-md-deploy-scope-callout.md`

## Memory
`gotcha-vercel-project-cutover-silent-abandon.md` (added this session) — pointer included in the callout.

## Test plan
- [x] `git diff` shows 2 inserted lines on CLAUDE.md, no unrelated drift
- [x] Insertion lands between "Default boundary" line and "How repos connect:"
- [x] Plan file exists at the cited path
- [ ] Reviewer confirms wording matches the deploy reality (project ID, rootDirectory, repo path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)