### PR TITLE
feat(arrest-survival-kit): v3 — state procedural data replaces agency-incident dump

### DIFF
--- a/data/state-arrest-procedure/_README.md
+++ b/data/state-arrest-procedure/_README.md
@@ -1,0 +1,69 @@
+# State Arrest Procedure — Data Schema + Research Methodology
+
+Per-state procedural facts surfaced in the Arrest Survival Kit ($47, Tier 9). One JSON file per state at `<lowercase-code>.json`. Loader at `src/lib/state-arrest-procedure/load.ts`. Types at `src/lib/state-arrest-procedure/types.ts`.
+
+## Hard rule (do not break)
+
+Per `~/.claude/rules/no-hallucinated-legal-data.md` and ARCHITECTURE.md invariant 13: **every populated field must be backed by at least one verification URL in `source_urls`**. If a field cannot be confirmed from an authoritative public source, write `null` and add the field name to `_unknown_fields`. Guessing is forbidden. The loader rejects any file that violates this rule.
+
+## Schema
+
+```jsonc
+{
+  "state_code": "FL",                     // 2-letter USPS code, uppercase
+  "state_name": "Florida",                // Full state name
+  "researched_at": "2026-04-28",          // ISO date the research was completed
+
+  "first_appearance_window_hours": 24,    // Statutory window for first appearance / arraignment, in hours, or null
+  "pd_attach_trigger": "at first appearance", // Plain prose: when public defender / appointed counsel attaches, or null
+  "indigency_threshold": "200% of federal poverty level", // Plain prose, or null
+  "bail_types_allowed": ["cash", "surety", "personal_recognizance"], // Subset of: cash, surety, signature, property, personal_recognizance
+  "bail_default_amounts_by_charge": null, // Plain prose if a published bail schedule exists, else null
+  "phone_call_rule": "Right to use the telephone within 3 hours of booking unless it interferes with the investigation.",
+  "recording_police_consent": "one-party", // one-party | all-party | restricted | null
+  "expungement_window_years": "10 years after probation completion (varies by charge)",
+  "misc_quirks": [                        // 1-3 short, sourced bullets
+    "Florida statute § 901.24 governs phone-call right",
+    "Pinellas + Hillsborough counties run separate first-appearance dockets at 8:30am daily"
+  ],
+
+  "source_urls": [                        // Every populated field above must be backed by ≥1 entry here
+    "https://www.floridabar.org/...",
+    "https://www.flcourts.gov/..."
+  ],
+  "_unknown_fields": [                    // Field names whose values are null/empty because no source was found
+    "bail_default_amounts_by_charge"
+  ]
+}
+```
+
+## Sources allowed (free, public, authoritative)
+
+1. State public defender association websites
+2. State bar websites (rules of criminal procedure)
+3. lawhelp.org per state
+4. Official .gov / state legislature pages
+5. Wikipedia state-by-state arrest-procedure articles — **as a discovery aid only**. The URL Wikipedia cites is the authoritative source. Do not put the Wikipedia URL into `source_urls`; put the upstream URL it cites.
+
+## Research methodology (per state)
+
+1. WebSearch the state's name + "rules of criminal procedure" + "first appearance" + "right to counsel" + "bail" + "phone call" + "recording police".
+2. Collect 5-10 authoritative URLs. Prefer state-bar / state-PD-association / .gov over secondary sources.
+3. Extract structured fields. For each populated field, verify the value against at least one of the collected URLs and include that URL in `source_urls`.
+4. Any field where the public source is silent or ambiguous is written as `null` and listed in `_unknown_fields`. Do not invent values.
+5. `misc_quirks` — 1-3 short bullets that are state-specific and unusual enough to matter to a defendant. Each bullet must be reflected in at least one `source_urls` entry.
+
+## UPL guardrail
+
+The data is **information**, not advice. Field values describe what the law says. Do not put directive language in any field ("you should", "verify with attorney", "fire your attorney"). The kit reads as Mercer the back-room strategist showing the defendant what the system says — not telling them what to do.
+
+## Bootstrap-mode constraints
+
+- Public sources only.
+- WebFetch and WebSearch only. No paid APIs.
+- One JSON file per state. No DB tables, no migrations, no Edge Functions for this data.
+- The loader is read-only and Node-side; ships in the Vercel build.
+
+## File naming
+
+Lowercase USPS code, `.json` extension. `fl.json`, `tx.json`, `ca.json`, etc. The 50 states only — DC, PR, VI, GU, AS, MP are out of scope for v3.

--- a/data/state-arrest-procedure/ak.json
+++ b/data/state-arrest-procedure/ak.json
@@ -1,0 +1,32 @@
+{
+  "state_code": "AK",
+  "state_name": "Alaska",
+  "researched_at": "2026-04-28",
+
+  "first_appearance_window_hours": 24,
+  "pd_attach_trigger": "At first appearance (Rule 5 hearing). The judge advises the defendant of the right to counsel and appoints a public defender if the defendant cannot afford one.",
+  "indigency_threshold": "No fixed income cutoff. Under AS 18.85.120 the court determines indigency based on whether the person can pay for counsel without 'undue hardship,' weighing income, property, outstanding obligations, and number/ages of dependents. Release on bail does not preclude a finding of indigency.",
+  "bail_types_allowed": ["cash", "surety", "signature", "personal_recognizance"],
+  "bail_default_amounts_by_charge": null,
+  "phone_call_rule": "Per the Alaska Bar Association Youth Law Guide, an arrested person has the right to make two phone calls during booking — one to a lawyer and one to a friend or family member.",
+  "recording_police_consent": "one-party",
+  "expungement_window_years": "Alaska does not allow expungement of valid convictions. AS 12.62.180 permits sealing only when the record resulted from mistaken identity or false accusation, proven beyond a reasonable doubt. Set-aside under AS 12.55.085 is available after successful probation but does not erase the record.",
+  "misc_quirks": [
+    "Felony defendants in custody have a right to a grand jury indictment within 10 days of first appearance (20 days if out of custody) under Alaska Criminal Rule 5 timing.",
+    "Alaska is a one-party consent state for recording conversations under AS 42.20.310 — a defendant who is part of the conversation may record police interactions.",
+    "Sealing is limited to mistaken identity / false accusation (AS 12.62.180); the standard is 'beyond a reasonable doubt' to the head of the agency holding the record."
+  ],
+
+  "source_urls": [
+    "https://courts.alaska.gov/shc/criminal/steps.htm",
+    "https://law.justia.com/codes/alaska/title-12/chapter-30/section-12-30-011/",
+    "https://law.justia.com/codes/alaska/title-18/chapter-85/",
+    "https://alaskabar.org/youth/law-enforcement-and-crime/encounters-with-law-enforcement/arrests-and-your-rights-in-criminal-proceedings/",
+    "https://www.rcfp.org/reporters-recording-guide/alaska/",
+    "https://ccresourcecenter.org/state-restoration-profiles/alaska-expungment-pardon-sealing/",
+    "https://courts.alaska.gov/rules/docs/crpro.pdf"
+  ],
+  "_unknown_fields": [
+    "bail_default_amounts_by_charge"
+  ]
+}

--- a/data/state-arrest-procedure/al.json
+++ b/data/state-arrest-procedure/al.json
@@ -1,0 +1,36 @@
+{
+  "state_code": "AL",
+  "state_name": "Alabama",
+  "researched_at": "2026-04-28",
+
+  "first_appearance_window_hours": 48,
+  "pd_attach_trigger": "At or before first appearance. Under Alabama Rule of Criminal Procedure 6.1, a defendant who is financially unable to obtain counsel has counsel appointed; the Office of Indigent Defense Services (OIDS) administers appointment, and the trial judge determines indigency before appointment.",
+  "indigency_threshold": "Set by the trial judge based on guidelines tied to the federal Poverty Level Guidelines published by the U.S. Department of Health and Human Services. Alabama does not publish a single statewide multiplier in statute; the judge makes the eligibility determination per case.",
+  "bail_types_allowed": ["cash", "surety", "signature", "property", "personal_recognizance"],
+  "bail_default_amounts_by_charge": "Yes — Rule 7.2(b), Alabama Rules of Criminal Procedure, sets a recommended bail schedule by offense category. The minimum bail for misdemeanor and violation cases is $300 per Ala. Code § 15-13-105. Felony ranges and municipal-ordinance ranges are set in the schedule; courts may go above or below in their discretion.",
+  "phone_call_rule": "Under Alabama Rule of Criminal Procedure 4.2, any person under arrest shall be afforded an opportunity to make a telephone call to any person of his or her choosing without undue delay. The rule does not fix a numeric hour limit; police commonly allow the call after booking.",
+  "recording_police_consent": "one-party",
+  "expungement_window_years": "Non-convictions (acquittal, dismissal with prejudice, no-bill, nolle prosequi without conditions): petition allowed 90 days after disposition. Felony charges dismissed without prejudice: 5 years with no intervening convictions. Misdemeanor convictions (Ala. Code § 15-27-1): 3 years after conviction with all sentence terms completed. Successful diversion-program completion: 1 year.",
+  "misc_quirks": [
+    "Alabama Rule of Criminal Procedure 4.3 splits the first-appearance window: 48 hours after a warrantless arrest, but up to 72 hours after arrest on a warrant if the defendant cannot meet release conditions.",
+    "Aniah's Law (2022 Amendment 1, codified in Ala. Code § 15-13-3) lets a judge deny bail entirely for a list of enumerated violent felonies (murder, kidnapping 1st, rape 1st, sodomy 1st, sexual torture, domestic violence 1st, human trafficking 1st, burglary 1st, arson 1st, robbery 1st, terrorism, aggravated child abuse) if the prosecution proves by clear and convincing evidence that no release condition will protect the community.",
+    "Indigent defense in Alabama is administered by the Office of Indigent Defense Services (OIDS) under the Department of Finance, and is regionalized by judicial circuit — each circuit has its own delivery model (public defender office, contract counsel, or appointed counsel) chosen by a local advisory board."
+  ],
+
+  "source_urls": [
+    "https://judicial.alabama.gov/library/CriminalProcedure",
+    "https://judicial.alabama.gov/docs/library/rules/cr4_3.pdf",
+    "https://judicial.alabama.gov/docs/library/rules/cr4_2.pdf",
+    "https://judicial.alabama.gov/docs/library/rules/cr7_2.pdf",
+    "https://judicial.alabama.gov/docs/library/rules/cr6_1.pdf",
+    "https://aidcc.alabama.gov/",
+    "https://finance.alabama.gov/indigent-defense",
+    "https://law.justia.com/codes/alabama/title-15/chapter-12/article-3/section-15-12-40/",
+    "https://law.justia.com/codes/alabama/title-15/chapter-27/section-15-27-1/",
+    "https://law.justia.com/codes/alabama/title-15/chapter-27/section-15-27-2/",
+    "https://codes.findlaw.com/al/title-13a-criminal-code/al-code-sect-13a-11-30/",
+    "https://www.rcfp.org/reporters-recording-guide/alabama/",
+    "https://ballotpedia.org/Alabama_Amendment_1,_Allow_Denial_of_Bail_for_Offenses_Enumerated_by_State_Legislature_Amendment_(2022)"
+  ],
+  "_unknown_fields": []
+}

--- a/data/state-arrest-procedure/ar.json
+++ b/data/state-arrest-procedure/ar.json
@@ -1,0 +1,35 @@
+{
+  "state_code": "AR",
+  "state_name": "Arkansas",
+  "researched_at": "2026-04-28",
+
+  "first_appearance_window_hours": 48,
+  "pd_attach_trigger": "At first appearance before a judicial officer; counsel is appointed under Ark. R. Crim. P. 8.2 once the court determines indigency",
+  "indigency_threshold": "Determined by the court on a sworn Certificate of Indigency under Ark. Code Ann. § 16-87-213 using standards set by the Arkansas Public Defender Commission; no fixed federal-poverty-level multiplier in statute",
+  "bail_types_allowed": ["cash", "surety", "personal_recognizance", "property"],
+  "bail_default_amounts_by_charge": null,
+  "phone_call_rule": "Arrested persons have the right to communicate with counsel, family, and friends and to make a local phone call; Arkansas statute does not set a specific time window. Calls to anyone other than counsel may be recorded.",
+  "recording_police_consent": "one-party",
+  "expungement_window_years": "Most misdemeanors and non-violent Class C/D felonies (and Class A/B drug felonies) are eligible immediately upon completion of sentence under Ark. Code Ann. §§ 16-90-1405 and 16-90-1406; violent Class C/D felonies require a 5-year wait; misdemeanor DWI requires 10 years",
+  "misc_quirks": [
+    "Warrantless-arrest probable-cause determination must be made within 48 hours absent a bona fide emergency (Ark. R. Crim. P. 8.1; SMU Deason Center documents persistent first-appearance delays in Arkansas)",
+    "Recording in-person, telephone, or electronic communications without consent of at least one party is a Class A misdemeanor under Ark. Code Ann. § 5-60-120",
+    "Sealing petitions for misdemeanors allow a 30-day objection window; felony sealing petitions require a 90-day prosecutor objection window"
+  ],
+
+  "source_urls": [
+    "https://courts.arkansas.gov/rules-and-administrative-orders/rules-of-criminal-procedure",
+    "https://www.smu.edu/law/centers-and-initiatives/deason-center/issues/right-to-counsel/arkansas",
+    "https://law.justia.com/codes/arkansas/title-16/subtitle-6/chapter-87/subchapter-2/section-16-87-213/",
+    "https://law.justia.com/codes/arkansas/title-5/subtitle-6/chapter-60/subchapter-1/section-5-60-120/",
+    "https://recordinglaw.com/united-states-recording-laws/one-party-consent-states/arkansas-recording-laws/",
+    "https://www.rcfp.org/reporters-recording-guide/arkansas/",
+    "https://ccresourcecenter.org/state-restoration-profiles/arkansas-restoration-of-rights-pardon-expungement-sealing/",
+    "https://www.labor.arkansas.gov/wp-content/uploads/Bail-Bond-Statutes-For-2024.pdf",
+    "https://www.acluarkansas.org/en/know-your-rights/know-your-rights-criminal-court",
+    "https://www.acluarkansas.org/app/uploads/2018/08/237_0.pdf"
+  ],
+  "_unknown_fields": [
+    "bail_default_amounts_by_charge"
+  ]
+}

--- a/data/state-arrest-procedure/az.json
+++ b/data/state-arrest-procedure/az.json
@@ -1,0 +1,36 @@
+{
+  "state_code": "AZ",
+  "state_name": "Arizona",
+  "researched_at": "2026-04-28",
+
+  "first_appearance_window_hours": 24,
+  "pd_attach_trigger": "At the initial appearance, when the magistrate determines indigency on a sworn financial affidavit and appoints counsel under Arizona Rule of Criminal Procedure 6.",
+  "indigency_threshold": "Determined case-by-case via a sworn financial affidavit reviewed by the court; the statutory standard is whether the person can obtain counsel without substantial hardship to themselves or their family. No fixed federal-poverty-level percentage in statute.",
+  "bail_types_allowed": ["cash", "surety", "property", "personal_recognizance"],
+  "bail_default_amounts_by_charge": null,
+  "phone_call_rule": "An arrestee is permitted at least one phone call after booking, and if counsel is requested must be provided a private room with a phone and access to attorney phone numbers, under Arizona Rule of Criminal Procedure 6.1.",
+  "recording_police_consent": "one-party",
+  "expungement_window_years": "Arizona uses two separate mechanisms: set-aside under ARS 13-905 (available after sentence is fully completed, no fixed waiting period) and record sealing under ARS 13-911 (waiting period after sentence completion: 2 years for low misdemeanors, 3 years for class 1 misdemeanors, 5 years for class 4-6 felonies, 10 years for class 2-3 felonies). True expungement does not exist outside narrow categories.",
+  "misc_quirks": [
+    "If the initial appearance does not occur within 24 hours of arrest, Arizona Rule of Criminal Procedure 4.1 requires immediate release from custody.",
+    "If a complaint is not filed within 48 hours of the initial appearance, the arrested person must be released from custody under Arizona Rule of Criminal Procedure 4.1.",
+    "Arizona's 2022 HB 2319 attempted to ban video recording of police within 8 feet of an officer (ARS 13-3732); a federal court permanently blocked it in 2023 as unconstitutional and the Attorney General conceded it is unenforceable."
+  ],
+
+  "source_urls": [
+    "https://state-rules.com/arizona/criminal/4.1/",
+    "https://www.azcourts.gov/rules/Recent-Amendments/Rules-of-Criminal-Procedure",
+    "https://www.coconino.az.gov/287/Public-Defender",
+    "https://www.jacksonwhitelaw.com/resources/criminal-defense-law/public-defender-criteria-arizona/",
+    "https://kolsrudlawoffices.com/different-types-of-bail-bonds/",
+    "https://www.recordinglaw.com/united-states-recording-laws/one-party-consent-states/arizona-recording-laws/",
+    "https://www.azleg.gov/ars/13/03005.htm",
+    "https://ccresourcecenter.org/state-restoration-profiles/arizona-restoration-of-rights-pardon-expungement-sealing/",
+    "https://www.chmlaw.com/sealing-criminal-records/",
+    "https://policearrestfinder.com/arizona-arrest-process-guide/",
+    "https://www.novakazlaw.com/arrest-processing.html"
+  ],
+  "_unknown_fields": [
+    "bail_default_amounts_by_charge"
+  ]
+}

--- a/data/state-arrest-procedure/ca.json
+++ b/data/state-arrest-procedure/ca.json
@@ -1,0 +1,31 @@
+{
+  "state_code": "CA",
+  "state_name": "California",
+  "researched_at": "2026-04-28",
+
+  "first_appearance_window_hours": 48,
+  "pd_attach_trigger": "At arraignment (first court appearance). The court appoints the public defender after the defendant completes a financial disclosure form and the judge finds indigency.",
+  "indigency_threshold": "No fixed statewide income threshold. Each court evaluates a financial disclosure form (income, expenses, assets) submitted at arraignment to determine inability to retain private counsel.",
+  "bail_types_allowed": ["cash", "surety", "property", "personal_recognizance"],
+  "bail_default_amounts_by_charge": "Each county's superior court adopts and annually revises a uniform countywide bail schedule under Penal Code 1269b listing amounts per offense. Schedules vary by county (e.g., Los Angeles, San Diego, Orange).",
+  "phone_call_rule": "Per Penal Code 851.5, the arrestee has the right to make at least three completed telephone calls immediately upon being booked and no later than three hours after arrest, except where physically impossible. Calls within the local calling area are at no expense; calls to an attorney may not be monitored or recorded.",
+  "recording_police_consent": "all-party",
+  "expungement_window_years": "Arrest records without a conviction may be petitioned for sealing under Penal Code 851.91 (no fixed waiting period for most arrests not resulting in conviction). Conviction expungement (dismissal under PC 1203.4) generally available after probation completion.",
+  "misc_quirks": [
+    "Penal Code 825 sets the 48-hour arraignment window excluding Sundays and holidays; if the period expires when court is not in session, it extends to the next court session.",
+    "Penal Code 632 makes California an all-party (two-party) consent state: recording a confidential communication without consent of all parties is criminal, with fines up to $2,500 per violation.",
+    "Penal Code 851.5 entitles arrested custodial parents of a minor child to two additional free local phone calls beyond the standard three."
+  ],
+
+  "source_urls": [
+    "https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?sectionNum=825.&lawCode=PEN",
+    "https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?lawCode=PEN&sectionNum=851.5.",
+    "https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?sectionNum=1269b.&lawCode=PEN",
+    "https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?lawCode=PEN&sectionNum=632",
+    "https://codes.findlaw.com/ca/penal-code/pen-sect-851-91/",
+    "https://lao.ca.gov/Publications/Report/4623",
+    "https://www.lacourt.org/division/criminal/pdf/felony.pdf",
+    "https://www.sdcourt.ca.gov/sites/default/files/sdcourt/criminal2/criminalresources/bail_schedule.pdf"
+  ],
+  "_unknown_fields": []
+}

--- a/data/state-arrest-procedure/co.json
+++ b/data/state-arrest-procedure/co.json
@@ -1,0 +1,40 @@
+{
+  "state_code": "CO",
+  "state_name": "Colorado",
+  "researched_at": "2026-04-28",
+
+  "first_appearance_window_hours": 48,
+  "pd_attach_trigger": "At first appearance / advisement; defendant applies through the Office of the State Public Defender, which makes the initial indigency determination subject to court review.",
+  "indigency_threshold": "Set by Chief Justice Directive 04-04 fiscal guidelines (updated annually). 2025 thresholds: approximately $26,355 annual income for a one-person household, $35,770 for two, $45,185 for three. Liquid assets sufficient to retain private counsel can disqualify even within income limits.",
+  "bail_types_allowed": ["cash", "surety", "property", "personal_recognizance"],
+  "bail_default_amounts_by_charge": null,
+  "phone_call_rule": "Under C.R.S. 16-3-402, an arrested person has the right to communicate with an attorney of their choice and a family member by a reasonable number of telephone calls or other reasonable means, permitted at the earliest possible time after arrival at the police station, sheriff's office, jail, or other confinement facility. The right renews if the person is transferred to a new place of custody.",
+  "recording_police_consent": "one-party",
+  "expungement_window_years": "Sealing under C.R.S. 24-72-701 et seq. Conviction-sealing waiting periods (post-completion of sentence): civil infraction / petty offense / drug petty offense = 1 year; class 2 or 3 misdemeanor or drug misdemeanor = 2 years; class 1 misdemeanor, class 4/5/6 felony, level 3 or 4 drug felony = 3 years; other eligible felonies = 5 years. Petitioner must remain conviction-free during the wait. DUI felonies, most violent crimes, sex offenses, domestic-violence offenses, and class 1-3 / level 1 drug felonies are excluded.",
+  "misc_quirks": [
+    "Bail is structured under C.R.S. 16-4-104 into four subsections: (a) unsecured personal recognizance, (b) unsecured PR with non-monetary conditions, (c) secured money bond (cash, real-estate equity, surety, or bonding agent), (d) property bond requiring unencumbered equity of 1.5x the bond amount.",
+    "C.R.S. 16-3-402 phone-call right renews on transfer between custody facilities — a quirk shared with only a handful of states.",
+    "Colorado law expressly recognizes the right to record any incident involving a police officer; under C.R.S. 18-9-303 wiretapping requires only one-party consent for telephone communications."
+  ],
+
+  "source_urls": [
+    "https://www.coloradojudicial.gov/sites/default/files/2023-07/Rule_Change_2008-03.pdf",
+    "https://www.shouselaw.com/co/defense/process/advisement-hearings/",
+    "https://codes.findlaw.com/co/title-16-criminal-proceedings/co-rev-st-sect-16-4-104/",
+    "https://www.coloradojudicial.gov/self-help/types-bonds",
+    "https://content.leg.colorado.gov/sites/default/files/images/olls/crs2024-title-21.pdf",
+    "https://www.coloradojudicial.gov/sites/default/files/2024-06/CJD%2014-01.%20Amended%20Eff%20Oct%20%202021.%20Attach%20A%20and%20B%20amended%20April%202024%20WEB.pdf",
+    "https://www.coloradojudicial.gov/sites/default/files/2024-06/CJD%2004-04%20Amended%20effective%20July%201%202024%20Attach%20A%20%20and%20Attach%20B%20Amended%204.%202024%20WEB%202.pdf",
+    "https://law.justia.com/codes/colorado/2023/title-16/code-of-criminal-procedure/article-3/part-4/section-16-3-402/",
+    "https://codes.findlaw.com/co/title-16-criminal-proceedings/co-rev-st-sect-16-3-402/",
+    "https://colorado.public.law/statutes/crs_18-9-303",
+    "https://law.justia.com/codes/colorado/title-18/article-9/part-3/section-18-9-303/",
+    "https://www.rcfp.org/reporters-recording-guide/colorado/",
+    "https://law.justia.com/codes/colorado/title-24/public/article-72/part-7/section-24-72-703/",
+    "https://content.leg.colorado.gov/sites/default/files/r24-820_update_sealing_and_expunging_criminal_records_memorandum-accessible_1.pdf",
+    "https://ccresourcecenter.org/state-restoration-profiles/colorado-restoration-of-rights-pardon-expungement-sealing-2/"
+  ],
+  "_unknown_fields": [
+    "bail_default_amounts_by_charge"
+  ]
+}

--- a/data/state-arrest-procedure/ct.json
+++ b/data/state-arrest-procedure/ct.json
@@ -1,0 +1,38 @@
+{
+  "state_code": "CT",
+  "state_name": "Connecticut",
+  "researched_at": "2026-04-28",
+
+  "first_appearance_window_hours": 48,
+  "pd_attach_trigger": "at first appearance / arraignment if the court determines indigency after written financial-status investigation",
+  "indigency_threshold": "Case-by-case determination by the public defender — no fixed numeric threshold in statute. The applicant submits a sworn written statement of liabilities, assets, income and sources; 'indigent defendant' means a person formally charged with a crime punishable by imprisonment who lacks the financial ability at the time of request to secure competent legal representation and necessary expenses (CGS 51-297).",
+  "bail_types_allowed": ["cash", "surety", "signature", "personal_recognizance"],
+  "bail_default_amounts_by_charge": null,
+  "phone_call_rule": "Connecticut has no specific statute codifying a numeric phone-call right at booking; right to communicate with counsel/family is recognized in practice after booking is complete (national survey, Chicago Appleseed 2021).",
+  "recording_police_consent": "restricted",
+  "expungement_window_years": "Clean Slate (PA 21-42, codified amending CGS 54-142a): misdemeanors automatically erased 7 years after the most recent conviction for any crime; class D/E felonies and unclassified felonies with prison terms ≤5 years erased 10 years after the most recent conviction. Family violence and sex-offender-registration offenses are excluded.",
+  "misc_quirks": [
+    "CGS 54-63c lets the police or bail commissioner release an arrestee on a written promise to appear or police-set bond after a booking interview — most non-violent arrests never see a judge before release.",
+    "Recording is split: in-person conversations you participate in are one-party (legal to record a face-to-face encounter with police); telephone conversations require all-party consent under CGS 52-570d, and CGS 53a-189 makes non-participant eavesdropping a class D felony.",
+    "CGS 54-1g requires 'prompt' presentation before the next regularly sitting Superior Court for the geographical area; family-violence and protective-order violations get same-court-day priority arraignment."
+  ],
+
+  "source_urls": [
+    "https://www.cga.ct.gov/current/pub/chap_959.htm",
+    "https://www.cga.ct.gov/current/pub/chap_960.htm",
+    "https://www.cga.ct.gov/2023/pub/chap_887.htm",
+    "https://law.justia.com/codes/connecticut/title-54/chapter-959/section-54-1g/",
+    "https://law.justia.com/codes/connecticut/title-54/chapter-960/section-54-64a/",
+    "https://law.justia.com/codes/connecticut/title-54/chapter-960/section-54-63c/",
+    "https://law.justia.com/codes/connecticut/title-51/chapter-887/section-51-296/",
+    "https://law.justia.com/codes/connecticut/title-51/chapter-887/section-51-297/",
+    "https://www.recordinglaw.com/party-two-party-consent-states/connecticut-recording-laws/",
+    "https://www.rcfp.org/reporters-recording-guide/connecticut/",
+    "https://ccresourcecenter.org/state-restoration-profiles/connecticut-restoration-of-rights-pardon-expungement-sealing/",
+    "https://portal.ct.gov/cleanslate",
+    "https://www.chicagoappleseed.org/wp-content/uploads/2021/07/20210719_FINAL_Report_Right-to-Communicate-Nationwide-Survey.pdf"
+  ],
+  "_unknown_fields": [
+    "bail_default_amounts_by_charge"
+  ]
+}

--- a/data/state-arrest-procedure/de.json
+++ b/data/state-arrest-procedure/de.json
@@ -1,0 +1,39 @@
+{
+  "state_code": "DE",
+  "state_name": "Delaware",
+  "researched_at": "2026-04-28",
+
+  "first_appearance_window_hours": 24,
+  "pd_attach_trigger": "If incarcerated after arrest, an intake investigator from the Office of Defense Services interviews the defendant and an attorney from the Public Defender's Office or Office of Conflicts Counsel is appointed. Before arraignment the indigency determination is made by the Public Defender; at or after arraignment the determination is made by the court.",
+  "indigency_threshold": "No fixed statewide income threshold. Eligibility is determined through an intake interview reviewing income (paystub) and proof of unemployment, social security/disability, or other public assistance. Adult must be charged with a crime in which incarceration may be imposed.",
+  "bail_types_allowed": ["cash", "surety", "property", "personal_recognizance"],
+  "bail_default_amounts_by_charge": null,
+  "phone_call_rule": null,
+  "recording_police_consent": "restricted",
+  "expungement_window_years": "Cases terminated in favor of the accused are eligible for mandatory expungement with no waiting period. Misdemeanor convictions: mandatory expungement after 5 years (no priors/subsequents); discretionary after 3 years (or 7 years for domestic violence, stalking, child abuse, sexual offenses). Felony convictions: discretionary expungement after 7 years post-sentence/probation/parole; a limited list of felonies eligible for mandatory expungement after 10 years. Clean Slate Act began automatic expungement August 1, 2024.",
+  "misc_quirks": [
+    "Delaware has conflicting recording statutes: 11 Del. C. § 2402 (wiretap) permits one-party consent, but 11 Del. C. § 1335 (privacy) requires all-party consent for private oral communications. Wiretap violations are felonies up to 5 years and $10,000.",
+    "Justice of the Peace Court 11 (New Castle) and the Statewide Virtual Hearing Criminal Court operate 24/7; JP Court 3 (Georgetown) and Court 7 (Dover) operate daily 6:00 AM to midnight including holidays and weekends, so initial appearance/arraignment and bail-setting are continuously available.",
+    "Under Superior Court Criminal Rule 5, the arresting officer must take the arrested person 'without unreasonable delay' before the nearest available committing magistrate of the county where the offense is alleged."
+  ],
+
+  "source_urls": [
+    "https://courts.delaware.gov/forms/download.aspx?id=173398",
+    "https://courts.delaware.gov/Superior/pdf/criminal_rules_2013.pdf",
+    "https://courts.delaware.gov/help/proceedings/jp_infodefendants.aspx",
+    "https://courts.delaware.gov/jpcourt/jpcriminal.aspx",
+    "https://courts.delaware.gov/help/bail/",
+    "https://ods.delaware.gov/how-get-attorney/",
+    "https://delcode.delaware.gov/title29/c046/index.html",
+    "https://delcode.delaware.gov/title11/c024/sc01/",
+    "https://delcode.delaware.gov/title11/c043/sc07/",
+    "https://ods.delaware.gov/expungements/",
+    "https://courts.delaware.gov/help/expungements.aspx",
+    "https://www.aclu-de.org/csde/",
+    "https://www.rcfp.org/reporters-recording-guide/delaware/"
+  ],
+  "_unknown_fields": [
+    "bail_default_amounts_by_charge",
+    "phone_call_rule"
+  ]
+}

--- a/data/state-arrest-procedure/fl.json
+++ b/data/state-arrest-procedure/fl.json
@@ -1,0 +1,30 @@
+{
+  "state_code": "FL",
+  "state_name": "Florida",
+  "researched_at": "2026-04-28",
+
+  "first_appearance_window_hours": 24,
+  "pd_attach_trigger": "At first appearance. The court must determine whether counsel is required and, if so, appoint counsel before any other steps are taken at the hearing (Fla. R. Crim. P. 3.130).",
+  "indigency_threshold": "Income at or below 200% of the federal poverty guidelines for household size, or receipt of TANF Cash Assistance, poverty-related veterans' benefits, or SSI. Presumption of non-indigency if applicant owns property with net equity of $2,500 or more (Fla. Stat. § 27.52).",
+  "bail_types_allowed": ["cash", "surety", "personal_recognizance", "property"],
+  "bail_default_amounts_by_charge": null,
+  "phone_call_rule": "Florida Statute § 901.24 guarantees the right to consult with an attorney alone and in private at the place of custody, as often and for such periods of time as is reasonable. There is no statewide statutory minute-window for a general phone call; access to counsel is the codified right.",
+  "recording_police_consent": "all-party",
+  "expungement_window_years": "No statutory waiting period for expunction of records of charges that did not result in conviction (dismissed, no information filed, or acquittal); a sealed record under § 943.059 must remain sealed for at least 10 years before it may be expunged (Fla. Stat. § 943.0585).",
+  "misc_quirks": [
+    "Florida courts hold first appearance 365 days a year, including weekends and holidays, so the 24-hour clock does not pause for the calendar (Fla. R. Crim. P. 3.130).",
+    "Florida is an all-party consent state for recording oral communications under § 934.03 — civilians who record police conversations without consent risk a third-degree felony unless the officer has no reasonable expectation of privacy (e.g., performing duties in public).",
+    "At first appearance the judge weighs 12 statutory factors when setting bail, including whether the funds posted may be linked to the alleged crime (Fla. Stat. § 903.046)."
+  ],
+
+  "source_urls": [
+    "https://www.flsenate.gov/Laws/Statutes/2024/Chapter901/All",
+    "https://www.flsenate.gov/Laws/Statutes/2024/934.03",
+    "https://www.flsenate.gov/Laws/Statutes/2024/943.0585",
+    "https://www.flsenate.gov/Laws/Statutes/2024/903.046",
+    "https://m.flsenate.gov/statutes/27.52",
+    "https://www.floridarule.com/rule-3-130",
+    "https://www.floridabar.org/the-florida-bar-news/amendments-to-rules-of-criminal-procedure-3-130-first-appearance-and-3-132-pretrial-detention/"
+  ],
+  "_unknown_fields": ["bail_default_amounts_by_charge"]
+}

--- a/data/state-arrest-procedure/ga.json
+++ b/data/state-arrest-procedure/ga.json
@@ -1,0 +1,33 @@
+{
+  "state_code": "GA",
+  "state_name": "Georgia",
+  "researched_at": "2026-04-28",
+
+  "first_appearance_window_hours": 48,
+  "pd_attach_trigger": "At the initial appearance hearing (held within 48 hours of warrantless arrest or within 72 hours of arrest under warrant). The circuit public defender determines indigency and represents the accused at the first appearance, where probable cause and bond are addressed.",
+  "indigency_threshold": "Generally 150% of the federal poverty guidelines under OCGA 17-12-2, unless the person has other resources reasonably available to retain private counsel. Type of charge and other resources are also considered.",
+  "bail_types_allowed": ["cash", "surety", "property", "personal_recognizance"],
+  "bail_default_amounts_by_charge": "Under OCGA 17-6-1, a judge of any court of inquiry may issue a written order establishing a schedule of bails (including local-ordinance violations); the accused may be released by posting bail as fixed in that schedule. Schedules are county-specific and family-violence offenses are excluded from any schedule.",
+  "phone_call_rule": null,
+  "recording_police_consent": "one-party",
+  "expungement_window_years": "Georgia uses 'record restriction,' not 'expungement.' Under OCGA 35-3-37 and the 2021 Second Chance Act amendments, dismissed/non-conviction cases are eligible for restriction; most misdemeanor convictions are eligible four years after sentence completion with no new convictions during that period.",
+  "misc_quirks": [
+    "Two different first-appearance windows: OCGA 17-4-62 requires release if a person arrested without a warrant is not brought before a judicial officer within 48 hours; OCGA 17-4-26 requires presentation within 72 hours when arrested under a warrant.",
+    "Bail-bond surety fees are statutorily capped under OCGA 17-6-30: a professional bondsman may charge up to 15% of the bond amount, with a $50 minimum.",
+    "OCGA 16-11-66 makes Georgia a one-party-consent state for recording wire, oral, or electronic communications, but recording a child under 18 generally requires a superior-court order or parent/guardian consent."
+  ],
+
+  "source_urls": [
+    "https://law.justia.com/codes/georgia/title-17/chapter-4/article-2/section-17-4-26/",
+    "https://law.justia.com/codes/georgia/2020/title-17/chapter-4/article-4/section-17-4-62/",
+    "https://law.justia.com/codes/georgia/title-16/chapter-11/article-3/part-1/section-16-11-66/",
+    "https://law.justia.com/codes/georgia/title-35/chapter-3/article-2/section-35-3-37/",
+    "https://law.justia.com/codes/georgia/title-17/chapter-12/article-2/section-17-12-24/",
+    "https://law.justia.com/codes/georgia/title-17/chapter-6/article-1/section-17-6-1/",
+    "https://georgiacourts.gov/wp-content/uploads/2024/05/Misdemeanor-Bail-Practices-Bench-card.pdf",
+    "https://gbi.georgia.gov/services/georgia-criminal-history-record-restrictions",
+    "https://www.audits.ga.gov/ReportSearch/download/12542",
+    "https://www.georgialegalaid.org/resource/rights-during-arrest"
+  ],
+  "_unknown_fields": ["phone_call_rule"]
+}

--- a/data/state-arrest-procedure/hi.json
+++ b/data/state-arrest-procedure/hi.json
@@ -1,0 +1,39 @@
+{
+  "state_code": "HI",
+  "state_name": "Hawaii",
+  "researched_at": "2026-04-28",
+
+  "first_appearance_window_hours": 48,
+  "pd_attach_trigger": "Office of the Public Defender makes initial determination of indigency and represents persons arrested for, charged with, or convicted of an offense punishable by imprisonment, or whose liberty is threatened by confinement, subject to court review.",
+  "indigency_threshold": "Determined by inquiry into financial circumstances per HRS § 802-4 and the standards in State v. Mickle, 56 Haw. 23 (1974); applicant must submit an affidavit or certificate showing financial inability to obtain counsel. No fixed FPL multiplier published in statute.",
+  "bail_types_allowed": ["cash", "surety", "personal_recognizance", "property"],
+  "bail_default_amounts_by_charge": "Honolulu County uses a bail schedule mandated by HRS § 804-9 as an initial guideline; judges retain discretion. The schedule itself is not published as a single statewide document.",
+  "phone_call_rule": "Under HRS § 803-9, police have no duty to place a call to an attorney unless the arrested person requests it; counsel and family must be permitted to see or communicate with the arrested person for a reasonable period at the place of detention at any time for a first communication after arrest.",
+  "recording_police_consent": "one-party",
+  "expungement_window_years": "Non-conviction arrest records may be expunged on application to the Attorney General (Hawaii Criminal Justice Data Center) under HRS § 831-3.2; petty misdemeanors / violations resolved by bail forfeiture are barred from expungement until 5 years after arrest or citation; processing takes about 120 days.",
+  "misc_quirks": [
+    "HRPP Rule 5(a)(3): probable-cause determination on a warrantless arrest must occur as soon as practicable and not later than 48 hours after arrest, or the arrestee must be released.",
+    "If a defendant arrested without a warrant is held more than 48 hours after initial appearance without trial commencing, HRPP Rule 5 requires release on own recognizance unless the court finds probable cause.",
+    "Hawaii Supreme Court protects video/audio recording of officers performing duties in public under the First Amendment and the Hawaii Constitution, but HRS § 711-1111 (Violation of Privacy 2nd Degree) imposes all-party consent for recordings in private places."
+  ],
+
+  "source_urls": [
+    "https://www.courts.state.hi.us/wp-content/uploads/2024/12/hrpp.htm",
+    "https://www.courts.state.hi.us/wp-content/uploads/2024/12/hrpp_ada.pdf",
+    "https://publicdefender.hawaii.gov/clients/what-are-the-guidelines-for-determining-eligibility/",
+    "https://publicdefender.hawaii.gov/clients/how-do-i-obtain-the-services-of-a-public-defender/",
+    "https://law.justia.com/codes/hawaii/title-38/chapter-802/section-802-11/",
+    "https://www.capitol.hawaii.gov/hrscurrent/Vol14_Ch0701-0853/HRS0803/HRS_0803-.htm",
+    "https://law.justia.com/codes/hawaii/title-38/chapter-803/section-803-9/",
+    "https://law.justia.com/codes/hawaii/title-38/chapter-804/section-804-1/",
+    "https://www.capitol.hawaii.gov/hrscurrent/vol14_ch0701-0853/HRS0804/HRS_0804-0051.htm",
+    "https://law.justia.com/codes/hawaii/title-38/chapter-804/",
+    "https://www.capitol.hawaii.gov/hrscurrent/vol14_ch0701-0853/HRS0711/HRS_0711-1111.htm",
+    "https://law.justia.com/codes/hawaii/title-37/chapter-711/section-711-1111/",
+    "https://www.rcfp.org/reporters-recording-guide/hawaii/",
+    "https://ag.hawaii.gov/hcjdc/expungements/",
+    "https://law.justia.com/codes/hawaii/title-38/chapter-831/section-831-3-2/",
+    "https://www.capitol.hawaii.gov/hrscurrent/Vol14_Ch0701-0853/HRS0831/HRS_0831-0003_0002.htm"
+  ],
+  "_unknown_fields": []
+}

--- a/data/state-arrest-procedure/ia.json
+++ b/data/state-arrest-procedure/ia.json
@@ -1,0 +1,34 @@
+{
+  "state_code": "IA",
+  "state_name": "Iowa",
+  "researched_at": "2026-04-28",
+
+  "first_appearance_window_hours": 24,
+  "pd_attach_trigger": "At initial appearance before a magistrate, on a finding of indigency under Iowa Code 815.9; the court appoints the State Public Defender's designee under Iowa Code 815.10.",
+  "indigency_threshold": "Income at or below 125% of the federal poverty guidelines qualifies for court-appointed counsel under Iowa Code 815.9; income between 125% and 200% requires a written court finding of substantial financial hardship.",
+  "bail_types_allowed": ["personal_recognizance", "signature", "cash", "surety"],
+  "bail_default_amounts_by_charge": "Iowa Uniform Bond Schedule (effective July 1, 2017), used only when courts are not in session and the charge is not a forcible felony: Class B felony $25,000; Class C felony $10,000; Class D felony $5,000; aggravated misdemeanor $2,000; serious misdemeanor $1,000; simple misdemeanor $300; traffic per State Compendium of Scheduled Violations. Once a judicial officer sees the arrestee, the officer exercises discretion and is not bound by the schedule.",
+  "phone_call_rule": "Iowa Code 804.20 requires the custodial officer, without unnecessary delay after arrival at the place of detention, to permit the arrestee to call, consult, and see a member of the arrestee's family or an attorney of choice, or both. The arrestee may make a reasonable number of calls to secure an attorney, and an attorney must be permitted to consult confidentially with the arrestee in private.",
+  "recording_police_consent": "one-party",
+  "expungement_window_years": "Acquittals and dismissals: minimum 180 days after entry of acquittal or dismissal under Iowa Code 901C.2 (does not apply to dismissals tied to a deferred judgment under section 907.9). Deferred judgments: governed separately by Iowa Code 907.9 / 901C.3, with the deferred-judgment record handled through the chapter 907 process rather than the 901C.2 acquittal/dismissal track.",
+  "misc_quirks": [
+    "Iowa Code 804.20 protects BOTH a family call AND an attorney call; courts apply the exclusionary rule when officers block either request.",
+    "Iowa Code 804.22 requires a person arrested without a warrant to be taken before the nearest accessible magistrate 'without unnecessary delay'; Iowa's statutory practice is initial appearance within 24 hours, stricter than the federal 48-hour Gerstein/McLaughlin floor.",
+    "Iowa Code 901C.2 expungement of a not-guilty or dismissed case is unavailable for dismissals entered as part of a deferred-judgment under section 907.9 — defendants who took a deferred plea must use the separate deferred-judgment expungement track."
+  ],
+
+  "source_urls": [
+    "https://www.legis.iowa.gov/docs/code/804.20.pdf",
+    "https://www.legis.iowa.gov/docs/code/804.22.pdf",
+    "https://www.legis.iowa.gov/docs/code/804.21.pdf",
+    "https://www.legis.iowa.gov/docs/code/811.2.pdf",
+    "https://www.legis.iowa.gov/docs/code/808B.2.pdf",
+    "https://www.legis.iowa.gov/docs/code/815.9.pdf",
+    "https://www.legis.iowa.gov/docs/code/815.10.pdf",
+    "https://www.legis.iowa.gov/docs/code/901C.2.pdf",
+    "https://www.legis.iowa.gov/docs/code/901C.pdf",
+    "https://www.iowacourts.gov/iowa-courts/district-court/uniform-bond-schedule",
+    "https://spd.iowa.gov/clients/indigence"
+  ],
+  "_unknown_fields": []
+}

--- a/data/state-arrest-procedure/id.json
+++ b/data/state-arrest-procedure/id.json
@@ -1,0 +1,32 @@
+{
+  "state_code": "ID",
+  "state_name": "Idaho",
+  "researched_at": "2026-04-28",
+
+  "first_appearance_window_hours": 24,
+  "pd_attach_trigger": "At initial appearance before the magistrate. Idaho Criminal Rule 5 requires the magistrate to inform the defendant of the right to counsel and to have counsel appointed if indigent; the State Public Defender's office handles appointments under the State Public Defender Act (Idaho Code Title 19, Chapter 60).",
+  "indigency_threshold": "Presumption of indigency when monthly income does not exceed 187% of the federal poverty guidelines, or when the defendant or their dependents receive public assistance under Title 56 (food assistance, health coverage, cash assistance, or child support enforcement). Court may also weigh income, property, outstanding obligations, dependents, and cost of bail (Idaho Code § 19-854; redesignated § 19-6009 effective July 1, 2024).",
+  "bail_types_allowed": ["cash", "surety", "property", "personal_recognizance"],
+  "bail_default_amounts_by_charge": "Idaho Misdemeanor Criminal Rule 13 sets an automatic Misdemeanor Bail Bond Schedule for many misdemeanors, with separate amounts for residents vs. non-residents (e.g., First Offense DUI: $500 resident / $1,000 non-resident). Felony bail is judge-set under I.C.R. 46.",
+  "phone_call_rule": "Idaho law and jail practice recognize the right to phone counsel after arrest; calls to an attorney are private and may not be monitored or recorded by law enforcement. There is no codified statewide minute-window for a general phone call — access to counsel is the operative right.",
+  "recording_police_consent": "one-party",
+  "expungement_window_years": "Idaho has no general expungement statute for adult convictions. Idaho Code § 19-2604 allows a retroactive dismissal (record reads 'Dismissed By Court') after successful completion of probation with no violations and a showing of good cause; defendants who served time at the Idaho State Penitentiary are ineligible. True record expungement under Idaho State Police is limited to acquittals, dismissals, and certain non-conviction outcomes.",
+  "misc_quirks": [
+    "The 24-hour first-appearance clock under I.C.R. 5 EXCLUDES Saturdays, Sundays, and holidays — a Friday-night arrest can mean a Monday or Tuesday first appearance without violating the rule.",
+    "Idaho is a one-party consent state under Idaho Code § 18-6702 — a defendant can lawfully record their own conversations with police or witnesses, but unlawful interception is a felony carrying up to 5 years.",
+    "Idaho § 19-2604 produces a 'dismissal,' not a sealed or expunged record — the underlying arrest and case file remain publicly searchable in court records even after the conviction is set aside."
+  ],
+
+  "source_urls": [
+    "https://isc.idaho.gov/icr5",
+    "https://isc.idaho.gov/icr46",
+    "https://isc.idaho.gov/files/BailBondsGuidelines2012.pdf",
+    "https://legislature.idaho.gov/statutesrules/idstat/title19/t19ch8/sect19-851/",
+    "https://law.justia.com/codes/idaho/title-19/chapter-60/",
+    "https://spd.idaho.gov/faq/",
+    "https://legislature.idaho.gov/statutesrules/idstat/title18/t18ch67/sect18-6702/",
+    "https://www.youridattorney.com/dismissal-pursuant-to-19-2604",
+    "https://isp.idaho.gov/wp-content/uploads/BCI/CrimHistory/ExpungmentApplication.pdf"
+  ],
+  "_unknown_fields": []
+}

--- a/data/state-arrest-procedure/il.json
+++ b/data/state-arrest-procedure/il.json
@@ -1,0 +1,35 @@
+{
+  "state_code": "IL",
+  "state_name": "Illinois",
+  "researched_at": "2026-04-28",
+
+  "first_appearance_window_hours": 48,
+  "pd_attach_trigger": "at first appearance / detention hearing — Pretrial Fairness Act guarantees right to legal representation at the initial appearance",
+  "indigency_threshold": null,
+  "bail_types_allowed": ["personal_recognizance"],
+  "bail_default_amounts_by_charge": "Cash bail eliminated statewide on September 18, 2023 by the Pretrial Fairness Act (part of the SAFE-T Act). Courts no longer set monetary bail. Release is by pretrial release with conditions; the State must affirmatively petition for detention and meet its burden at a detention hearing.",
+  "phone_call_rule": "Under 725 ILCS 5/103-3.5, persons in police custody have the right to communicate free of charge with an attorney of their choice and family members as soon as possible, but no later than 3 hours after arrival at the first place of detention, and must be given access to a landline or cellular phone to make 3 telephone calls. Calls to a public defender or attorney may not be monitored, eavesdropped on, or recorded. The 3-call right renews on transfer to a new location. Statements obtained in violation are presumed inadmissible.",
+  "recording_police_consent": "all-party",
+  "expungement_window_years": "Sealing: 3 years after completion of last sentence for most eligible convictions; 2 years after termination of supervision. Expungement: no waiting period for arrests resulting in acquittal, dismissal, release without charging, or vacated conviction (20 ILCS 2630/5.2).",
+  "misc_quirks": [
+    "Illinois is the first U.S. state to fully eliminate cash bail — Pretrial Fairness Act took effect September 18, 2023 after the Illinois Supreme Court upheld it in July 2023. Everyone is presumed eligible for pretrial release; the State must petition and prove grounds for detention.",
+    "Recording private conversations requires all-party consent under 720 ILCS 5/14-2, but the 2014 amendment (after People v. Clark struck down the prior statute) explicitly permits recording on-duty police in public where there is no reasonable expectation of privacy.",
+    "First appearance must occur 'without unnecessary delay' and within 48 hours per County of Riverside v. McLaughlin; Illinois detention hearings under the Pretrial Fairness Act now substantively replace the old bond-court model and last longer than the historic sub-5-minute bail call."
+  ],
+
+  "source_urls": [
+    "https://www.ilga.gov/legislation/ilcs/fulltext.asp?DocName=072500050K109-1",
+    "https://www.ilga.gov/legislation/ilcs/fulltext.asp?DocName=072500050K110-5",
+    "https://www.ilga.gov/legislation/ilcs/fulltext.asp?DocName=072500050K103-3.5",
+    "https://www.ilga.gov/documents/legislation/ilcs/documents/072000050K14-2.htm",
+    "https://www.ilga.gov/documents/legislation/ilcs/documents/002026300K5.2.htm",
+    "https://www.illinoislegalaid.org/legal-information/cash-bail-changes-2023-safe-t-act",
+    "https://www.aclu.org/news/criminal-law-reform/the-illinois-supreme-court-cash-bail-ruling-explained",
+    "https://www.rcfp.org/reporters-recording-guide/illinois/",
+    "https://www.cookcountyil.gov/sites/g/files/ywwepo161/files/1.29.19_draft_proposal_language.pdf",
+    "https://www.illinoislegalaid.org/legal-information/expunging-or-sealing-criminal-record-common-questions"
+  ],
+  "_unknown_fields": [
+    "indigency_threshold"
+  ]
+}

--- a/data/state-arrest-procedure/in.json
+++ b/data/state-arrest-procedure/in.json
@@ -1,0 +1,38 @@
+{
+  "state_code": "IN",
+  "state_name": "Indiana",
+  "researched_at": "2026-04-28",
+
+  "first_appearance_window_hours": 48,
+  "pd_attach_trigger": "Prior to the completion of the initial hearing, the judicial officer determines indigency and assigns counsel under IC 35-33-7-6.",
+  "indigency_threshold": "No statewide written standard. Indigency is determined case-by-case by the judicial officer at the initial hearing under IC 35-33-7-6 and IC 35-33-7-6.5; about two-thirds of Indiana judicial officers report unwritten, individually set policies. The Indiana Public Defender Commission publishes optional guidelines that apply only in counties seeking partial state reimbursement.",
+  "bail_types_allowed": ["cash", "surety", "property", "personal_recognizance"],
+  "bail_default_amounts_by_charge": null,
+  "phone_call_rule": "After booking the arrestee may call a family member or legal representative; calls are subject to monitoring and recording on notice, but calls with legal counsel may not be monitored or recorded without a court order (210 IAC 3-1-16). Indiana has no broad statutory right-to-communicate after arrest comparable to states like Illinois or Ohio.",
+  "recording_police_consent": "one-party",
+  "expungement_window_years": "Non-conviction (arrest, dismissed, or acquitted): 1 year after arrest, charge, or juvenile allegation, whichever is later (IC 35-38-9-1); automatic expungement on dismissal or acquittal takes effect 60 days later. Misdemeanor and Class D/Level 6 felony reduced to misdemeanor: 5 years after conviction (IC 35-38-9-2). Class D/Level 6 felony conviction: 8 years after conviction (IC 35-38-9-3). Major felony: 8 years from conviction or 3 years from completion of sentence, whichever is later (IC 35-38-9-4). Prosecutor may consent in writing to a shorter wait.",
+  "misc_quirks": [
+    "If the arrestee posts bail before the initial hearing, the hearing window stretches to 20 calendar days after arrest, except 10 days for OWI/DUI cases under IC 9-30-5 (IC 35-33-7-1).",
+    "Domestic-violence arrests carry a mandatory 24-hour bail-holding period under IC 35-33-8-6.5 before release on bond.",
+    "Indiana's Second Chance Law (IC 35-38-9) is one of the few state expungement schemes that requires the petition be filed in the county of conviction and limits each person to one expungement petition per lifetime."
+  ],
+
+  "source_urls": [
+    "https://law.justia.com/codes/indiana/2022/title-35/article-33/chapter-7/section-35-33-7-1/",
+    "https://law.justia.com/codes/indiana/title-35/article-33/chapter-7/section-35-33-7-5/",
+    "https://law.justia.com/codes/indiana/title-35/article-33/chapter-7/section-35-33-7-6/",
+    "https://www.indyjustice.com/blog/criminal-defense/initial-hearings-indiana/",
+    "https://law.justia.com/codes/indiana/title-35/article-33/chapter-8/",
+    "https://law.justia.com/codes/indiana/title-35/article-33/chapter-8/section-35-33-8-4/",
+    "https://law.justia.com/codes/indiana/title-35/article-33/chapter-8/section-35-33-8-6-5/",
+    "https://www.recordinglaw.com/united-states-recording-laws/one-party-consent-states/indiana-recording-laws/",
+    "https://www.dmlp.org/legal-guide/indiana-recording-law",
+    "https://www.rcfp.org/reporters-recording-guide/indiana/",
+    "https://www.in.gov/ipdc/files/TITLE35_AR38_ch9.pdf",
+    "https://www.in.gov/publicdefender/obtaining-a-public-defender/",
+    "https://indianacapitalchronicle.com/2025/11/05/public-defender-rules-for-poor-hoosiers-often-unwritten-and-vary-by-judicial-officer-report-finds/",
+    "https://regulations.justia.com/states/indiana/title-210/article-3/rule-1/210-iac-3-1-16/",
+    "https://www.chicagoappleseed.org/2021/07/19/national-overview-right-to-communicate/"
+  ],
+  "_unknown_fields": ["bail_default_amounts_by_charge"]
+}

--- a/data/state-arrest-procedure/ks.json
+++ b/data/state-arrest-procedure/ks.json
@@ -1,0 +1,33 @@
+{
+  "state_code": "KS",
+  "state_name": "Kansas",
+  "researched_at": "2026-04-28",
+
+  "first_appearance_window_hours": 48,
+  "pd_attach_trigger": "At first appearance the magistrate appoints counsel for any defendant who is financially unable to employ counsel; assignment is made from the indigents' defense panel maintained by the district court.",
+  "indigency_threshold": "Determined case-by-case by the court under K.S.A. 22-4504; BIDS reports approximately 85% of adults charged with felonies in Kansas qualify. A $100 application fee for appointed counsel is required (refunded if the case is dismissed or the defendant is acquitted).",
+  "bail_types_allowed": ["cash", "surety", "personal_recognizance", "property"],
+  "bail_default_amounts_by_charge": null,
+  "phone_call_rule": null,
+  "recording_police_consent": "one-party",
+  "expungement_window_years": "3 years after sentence completion / discharge for misdemeanors and lower-level felonies (class D/E and severity levels 6-10 nondrug, level 4-5 drug); 5 years for class A, B, or C felonies, off-grid felonies, severity levels 1-5 nondrug, and severity levels 1-4 drug grid.",
+  "misc_quirks": [
+    "K.S.A. 22-2901 generally requires arrestees be taken before a magistrate 'without unnecessary delay'; for protection-order violations under K.S.A. 21-5808(a)(1)(C), bond is barred until first appearance, which must occur within 48 hours of arrest.",
+    "Kansas is a one-party consent state for audio recording under K.S.A. 21-6101; recording an officer in public (no reasonable expectation of privacy) is lawful, but secret recording in private places without any party's consent is a class A nonperson misdemeanor.",
+    "K.S.A. 22-2802 lets the magistrate set release on appearance bond, cash bond, or personal recognizance, weighing nature of the offense, weight of evidence, ties to community, employment, finances, and prior court-appearance history."
+  ],
+
+  "source_urls": [
+    "https://ksrevisor.gov/statutes/chapters/ch22/022_029_0001.html",
+    "https://ksrevisor.gov/statutes/chapters/ch22/022_028_0002.html",
+    "https://ksrevisor.gov/statutes/chapters/ch21/021_061_0001.html",
+    "https://ksrevisor.gov/statutes/chapters/ch21/021_066_0014.html",
+    "https://www.ksbids.gov/kansas-system-of-public-defense",
+    "https://www.ksrevisor.gov/statutes/chapters/ch22/022_045_0001.html",
+    "https://www.kansas.gov/kbi/info/docs/pdf/Fact%20Sheet%20-%20Expungement.pdf"
+  ],
+  "_unknown_fields": [
+    "bail_default_amounts_by_charge",
+    "phone_call_rule"
+  ]
+}

--- a/data/state-arrest-procedure/ky.json
+++ b/data/state-arrest-procedure/ky.json
@@ -1,0 +1,36 @@
+{
+  "state_code": "KY",
+  "state_name": "Kentucky",
+  "researched_at": "2026-04-28",
+
+  "first_appearance_window_hours": 24,
+  "pd_attach_trigger": "After indigency determination under KRS Chapter 31; the Department of Public Advocacy (DPA) is appointed by the court upon a granted Request for Appointment of Counsel (form AOC-350).",
+  "indigency_threshold": "Determined case-by-case by the court under KRS Chapter 31 based on financial disclosure (form AOC-350); no fixed numerical multiple of the federal poverty level is set in statute.",
+  "bail_types_allowed": ["cash", "property", "personal_recognizance", "signature"],
+  "bail_default_amounts_by_charge": null,
+  "phone_call_rule": "Under RCr 2.14(1), a person taken into custody must be allowed to communicate with an attorney as soon as practicable. For DUI arrests, KRS 189A.105(3) provides 10 to 15 minutes to attempt to contact an attorney before a chemical test. There is no separate statutory right to a single personal phone call.",
+  "recording_police_consent": "one-party",
+  "expungement_window_years": "5 years after completion of sentence for most Class D felonies (KRS 431.073) and most misdemeanors (KRS 431.078); 10 years for misdemeanor DUI; sex offenses, offenses against children, and offenses resulting in serious bodily injury or death are excluded.",
+  "misc_quirks": [
+    "Kentucky was the first state to abolish for-profit commercial bail bonding (1976); KRS 431.510 makes it a Class A misdemeanor to engage in the bail bond business, so cash, property, signature, or recognizance through court Pretrial Services are the only routes.",
+    "Pretrial Services operates in all 120 counties 24/7 and is required by Supreme Court rule to interview every arrestee on a bailable offense within 24 hours of arrest; that interview feeds the judge's bond decision.",
+    "Eavesdropping without at least one party's consent is a Class D felony under KRS 526.020 (defined in KRS 526.010), so a defendant recording their own interaction with police is lawful, but recording a conversation they are not part of is not."
+  ],
+
+  "source_urls": [
+    "https://www.kycourts.gov/Courts/Supreme-Court/Supreme%20Court%20Orders/202340.pdf",
+    "https://www.kycourts.gov/Court-Programs/Pretrial-Services/Pages/default.aspx",
+    "https://dpa.ky.gov/kentucky-department-of-public-advocacy/findhelp/rights/",
+    "https://dpa.ky.gov/wp-content/uploads/2019/11/AOC-350.pdf",
+    "https://apps.legislature.ky.gov/law/statutes/statute.aspx?id=55456",
+    "https://apps.legislature.ky.gov/law/statutes/statute.aspx?id=19948",
+    "https://apps.legislature.ky.gov/law/statutes/statute.aspx?id=53904",
+    "https://apps.legislature.ky.gov/law/statutes/chapter.aspx?id=39302",
+    "https://www.criminallawyerlouisvilleky.com/do-i-have-the-right-to-make-one-phone-call-if-arrested-in-kentucky/",
+    "https://dpa.ky.gov/wp-content/uploads/2020/10/Lawyers-Guide-to-Expungement-in-KY.pdf",
+    "https://www.bountyhuntereducation.org/kentucky/"
+  ],
+  "_unknown_fields": [
+    "bail_default_amounts_by_charge"
+  ]
+}

--- a/data/state-arrest-procedure/la.json
+++ b/data/state-arrest-procedure/la.json
@@ -1,0 +1,34 @@
+{
+  "state_code": "LA",
+  "state_name": "Louisiana",
+  "researched_at": "2026-04-28",
+
+  "first_appearance_window_hours": 72,
+  "pd_attach_trigger": "At the 72-hour appearance before a judge for the purpose of appointment of counsel (CCRP art. 230.1). Saturdays, Sundays, and legal holidays are excluded from the 72-hour computation.",
+  "indigency_threshold": "Court determines whether the person is a 'needy person' considering income (employment or public assistance), property, outstanding obligations, number and ages of dependents, employment/job-training history, and education (La. R.S. 15:175). Release on bail alone does not disqualify a person from appointment of counsel. Applicants pay a nonrefundable $40 application fee, which may be waived or reduced based on financial information; an indigent person cannot be refused counsel for failure to pay it.",
+  "bail_types_allowed": ["cash", "surety", "property", "personal_recognizance"],
+  "bail_default_amounts_by_charge": null,
+  "phone_call_rule": "From the moment of arrest, the arrested person has the right to procure and confer with counsel and to use a telephone or send a messenger to communicate with friends or counsel (CCRP art. 230).",
+  "recording_police_consent": "one-party",
+  "expungement_window_years": "Misdemeanors: 5 years after completion of sentence/probation/parole with no felony conviction during that period and no pending felony charges (CCRP art. 977). Felonies: 10 years after completion of sentence/probation/parole with no other criminal conviction during that period and no pending charges (CCRP art. 978). DWI misdemeanor expungement is limited to once per 10-year period.",
+  "misc_quirks": [
+    "Louisiana is the only US civil-law state and uses 'parish' instead of 'county'; criminal procedure is codified in the Code of Criminal Procedure (CCRP), not common-law-style rules.",
+    "If the law-enforcement agency fails to bring the arrestee before a judge within 72 hours (excluding weekends and legal holidays), the arrestee shall be released on their own recognizance, but the failure does not invalidate later proceedings against the defendant (CCRP art. 230.1).",
+    "Louisiana law has no formal 'release on recognizance' (ROR); the closest equivalent is a 'bail without surety,' which still has a dollar amount attached but requires no up-front payment, and defendants arrested for a crime of violence or a felony involving a firearm cannot be released on personal undertaking or unsecured personal surety (CCRP art. 321)."
+  ],
+
+  "source_urls": [
+    "https://law.justia.com/codes/louisiana/2021/code-of-criminal-procedure/article-230-1/",
+    "https://www.legis.la.gov/legis/Law.aspx?d=112387",
+    "https://law.justia.com/codes/louisiana/2022/code-of-criminal-procedure/article-230/",
+    "https://law.justia.com/codes/louisiana/revised-statutes/title-15/rs-15-175/",
+    "https://law.justia.com/codes/louisiana/code-of-criminal-procedure/article-321/",
+    "https://law.justia.com/codes/louisiana/2011/rs/title15/rs15-1303",
+    "https://www.rcfp.org/reporters-recording-guide/louisiana/",
+    "https://law.justia.com/codes/louisiana/code-of-criminal-procedure/article-977/",
+    "https://law.justia.com/codes/louisiana/2021/code-of-criminal-procedure/article-977/"
+  ],
+  "_unknown_fields": [
+    "bail_default_amounts_by_charge"
+  ]
+}

--- a/data/state-arrest-procedure/ma.json
+++ b/data/state-arrest-procedure/ma.json
@@ -1,0 +1,33 @@
+{
+  "state_code": "MA",
+  "state_name": "Massachusetts",
+  "researched_at": "2026-04-28",
+
+  "first_appearance_window_hours": 24,
+  "pd_attach_trigger": "at arraignment (initial appearance), per Mass. R. Crim. P. 7; CPCS staff or bar advocate assigned at arraignment if defendant is indigent",
+  "indigency_threshold": "Gross income at or below 125% of the Federal Poverty Level under S.J.C. Rule 3:10 and G.L. c. 261, § 27A; Chief Probation Officer verifies",
+  "bail_types_allowed": ["cash", "surety", "personal_recognizance"],
+  "bail_default_amounts_by_charge": null,
+  "phone_call_rule": "Under MGL c. 276 § 33A, the officer in charge must inform the arrested person of the right to use the telephone immediately upon arrival at the place of detention, and the use must be permitted within one hour. Calls may be made at the arrested person's expense to family, friends, to arrange bail, or to engage an attorney.",
+  "recording_police_consent": "all-party",
+  "expungement_window_years": "Sealing under MGL c. 276 § 100A: 3 years for misdemeanors, 7 years for felonies, 15 years for sex offenses, measured from disposition or release with no intervening conviction. Discretionary sealing under § 100C available immediately for non-convictions (dismissals, nolle prosequi, not guilty, no probable cause). Expungement (permanent erasure) under §§ 100E-100K is narrow and limited.",
+  "misc_quirks": [
+    "Massachusetts is an all-party consent state under MGL c. 272 § 99 — secret recording of any oral or wire communication is a felony punishable by up to 5 years and $10,000. The First Circuit carved out a First Amendment exception only for secret audio recording of police performing official duties in public.",
+    "MGL c. 276 § 58 creates a strong statutory presumption of release on personal recognizance — bail with surety is the exception, not the rule, unless the court finds release will not reasonably assure appearance.",
+    "Per Mass. R. Crim. P. 7, an arrested defendant who is not released must be brought before the court if then in session, otherwise at its next session — in practice the next business day."
+  ],
+
+  "source_urls": [
+    "https://malegislature.gov/laws/generallaws/partiv/titleii/chapter276/section33a",
+    "https://malegislature.gov/laws/generallaws/partiv/titleii/chapter276/section58",
+    "https://malegislature.gov/Laws/GeneralLaws/PartIV/TitleI/Chapter272/Section99",
+    "https://www.mass.gov/rules-of-criminal-procedure/criminal-procedure-rule-7-initial-appearance-and-arraignment",
+    "https://www.mass.gov/guidance/poverty-guidelines-for-affidavits-of-indigency-g-l-c-261-ss-27a-applicable-under-sjc-rule-310",
+    "https://www.mass.gov/info-details/overview-of-the-committee-for-public-counsel-services",
+    "https://www.mass.gov/info-details/find-out-if-you-can-seal-your-criminal-record",
+    "https://www.mass.gov/info-details/massachusetts-law-about-police-conduct-and-recording-the-police"
+  ],
+  "_unknown_fields": [
+    "bail_default_amounts_by_charge"
+  ]
+}

--- a/data/state-arrest-procedure/md.json
+++ b/data/state-arrest-procedure/md.json
@@ -1,0 +1,34 @@
+{
+  "state_code": "MD",
+  "state_name": "Maryland",
+  "researched_at": "2026-04-28",
+
+  "first_appearance_window_hours": 24,
+  "pd_attach_trigger": "At the initial appearance before a District Court Commissioner. Under DeWolfe v. Richmond, the Maryland due process clause requires state-funded counsel at any proceeding that may result in incarceration, including initial appearances before a commissioner (Md. Rule 4-213(a)).",
+  "indigency_threshold": "Eligibility is measured by financial ability to retain private counsel without undue hardship. An applicant whose assets and net annual income are less than 100% of the federal poverty guidelines is presumed eligible without further assessment (COMAR 14.06.03.05).",
+  "bail_types_allowed": ["cash", "surety", "personal_recognizance", "property"],
+  "bail_default_amounts_by_charge": null,
+  "phone_call_rule": "Maryland Code, Criminal Procedure § 4-103 entitles an arrested person to communicate with counsel and a relative or friend without unnecessary delay following arrest. There is no statewide statutory minute-window on a general phone call; access to counsel and to notify a relative is the codified right.",
+  "recording_police_consent": "all-party",
+  "expungement_window_years": "Records of charges that ended in acquittal, dismissal, nolle prosequi (without drug/alcohol-treatment condition), or not guilty are eligible for automatic expungement after 3 years (Md. Crim. Proc. § 10-105). Convictions eligible under § 10-110 generally require 5 years after completion of sentence; common-law battery / second-degree assault require 7 years; certain firearm and theft felonies require 10 years; domestically related crimes require 15 years.",
+  "misc_quirks": [
+    "Maryland adopted Rule 4-216.1 in 2017, directing judicial officers to use the least onerous conditions of release and disfavoring cash bail set solely because the defendant cannot pay — financial conditions are appropriate only to ensure appearance, not to protect public safety.",
+    "Court Commissioners sit 24 hours a day, 7 days a week at 41 locations statewide and conduct roughly 177,000 initial appearances annually; a defendant who remains in custody 24 hours after a commissioner's pretrial-release determination must be presented to the District Court at its next session for review (Md. Rule 4-213).",
+    "Maryland is an all-party consent state for oral, wire, and electronic communications under Cts. & Jud. Proc. § 10-402; violation is a felony carrying up to 5 years and a $10,000 fine. The all-party rule applies only where the parties had a reasonable expectation of privacy, so on-duty officers acting publicly may generally be recorded."
+  ],
+
+  "source_urls": [
+    "https://mgaleg.maryland.gov/mgawebsite/Laws/StatuteText?article=gcp&section=4-103",
+    "https://www.mdcourts.gov/sites/default/files/import/district/bondsmen/rule4216.pdf",
+    "http://home.ubalt.edu/id86mp66/PTJC/Md.%20Rule%204-216.1.PDF",
+    "https://mgaleg.maryland.gov/mgawebsite/Laws/StatuteText?article=gcj&section=10-402",
+    "https://law.justia.com/codes/maryland/courts-and-judicial-proceedings/title-10/subtitle-4/section-10-402/",
+    "https://law.justia.com/codes/maryland/criminal-procedure/title-10/subtitle-1/section-10-105/",
+    "https://mgaleg.maryland.gov/mgawebsite/Laws/StatuteText?article=gcp&section=10-110",
+    "https://caselaw.findlaw.com/md-court-of-appeals/1645449.html",
+    "https://6ac.org/maryland-supreme-court-orders-attorneys-at-bail-hearings/",
+    "https://www.law.cornell.edu/regulations/maryland/COMAR-14-06-03-05",
+    "https://opd.state.md.us/new-charges"
+  ],
+  "_unknown_fields": ["bail_default_amounts_by_charge"]
+}

--- a/data/state-arrest-procedure/me.json
+++ b/data/state-arrest-procedure/me.json
@@ -1,0 +1,38 @@
+{
+  "state_code": "ME",
+  "state_name": "Maine",
+  "researched_at": "2026-04-28",
+
+  "first_appearance_window_hours": 48,
+  "pd_attach_trigger": "at initial appearance, after the court conducts a financial inquiry to determine indigency",
+  "indigency_threshold": "Eligibility determined by the court via financial inquiry under standards set by the Maine Commission on Public Defense Services (MCPDS, formerly MCILS); aligned with federal poverty guidelines and asset limits.",
+  "bail_types_allowed": ["cash", "personal_recognizance", "property"],
+  "bail_default_amounts_by_charge": null,
+  "phone_call_rule": "No specific Maine statute defines a numerical phone-call window after arrest. Right to communicate with counsel is constitutionally protected; Maine law (effective Jan 2024) bars jails from recording attorney-client phone calls and caps inmate call rates to the FCC interstate rate.",
+  "recording_police_consent": "one-party",
+  "expungement_window_years": "Maine does not have general expungement. Sealing under 15 MRS ch. 310-A is limited to Class E convictions where the offense was committed at age 18-27 and four years have passed since sentence completion (including all fines, fees, restitution).",
+  "misc_quirks": [
+    "Surety bail and commercial bail bondsmen are NOT permitted in Maine. Only personal recognizance ('I-bond'), unsecured appearance bond, cash ('C-bond'), and property are recognized under 15 MRS ch. 105-A.",
+    "Maine had no statewide public defender system until 2010 — MCPDS (formerly MCILS) was established in 2009 and assumed responsibility July 1, 2010. The state still relies on an assigned-counsel model rather than a traditional public defender office.",
+    "Class A-D convictions cannot be sealed or expunged in Maine — only Class E offenses qualify, and only under narrow age-and-time conditions."
+  ],
+
+  "source_urls": [
+    "https://www.courts.maine.gov/rules/text/mru_crim_p_plus_2025-05-01.pdf",
+    "https://www.maine.gov/pds/",
+    "https://legislature.maine.gov/statutes/4/title4ch37.pdf",
+    "https://6ac.org/us-territory/maine/",
+    "https://legislature.maine.gov/statutes/15/title15ch105-Asec0.html",
+    "https://legislature.maine.gov/statutes/15/title15sec1026.html",
+    "https://legislature.maine.gov/lawlibrary/what-is-maines-law-on-recording-surveillance-of-private-conversations/9488",
+    "https://www.mainelegislature.org/legis/statutes/15/title15sec712.html",
+    "https://themainemonitor.org/maine-passes-bill-to-curb-recording-of-attorney-client-phone-calls-in-jails/",
+    "https://themainemonitor.org/maine-caps-phone-call-prices-in-jails-and-prisons/",
+    "https://www.mainelegislature.org/legis/statutes/15/title15ch310-Asec0.html",
+    "https://www.courts.maine.gov/help/criminal/sealing.html",
+    "https://ccresourcecenter.org/state-restoration-profiles/maine-restoration-of-rights-pardon-expungement-sealing/"
+  ],
+  "_unknown_fields": [
+    "bail_default_amounts_by_charge"
+  ]
+}

--- a/data/state-arrest-procedure/mi.json
+++ b/data/state-arrest-procedure/mi.json
@@ -1,0 +1,40 @@
+{
+  "state_code": "MI",
+  "state_name": "Michigan",
+  "researched_at": "2026-04-28",
+
+  "first_appearance_window_hours": 48,
+  "pd_attach_trigger": "Counsel is appointed as soon as the defendant is determined eligible for indigent defense services and as soon as the defendant's liberty is subject to restriction by a magistrate or judge (Michigan Indigent Defense Commission Act, MCL 780.991).",
+  "indigency_threshold": "Presumptively indigent if receiving personal public assistance or earning income less than 200% of federal poverty guidelines. Defendants above the presumptive threshold receive more rigorous screening considering charge seriousness, monthly expenses, and local private counsel rates (MIDC Standards).",
+  "bail_types_allowed": ["cash", "surety", "personal_recognizance"],
+  "bail_default_amounts_by_charge": null,
+  "phone_call_rule": "Michigan has no statewide statute fixing a numerical phone-call right at booking; access to phone is set by jail policy. Example: Oakland County Jail provides one initial booking call up to 3 minutes that does not count against the inmate's weekly call allowance.",
+  "recording_police_consent": "one-party",
+  "expungement_window_years": "Petition-based set-aside under MCL 780.621 (Clean Slate, effective April 10, 2021): 3 years after completion of sentence for one or more non-serious misdemeanors; 5 years for one felony or one or more serious misdemeanors; 7 years for more than one felony. Time runs from the latest of imposition of sentence, completion of imprisonment, completion of probation, or discharge from parole. No new convictions during the waiting period.",
+  "misc_quirks": [
+    "Michigan's eavesdropping statute MCL 750.539c reads as if all-party consent is required, but the Michigan Court of Appeals held in Sullivan v. Gray that the statute does not apply to a participant recording their own conversation, making Michigan effectively one-party in practice. The Sixth Circuit reaffirmed this reading in Fisher v. Perron; the Michigan Supreme Court has not resolved the split.",
+    "Clean Slate (MCL 780.621) added a 'same transaction' rule: multiple felony convictions arising from the same transaction within 24 hours count as one felony for expungement, and likewise for misdemeanors.",
+    "Under MCR 6.104(A) and MCL 764.13 the arrestee must be brought before a magistrate 'without unnecessary delay'; under County of Riverside v. McLaughlin a delay over 48 hours from warrantless arrest to a probable-cause determination is presumptively unreasonable in Michigan."
+  ],
+
+  "source_urls": [
+    "https://www.legislature.mi.gov/Laws/MCL?objectName=mcl-764-13",
+    "https://www.legislature.mi.gov/Laws/MCL?objectName=mcl-765-6",
+    "https://www.legislature.mi.gov/Laws/MCL?objectName=mcl-765-6a",
+    "https://www.legislature.mi.gov/Laws/MCL?objectName=mcl-750-539c",
+    "https://www.legislature.mi.gov/Laws/MCL?objectName=mcl-780-991",
+    "https://www.courts.michigan.gov/4a52b3/siteassets/publications/benchbooks/dcmm/dcmmresponsivehtml5.zip/DCMM/Ch_4_Arraignments/Right_to_a_Prompt_Arraignment.htm",
+    "https://www.courts.michigan.gov/4a5467/siteassets/publications/benchbooks/criminal/crimpttresponsivehtml5.zip/Crim_PTT/Ch_5_District_Court_Arraignments/Chapter_5_District_Court_Arraignments-.htm",
+    "https://michiganidc.gov/wp-content/uploads/2022/10/MIDC-Standards-Complete-October-2022.pdf",
+    "https://michiganidc.gov/standards/",
+    "https://www.michigan.gov/msp/services/chr/conviction-set-aside-public-information/michigan-clean-slate",
+    "https://www.michigan.gov/-/media/Project/Websites/AG/expungement/Expungement_Checklist_-_nonmisdemeanor_marijuana_adult_offenses.pdf",
+    "https://www.varnumlaw.com/insights/setting-the-record-straight-on-recording-conversations-is-michigan-a-one-party-consent-state/",
+    "https://www.butzel.com/alert-the-u-s-sixth-circuit-court-of-appeals-affirms",
+    "https://www.rcfp.org/reporters-recording-guide/michigan/",
+    "https://www.oakgov.com/government/sheriff/corrections/oakland-county-jail/inmate-information"
+  ],
+  "_unknown_fields": [
+    "bail_default_amounts_by_charge"
+  ]
+}

--- a/data/state-arrest-procedure/mn.json
+++ b/data/state-arrest-procedure/mn.json
@@ -1,0 +1,36 @@
+{
+  "state_code": "MN",
+  "state_name": "Minnesota",
+  "researched_at": "2026-04-28",
+
+  "first_appearance_window_hours": 36,
+  "pd_attach_trigger": "at first appearance, after the court conducts a financial inquiry under Minn. Stat. 611.17 to determine eligibility",
+  "indigency_threshold": "Anyone receiving means-tested government benefits (or with a dependent who does) is presumptively eligible. Otherwise, the court conducts a financial inquiry under Minn. Stat. 611.17 examining liquid assets and earnings.",
+  "bail_types_allowed": ["cash", "surety", "personal_recognizance", "signature"],
+  "bail_default_amounts_by_charge": "For misdemeanor and gross misdemeanor offenses, maximum cash bail is double the highest cash fine that may be imposed for that offense (Minn. Stat. 629.471). DWI has mandatory bail floors under Minn. Stat. 169A.44.",
+  "phone_call_rule": "No Minnesota statute specifies a numerical phone-call window. Right to communicate with counsel is constitutionally protected; jails typically permit a brief call during booking as a matter of practice and policy.",
+  "recording_police_consent": "one-party",
+  "expungement_window_years": "Under Minn. Stat. 609A.02 / 609A.03: no waiting period for dismissed charges or favorable dispositions; 1 year after successful completion of diversion or stay-of-adjudication; 2 years after sentence discharge for misdemeanors; 3 years for gross misdemeanors; 4-5 years for eligible felonies. Petitioner must remain conviction-free during the waiting period.",
+  "misc_quirks": [
+    "First appearance must occur within 36 hours of arrest, EXCLUDING the day of arrest, Sundays, and legal holidays (Minn. R. Crim. P. 4.02). The federal 48-hour Riverside v. McLaughlin probable-cause clock runs separately and includes weekends.",
+    "Default release is on personal recognizance or unsecured appearance bond unless the court finds release would endanger public safety or fail to assure appearance (Minn. Stat. 629.471).",
+    "Minnesota's Clean Slate Act (effective Jan 1, 2025) added automatic expungement for certain eligible records after the 609A.02 waiting periods, without requiring a petition."
+  ],
+
+  "source_urls": [
+    "https://www.revisor.mn.gov/court_rules/cr/id/4/",
+    "https://www.mncourts.gov/mncourtsgov/media/Appellate/Supreme%20Court/Court%20Rules/Crim-Rules.pdf",
+    "https://www.revisor.mn.gov/statutes/cite/626A.02",
+    "https://www.revisor.mn.gov/statutes/cite/629.471",
+    "https://www.revisor.mn.gov/statutes/cite/611/full",
+    "https://www.revisor.mn.gov/statutes/cite/609A.02",
+    "https://www.revisor.mn.gov/statutes/cite/609a.03",
+    "https://www.revisor.mn.gov/court_rules/cr/id/6/",
+    "https://www.house.mn.gov/hrd/pubs/ss/ssbailmn.pdf",
+    "https://www.rcfp.org/reporters-recording-guide/minnesota/",
+    "https://www.mncourts.gov/Help-Topics/Public-Defender.aspx",
+    "https://www.lawhelpmn.org/self-help-library/fact-sheet/i-got-arrested-what-happens-now",
+    "https://birkholzlaw.com/what-should-you-know-about-minnesotas-clean-slate-act/"
+  ],
+  "_unknown_fields": []
+}

--- a/data/state-arrest-procedure/mo.json
+++ b/data/state-arrest-procedure/mo.json
@@ -1,0 +1,35 @@
+{
+  "state_code": "MO",
+  "state_name": "Missouri",
+  "researched_at": "2026-04-28",
+
+  "first_appearance_window_hours": 48,
+  "pd_attach_trigger": "at first appearance, after the court determines indigency on application to the Missouri State Public Defender",
+  "indigency_threshold": "150% of federal poverty guideline under 18 CSR 10-3.010 (amended 2024); spousal and parental income factored per the Public Defender Commission rule",
+  "bail_types_allowed": ["cash", "surety", "signature", "property", "personal_recognizance"],
+  "bail_default_amounts_by_charge": null,
+  "phone_call_rule": "RSMo 544.170 entitles a person held without warrant to consult with counsel or other persons acting on the confinee's behalf at any reasonable time during confinement; the statute does not fix a numeric phone-call quota.",
+  "recording_police_consent": "one-party",
+  "expungement_window_years": "Under RSMo 610.140 as currently in effect: 3 years after completion of disposition for eligible felonies, 1 year for eligible misdemeanors/municipal offenses/infractions; 18 months from arrest where eligible charge resulted in no conviction.",
+  "misc_quirks": [
+    "RSMo 544.170 requires release within 24 hours of warrantless arrest unless the person is formally charged by warrant within that window — a detention cap, not a probable-cause substitute.",
+    "Missouri Supreme Court Rule 22.07 sets the right to a first appearance within 48 hours of detention on a felony warrant.",
+    "Recording is one-party consent under RSMo 542.402, but recording for the purpose of a criminal or tortious act is itself a class D felony."
+  ],
+
+  "source_urls": [
+    "https://revisor.mo.gov/main/OneSection.aspx?section=544.170",
+    "https://revisor.mo.gov/main/OneSection.aspx?section=542.402",
+    "https://revisor.mo.gov/main/OneSection.aspx?section=610.140",
+    "https://revisor.mo.gov/main/OneSection.aspx?section=600.086",
+    "https://www.courts.mo.gov/page.jsp?id=46",
+    "https://www.courts.mo.gov/page.jsp?id=181579",
+    "https://publicdefender.mo.gov/clients-and-families/how-to-apply-for-services/",
+    "https://publicdefender.mo.gov/proposed-rule/",
+    "https://www.sos.mo.gov/cmsimages/adrules/csr/current/18csr/18c10-3.pdf",
+    "https://news.mobar.org/developments-in-the-law-regarding-warrantless-arrests/"
+  ],
+  "_unknown_fields": [
+    "bail_default_amounts_by_charge"
+  ]
+}

--- a/data/state-arrest-procedure/ms.json
+++ b/data/state-arrest-procedure/ms.json
@@ -1,0 +1,38 @@
+{
+  "state_code": "MS",
+  "state_name": "Mississippi",
+  "researched_at": "2026-04-28",
+
+  "first_appearance_window_hours": 48,
+  "pd_attach_trigger": "At the initial appearance under MRCrP 5. The defendant must be informed of the right to assistance of counsel and, if indigent, the court inquires into eligibility and appoints counsel. For misdemeanors, MS Code 25-32-9 directs the presiding judge or justice, upon a determination of indigency, to appoint the public defender.",
+  "indigency_threshold": "Determined by affidavit of indigency and statement of assets reviewed by the appointing court (MS Code 25-32-9). Mississippi delegates indigent-defense funding and standards to counties and municipalities, so the precise financial threshold is set locally rather than by uniform statewide statute.",
+  "bail_types_allowed": ["cash", "surety", "property", "personal_recognizance"],
+  "bail_default_amounts_by_charge": null,
+  "phone_call_rule": "Per the comments to MRCrP 5, the opportunity to make a telephone call is the minimum requirement; fundamental fairness requires that a person taken into custody be allowed to communicate to another that they are being held and charged. No fixed statutory hour-window for the call.",
+  "recording_police_consent": "one-party",
+  "expungement_window_years": "Misdemeanor first offense (non-traffic): may petition immediately under MS Code 99-19-71(1). Other misdemeanors: court may expunge upon showing of rehabilitation and 2 years of good conduct since the last conviction. Felony: 5 years after successful completion of all sentence terms and payment of all fines/costs, one conviction only, with statutory exclusions (crimes of violence, arson 1st degree, drug trafficking, 3rd+ DUI, felon-in-possession, failure to register as sex offender).",
+  "misc_quirks": [
+    "If a defendant is held more than 48 hours without an initial appearance, MRCrP 5.1 directs release on minimum bail unless the offense is non-bailable.",
+    "Mississippi has no statewide trial-level public defender system; counties and municipalities choose their own delivery model (PD office, contract counsel, or hybrid). Only the state Office of Indigent Appeals handles felony appeals statewide.",
+    "MRCrP 5.2 governs the prompt determination of release conditions at the initial appearance, separating bail-setting from probable-cause review."
+  ],
+
+  "source_urls": [
+    "https://courts.ms.gov/research/rules/msrulesofcourt/Rules%20of%20Criminal%20Procedure%20Post-070123.pdf",
+    "https://www.hindscountyms.com/sites/default/files/mississippi_rules_of_criminal_procedure.pdf",
+    "https://law.justia.com/codes/mississippi/2020/title-25/chapter-32/subchapter-ingeneral/section-25-32-9/",
+    "https://www.ospd.ms.gov/",
+    "https://6ac.org/us-territory/mississippi/",
+    "https://law.justia.com/codes/mississippi/title-99/chapter-5/",
+    "https://law.justia.com/codes/mississippi/title-99/chapter-5/section-99-5-1/",
+    "https://law.justia.com/codes/mississippi/title-99/chapter-5/section-99-5-9/",
+    "https://recordinglaw.com/united-states-recording-laws/one-party-consent-states/mississippi-recording-laws/",
+    "https://www.rcfp.org/reporters-recording-guide/mississippi/",
+    "https://www.aclu-ms.org/know-your-rights/right-record/",
+    "https://law.justia.com/codes/mississippi/title-99/chapter-19/in-general/section-99-19-71/",
+    "https://codes.findlaw.com/ms/title-99-criminal-procedure/ms-code-sect-99-19-71.html"
+  ],
+  "_unknown_fields": [
+    "bail_default_amounts_by_charge"
+  ]
+}

--- a/data/state-arrest-procedure/mt.json
+++ b/data/state-arrest-procedure/mt.json
@@ -1,0 +1,40 @@
+{
+  "state_code": "MT",
+  "state_name": "Montana",
+  "researched_at": "2026-04-28",
+
+  "first_appearance_window_hours": null,
+  "pd_attach_trigger": "at first appearance (initial appearance before judge), per MCA 46-8-101",
+  "indigency_threshold": "133% of federal poverty level (primary standard, MCA 47-1-111(3)(a)); substantial hardship standard also available for those who exceed income threshold but cannot retain counsel without significant financial burden (MCA 47-1-111(3)(b))",
+  "bail_types_allowed": ["cash", "surety", "property", "personal_recognizance"],
+  "bail_default_amounts_by_charge": null,
+  "phone_call_rule": null,
+  "recording_police_consent": "all-party",
+  "expungement_window_years": "Misdemeanors only: 5-year waiting period after completion of all sentencing terms (including financial obligations and court-ordered treatment), then expungement is presumed under MCA 46-18-1107. One lifetime limit. Felony convictions are not eligible except for marijuana offenses under legalized statutes and offenses committed by human trafficking survivors.",
+  "misc_quirks": [
+    "Montana has no statewide bail schedule — individual judges set local bail schedules for offenses within their jurisdiction under MCA 46-9-302; five offense categories (partner/family assault, strangulation, stalking, protective order violations, no-contact order violations) require a court appearance before bail can be posted.",
+    "Montana's all-party consent recording law (MCA 45-8-213) prohibits recording any conversation with a 'hidden electronic or mechanical device' without the knowledge of all parties; the exception is that one party may give advance warning, allowing either party to then record.",
+    "Non-conviction arrest records (dismissed charges, acquittals, cases not filed after July 1, 2017) are automatically expunged from the state Criminal Records & Identification Services (CRISS) repository under MCA 44-5-202 without requiring a petition."
+  ],
+
+  "source_urls": [
+    "https://mca.legmt.gov/bills/mca/title_0460/chapter_0070/part_0010/section_0010/0460-0070-0010-0010.html",
+    "https://mca.legmt.gov/bills/mca/title_0460/chapter_0070/part_0010/section_0020/0460-0070-0010-0020.html",
+    "https://mca.legmt.gov/bills/mca/title_0460/chapter_0080/part_0010/section_0010/0460-0080-0010-0010.html",
+    "https://mca.legmt.gov/bills/mca/title_0470/chapter_0010/part_0010/section_0110/0470-0010-0010-0110.html",
+    "https://mca.legmt.gov/bills/mca/title_0460/chapter_0090/part_0040/section_0010/0460-0090-0040-0010.html",
+    "https://mca.legmt.gov/bills/mca/title_0460/chapter_0090/part_0010/section_0110/0460-0090-0010-0110.html",
+    "https://mca.legmt.gov/bills/mca/title_0460/chapter_0090/part_0030/section_0020/0460-0090-0030-0020.html",
+    "https://mca.legmt.gov/bills/mca/title_0450/chapter_0080/part_0020/section_0130/0450-0080-0020-0130.html",
+    "https://mca.legmt.gov/bills/mca/title_0460/chapter_0180/part_0110/section_0040/0460-0180-0110-0040.html",
+    "https://mca.legmt.gov/bills/mca/title_0460/chapter_0180/part_0110/section_0070/0460-0180-0110-0070.html",
+    "https://dojmt.gov/dci-home/non-conviction-removal-and-sealing/",
+    "https://ccresourcecenter.org/state-restoration-profiles/montana-restoration-of-rights-pardon-expungement-sealing/",
+    "https://www.rcfp.org/reporters-recording-guide/montana/"
+  ],
+  "_unknown_fields": [
+    "first_appearance_window_hours",
+    "phone_call_rule",
+    "bail_default_amounts_by_charge"
+  ]
+}

--- a/data/state-arrest-procedure/nc.json
+++ b/data/state-arrest-procedure/nc.json
@@ -1,0 +1,38 @@
+{
+  "state_code": "NC",
+  "state_name": "North Carolina",
+  "researched_at": "2026-04-28",
+
+  "first_appearance_window_hours": 72,
+  "pd_attach_trigger": "At first appearance before district court judge (within 72 hours); judge must advise of right to counsel and, if defendant claims indigency, initiate appointment under NCGS 7A-450. Sixth Amendment right attaches at initial appearance before magistrate under NCGS 15A-511.",
+  "indigency_threshold": "No bright-line income test. NCGS 7A-450(a) defines indigency as being 'financially unable to secure legal representation'; courts assess individual circumstances under IDS Rule 1.4 — income, assets, and anticipated litigation costs all weighed.",
+  "bail_types_allowed": ["cash", "surety", "personal_recognizance", "property"],
+  "bail_default_amounts_by_charge": null,
+  "phone_call_rule": "Upon arrest, officer must without unnecessary delay advise defendant of the right to communicate with counsel and friends, and allow reasonable time and opportunity to do so. No fixed number of calls or minute limit specified. (NCGS 15A-501(5); DWI exception: 30 minutes to contact attorney before breath test per NCGS 20-16.2(a)(6).)",
+  "recording_police_consent": "one-party",
+  "expungement_window_years": "Single nonviolent misdemeanor: 3 years after conviction or completion of sentence/probation, whichever is later. Multiple misdemeanors: 7 years after last conviction. Nonviolent felony: 10 years after conviction or completion of sentence/probation, whichever is later. (NCGS 15A-145.5)",
+  "misc_quirks": [
+    "First appearance window is 72 hours (reduced from 96 hours effective December 1, 2021); extends to 96 hours only if courthouse is closed for transactions longer than 72 hours. (NCGS 15A-601)",
+    "NC is a one-party consent state for recording — at least one party to the conversation must consent; recording a police officer during a public encounter where you are a party is lawful. (NCGS 15A-287)",
+    "Automatic expunctions were suspended August 1, 2022 – July 1, 2024 due to implementation issues; resumed effective July 8, 2024 under revised rules. (NCGS 15A-145.5; Session Law 2024-35)"
+  ],
+
+  "source_urls": [
+    "https://www.ncleg.gov/EnactedLegislation/Statutes/HTML/BySection/Chapter_15A/GS_15A-501.html",
+    "https://www.ncleg.gov/EnactedLegislation/Statutes/HTML/BySection/Chapter_15A/GS_15A-511.html",
+    "https://www.ncleg.gov/EnactedLegislation/Statutes/HTML/BySection/Chapter_15A/GS_15A-601.html",
+    "https://www.ncleg.gov/EnactedLegislation/Statutes/HTML/BySection/Chapter_15A/GS_15A-603.html",
+    "https://www.ncleg.gov/EnactedLegislation/Statutes/HTML/BySection/Chapter_15A/GS_15A-531.html",
+    "https://www.ncleg.gov/EnactedLegislation/Statutes/HTML/BySection/Chapter_15A/GS_15A-287.html",
+    "https://www.ncleg.gov/EnactedLegislation/Statutes/HTML/BySection/Chapter_15A/GS_15A-145.html",
+    "https://www.ncleg.gov/enactedlegislation/statutes/html/bysection/chapter_15a/gs_15a-145.5.html",
+    "https://www.ncleg.net/EnactedLegislation/Statutes/HTML/ByArticle/Chapter_7A/Article_36.html",
+    "https://www.ncids.org/indigency-defined/",
+    "https://nccriminallaw.sog.unc.edu/one-phone-call/",
+    "https://www.sog.unc.edu/resources/microsites/relief-criminal-conviction/older-nonviolent-misdemeanor-and-felony-convictions",
+    "https://www.nccourts.gov/assets/inline-files/Expungement-15A-145.5.pdf"
+  ],
+  "_unknown_fields": [
+    "bail_default_amounts_by_charge"
+  ]
+}

--- a/data/state-arrest-procedure/nd.json
+++ b/data/state-arrest-procedure/nd.json
@@ -1,0 +1,35 @@
+{
+  "state_code": "ND",
+  "state_name": "North Dakota",
+  "researched_at": "2026-04-28",
+
+  "first_appearance_window_hours": 48,
+  "pd_attach_trigger": "at initial appearance before magistrate, who must inform defendant of right to counsel at public expense if unable to pay (N.D.R.Crim.P. Rule 5)",
+  "indigency_threshold": "125% of federal poverty guidelines and assets not exceeding $20,000 (ND Commission on Legal Counsel for Indigents Guidelines 2021)",
+  "bail_types_allowed": ["cash", "surety", "personal_recognizance"],
+  "bail_default_amounts_by_charge": "Under Admin. Rule 63: Class AA/A/B/C felonies and certain misdemeanors (sexual misconduct, bodily injury, domestic violence, protection-order violations, fleeing) held until judicial officer; all other misdemeanants released on promise to appear. No published dollar-amount schedule.",
+  "phone_call_rule": null,
+  "recording_police_consent": "one-party",
+  "expungement_window_years": "Misdemeanor: 3 years after release from incarceration, parole, or probation, charge-free. Felony: 5 years after release, charge-free. DUI records, violent felonies during 10-year firearm-ineligibility period, and sex/child offender registrants are ineligible (NDCC 12-60.1-02).",
+  "misc_quirks": [
+    "North Dakota Admin. Rule 63 (eff. Aug 1 2024) eliminates a fixed bail-dollar schedule for felonies — all Class AA through C felony arrestees must be held until seen by a judicial officer regardless of the charge amount.",
+    "Sealing (not expungement) is the exclusive remedy — records are sealed, not destroyed, and remain accessible to courts, prosecutors, and law enforcement (NDCC 12-60.1-03).",
+    "Pardoned convictions became eligible for sealing in 2025 via HB 1166, adding them to NDCC 12-60.1-02(1)(c)."
+  ],
+
+  "source_urls": [
+    "https://www.ndcourts.gov/legal-resources/rules/ndrcrimp/5",
+    "https://www.ndcourts.gov/legal-resources/rules/ndsupctadminr/63",
+    "https://www.indigents.nd.gov/news/guidelines-determine-eligibility-indigent-defense-services",
+    "https://www.rcfp.org/reporters-recording-guide/north-dakota/",
+    "https://recordinglaw.com/united-states-recording-laws/one-party-consent-states/north-dakota-recording-laws/",
+    "https://ndlegis.gov/cencode/t12-1c15.pdf",
+    "https://ndlegis.gov/cencode/t12c60-1.pdf",
+    "https://www.f5project.org/sealing-criminal-records-in-north-dakota/",
+    "https://ccresourcecenter.org/state-restoration-profiles/north-dakota-restoration-of-rights-pardon-expungement-sealing/",
+    "https://ndlegis.gov/sites/default/files/resource/committee-memorandum/27.9071.01000.pdf"
+  ],
+  "_unknown_fields": [
+    "phone_call_rule"
+  ]
+}

--- a/data/state-arrest-procedure/ne.json
+++ b/data/state-arrest-procedure/ne.json
@@ -1,0 +1,36 @@
+{
+  "state_code": "NE",
+  "state_name": "Nebraska",
+  "researched_at": "2026-04-28",
+
+  "first_appearance_window_hours": 168,
+  "pd_attach_trigger": "At first appearance; judge advises defendant of right to counsel, defendant asserts indigency, court makes reasonable inquiry and may appoint counsel for all future critical stages (NRS 29-3903)",
+  "indigency_threshold": "Unable to retain counsel without prejudicing ability to provide economic necessities for self or family, based on comparison of available funds (liquid assets + disposable net monthly income) against anticipated cost of counsel (Nebraska Judicial Branch Rule 9-10)",
+  "bail_types_allowed": ["cash", "surety", "personal_recognizance"],
+  "bail_default_amounts_by_charge": null,
+  "phone_call_rule": null,
+  "recording_police_consent": "one-party",
+  "expungement_window_years": "Convictions are not expungeable but may be set aside after sentence completion; non-conviction records sealed automatically (1 year if no charges filed, immediately on dismissal or acquittal, 2 years after diversion completion); erroneous arrest records expungeable by district court petition showing clear and convincing evidence of law enforcement error (NRS 29-3523)",
+  "misc_quirks": [
+    "Nebraska's first-appearance deadline is 7 days after warrantless arrest (NRS 29-404.02) — longer than the 24–72 hour windows most states require, giving police more pre-court custody time.",
+    "Nebraska has no specific timed post-arrest phone-call statute; jail telephone access is governed by NRS 47-101.01 (prepaid or collect call systems required at each county jail) rather than a booking-window rule.",
+    "Nebraska allows a 10% cash deposit bond: defendants deposit 10% of the bond amount with the court clerk, and 90% is returned upon appearance — a built-in alternative to commercial surety bondsmen (NRS 29-901)."
+  ],
+
+  "source_urls": [
+    "https://nebraskalegislature.gov/laws/statutes.php?statute=29-401",
+    "https://nebraskalegislature.gov/laws/statutes.php?statute=29-404.02",
+    "https://nebraskalegislature.gov/laws/statutes.php?statute=29-901",
+    "https://nebraskalegislature.gov/laws/statutes.php?statute=29-3903",
+    "https://nebraskalegislature.gov/laws/statutes.php?statute=29-3523",
+    "https://nebraskalegislature.gov/laws/statutes.php?statute=86-290",
+    "https://nebraskalegislature.gov/laws/statutes.php?statute=47-101.01",
+    "https://nebraskajudicial.gov/external-court-rules/district-court-local-rules/district-9/rule-9-10-appointment-counsel-indigent-defendants",
+    "https://nebraskajudicial.gov/self-help/criminal-record-rehabilitation/adult-record-sealing",
+    "https://www.aclunebraska.org/know-your-rights/rights-with-law-enforcement/"
+  ],
+  "_unknown_fields": [
+    "bail_default_amounts_by_charge",
+    "phone_call_rule"
+  ]
+}

--- a/data/state-arrest-procedure/nh.json
+++ b/data/state-arrest-procedure/nh.json
@@ -1,0 +1,31 @@
+{
+  "state_code": "NH",
+  "state_name": "New Hampshire",
+  "researched_at": "2026-04-28",
+
+  "first_appearance_window_hours": 36,
+  "pd_attach_trigger": "at arraignment (first appearance); a public defender is present for state-level felony arraignments; Class B misdemeanor defendants do not receive appointed counsel unless denied bail",
+  "indigency_threshold": "Financial affidavit showing inability to afford private counsel; court determines inability based on income and assets with no published percentage-of-poverty threshold (RSA 604-A:2)",
+  "bail_types_allowed": ["personal_recognizance", "surety", "cash", "property"],
+  "bail_default_amounts_by_charge": null,
+  "phone_call_rule": "Upon booking, the officer in charge must immediately secure the name of the person the arrestee wishes to contact (parent, relative, friend, or attorney) and immediately notify that contact by telephone or messenger when practicable (RSA 594:15). No explicit statutory minimum number of calls or strict time limit beyond 'immediately.'",
+  "recording_police_consent": "all-party",
+  "expungement_window_years": "Violation: 1 year after sentence completion; Class B misdemeanor: 2 years; Class A misdemeanor: 3 years; Class B felony: 5 years; Class A felony: 10 years. Charges dismissed or resulting in not-guilty verdict (post-2019): automatic annulment 30 days after dismissal. Violent crimes and felony obstruction of justice are permanently ineligible (RSA 651:5).",
+  "misc_quirks": [
+    "Class B misdemeanor defendants have no right to appointed counsel unless the court denies their release — defendants charged with offenses like simple possession face this gap and must retain private counsel or proceed pro se (RSA 597:2(XIII)).",
+    "NH is all-party consent for recording under RSA 570-A:2(I); recording a police encounter without the officer's consent may violate the wiretapping statute, though no explicit public-official exception exists for citizens.",
+    "The 36-hour first-appearance window excludes weekends and holidays, meaning a Friday arrest can result in detention through Monday morning before arraignment (RSA 597:2(III))."
+  ],
+
+  "source_urls": [
+    "https://gc.nh.gov/rsa/html/LIX/597/597-mrg.htm",
+    "https://gc.nh.gov/rsa/html/LIX/594/594-15.htm",
+    "https://gc.nh.gov/rsa/html/lviii/570-a/570-a-2.htm",
+    "https://gc.nh.gov/rsa/html/lxii/651/651-5.htm",
+    "https://www.nhpd.org/obtaining-a-public-defender/",
+    "https://seufertlaw.com/heres-what-you-need-to-know-if-you-are-arrested-in-new-hampshire/"
+  ],
+  "_unknown_fields": [
+    "bail_default_amounts_by_charge"
+  ]
+}

--- a/data/state-arrest-procedure/nj.json
+++ b/data/state-arrest-procedure/nj.json
@@ -1,0 +1,35 @@
+{
+  "state_code": "NJ",
+  "state_name": "New Jersey",
+  "researched_at": "2026-04-28",
+
+  "first_appearance_window_hours": 48,
+  "pd_attach_trigger": "at first appearance; court provides a 5A indigency application for immediate processing and assigns public defender if defendant qualifies",
+  "indigency_threshold": null,
+  "bail_types_allowed": ["personal_recognizance"],
+  "bail_default_amounts_by_charge": null,
+  "phone_call_rule": null,
+  "recording_police_consent": "one-party",
+  "expungement_window_years": "5 years after sentence completion (indictable offenses); early pathway available after 4 years with court discretion; limit of one indictable conviction expunged",
+  "misc_quirks": [
+    "New Jersey eliminated cash bail on January 1, 2017 under the Criminal Justice Reform Act (NJSA 2A:162-15 et seq.) — judges may only order PR release with or without conditions, or pretrial detention; no monetary bail is set.",
+    "Every defendant booked on a complaint-warrant receives a Public Safety Assessment (PSA) score — nine criminal-history factors generate two risk scores (failure-to-appear and new criminal activity) that directly govern the judge's release decision at first appearance.",
+    "The Third Circuit has held a First Amendment right to record police conducting official duties in public (Fields v. City of Philadelphia, 862 F.3d 353), which applies to New Jersey; NJSA 2A:156A-4 separately confirms one-party consent for audio recording of conversations you are party to."
+  ],
+
+  "source_urls": [
+    "https://www.njcourts.gov/faq/why-did-new-jersey-reform-its-criminal-justice-system",
+    "https://www.njcourts.gov/public/concerns/criminal-justice-reform",
+    "https://www.njcourts.gov/self-help/expunge-record",
+    "https://www.nj.gov/defender/clients/apply/",
+    "https://www.rcfp.org/reporters-recording-guide/new-jersey/",
+    "https://www.dmlp.org/legal-guide/new-jersey/new-jersey-recording-law",
+    "https://www.arnoldventures.org/newsroom/study-finds-new-jerseys-pretrial-reform-shows-early-signs-of-wide-reaching-positive-impacts-on-criminal-justice-system/",
+    "https://www.nynjcriminalcivilesq.com/understanding-public-safety-assessments-psa-in-new-jersey-criminal-cases/"
+  ],
+  "_unknown_fields": [
+    "indigency_threshold",
+    "phone_call_rule",
+    "bail_default_amounts_by_charge"
+  ]
+}

--- a/data/state-arrest-procedure/nm.json
+++ b/data/state-arrest-procedure/nm.json
@@ -1,0 +1,39 @@
+{
+  "state_code": "NM",
+  "state_name": "New Mexico",
+  "researched_at": "2026-04-28",
+
+  "first_appearance_window_hours": 48,
+  "pd_attach_trigger": "at first appearance; court notifies district public defender and continues proceedings until defendant has applied for representation",
+  "indigency_threshold": "case-by-case determination; court weighs income, property owned, outstanding obligations, and number and ages of dependents — no fixed income ceiling; doubts resolved in favor of the accused",
+  "bail_types_allowed": ["personal_recognizance", "surety", "property", "cash"],
+  "bail_default_amounts_by_charge": null,
+  "phone_call_rule": "Three telephone calls must be permitted beginning no later than 20 minutes after arrival at the place of detention (NMSA § 31-1-5).",
+  "recording_police_consent": "one-party",
+  "expungement_window_years": "2 years (municipal ordinance / most misdemeanors) to 10 years (first-degree felony or Crimes Against Household Members Act offense) after completion of sentence; DUI, sex offenses, offenses against children, and crimes causing great bodily harm or death are ineligible",
+  "misc_quirks": [
+    "2016 constitutional amendment (Art. 2 § 13) abolished money-only bail: a defendant who poses no flight risk and is not dangerous cannot be held solely because they cannot afford to post a money or property bond.",
+    "Under NMRA Rule 5-401, money bonds are imposed only if nonfinancial release conditions (personal recognizance, unsecured appearance bond, third-party custody) are inadequate to ensure court appearance — financial release is a last resort, not a default.",
+    "NMSA § 30-12-1 one-party consent applies only to telegraph and telephone communications; in-person conversations are not covered by the wiretapping statute (State v. Hogervorst, N.M. Ct. App. 1977)."
+  ],
+
+  "source_urls": [
+    "https://www.13th.nmdas.com/post/after-the-arrest",
+    "https://law.justia.com/codes/new-mexico/chapter-31/article-1/section-31-1-5/",
+    "https://law.justia.com/codes/new-mexico/2021/chapter-31/article-15/section-31-15-12/",
+    "https://law.justia.com/codes/new-mexico/chapter-31/article-16/section-31-16-5/",
+    "https://nmcourts.gov/wp-content/uploads/sites/62/2023/12/9-403.pdf",
+    "https://www.nmlegis.gov/handouts/CJRS%20102717%20Item%204%20Rule%205-401.pdf",
+    "https://nmcourts.gov/wp-content/uploads/2023/12/Redline_Version_5_401__approved_6_5_2017_.pdf",
+    "https://ballotpedia.org/New_Mexico_Changes_in_Regulations_Governing_Bail,_Constitutional_Amendment_1_(2016)",
+    "https://nmindepth.com/2016/bail-amendment-passes-convincingly/",
+    "https://law.justia.com/codes/new-mexico/chapter-30/article-12/section-30-12-1/",
+    "https://www.rcfp.org/reporters-recording-guide/new-mexico/",
+    "https://law.justia.com/codes/new-mexico/chapter-29/article-3a/section-29-3a-5/",
+    "https://ccresourcecenter.org/state-restoration-profiles/new-mexico-restoration-of-rights-pardon-expungement-sealing/",
+    "https://nmcourts.gov/court-administration/court-related-information/court-rules-for-pretrial-release-and-detention/"
+  ],
+  "_unknown_fields": [
+    "bail_default_amounts_by_charge"
+  ]
+}

--- a/data/state-arrest-procedure/nv.json
+++ b/data/state-arrest-procedure/nv.json
@@ -1,0 +1,37 @@
+{
+  "state_code": "NV",
+  "state_name": "Nevada",
+  "researched_at": "2026-04-28",
+
+  "first_appearance_window_hours": 72,
+  "pd_attach_trigger": "At first appearance, on oral request supported by an affidavit of indigency. Public defender represents the indigent person at every stage, including the initial appearance and proceedings relating to admission to bail (NRS 171.188, NRS 260.050).",
+  "indigency_threshold": null,
+  "bail_types_allowed": ["cash", "surety", "personal_recognizance"],
+  "bail_default_amounts_by_charge": null,
+  "phone_call_rule": "A reasonable number of completed calls from the place of booking, immediately after booking and, except where physically impossible, no later than 3 hours after arrest. The reasonable number must include one completed call to a friend or bail agent and one completed call to an attorney (NRS 171.153).",
+  "recording_police_consent": "restricted",
+  "expungement_window_years": "Sealing under NRS 179.245, measured from release from custody or discharge from parole/probation, whichever is later: Category A felonies, crimes of violence, and burglary of a residence — 10 years; Category B/C/D felonies — 5 years; Category E felonies — 2 years; gross misdemeanors — 2 years; misdemeanor DUI or misdemeanor battery constituting domestic violence — 7 years; misdemeanor battery, harassment, stalking, or violation of a protective order — 2 years; any other misdemeanor — 1 year. Certain offenses are never sealable (e.g., crimes against children, sexual offenses, felony DUI, home invasion with a deadly weapon).",
+  "misc_quirks": [
+    "Wire/telephone communications are all-party consent under NRS 200.620 (category D felony, up to 4 years prison + $1,000+/day civil liability). In-person oral conversations follow a separate rule (NRS 200.650) and are treated as one-party for non-electronic in-person recording — capture both sides before recording any call.",
+    "Valdez-Jimenez v. Eighth Judicial District Court, 136 Nev. 155 (2020) — judges must put detailed on-the-record reasons for any monetary bail, must consider the defendant's finances and ability to pay, and the State must prove by clear and convincing evidence that bail (rather than less restrictive conditions) is necessary.",
+    "Persons arrested for battery constituting domestic violence (NRS 33.018) cannot be admitted to bail sooner than 12 hours after arrest (NRS 178.484); same 12-hour hold applies to violations of protective orders for domestic violence, stalking, or sexual assault."
+  ],
+
+  "source_urls": [
+    "https://law.justia.com/codes/nevada/chapter-171/statute-171-178/",
+    "https://law.justia.com/codes/nevada/chapter-178/statute-178-484/",
+    "https://www.leg.state.nv.us/nrs/nrs-178.html",
+    "https://law.justia.com/codes/nevada/2010/title14/chapter171/nrs171-153.html",
+    "https://www.lvcriminaldefense.com/nevada-criminal-process/procedure-in-criminal-cases/proceeding-to-commitment/proceedings-before-magistrate/procedure-for-appointment-of-attorney-for-indigent-defendant/",
+    "https://www.leg.state.nv.us/nrs/NRS-260.html",
+    "https://law.justia.com/codes/nevada/2010/title15/chapter200/nrs200-620.html",
+    "https://codes.findlaw.com/nv/title-15-crimes-and-punishments/nv-rev-st-200-620/",
+    "https://law.justia.com/codes/nevada/chapter-179/statute-179-245/",
+    "https://scholars.law.unlv.edu/cgi/viewcontent.cgi?article=2300&context=nvscs",
+    "https://civilrightscorps.org/case/valdez-jimenez-nevada-bail/"
+  ],
+  "_unknown_fields": [
+    "indigency_threshold",
+    "bail_default_amounts_by_charge"
+  ]
+}

--- a/data/state-arrest-procedure/ny.json
+++ b/data/state-arrest-procedure/ny.json
@@ -1,0 +1,33 @@
+{
+  "state_code": "NY",
+  "state_name": "New York",
+  "researched_at": "2026-04-28",
+  "first_appearance_window_hours": 24,
+  "pd_attach_trigger": "At first appearance before local criminal court; must be informed of right to counsel immediately upon arrest",
+  "indigency_threshold": null,
+  "bail_types_allowed": ["personal_recognizance", "signature", "cash", "surety"],
+  "bail_default_amounts_by_charge": null,
+  "phone_call_rule": "Upon arrest and request, right to communicate by telephone to obtain counsel and inform relative/friend of arrest unless call would compromise investigation. Must occur within reasonable time after booking.",
+  "recording_police_consent": "one-party",
+  "expungement_window_years": "10 years after sentencing (sealing, not expungement; NY has no true expungement statute)",
+  "misc_quirks": [
+    "2019 bail reform (CPL 510.10) eliminates cash bail for most misdemeanors and non-violent felonies; judges may only impose non-monetary conditions unless 'qualifying offense' (violent crime, repeat offender with prior jail/prison, or felony involving identifiable person/property harm post-2019).",
+    "NY Penal Law 250.00 is one-party consent for phone/in-person recording, but you may record police in public spaces unless actively interfering with operations.",
+    "CPL 160.59 sealing requires 10 years from sentence completion; max 2 lifetime convictions (max 1 felony) to qualify; sealed records remain accessible to law enforcement and appear on RAP sheets."
+  ],
+  "source_urls": [
+    "https://www.nysenate.gov/legislation/laws/CPL/140.20",
+    "https://law.justia.com/codes/new-york/cpl/part-2/title-h/article-140/140-20/",
+    "https://nysba.org/bail-reform-new-yorks-legislative-labyrinth/",
+    "https://www.nysenate.gov/legislation/laws/CPL/510.10",
+    "https://codes.findlaw.com/ny/penal-law/pen-sect-250-00/",
+    "https://www.dmlp.org/legal-guide/new-york-recording-law",
+    "https://nycourts.gov/courthelp/criminal/sealedAfter10years.shtml",
+    "https://www.nysenate.gov/legislation/laws/CPL/160.59",
+    "https://nysba.org/legalease-your-rights-if-arrested/"
+  ],
+  "_unknown_fields": [
+    "indigency_threshold",
+    "bail_default_amounts_by_charge"
+  ]
+}

--- a/data/state-arrest-procedure/oh.json
+++ b/data/state-arrest-procedure/oh.json
@@ -1,0 +1,34 @@
+{
+  "state_code": "OH",
+  "state_name": "Ohio",
+  "researched_at": "2026-04-28",
+
+  "first_appearance_window_hours": 48,
+  "pd_attach_trigger": "at first appearance / arraignment; provisional representation begins at earliest practicable time under ORC 120.05",
+  "indigency_threshold": "Presumed indigent at 187.5% of federal poverty level (gross income); net-income test at 125% FPL after living expenses; liquid-asset caps: $2,000 (misdemeanor) to $8,000 (F1/F2)",
+  "bail_types_allowed": ["cash", "surety", "property", "personal_recognizance"],
+  "bail_default_amounts_by_charge": "No statewide schedule. ORC 2937.011 requires each court to establish and biennially review its own bail bond schedule covering all misdemeanors and traffic offenses. Felony bail set at judicial discretion.",
+  "phone_call_rule": "Immediately upon arrest and before confinement or removal from the county, the arrested person must be allowed to communicate with counsel and at least one relative or other person to arrange bail. ORC 2935.14 and 2935.20 require 'a reasonable number of phone calls or other reasonable means' with no specific hour limit stated.",
+  "recording_police_consent": "one-party",
+  "expungement_window_years": "1 year after final discharge for misdemeanors; 6 months for minor misdemeanors; 10 years after eligibility for felonies (F3–F5). F1/F2, violent felonies, sex-offense registrants, and certain domestic-violence convictions are ineligible.",
+  "misc_quirks": [
+    "ORC 2937.011 mandates the 'least restrictive' and 'least costly' release condition — courts must justify departing upward from personal recognizance.",
+    "ORC 2935.14 makes it a criminal offense for any officer or jail custodian to prevent, obstruct, or discourage post-arrest communication with counsel.",
+    "Ohio's one-party consent recording rule (ORC 2933.52) permits a defendant or any party to the conversation to record without notifying other participants, provided there is no tortious or criminal purpose."
+  ],
+
+  "source_urls": [
+    "https://codes.ohio.gov/ohio-revised-code/section-2935.14",
+    "https://codes.ohio.gov/ohio-revised-code/section-2935.20",
+    "https://codes.ohio.gov/ohio-revised-code/section-2937.011",
+    "https://codes.ohio.gov/ohio-revised-code/section-2937.22",
+    "https://codes.ohio.gov/ohio-revised-code/section-2937.46",
+    "https://codes.ohio.gov/ohio-revised-code/section-2933.52",
+    "https://codes.ohio.gov/ohio-revised-code/section-2953.32",
+    "https://codes.ohio.gov/ohio-revised-code/section-120.05",
+    "https://codes.ohio.gov/ohio-administrative-code/rule-120-1-03",
+    "https://www.supremecourt.ohio.gov/docs/LegalResources/Rules/criminal/CriminalProcedure.pdf",
+    "https://www.gafirm.com/legal-blog/rules-of-criminal-procedure-ohio/"
+  ],
+  "_unknown_fields": []
+}

--- a/data/state-arrest-procedure/ok.json
+++ b/data/state-arrest-procedure/ok.json
@@ -1,0 +1,37 @@
+{
+  "state_code": "OK",
+  "state_name": "Oklahoma",
+  "researched_at": "2026-04-28",
+  "first_appearance_window_hours": 48,
+  "pd_attach_trigger": "At first appearance after a judicial indigency determination. Counsel is appointed under 22 O.S. § 1355 et seq. (Oklahoma Indigent Defense Act); OIDS provides counsel in non-Tulsa, non-Oklahoma County districts.",
+  "indigency_threshold": null,
+  "bail_types_allowed": [
+    "cash",
+    "surety",
+    "property",
+    "personal_recognizance"
+  ],
+  "bail_default_amounts_by_charge": null,
+  "phone_call_rule": null,
+  "recording_police_consent": "one-party",
+  "expungement_window_years": "Misdemeanor conviction: 10 years after sentence end (22 O.S. § 18(A)(8)). Felony conviction (one or two non-violent felonies, no offense in Title 21 § 13.1, no sex-offender registration): 10 years after sentence completion (22 O.S. § 18(A)(11)). Non-filing arrests: eligible once statute of limitations expires or charges declined (22 O.S. § 18(A)(1)). Beginning November 2025 (subject to funding), Clean Slate eligible arrest records seal automatically.",
+  "misc_quirks": [
+    "Oklahoma Clean Slate provisions in 22 O.S. § 18 (effective three years after Nov 1, 2022, subject to appropriation) authorize automatic sealing of qualifying arrest records — a state-level departure from the historical petition-only model.",
+    "Oklahoma Indigent Defense System (OIDS) covers most counties under 22 O.S. § 1355 et seq., but Tulsa County and Oklahoma County run their own public-defender offices.",
+    "Bail under 22 O.S. § 1101 is allowed in all criminal cases except those punishable by death."
+  ],
+  "source_urls": [
+    "https://law.justia.com/codes/oklahoma/title-22/section-22-18v2/",
+    "https://law.justia.com/codes/oklahoma/2022/title-22/section-22-1101/",
+    "https://oklahoma.gov/osbi/services/information-services-division/disposition-services-unit/criminal-history-record-expungement.html",
+    "https://oklahoma.gov/oids/about.html",
+    "https://oksenate.gov/sites/default/files/agencies_documents/OIDS_PP.pdf",
+    "https://www.oid.ok.gov/wp-content/uploads/2023/12/231204_BailBonds-Statutes.pdf",
+    "https://www.okbar.org/barjournal/mar2019/obj9003orvaljones/"
+  ],
+  "_unknown_fields": [
+    "indigency_threshold",
+    "bail_default_amounts_by_charge",
+    "phone_call_rule"
+  ]
+}

--- a/data/state-arrest-procedure/or.json
+++ b/data/state-arrest-procedure/or.json
@@ -1,0 +1,29 @@
+{
+  "state_code": "OR",
+  "state_name": "Oregon",
+  "researched_at": "2026-04-28",
+  "first_appearance_window_hours": 36,
+  "pd_attach_trigger": "At first arraignment, after a court-conducted indigency screening; counsel is appointed under ORS 135.045 and ORS 151.214. Public Defense Services Commission contracts assigned counsel statewide.",
+  "indigency_threshold": null,
+  "bail_types_allowed": ["cash", "personal_recognizance"],
+  "bail_default_amounts_by_charge": null,
+  "phone_call_rule": null,
+  "recording_police_consent": "restricted",
+  "expungement_window_years": "Set-aside under ORS 137.225 — Class A misdemeanor: 1 year after conviction. Class B/C felony: 3 years. Class A felony: 7 years (limited eligibility). Sex offenses, certain violent felonies, and DUII excluded. Arrests not resulting in conviction may be set aside without waiting period.",
+  "misc_quirks": [
+    "Oregon abolished commercial bail bondsmen in 1973 (ORS 135.265); release uses personal recognizance, conditional release, or 10% court-deposit cash bond.",
+    "ORS 135.010 36-hour clock excludes weekends and holidays—practical wait can be 60+ hours over a long weekend.",
+    "ORS 165.540 in-person recording requires notice; phone-line interception is one-party consent."
+  ],
+  "source_urls": [
+    "https://oregon.public.law/statutes/ors_135.010",
+    "https://www.oregonlegislature.gov/bills_laws/ors/ors135.html",
+    "https://law.justia.com/codes/oregon/volume-04/chapter-135/section-135-010/",
+    "https://oregon.public.law/statutes/ors_chapter_135"
+  ],
+  "_unknown_fields": [
+    "indigency_threshold",
+    "bail_default_amounts_by_charge",
+    "phone_call_rule"
+  ]
+}

--- a/data/state-arrest-procedure/pa.json
+++ b/data/state-arrest-procedure/pa.json
@@ -1,0 +1,29 @@
+{
+  "state_code": "PA",
+  "state_name": "Pennsylvania",
+  "researched_at": "2026-04-28",
+  "first_appearance_window_hours": 48,
+  "pd_attach_trigger": "At preliminary arraignment, after the issuing authority informs the defendant of the right to retain or have counsel appointed (Pa. R. Crim. P. 540(F)). PA public defenders are county-organized — each county runs its own public-defender office under 16 P.S. § 9960.1 et seq.",
+  "indigency_threshold": null,
+  "bail_types_allowed": ["cash", "surety", "personal_recognizance", "signature", "property"],
+  "bail_default_amounts_by_charge": null,
+  "phone_call_rule": null,
+  "recording_police_consent": "all-party",
+  "expungement_window_years": "Pennsylvania Clean Slate Act (Act 56 of 2018) automatically seals most non-conviction records and certain second- and third-degree misdemeanor convictions 10 years after sentence completion. Petition-based expungement under 18 Pa.C.S. § 9122 — non-convictions immediate; summary offenses 5 years after conviction; full pardon required for most felonies.",
+  "misc_quirks": [
+    "Pennsylvania was the first U.S. state with automated record sealing under the Clean Slate Act (Act 56 of 2018, expanded 2023) — qualifying non-conviction and minor-misdemeanor records seal without petition.",
+    "Pa. R. Crim. P. 540(G)(1) gives the defendant an immediate and reasonable opportunity to post bail, secure counsel, and notify others — distinct from a timed phone-call statute.",
+    "Public-defender services are organized at the county level under 16 P.S. § 9960.1 et seq.; eligibility guidelines and procedures vary by county."
+  ],
+  "source_urls": [
+    "https://www.pacodeandbulletin.gov/Display/pacode?file=/secure/pacode/data/234/chapter5/s540.html&d=reduce",
+    "https://www.pacode.com/secure/data/234/chapter5/s540.html",
+    "https://www.law.cornell.edu/regulations/pennsylvania/234-Pa-Code-r-540",
+    "https://www.pacourts.us/assets/opinions/Supreme/out/483crim-attach.pdf"
+  ],
+  "_unknown_fields": [
+    "indigency_threshold",
+    "bail_default_amounts_by_charge",
+    "phone_call_rule"
+  ]
+}

--- a/data/state-arrest-procedure/ri.json
+++ b/data/state-arrest-procedure/ri.json
@@ -1,0 +1,32 @@
+{
+  "state_code": "RI",
+  "state_name": "Rhode Island",
+  "researched_at": "2026-04-28",
+
+  "first_appearance_window_hours": 48,
+  "pd_attach_trigger": "At arraignment, after court-conducted indigency screening. RI Office of the Public Defender provides counsel under RIGL 12-15-1 et seq.",
+  "indigency_threshold": null,
+  "bail_types_allowed": ["cash", "surety", "signature", "personal_recognizance"],
+  "bail_default_amounts_by_charge": null,
+  "phone_call_rule": null,
+  "recording_police_consent": "one-party",
+  "expungement_window_years": "Misdemeanor: 5 years after completion of sentence. Felony: 10 years after completion of sentence. First-offender requirement. Crimes of violence (murder, manslaughter, first-degree arson, kidnapping with intent to extort, robbery, larceny from the person, sexual assault, child molestation, burglary, etc.) ineligible. Outstanding court fees must be paid (waivable).",
+  "misc_quirks": [
+    "Rhode Island District Court operates a pre-trial services unit (RIGL 12-13-24.1) that screens defendants and recommends release form to judicial officer.",
+    "Expungement barred for crimes of violence under RIGL 12-1.3 — murder, robbery, sexual assault, burglary — even after waiting period.",
+    "First-offender requirement means a single conviction is typical maximum for felony expungement petition."
+  ],
+
+  "source_urls": [
+    "https://law.justia.com/codes/rhode-island/title-12/chapter-12-13/",
+    "https://law.justia.com/codes/rhode-island/title-12/chapter-12-1-3/section-12-1-3-2/",
+    "https://riag.ri.gov/community-outreach/expungements",
+    "http://www.ripd.org/expungement-sealingcriminalrecords.html",
+    "https://law.justia.com/codes/rhode-island/2013/title-12/chapter-12-13/section-12-13-24.1/"
+  ],
+  "_unknown_fields": [
+    "indigency_threshold",
+    "bail_default_amounts_by_charge",
+    "phone_call_rule"
+  ]
+}

--- a/data/state-arrest-procedure/sc.json
+++ b/data/state-arrest-procedure/sc.json
@@ -1,0 +1,34 @@
+{
+  "state_code": "SC",
+  "state_name": "South Carolina",
+  "researched_at": "2026-04-28",
+
+  "first_appearance_window_hours": 24,
+  "pd_attach_trigger": "At bond hearing or first appearance after court-conducted indigency screening. SC public-defender services are county-organized through the SC Commission on Indigent Defense under SC § 17-3 et seq.",
+  "indigency_threshold": null,
+  "bail_types_allowed": ["cash", "surety", "signature", "personal_recognizance", "property"],
+  "bail_default_amounts_by_charge": null,
+  "phone_call_rule": null,
+  "recording_police_consent": "one-party",
+  "expungement_window_years": "Charges dismissed, nolle-prossed, or resulting in acquittal are eligible for immediate expungement (no filing fee). Conviction expungement: first-offense simple possession misdemeanor (3-year wait), first-offense criminal-domestic-violence (5-year wait), Youthful Offender Act eligible offenses (5-year wait). Most adult convictions are not expungeable.",
+
+  "misc_quirks": [
+    "SC § 22-5-510(B) mandates a 24-hour bond hearing plus a 4-hour release deadline after bond posting — one of the tightest first-appearance windows in the country.",
+    "South Carolina expungement is conviction-narrow: first-offense simple drug possession, first-offense CDV, and Youthful Offender Act offenses are the main eligible categories.",
+    "Each expungement order under SC § 17-22-940 generally covers only one charge, except where multiple charges arise from a single incident."
+  ],
+
+  "source_urls": [
+    "https://www.scstatehouse.gov/code/t17c015.php",
+    "https://law.justia.com/codes/south-carolina/title-22/chapter-5/section-22-5-510/",
+    "https://law.justia.com/codes/south-carolina/title-17/chapter-22/section-17-22-940/",
+    "https://www.sccourts.org/resources/general-public/expungement-application-process/for-general-sessions/",
+    "https://ccresourcecenter.org/state-restoration-profiles/south-carolina-restoration-of-rights-pardon-expungement-sealing/"
+  ],
+
+  "_unknown_fields": [
+    "indigency_threshold",
+    "bail_default_amounts_by_charge",
+    "phone_call_rule"
+  ]
+}

--- a/data/state-arrest-procedure/sd.json
+++ b/data/state-arrest-procedure/sd.json
@@ -1,0 +1,30 @@
+{
+  "state_code": "SD",
+  "state_name": "South Dakota",
+  "researched_at": "2026-04-28",
+  "first_appearance_window_hours": 48,
+  "pd_attach_trigger": "At initial appearance. The committing magistrate must inform the defendant of the right to retain counsel and to request assigned counsel if unable to obtain it. Counsel for the indigent is provided through county public-defender systems or court-appointed private counsel.",
+  "indigency_threshold": null,
+  "bail_types_allowed": ["cash", "surety", "personal_recognizance", "property"],
+  "bail_default_amounts_by_charge": null,
+  "phone_call_rule": null,
+  "recording_police_consent": "one-party",
+  "expungement_window_years": "South Dakota uses sealing rather than full expungement. Records may be sealed after 1 year from arrest if no formal charging document was filed, or if dismissed before probable-cause determination.",
+  "misc_quirks": [
+    "South Dakota uses sealing under SDCL 23A-3-26 et seq. rather than expungement; sealing applies primarily to arrest records when charges were never filed or dismissed pre-probable-cause.",
+    "Counsel for indigent defendants is provided through county public-defender offices where available, or court-appointed private counsel; South Dakota has no statewide public-defender agency for trial-level representation.",
+    "SDCL 23A-43 expressly notes that information considered in bail proceedings need not conform to the rules of evidence."
+  ],
+  "source_urls": [
+    "https://sdlegislature.gov/Statutes/23A-43",
+    "https://law.justia.com/codes/south-dakota/title-23a/chapter-43/",
+    "https://law.justia.com/codes/south-dakota/title-23a/chapter-04/section-23a-4-3/",
+    "https://law.justia.com/codes/south-dakota/2010/title-23a/chapter-03/statute-23a-3-26/",
+    "https://sdlegislature.gov/Statutes/23A"
+  ],
+  "_unknown_fields": [
+    "indigency_threshold",
+    "bail_default_amounts_by_charge",
+    "phone_call_rule"
+  ]
+}

--- a/data/state-arrest-procedure/tn.json
+++ b/data/state-arrest-procedure/tn.json
@@ -1,0 +1,36 @@
+{
+  "state_code": "TN",
+  "state_name": "Tennessee",
+  "researched_at": "2026-04-28",
+  "first_appearance_window_hours": 48,
+  "pd_attach_trigger": "At initial appearance, after court-conducted indigency screening. Counsel is appointed under TCA § 40-14-202 and the Public Defenders Conference covers most judicial districts.",
+  "indigency_threshold": null,
+  "bail_types_allowed": [
+    "cash",
+    "surety",
+    "signature",
+    "personal_recognizance",
+    "property"
+  ],
+  "bail_default_amounts_by_charge": null,
+  "phone_call_rule": null,
+  "recording_police_consent": "one-party",
+  "expungement_window_years": "Dismissed, nolle-prossed, or acquitted charges are eligible for immediate expungement. Conviction expungement: most eligible misdemeanors and Class E felonies after 5 years from sentence completion (single-conviction limit, certain offenses excluded). Diversion completions under TCA § 40-35-313 also qualify.",
+  "misc_quirks": [
+    "TCA § 40-11-118 requires magistrates to consider specific factors when setting bail: length of community residence, employment history, financial condition, family ties, prior record, nature of offense, apparent probability of conviction, and danger to community.",
+    "Tennessee Rule 5 allows initial appearances to be conducted by audio-visual technology when a not-guilty plea is entered.",
+    "Tennessee expungement under TCA § 40-32-101 generally requires a single-conviction limit and excludes named offenses (certain DUIs, sex offenses, violent felonies)."
+  ],
+  "source_urls": [
+    "https://www.tncourts.gov/courts/rules-criminal-procedure/rules/rules-criminal-procedure-rules/rule-5-initial-appearance",
+    "https://law.justia.com/codes/tennessee/title-40/chapter-11/part-1/section-40-11-118/",
+    "https://codes.findlaw.com/tn/title-40-criminal-procedure/tn-code-sect-40-32-101/",
+    "https://law.justia.com/codes/tennessee/title-40/chapter-32/section-40-32-101/",
+    "https://www.tncourts.gov/expungements"
+  ],
+  "_unknown_fields": [
+    "indigency_threshold",
+    "bail_default_amounts_by_charge",
+    "phone_call_rule"
+  ]
+}

--- a/data/state-arrest-procedure/tx.json
+++ b/data/state-arrest-procedure/tx.json
@@ -1,0 +1,30 @@
+{
+  "state_code": "TX",
+  "state_name": "Texas",
+  "researched_at": "2026-04-28",
+  "first_appearance_window_hours": 48,
+  "pd_attach_trigger": "At magistration, the magistrate informs the defendant of the right to counsel and the right to appointed counsel if indigent. Counsel is appointed under Texas Code of Criminal Procedure Article 1.051.",
+  "indigency_threshold": null,
+  "bail_types_allowed": ["cash", "surety", "personal_recognizance", "property"],
+  "bail_default_amounts_by_charge": null,
+  "phone_call_rule": null,
+  "recording_police_consent": "one-party",
+  "expungement_window_years": "Texas uses two distinct remedies under Code of Criminal Procedure Chapter 55/55A (full expunction — records destroyed) and orders of nondisclosure under Government Code Chapter 411 (waiting periods 2–5 years for misdemeanor, 5+ years for eligible felonies). Acquittal, pardon, or charge dismissal generally support immediate expunction.",
+  "misc_quirks": [
+    "Senate Bill 6 (Damon Allen Act, 2021) added pretrial-risk-assessment requirements and barred personal-bond release for certain serious offenses without a magistrate hearing.",
+    "Texas distinguishes 'expunction' (CCP Chapter 55/55A — records destroyed) from 'orders of nondisclosure' (Gov. Code Chapter 411 — records sealed from most employers/landlords). Most diversion completions yield nondisclosure, not expunction.",
+    "Class C misdemeanor expunctions have concurrent jurisdiction in district court, municipal courts of record, and justice courts (H.B. 557, 2017)."
+  ],
+  "source_urls": [
+    "https://codes.findlaw.com/tx/code-of-criminal-procedure/crim-ptx-crim-pro-art-15-17/",
+    "https://statutes.capitol.texas.gov/Docs/CR/htm/CR.55.htm",
+    "https://statutes.capitol.texas.gov/Docs/CR/htm/CR.55A.htm",
+    "https://law.justia.com/codes/texas/2024/code-of-criminal-procedure/title-1/chapter-55/article-55-02/",
+    "https://www.tmcec.com/wp-content/uploads/2022/01/Bench_Book_-Chapter-18.pdf"
+  ],
+  "_unknown_fields": [
+    "indigency_threshold",
+    "bail_default_amounts_by_charge",
+    "phone_call_rule"
+  ]
+}

--- a/data/state-arrest-procedure/ut.json
+++ b/data/state-arrest-procedure/ut.json
@@ -1,0 +1,35 @@
+{
+  "state_code": "UT",
+  "state_name": "Utah",
+  "researched_at": "2026-04-28",
+  "first_appearance_window_hours": 48,
+  "pd_attach_trigger": "At initial appearance after court-conducted indigency screening. Counsel is appointed under Utah Code § 77-32 (now restated in § 78B-22). Utah Indigent Defense Commission funds and oversees county indigent-defense systems.",
+  "indigency_threshold": null,
+  "bail_types_allowed": [
+    "cash",
+    "surety",
+    "personal_recognizance",
+    "property"
+  ],
+  "bail_default_amounts_by_charge": null,
+  "phone_call_rule": null,
+  "recording_police_consent": "one-party",
+  "expungement_window_years": "Varies by offense class — misdemeanor B 4 years after sentence end; misdemeanor A 5 years; Class A misdemeanor / felony 7 years; second-degree felony 10 years. Acquittals, dismissals, and successful pleas in abeyance yield immediate expungement. Utah Clean Slate Act (HB 35, 2019) authorizes automatic expungement of qualifying minor records.",
+  "misc_quirks": [
+    "Utah Clean Slate Act (HB 35, 2019, effective May 2024) authorizes automatic expungement of qualifying minor records without petition.",
+    "Utah Code § 77-20 (post-2020 reform) requires the court to consider the individual's ability to pay and set the lowest bail amount reasonably calculated to ensure appearance.",
+    "Utah uses 'pleas in abeyance' — successful completion of a problem-solving-court program can yield case dismissal plus expungement under URCRP Rule 4-403."
+  ],
+  "source_urls": [
+    "https://legacy.utcourts.gov/rules/view.php?type=urcrp&rule=7",
+    "https://le.utah.gov/xcode/Title77/Chapter20/77-20-S205.html",
+    "https://le.utah.gov/interim/2021/pdf/00002072.pdf",
+    "https://law.justia.com/codes/utah/2020/title-77/chapter-20/section-1/",
+    "https://codes.findlaw.com/ut/title-77-utah-code-of-criminal-procedure/ut-code-sect-77-2a-3.html"
+  ],
+  "_unknown_fields": [
+    "indigency_threshold",
+    "bail_default_amounts_by_charge",
+    "phone_call_rule"
+  ]
+}

--- a/data/state-arrest-procedure/va.json
+++ b/data/state-arrest-procedure/va.json
@@ -1,0 +1,30 @@
+{
+  "state_code": "VA",
+  "state_name": "Virginia",
+  "researched_at": "2026-04-28",
+  "first_appearance_window_hours": 72,
+  "pd_attach_trigger": "At arraignment or first appearance, after court-conducted indigency screening. Counsel is appointed under VA Code § 19.2-159; the Virginia Indigent Defense Commission and county public-defender offices provide counsel.",
+  "indigency_threshold": null,
+  "bail_types_allowed": ["cash", "surety", "personal_recognizance", "property"],
+  "bail_default_amounts_by_charge": null,
+  "phone_call_rule": null,
+  "recording_police_consent": "one-party",
+  "expungement_window_years": "Under VA Code § 19.2-392.2, expungement is available when a charge is dismissed, nolle-prossed, or results in acquittal — petition filed in the circuit court of disposition. Beginning July 1, 2026, Virginia's automatic-sealing scheme under § 19.2-392.7 et seq. takes effect for qualifying offenses (most misdemeanors after 7 years, certain felonies after 10 years). Marijuana former offenses qualify for automatic expungement under § 19.2-392.2:1.",
+  "misc_quirks": [
+    "Virginia is in transition: the new automatic-sealing scheme under VA Code § 19.2-392.7 et seq. takes effect July 1, 2026, supplementing (not replacing) traditional § 19.2-392.2 petition-based expungement.",
+    "Virginia's old marijuana offenses qualify for automatic expungement under § 19.2-392.2:1 (added by 2021 special session).",
+    "Virginia courts use the term 'magistrate' for the initial-appearance officer who sets bail; magistrates are not judges and operate under VA Code § 19.2-44 et seq."
+  ],
+  "source_urls": [
+    "https://law.lis.virginia.gov/vacode/title19.2/chapter23.1/section19.2-392.2/",
+    "https://law.lis.virginia.gov/vacodefull/title19.2/chapter23.1/",
+    "https://law.lis.virginia.gov/vacodefull/title19.2/chapter23.2/",
+    "https://law.justia.com/codes/virginia/2022/title-19-2/chapter-23-1/section-19-2-392-2-1/",
+    "https://vacode.org/19.2-392.2/"
+  ],
+  "_unknown_fields": [
+    "indigency_threshold",
+    "bail_default_amounts_by_charge",
+    "phone_call_rule"
+  ]
+}

--- a/data/state-arrest-procedure/vt.json
+++ b/data/state-arrest-procedure/vt.json
@@ -1,0 +1,34 @@
+{
+  "state_code": "VT",
+  "state_name": "Vermont",
+  "researched_at": "2026-04-28",
+
+  "first_appearance_window_hours": 48,
+  "pd_attach_trigger": "At arraignment, after court-conducted indigency screening. Counsel is appointed under 13 V.S.A. § 5231 et seq.; the Office of the Defender General provides counsel through county-based public-defender offices.",
+  "indigency_threshold": null,
+  "bail_types_allowed": ["cash", "surety", "personal_recognizance", "signature"],
+  "bail_default_amounts_by_charge": null,
+  "phone_call_rule": null,
+  "recording_police_consent": "one-party",
+  "expungement_window_years": "Major revision effective July 1, 2025: the term 'expungement' was largely dropped from 13 V.S.A. ch. 230 in favor of 'sealing.' Sealing now applies to most misdemeanors (except 'listed crimes' involving violence and sexual misconduct) and non-violent felonies. Waiting periods vary — most non-conviction records and qualifying misdemeanors after waiting periods set in § 7602 et seq.",
+
+  "misc_quirks": [
+    "Vermont sealing law was significantly revised effective July 1, 2025 — the term 'expungement' was largely replaced with 'sealing,' and qualifying-crime categories were expanded to include most non-violent felonies.",
+    "Vermont strongly favors release on personal recognizance under 13 V.S.A. § 7554; cash and surety bail are statutorily disfavored and require finding that no less-restrictive condition will reasonably ensure appearance.",
+    "Vermont has no comprehensive wiretap chapter on the model of most states; participant recording posture is set by case law (State v. Geraw)."
+  ],
+
+  "source_urls": [
+    "https://legislature.vermont.gov/statutes/section/13/229/07553",
+    "https://legislature.vermont.gov/statutes/section/13/230/07601",
+    "https://law.justia.com/codes/vermont/title-13/chapter-229/section-7554/",
+    "https://www.vermontjudiciary.org/criminal/expungement",
+    "https://legislature.vermont.gov/statutes/fullchapter/13/230"
+  ],
+
+  "_unknown_fields": [
+    "indigency_threshold",
+    "bail_default_amounts_by_charge",
+    "phone_call_rule"
+  ]
+}

--- a/data/state-arrest-procedure/wa.json
+++ b/data/state-arrest-procedure/wa.json
@@ -1,0 +1,35 @@
+{
+  "state_code": "WA",
+  "state_name": "Washington",
+  "researched_at": "2026-04-28",
+  "first_appearance_window_hours": 48,
+  "pd_attach_trigger": "At preliminary appearance, after court-conducted indigency screening under CrR 3.1. Public-defender services are county-organized, with state oversight through the Washington State Office of Public Defense (RCW 2.70).",
+  "indigency_threshold": null,
+  "bail_types_allowed": [
+    "cash",
+    "surety",
+    "personal_recognizance",
+    "property"
+  ],
+  "bail_default_amounts_by_charge": null,
+  "phone_call_rule": null,
+  "recording_police_consent": "all-party",
+  "expungement_window_years": "Washington uses 'vacation' rather than expungement. Under RCW 9.94A.640 (felony) and RCW 9.96.060 (misdemeanor), a person discharged after sentence completion may petition for vacation of the conviction record. Misdemeanor: 3 years (most), 5 years (DUI). Felony: 5 years (Class C), 10 years (Class B), Class A felonies generally not vacatable. Acquitted or dismissed charges may be eligible for non-conviction-record sealing.",
+  "misc_quirks": [
+    "Washington uses 'vacation' (RCW 9.94A.640 / 9.96.060) rather than expungement; the conviction is set aside but a record of the case may persist in court archives.",
+    "Washington RCW 9.73.030 is one of the strictest two-party-consent recording statutes in the country — even short on-call recordings of customer-service representatives have produced civil claims.",
+    "Public-defender systems are county-organized under RCW 10.101 with state oversight through RCW 2.70 (Office of Public Defense)."
+  ],
+  "source_urls": [
+    "https://www.courts.wa.gov/court_rules/pdf/CrR/SUP_CrR_03_02_00.pdf",
+    "https://www.courts.wa.gov/court_rules/?fa=court_rules.display&group=sup&set=CrR&ruleid=supCrR3.2",
+    "https://app.leg.wa.gov/RCW/default.aspx?cite=9.94a.640",
+    "https://app.leg.wa.gov/rcw/default.aspx?cite=9.96.060",
+    "https://www.washingtonlawhelp.org/en/vacate-felony-conviction"
+  ],
+  "_unknown_fields": [
+    "indigency_threshold",
+    "bail_default_amounts_by_charge",
+    "phone_call_rule"
+  ]
+}

--- a/data/state-arrest-procedure/wi.json
+++ b/data/state-arrest-procedure/wi.json
@@ -1,0 +1,36 @@
+{
+  "state_code": "WI",
+  "state_name": "Wisconsin",
+  "researched_at": "2026-04-28",
+
+  "first_appearance_window_hours": 48,
+  "pd_attach_trigger": "At initial appearance, after court-conducted indigency screening. Counsel is appointed under Wis. Stat. § 977; the Wisconsin State Public Defender operates the statewide trial-level indigent-defense system.",
+  "indigency_threshold": "Wisconsin State Public Defender uses the income guidelines in Wis. Stat. § 977.075 — the indigency standard is tied to a percentage of federal poverty guidelines, with the specific thresholds reviewed periodically by the SPD Board.",
+  "bail_types_allowed": ["cash", "surety", "personal_recognizance", "signature"],
+  "bail_default_amounts_by_charge": null,
+  "phone_call_rule": null,
+  "recording_police_consent": "one-party",
+  "expungement_window_years": "Under Wis. Stat. § 973.015, expungement is available only at sentencing — the court may order expungement upon successful completion of the sentence if the defendant was under 25 at the time of the offense AND the maximum penalty was 6 years or less. Wisconsin's expungement statute is unusually narrow: there is no post-sentence petition pathway for adults outside the under-25 window.",
+
+  "misc_quirks": [
+    "Wisconsin Wis. Stat. § 973.015 is unusual: expungement must be ordered at sentencing for defendants under 25 with maximum-penalty-≤6-years offenses; there is no general post-sentence petition pathway for adults.",
+    "Wisconsin strongly favors signature and PR bonds under Wis. Stat. ch. 969; cash and surety are statutorily disfavored when less-restrictive conditions will reasonably ensure appearance.",
+    "Wisconsin State Public Defender (Wis. Stat. § 977) operates a statewide trial-level indigent-defense system, distinct from county-organized systems used in many neighboring states."
+  ],
+
+  "source_urls": [
+    "https://docs.legis.wisconsin.gov/statutes/statutes/969",
+    "https://docs.legis.wisconsin.gov/statutes/statutes/970/01",
+    "https://docs.legis.wisconsin.gov/statutes/statutes/973/015",
+    "https://docs.legis.wisconsin.gov/statutes/statutes/977",
+    "https://docs.legis.wisconsin.gov/statutes/statutes/977/075",
+    "https://docs.legis.wisconsin.gov/statutes/statutes/968/31",
+    "https://law.justia.com/codes/wisconsin/chapter-968/section-968-31/",
+    "https://wilawlibrary.gov/topics/justice/crimlaw/arrest.php"
+  ],
+
+  "_unknown_fields": [
+    "bail_default_amounts_by_charge",
+    "phone_call_rule"
+  ]
+}

--- a/data/state-arrest-procedure/wv.json
+++ b/data/state-arrest-procedure/wv.json
@@ -1,0 +1,34 @@
+{
+  "state_code": "WV",
+  "state_name": "West Virginia",
+  "researched_at": "2026-04-28",
+  "first_appearance_window_hours": 48,
+  "pd_attach_trigger": "At initial appearance, after court-conducted indigency screening. Counsel is appointed under WV Code § 29-21 et seq.; West Virginia Public Defender Services administers a statewide indigent-defense program.",
+  "indigency_threshold": null,
+  "bail_types_allowed": [
+    "cash",
+    "surety",
+    "personal_recognizance",
+    "property"
+  ],
+  "bail_default_amounts_by_charge": "WV Code § 62-1C-2 caps cash bail in misdemeanor cases at three times the maximum statutory fine for the offense (or three times the highest maximum fine when multiple misdemeanors are charged).",
+  "phone_call_rule": null,
+  "recording_police_consent": "one-party",
+  "expungement_window_years": "Misdemeanor: typically 1 year after sentence completion. Non-violent felony: 5 years after sentence completion. WV Code § 61-11-26 covers petitions for offenses arising from the same transaction or series of transactions. WV Code § 61-11-26a covers expungement after approved treatment / job program completion.",
+  "misc_quirks": [
+    "West Virginia caps misdemeanor cash bail at three times the maximum statutory fine (WV Code § 62-1C-2) — an explicit statutory cap rare among states.",
+    "West Virginia non-violent-felony expungement under WV Code § 61-11-26 covers offenses 'arising from the same transaction or series of transactions,' allowing multiple counts from one event to be packaged into a single petition.",
+    "WV Code § 61-11-26a authorizes expungement after successful completion of an approved treatment or recovery and job program — a recovery-based pathway distinct from waiting-period expungement."
+  ],
+  "source_urls": [
+    "https://code.wvlegislature.gov/62-1C-1/",
+    "https://code.wvlegislature.gov/62-1C-2/",
+    "https://code.wvlegislature.gov/62-1D/",
+    "https://codes.findlaw.com/wv/chapter-61-crimes-and-their-punishment/wv-code-sect-61-11-26.html",
+    "https://law.justia.com/codes/west-virginia/chapter-61/article-11/section-61-11-26a/"
+  ],
+  "_unknown_fields": [
+    "indigency_threshold",
+    "phone_call_rule"
+  ]
+}

--- a/data/state-arrest-procedure/wy.json
+++ b/data/state-arrest-procedure/wy.json
@@ -1,0 +1,35 @@
+{
+  "state_code": "WY",
+  "state_name": "Wyoming",
+  "researched_at": "2026-04-28",
+  "first_appearance_window_hours": 48,
+  "pd_attach_trigger": "At initial appearance, after court-conducted indigency screening. Counsel is appointed under Wyo. Stat. § 7-6 et seq.; the Wyoming Office of the State Public Defender administers a statewide indigent-defense program.",
+  "indigency_threshold": null,
+  "bail_types_allowed": [
+    "cash",
+    "surety",
+    "personal_recognizance",
+    "property"
+  ],
+  "bail_default_amounts_by_charge": null,
+  "phone_call_rule": null,
+  "recording_police_consent": "one-party",
+  "expungement_window_years": "Under Wyo. Stat. § 7-13-1501, a person convicted of a non-firearm misdemeanor may petition the convicting court for expungement. Waiting periods: at least 5 years after sentence completion for non-status offenses, at least 1 year for status offenses. The misdemeanor must not have involved use or attempted use of a firearm. Filing fee is $100; the prosecuting attorney has 30 days to object.",
+  "misc_quirks": [
+    "Wyoming expungement under Wyo. Stat. § 7-13-1501 categorically excludes any misdemeanor that involved the use or attempted use of a firearm, with no waiting-period workaround.",
+    "Wyoming requires a $100 filing fee for misdemeanor-expungement petitions and gives the prosecuting attorney 30 days to object before the court may summarily enter an order.",
+    "Wyoming's statewide indigent-defense system (Wyo. Stat. § 7-6-101 et seq.) is operated by the Office of the State Public Defender, distinct from county-organized PD systems in many western states."
+  ],
+  "source_urls": [
+    "https://www.wyocourts.gov/app/uploads/2025/01/Wyoming-Rules-of-Criminal-Procedure.pdf",
+    "https://law.justia.com/codes/wyoming/title-7/chapter-13/article-15/section-7-13-1501/",
+    "https://codes.findlaw.com/wy/title-7-criminal-procedure/wy-st-sect-7-13-1501.html",
+    "https://www.wyocourts.gov/legal-help-by-topic/expungements/",
+    "https://wyoleg.gov/statutes/compress/title07.pdf"
+  ],
+  "_unknown_fields": [
+    "indigency_threshold",
+    "bail_default_amounts_by_charge",
+    "phone_call_rule"
+  ]
+}

--- a/docs/plans/2026-04-27-arrest-survival-kit-v3.md
+++ b/docs/plans/2026-04-27-arrest-survival-kit-v3.md
@@ -1,0 +1,70 @@
+# Plan: Arrest Survival Kit v3 — replace agency-incident dump with state procedural data
+
+> User-provided spec, saved here per LARGE_BUILD plan-file requirement.
+> Worktree: `.claude/worktrees/asks-v3` on branch `feat/arrest-survival-kit-v3` from `origin/master`.
+
+## Why
+
+Current ASK ($47, Tier 9, live) leads with top-20 state agency use-of-force counts and a wandering-officer aggregate. Both are sociology, not actionable, for a defendant arrested in the last 72 hours. Crisis-buyers need what happens next in their state: bail process, PD-attach timing, first-appearance window, indigency threshold, recording-police law, expungement window, bond types, phone-call rule.
+
+Repositioning: from "First-72-hours checklist tuned to your state" to "What happens to you in $STATE in the next 72 hours."
+
+## Files to CREATE
+
+### Schema + loader
+- `src/lib/state-arrest-procedure/types.ts` — `StateArrestProcedure` interface plus `BailType` and `RecordingPoliceConsent` enums
+- `src/lib/state-arrest-procedure/load.ts` — `getStateArrestProcedure(code)`, `listStateArrestProcedures()`, `validateStateArrestProcedure(raw, filename)`, `clearStateArrestProcedureCache()`
+- `data/state-arrest-procedure/_README.md` — schema doc + research methodology + UPL + no-hallucination rule
+- `data/state-arrest-procedure/<lowercase-code>.json` — one file per state (50 total)
+
+### Tests
+- `tests/state-arrest-procedure-load.test.ts` — loader validation: rejects missing source_urls when fields populated, accepts a valid file, lookup by code is case-insensitive, _unknown_fields invariant rejects mislabeled fields, recording_police_consent enum validation, bail_types_allowed enum validation
+
+## Files to MODIFY
+
+- `src/lib/defense-intelligence/query.ts` — `queryArrestSurvivalKit`: load state procedure data via loader; keep agency_incidents and officer_external_intel queries (defense-in-depth) but expose them as a smaller "regional context" block on the returned shape
+- `src/lib/tier9-reports/render.ts` — `renderArrestSurvivalKit`: lead with procedural facts (first-appearance window, phone-call rule, PD attach, indigency, bail types, recording, expungement); demote agency/officer to bottom; cite every legal claim with source_url visibly
+- `src/app/arrest-survival-kit/page.tsx` — hero + value props + sample table + trust copy + FAQ
+- `src/lib/products.ts` `STANDALONE_PRODUCTS["arrest-survival-kit"]` — description
+- `src/lib/tiers.ts` `TIER_CORE["arrest-survival-kit"]` — deliveryDetail
+- `src/lib/drip-emails.ts` — 3 ASK drip emails (delivery, day-3, day-7 upsell) — subject + body
+- `ARCHITECTURE.md` — add a Component Map row for state-arrest-procedure subsystem if it materially changes the system map
+
+## Files NOT touched
+- Stripe price IDs, `tiers.ts.live`, `products.ts.isActive`
+- URL slug `/arrest-survival-kit`
+- DB tier_slugs and migrations
+- `content/blog/`, `scripts/blog-pipeline/`, `scripts/qa-existing-post*` (sibling-session forbidden zones)
+
+## Numbered tasks
+
+1. Write `types.ts` with `StateArrestProcedure` interface and the two enums.
+2. Write `load.ts` with validation, caching, and lookup.
+3. Write `tests/state-arrest-procedure-load.test.ts` with positive and negative fixtures.
+4. Write `data/state-arrest-procedure/_README.md` documenting schema and research methodology.
+5. Dispatch 50 state research agents (Opus, batches of 5) — each WebFetches authoritative sources, writes one JSON file with full source_urls and explicit `_unknown_fields`.
+6. Refactor `queryArrestSurvivalKit` to read state procedure data via the loader; keep agency/officer block as `regionalContext`.
+7. Refactor `renderArrestSurvivalKit` — procedural-first sections, every claim links to source_url.
+8. Update landing page hero, features, FAQ, sample-table copy to procedural framing.
+9. Update `STANDALONE_PRODUCTS["arrest-survival-kit"].description` and `TIER_CORE` slot deliveryDetail.
+10. Update 3 ASK drip emails to procedural framing.
+11. Run `npx tsc --noEmit --skipLibCheck` — green.
+12. Run `npx vitest run --reporter=basic` — green.
+13. Commit + push from worktree, open PR via `gh pr create`.
+
+## Acceptance
+
+- 50 of 50 state files written and validated by loader.
+- Every customer-facing claim in render output links to its source_url.
+- Render output contains no UPL phrasing (no "you should" directive language, no "verify with attorney" framing).
+- `tsc` clean, `vitest` clean.
+- PR open, body includes any state where research came up empty.
+
+## Hard constraints
+
+- Worktree-only. No edits in parent checkout.
+- No paid APIs. WebFetch and WebSearch only. Wikipedia is a discovery aid; the upstream URL it cites is the authoritative source.
+- `~/.claude/rules/no-hallucinated-legal-data.md`: every populated field needs a verification URL; null + `_unknown_fields` is the answer when source is missing.
+- `~/.claude/rules/never-cold-email-from-primary-domain.md`: no email sends from this work.
+- UPL: information not advice. Mercer voice. No directive language.
+- Brand: amber + navy on black, Playfair + Lato.

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "next": "^16.2.2",
         "next-mdx-remote": "^6.0.0",
         "node-html-parser": "^7.1.0",
+        "pdf-parse": "^2.4.5",
         "pg-copy-streams": "^7.0.0",
         "qrcode": "^1.5.4",
         "react": "19.2.3",
@@ -49,7 +50,7 @@
         "tailwindcss": "^4",
         "typescript": "^5",
         "typescript-eslint": "^8.58.0",
-        "vitest": "^4.1.5"
+        "vitest": "^4.1.2"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/src/app/arrest-survival-kit/page.tsx
+++ b/src/app/arrest-survival-kit/page.tsx
@@ -18,13 +18,13 @@ export function generateMetadata(): Metadata {
   return {
     title: `Arrest Survival Kit, ${TIER_CORE["arrest-survival-kit"].priceDisplay} | ImNotAnAttorney`,
     description:
-      "Know your rights before they read you yours. State-specific arrest procedures, first-48-hours action plan, bail hearing prep, and agency incident data.",
+      "What happens to you in the next 72 hours after arrest in your state. First-appearance window, public-defender attach, bail types, phone-call rule, recording-police law, expungement window. Sourced from state statutes and court rules.",
     alternates: { canonical: `${SITE_URL}/arrest-survival-kit` },
     openGraph: {
       title:
-        "Arrest Survival Kit, Know Your Rights Before They Read You Yours",
+        "Arrest Survival Kit, What Happens Next in Your State",
       description:
-        "State-specific rights checklist, first-48-hours action plan, bail hearing preparation, and agency incident data. Instant delivery.",
+        "Your state's first-appearance window, PD-attach trigger, bail types, phone-call rule, recording-police law, and expungement window. Sourced from state statutes and court rules. Instant delivery.",
       url: `${SITE_URL}/arrest-survival-kit`,
     },
   };
@@ -35,35 +35,36 @@ export function generateMetadata(): Metadata {
 /* ------------------------------------------------------------------ */
 
 const FEATURES = [
-  "Your constitutional rights during arrest, in plain English",
-  "State-specific arrest procedure rules for your jurisdiction",
-  "First 48 hours action timeline, what to do and when",
-  "Bail hearing preparation checklist",
-  "Agency incident data for your arresting agency (where available)",
-  "What NOT to say, the 5 statements that hurt defendants most",
-  "Upsell path to Officer Background Check for deeper analysis",
+  "First-appearance window in your state, in hours, with the rule that sets it",
+  "When the public defender attaches, and the indigency standard that gates eligibility",
+  "Bail / release types your state allows, with the statute that authorizes each",
+  "Phone-call rule, the statutory or court-rule right to contact a person after booking",
+  "Recording-police consent rule for your state, one-party / all-party / restricted",
+  "Expungement or sealing window, with the waiting period and statute citation",
+  "1-3 state-specific quirks the rest of the courtroom already knows",
+  "Universal constitutional rights checklist + first-72-hours timeline + what NOT to say",
 ] as const;
 
 const SAMPLE_ROWS = [
   {
-    category: "Rights covered",
-    details: "12 constitutional protections",
-    source: "Federal + State",
+    category: "First-appearance window",
+    details: "24 hours from arrest",
+    source: "Fla. R. Crim. P. 3.130",
   },
   {
-    category: "State-specific rules",
-    details: "8 FL arrest procedures",
-    source: "FL Legislature",
+    category: "Public defender attaches",
+    details: "At first appearance",
+    source: "Fla. R. Crim. P. 3.130",
   },
   {
-    category: "First 48 hours",
-    details: "7-step action plan",
-    source: "Defense methodology",
+    category: "Indigency standard",
+    details: "200% of federal poverty guidelines",
+    source: "Fla. Stat. \u00a7 27.52",
   },
   {
-    category: "Agency incidents",
-    details: "4 reported (2019\u20132025)",
-    source: "Fatal Encounters",
+    category: "Recording police",
+    details: "All-party consent",
+    source: "Fla. Stat. \u00a7 934.03",
   },
 ] as const;
 
@@ -71,33 +72,33 @@ const FAQ_ITEMS = [
   {
     question: "What\u2019s in the Arrest Survival Kit?",
     answer:
-      "A state-specific know-your-rights checklist written in plain English, a step-by-step action plan for the first 48 hours after arrest, bail hearing preparation materials, and agency incident data for your arresting agency (where available). Every data point includes a source.",
+      "Your state\u2019s procedural facts: first-appearance window, when the public defender attaches, indigency standard, bail / release types, the phone-call rule, recording-police consent, and expungement window. Plus the universal rights checklist, first-72-hours timeline, and a list of statements that hurt defendants. Every state-level fact links to its source statute or court rule.",
   },
   {
     question: "I\u2019ve already been arrested \u2014 is this still useful?",
     answer:
-      "Yes. Most of the kit\u2019s value is in what happens AFTER arrest \u2014 the first 48 hours, your bail hearing, and knowing what statements can hurt your case going forward. The rights checklist also helps you identify whether your rights were violated during the arrest itself.",
+      "Yes. The kit is built for the window AFTER arrest. The procedural section maps what the legal system will do next in your state. The rights checklist helps you read backward through the arrest itself; the first-72-hours timeline maps the rest of the window forward.",
   },
   {
     question: "Is this legal advice?",
     answer:
-      "No. This is legal INFORMATION \u2014 verified rights and procedures from official sources. Decisions about how to use this information stay with you.",
+      "No. This is legal information drawn from state statutes, court rules, and public-defender / state-bar publications. Every fact links to its source. Decisions about how to use this information stay with you and the people you bring into your case.",
   },
   {
     question: "How is it delivered?",
     answer:
-      "On purchase. Generated on demand for your state and sent to your inbox.",
+      "On purchase. Generated on demand for your state and sent to your inbox within about 60 seconds.",
   },
   {
-    question: "What if you don\u2019t have data for my agency?",
+    question: "What if my state\u2019s data is incomplete?",
     answer:
-      "The rights checklist and action plan are available for all 50 states. Agency incident data depends on public records availability \u2014 if we don\u2019t have data for your specific agency, you\u2019ll still receive everything else. You\u2019ll see coverage details before checkout.",
+      "Some procedural facts are county-by-county rather than statewide \u2014 published bail schedules are the most common gap. When that happens, the report flags the gap explicitly rather than guessing, and the rest of the section reflects what the state-level law does establish. The universal rights checklist and first-72-hours timeline apply in every state.",
   },
   {
     question:
       "How is this different from the Officer Background Check?",
     answer:
-      "The Arrest Survival Kit covers YOUR rights and what to do in the first 48 hours. The Officer Background Check (\u002497) digs into the arresting officer\u2019s track record \u2014 cross-case reliability, testimony challenges, and procedural violations. They complement each other: the Kit tells you what to do, the Background Check tells you who you\u2019re dealing with.",
+      "The Arrest Survival Kit covers what the legal system does next — the procedural map for your state. The Officer Background Check (\u002497) digs into the arresting officer\u2019s track record across cases. They complement each other: the Kit shows you the procedural floor, the Background Check shows you who\u2019s standing on the other side of the courtroom.",
   },
 ] as const;
 
@@ -139,22 +140,25 @@ export default function ArrestSurvivalKitPage() {
           </p>
 
           <p className="mb-6 text-base leading-relaxed text-zinc-400">
-            Most defendants don&rsquo;t know what to say &mdash; or what NOT to
-            say &mdash; in the first 48 hours after arrest. That silence costs
-            them. This kit makes sure it doesn&rsquo;t cost you.
+            Everyone in the courtroom &mdash; judge, prosecutor, defense
+            attorney &mdash; already knows what happens next in your state.
+            You&rsquo;re the only stranger in the room. This kit closes that
+            gap.
           </p>
 
           <h1
             id="hero-heading"
             className="font-display mt-4 text-4xl font-extrabold leading-tight text-white sm:text-5xl"
           >
-            Know Your Rights Before They Read You Yours
+            What Happens to You in the Next 72 Hours
           </h1>
 
           <p className="mt-4 text-lg text-zinc-400">
-            Your state-specific rights checklist, first-48-hours action plan,
-            and bail hearing preparation &mdash; delivered to your inbox on
-            purchase.
+            Your state&rsquo;s first-appearance window, when the public
+            defender attaches, bail / release types, the phone-call rule,
+            recording-police consent, and the expungement window. Sourced
+            from state statutes and court rules. Delivered to your inbox in
+            about 60 seconds.
           </p>
 
           <p className="mt-6 text-4xl font-extrabold text-amber-400">
@@ -163,11 +167,11 @@ export default function ArrestSurvivalKitPage() {
 
           <p className="mt-2 text-sm text-zinc-400">
             Less than a single hour in a holding cell feels like &mdash; for
-            information that could change every hour after it.
+            the procedural map of the next three days.
           </p>
 
           <p className="mt-2 text-sm text-zinc-300">
-            State-specific data from verified legal sources
+            Every fact links to its source statute or court rule
           </p>
 
           <div className="mt-6">
@@ -218,7 +222,7 @@ export default function ArrestSurvivalKitPage() {
           <div className="mt-8 overflow-x-auto rounded-lg border border-zinc-700">
             <table className="w-full text-left text-sm">
               <caption className="sr-only">
-                Sample arrest survival data &mdash; Pinellas County, FL
+                Sample arrest-survival procedural data &mdash; Florida
               </caption>
               <thead className="border-b border-zinc-700 bg-zinc-900">
                 <tr>
@@ -272,17 +276,17 @@ export default function ArrestSurvivalKitPage() {
           </h2>
 
           <p className="mt-4 text-zinc-400">
-            Every right listed in your kit comes from the actual text of your
-            state&rsquo;s statutes and the U.S. Constitution. No summaries from
-            unnamed sources. No guesswork. Every data point traces back to a
-            real source you can check yourself.
+            Every procedural fact comes from the actual text of your state&rsquo;s
+            statutes, court rules, and public-defender or state-bar
+            publications. No summaries from unnamed sources. No guesswork.
+            Every line links to a source you can check yourself.
           </p>
 
           <p className="mt-3 text-sm text-zinc-400">
-            Agency incident data compiled from Fatal Encounters and verified
-            public records. State-specific arrest procedures sourced from
-            official state legislature publications. Constitutional protections
-            referenced directly from federal and state law.
+            When a fact is genuinely county-level rather than statewide, the
+            report flags the gap explicitly &mdash; we don&rsquo;t fill it
+            with a guess. Constitutional protections reference federal and
+            state law directly.
           </p>
 
           <div className="mt-8">
@@ -319,10 +323,10 @@ export default function ArrestSurvivalKitPage() {
           </h2>
 
           <p className="mt-4 text-zinc-400">
-            The system doesn&rsquo;t wait for you to figure it out. Hearings get
-            scheduled, statements get used, and mistakes in the first 48 hours
-            follow you through trial. Know what to do before you&rsquo;re asked
-            to do it.
+            The system doesn&rsquo;t wait for you to figure it out. The
+            first-appearance window starts the moment you&rsquo;re booked.
+            Bail gets set. Statements get used. The kit gives you the
+            procedural map before you need it.
           </p>
 
           <div className="mt-6">
@@ -374,7 +378,7 @@ export default function ArrestSurvivalKitPage() {
             "@type": "Product",
             name: "Arrest Survival Kit",
             description:
-              "State-specific know-your-rights checklist, first-48-hours action plan, bail hearing preparation, and agency incident data. Instant delivery.",
+              "What happens to you in the next 72 hours after arrest in your state. First-appearance window, public-defender attach, bail / release types, phone-call rule, recording-police consent, and expungement window. Sourced from state statutes and court rules. Instant delivery.",
             url: `${SITE_URL}/arrest-survival-kit`,
             brand: {
               "@type": "Organization",

--- a/src/lib/defense-intelligence/query.ts
+++ b/src/lib/defense-intelligence/query.ts
@@ -16,6 +16,8 @@
  */
 
 import { createAdminClient } from "@/lib/supabase/admin";
+import { getStateArrestProcedure } from "@/lib/state-arrest-procedure/load";
+import type { StateArrestProcedure } from "@/lib/state-arrest-procedure/types";
 
 // Re-export existing Tier 9 types and functions (no breaking changes)
 export {
@@ -461,6 +463,14 @@ export type OfficerStatsStatus = "ok" | "no_officers" | "data_unavailable";
 export interface ArrestSurvivalKitData {
   stateName: string;
   stateCode: string;
+  /**
+   * v3 (2026-04-28): per-state arrest-procedure data — the headline content
+   * of the report. `null` when this state's JSON has not been researched yet
+   * — renderer falls back to a "data unavailable" message for procedure
+   * sections while still rendering universal rights + first-72-hours +
+   * regional context (agency/officer) below.
+   */
+  stateProcedure: StateArrestProcedure | null;
   agencyIncidents: Array<{
     agency: string;
     use_of_force_count: number;
@@ -599,9 +609,15 @@ export async function queryArrestSurvivalKit(
   const agencies = new Set(officers.map((o) => o.agency as string).filter(Boolean));
   const wanderingCount = officers.filter((o) => o.npi_is_wandering_officer === true).length;
 
+  // v3 (2026-04-28): load per-state procedural data — headline content.
+  // Loader returns `null` when the state's JSON file is missing; renderer
+  // shows a sensible "data unavailable" fallback rather than crashing.
+  const stateProcedure = getStateArrestProcedure(upperState);
+
   return {
     stateName,
     stateCode: upperState,
+    stateProcedure,
     agencyIncidents,
     agencyIncidentsStatus,
     agencyIncidentsStateCount,

--- a/src/lib/drip-emails.ts
+++ b/src/lib/drip-emails.ts
@@ -2193,17 +2193,17 @@ export const POST_PURCHASE_EMAILS: DripEmail[] = [
     key: "post_arrest_survival_kit_delivery",
     delayDays: 0,
     tier: "arrest-survival-kit",
-    subject: "Your Arrest Survival Kit is ready, here's how to use it",
+    subject: "Your Arrest Survival Kit is ready, here's how to read it",
     html: `
       <h1 style="color: #F59E0B;">Your Arrest Survival Kit Is Ready</h1>
-      <p>Your kit is a first-72-hours checklist tuned to your state, the actions, deadlines, and pitfalls that matter most in the window right after arrest. Here's how to use it:</p>
+      <p>Your kit leads with the procedural map for your state &mdash; the first-appearance window, when the public defender attaches, the bail / release types your state allows, the phone-call rule, recording-police consent, and the expungement window. Every line links to its source statute or court rule. Here's how to read it:</p>
       <ol>
-        <li><strong style="color: white;">Read the 72-hour checklist top to bottom once</strong>, every item matters and most have a deadline.</li>
-        <li><strong style="color: white;">Note the state-specific deadlines</strong>, DMV windows, evidence preservation, hearing dates that vary by jurisdiction.</li>
-        <li><strong style="color: white;">Walk the "what to say and not say" section</strong>, what you say in the first 72 hours often shapes the rest of the case.</li>
+        <li><strong style="color: white;">Start with the procedure table</strong>. The hours, deadlines, and statutes are what the rest of the courtroom already knows.</li>
+        <li><strong style="color: white;">Walk the rights checklist + first-72-hours timeline</strong>. Universal across states &mdash; a sanity check on what's been said and done so far.</li>
+        <li><strong style="color: white;">Read the "what NOT to say" list</strong>. Statements made in the first 72 hours often shape the rest of the case.</li>
       </ol>
       <p style="margin-top: 24px; padding: 16px; border-left: 3px solid #F59E0B; background: #1C1917;">
-        <strong style="color: white;">This kit provides legal information, not legal advice.</strong> If you have an attorney, share the checklist and walk through it together.
+        <strong style="color: white;">This kit provides legal information, not legal advice.</strong> If you have an attorney, share the procedure section and walk through it together.
       </p>
     `,
   },
@@ -2214,13 +2214,13 @@ export const POST_PURCHASE_EMAILS: DripEmail[] = [
     subject: "Three days in, questions worth bringing to your attorney",
     html: `
       <h1 style="color: #F59E0B;">Questions Worth Bringing to Your Next Meeting</h1>
-      <p>Three days into the survival window. Five questions drawn from the kit worth raising at your first or next attorney meeting:</p>
+      <p>Three days into the procedural window. Five questions drawn from the kit worth raising at your first or next attorney meeting:</p>
       <ul style="padding-left: 20px; color: #D4D4D8;">
-        <li>Are there state-specific deadlines from the 72-hour checklist I should be acting on right now, before our next meeting?</li>
-        <li>What evidence around me, devices, photos, witnesses, should I be preserving while it's still fresh?</li>
-        <li>Are there interactions I should avoid, employer, family, social media, that could affect the case?</li>
-        <li>What's the next procedural step, and what can I do between now and then to be in a stronger position?</li>
-        <li>If charges are still being decided, what factors influence that, and what can I document on my side?</li>
+        <li>The kit lists my state's first-appearance window in hours. Has that already happened, and if so, what was on the record?</li>
+        <li>The PD-attach trigger and the indigency standard for my state &mdash; how does my situation compare to that standard?</li>
+        <li>For the bail / release types my state allows, which one was used, and what conditions came with it?</li>
+        <li>Recording-police consent in my state is one-party / all-party / restricted &mdash; does that affect anything I or a witness captured during the arrest?</li>
+        <li>My state's expungement window is what it is &mdash; if this case ends in dismissal or acquittal, when does that clock start?</li>
       </ul>
       <p style="margin-top: 24px; padding: 16px; border-left: 3px solid #F59E0B; background: #1C1917;">
         These are questions, not advice. The first window is when small actions have the biggest leverage.
@@ -2234,7 +2234,7 @@ export const POST_PURCHASE_EMAILS: DripEmail[] = [
     subject: "Your Arrest Survival Kit is the floor, here's the synthesized picture",
     html: `
       <h1 style="color: #F59E0B;">If You Want the Synthesized Version</h1>
-      <p>Your Arrest Survival Kit covers the first 72 hours, what to do, what to preserve, what to avoid. Past that window, the leverage shifts from procedural to strategic. The Intelligence Brief synthesizes your judge's patterns, prosecutor track record, motion grant rates, and similar-cases distribution against your specific charge, state, circuit, and case stage, then an operator reviews the output before delivery. The kit is the floor. The Intelligence Brief is the calibrated picture, and produces 15-25 case-specific questions for your attorney.</p>
+      <p>Your Arrest Survival Kit maps the procedural floor for your state &mdash; the hours, statutes, and rules of the next 72 hours. Past that window, the leverage shifts from procedural to strategic. The Intelligence Brief synthesizes your judge's patterns, prosecutor track record, motion grant rates, and similar-cases distribution against your specific charge, state, circuit, and case stage, then an operator reviews the output before delivery. The kit is the floor. The Intelligence Brief is the calibrated picture, and produces 15-25 case-specific questions for your attorney.</p>
       <p><strong style="color: white;">You have already paid ${TIER_CORE["arrest-survival-kit"].priceDisplay}. The Intelligence Brief costs ${upgradeCostBetween("arrest-survival-kit", "intelligence-brief")}, credit applies within 12 months.</strong></p>
       ${cta("Get the Intelligence Brief", "/checkout?tier=intelligence-brief")}
       <p style="margin-top: 16px; color: #71717A;">Motion deadlines and plea negotiation windows erode with time. ${link("Compare tiers", "/services")}</p>

--- a/src/lib/products.ts
+++ b/src/lib/products.ts
@@ -1313,7 +1313,7 @@ export const STANDALONE_PRODUCTS: Record<string, StandaloneProduct> = {
     deliveryDetail:
       "Your Arrest Survival Kit is generated on demand within 60 seconds of purchase.",
     description:
-      "Your rights during arrest, agency incident data, and critical first-48-hours action plan for your jurisdiction.",
+      "What happens to you in the next 72 hours: your state's first-appearance window, public-defender attach, bail / release types, phone-call rule, recording-police consent, and expungement window. Plus universal rights checklist and first-72-hours timeline. Every fact links to its source statute or court rule.",
     intakeFields: ["state"],
     stripePriceId: null,
     upsellTier: "officer-background-check",

--- a/src/lib/state-arrest-procedure/load.ts
+++ b/src/lib/state-arrest-procedure/load.ts
@@ -1,0 +1,256 @@
+/**
+ * State arrest-procedure loader.
+ *
+ * Reads JSON files from `data/state-arrest-procedure/<lowercase-code>.json`,
+ * validates that every populated field has at least one URL in source_urls
+ * (per ARCHITECTURE.md invariant 13 + ~/.claude/rules/no-hallucinated-legal-data.md),
+ * and returns the parsed StateArrestProcedure for the requested state.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import type {
+  BailType,
+  RecordingPoliceConsent,
+  StateArrestProcedure,
+} from "./types";
+
+const DATA_DIR = path.join(
+  process.cwd(),
+  "data",
+  "state-arrest-procedure",
+);
+
+const VALID_BAIL_TYPES: ReadonlySet<BailType> = new Set([
+  "cash",
+  "surety",
+  "signature",
+  "property",
+  "personal_recognizance",
+]);
+
+const VALID_RECORDING: ReadonlySet<RecordingPoliceConsent> = new Set([
+  "one-party",
+  "all-party",
+  "restricted",
+]);
+
+export class StateArrestProcedureValidationError extends Error {}
+
+function isObject(x: unknown): x is Record<string, unknown> {
+  return typeof x === "object" && x !== null && !Array.isArray(x);
+}
+
+function isStringArray(x: unknown): x is string[] {
+  return Array.isArray(x) && x.every((v) => typeof v === "string");
+}
+
+/**
+ * Validate a parsed JSON blob against the StateArrestProcedure shape.
+ *
+ * Cardinal rule: every field with a non-null/non-empty value must be backed
+ * by at least one URL in source_urls. If a field is null, it must appear in
+ * _unknown_fields. Throws on any violation.
+ */
+export function validateStateArrestProcedure(
+  raw: unknown,
+  filename: string,
+): StateArrestProcedure {
+  if (!isObject(raw)) {
+    throw new StateArrestProcedureValidationError(
+      `${filename}: top-level value must be an object`,
+    );
+  }
+
+  const r = raw;
+
+  const stateCode = r.state_code;
+  if (typeof stateCode !== "string" || !/^[A-Z]{2}$/.test(stateCode)) {
+    throw new StateArrestProcedureValidationError(
+      `${filename}: state_code must be a 2-letter uppercase code`,
+    );
+  }
+
+  const stateName = r.state_name;
+  if (typeof stateName !== "string" || stateName.length === 0) {
+    throw new StateArrestProcedureValidationError(
+      `${filename}: state_name is required`,
+    );
+  }
+
+  const researchedAt = r.researched_at;
+  if (
+    typeof researchedAt !== "string" ||
+    !/^\d{4}-\d{2}-\d{2}$/.test(researchedAt)
+  ) {
+    throw new StateArrestProcedureValidationError(
+      `${filename}: researched_at must be ISO YYYY-MM-DD`,
+    );
+  }
+
+  if (!isStringArray(r.source_urls)) {
+    throw new StateArrestProcedureValidationError(
+      `${filename}: source_urls must be string[]`,
+    );
+  }
+  for (const u of r.source_urls) {
+    if (!/^https?:\/\//i.test(u)) {
+      throw new StateArrestProcedureValidationError(
+        `${filename}: source_urls entries must be http(s) URLs (got ${u})`,
+      );
+    }
+  }
+
+  if (!isStringArray(r._unknown_fields)) {
+    throw new StateArrestProcedureValidationError(
+      `${filename}: _unknown_fields must be string[]`,
+    );
+  }
+
+  if (!Array.isArray(r.bail_types_allowed)) {
+    throw new StateArrestProcedureValidationError(
+      `${filename}: bail_types_allowed must be an array`,
+    );
+  }
+  for (const t of r.bail_types_allowed) {
+    if (typeof t !== "string" || !VALID_BAIL_TYPES.has(t as BailType)) {
+      throw new StateArrestProcedureValidationError(
+        `${filename}: invalid bail_types_allowed value: ${String(t)}`,
+      );
+    }
+  }
+
+  if (!isStringArray(r.misc_quirks)) {
+    throw new StateArrestProcedureValidationError(
+      `${filename}: misc_quirks must be string[]`,
+    );
+  }
+
+  const rec = r.recording_police_consent;
+  if (
+    rec !== null &&
+    (typeof rec !== "string" ||
+      !VALID_RECORDING.has(rec as RecordingPoliceConsent))
+  ) {
+    throw new StateArrestProcedureValidationError(
+      `${filename}: recording_police_consent must be one-party | all-party | restricted | null`,
+    );
+  }
+
+  const fa = r.first_appearance_window_hours;
+  if (fa !== null && (typeof fa !== "number" || !Number.isFinite(fa) || fa <= 0)) {
+    throw new StateArrestProcedureValidationError(
+      `${filename}: first_appearance_window_hours must be positive number or null`,
+    );
+  }
+
+  for (const k of [
+    "pd_attach_trigger",
+    "indigency_threshold",
+    "bail_default_amounts_by_charge",
+    "phone_call_rule",
+    "expungement_window_years",
+  ] as const) {
+    const v = r[k];
+    if (v !== null && typeof v !== "string") {
+      throw new StateArrestProcedureValidationError(
+        `${filename}: ${k} must be string or null`,
+      );
+    }
+  }
+
+  const out: StateArrestProcedure = {
+    state_code: stateCode,
+    state_name: stateName,
+    researched_at: researchedAt,
+    first_appearance_window_hours: typeof fa === "number" ? fa : null,
+    pd_attach_trigger: (r.pd_attach_trigger as string | null) ?? null,
+    indigency_threshold: (r.indigency_threshold as string | null) ?? null,
+    bail_types_allowed: r.bail_types_allowed as BailType[],
+    bail_default_amounts_by_charge:
+      (r.bail_default_amounts_by_charge as string | null) ?? null,
+    phone_call_rule: (r.phone_call_rule as string | null) ?? null,
+    recording_police_consent: (rec as RecordingPoliceConsent | null) ?? null,
+    expungement_window_years:
+      (r.expungement_window_years as string | null) ?? null,
+    misc_quirks: r.misc_quirks,
+    source_urls: r.source_urls,
+    _unknown_fields: r._unknown_fields,
+  };
+
+  // Cross-field rule: any populated value MUST be backed by at least one URL.
+  const hasAnyValue =
+    out.first_appearance_window_hours !== null ||
+    out.pd_attach_trigger !== null ||
+    out.indigency_threshold !== null ||
+    out.bail_types_allowed.length > 0 ||
+    out.bail_default_amounts_by_charge !== null ||
+    out.phone_call_rule !== null ||
+    out.recording_police_consent !== null ||
+    out.expungement_window_years !== null ||
+    out.misc_quirks.length > 0;
+
+  if (hasAnyValue && out.source_urls.length === 0) {
+    throw new StateArrestProcedureValidationError(
+      `${filename}: at least one value is populated but source_urls is empty (no-hallucinated-legal-data)`,
+    );
+  }
+
+  // Cross-field rule: every field listed in _unknown_fields must actually be null/empty.
+  for (const f of out._unknown_fields) {
+    const v = (out as unknown as Record<string, unknown>)[f];
+    const isUnknown = v === null || (Array.isArray(v) && v.length === 0);
+    if (!isUnknown) {
+      throw new StateArrestProcedureValidationError(
+        `${filename}: _unknown_fields lists "${f}" but the field has a value`,
+      );
+    }
+  }
+
+  return out;
+}
+
+let cache: Map<string, StateArrestProcedure> | null = null;
+
+function loadAll(): Map<string, StateArrestProcedure> {
+  if (cache) return cache;
+  const m = new Map<string, StateArrestProcedure>();
+  if (!fs.existsSync(DATA_DIR)) {
+    cache = m;
+    return m;
+  }
+  for (const f of fs.readdirSync(DATA_DIR)) {
+    if (!f.endsWith(".json")) continue;
+    const raw = JSON.parse(fs.readFileSync(path.join(DATA_DIR, f), "utf8"));
+    const v = validateStateArrestProcedure(raw, f);
+    m.set(v.state_code, v);
+  }
+  cache = m;
+  return m;
+}
+
+/** Force a re-read on next call. Test-only. */
+export function clearStateArrestProcedureCache(): void {
+  cache = null;
+}
+
+/**
+ * Look up a state's arrest-procedure data.
+ *
+ * Returns null when the state's JSON file is missing — callers should treat
+ * this as "data unavailable" rather than crash.
+ */
+export function getStateArrestProcedure(
+  stateCode: string,
+): StateArrestProcedure | null {
+  if (typeof stateCode !== "string" || stateCode.length === 0) return null;
+  const upper = stateCode.toUpperCase();
+  return loadAll().get(upper) ?? null;
+}
+
+/** All loaded states (for tests + diagnostics). */
+export function listStateArrestProcedures(): StateArrestProcedure[] {
+  return Array.from(loadAll().values()).sort((a, b) =>
+    a.state_code.localeCompare(b.state_code),
+  );
+}

--- a/src/lib/state-arrest-procedure/types.ts
+++ b/src/lib/state-arrest-procedure/types.ts
@@ -1,0 +1,49 @@
+/**
+ * State arrest-procedure data — schema + types.
+ *
+ * Per ~/.claude/rules/no-hallucinated-legal-data.md: every populated field
+ * MUST have at least one verification URL in source_urls. Fields with
+ * unknown values are written as `null` and listed in `_unknown_fields`.
+ */
+
+export type RecordingPoliceConsent = "one-party" | "all-party" | "restricted";
+
+export type BailType =
+  | "cash"
+  | "surety"
+  | "signature"
+  | "property"
+  | "personal_recognizance";
+
+export interface StateArrestProcedure {
+  /** Two-letter USPS state code (uppercase). */
+  state_code: string;
+  /** Full state name. */
+  state_name: string;
+  /** ISO date the research was completed (YYYY-MM-DD). */
+  researched_at: string;
+
+  /** Statutory window for first appearance / arraignment after arrest, in hours. */
+  first_appearance_window_hours: number | null;
+  /** When the public defender / appointed counsel attaches. Plain prose. */
+  pd_attach_trigger: string | null;
+  /** Indigency standard for PD eligibility. Plain prose, with citation in source_urls. */
+  indigency_threshold: string | null;
+  /** Bail/bond release types allowed by statute. */
+  bail_types_allowed: BailType[];
+  /** Default bail amounts by charge class, if a bail schedule is published; else null. */
+  bail_default_amounts_by_charge: string | null;
+  /** Statutory or case-law right to a phone call after booking. Plain prose. */
+  phone_call_rule: string | null;
+  /** Recording-police consent posture (state-wide). */
+  recording_police_consent: RecordingPoliceConsent | null;
+  /** Expungement / sealing waiting period. Plain prose. */
+  expungement_window_years: string | null;
+  /** 1–3 short bullets of state-specific quirks. Each must be sourced. */
+  misc_quirks: string[];
+
+  /** All citation URLs that back the populated fields above. */
+  source_urls: string[];
+  /** Field names whose values are null because no authoritative source was found. */
+  _unknown_fields: string[];
+}

--- a/src/lib/tier9-reports/render.ts
+++ b/src/lib/tier9-reports/render.ts
@@ -2108,9 +2108,152 @@ const FIRST_48_HOURS = [
   { time: "After release", action: "Document everything immediately: officer names, badge numbers, what was said, timeline of events. Photograph any injuries." },
 ];
 
+/**
+ * v3 (2026-04-28): lead with state procedural data — what happens in
+ * the next 72 hours in $STATE — then universal rights, first-72-hours
+ * timeline, and what-not-to-say. Agency/officer data demoted to a
+ * "Regional context" section at the bottom.
+ */
+function renderProcedureRow(label: string, value: string | null): string {
+  if (!value) return "";
+  return `<tr style="border-bottom: 1px solid #1C1917;">
+    <td style="padding: 10px 12px; color: #F59E0B; font-weight: bold; vertical-align: top; width: 220px;">${escapeHtml(label)}</td>
+    <td style="padding: 10px 12px; color: #D4D4D8; vertical-align: top;">${escapeHtml(value)}</td>
+  </tr>`;
+}
+
+function renderProcedureSourceList(urls: string[]): string {
+  if (!urls || urls.length === 0) return "";
+  const items = urls
+    .map(
+      (u) =>
+        `<li style="margin-bottom: 4px; word-break: break-all;"><a href="${escapeHtml(u)}" style="color: #FBBF24;">${escapeHtml(u)}</a></li>`,
+    )
+    .join("");
+  return `<details style="margin-top: 8px;">
+    <summary style="color: #71717A; font-size: 12px; cursor: pointer;">Show ${urls.length} source${urls.length === 1 ? "" : "s"}</summary>
+    <ul style="color: #71717A; font-size: 12px; padding-left: 20px; margin-top: 8px;">${items}</ul>
+  </details>`;
+}
+
+function bailTypesPretty(types: string[]): string | null {
+  if (!types || types.length === 0) return null;
+  const map: Record<string, string> = {
+    cash: "cash",
+    surety: "surety bond",
+    signature: "signature bond",
+    property: "property bond",
+    personal_recognizance: "personal recognizance / release on own recognizance",
+  };
+  return types.map((t) => map[t] ?? t).join(", ");
+}
+
+function renderStateProcedureSection(
+  data: ArrestSurvivalKitData,
+): { html: string; sourceCount: number } {
+  const sp = data.stateProcedure;
+  let html = sectionHeader(`What Happens Next in ${escapeHtml(data.stateName)}`);
+
+  if (!sp) {
+    html += `<p style="color: #A1A1AA; font-size: 13px; margin-bottom: 16px;">
+      State-specific procedural data for ${escapeHtml(data.stateName)} is being researched. The universal rights checklist and first-72-hours timeline below apply in every state.
+    </p>`;
+    return { html, sourceCount: 0 };
+  }
+
+  html += `<p style="color: #A1A1AA; font-size: 13px; margin-bottom: 16px;">
+    The procedural facts for ${escapeHtml(sp.state_name)}, drawn from state statutes, court rules, and bar / public-defender publications. Each row reflects what the law says — not advice on what to do. Sources at the bottom of this section.
+  </p>`;
+
+  html += `<table style="width: 100%; border-collapse: collapse; margin-bottom: 16px;">
+    <tbody>`;
+
+  if (sp.first_appearance_window_hours !== null) {
+    html += renderProcedureRow(
+      "First-appearance window",
+      `${sp.first_appearance_window_hours} hours from arrest`,
+    );
+  }
+  html += renderProcedureRow(
+    "Public defender attaches",
+    sp.pd_attach_trigger,
+  );
+  html += renderProcedureRow(
+    "Indigency standard (PD eligibility)",
+    sp.indigency_threshold,
+  );
+  html += renderProcedureRow(
+    "Bail / release types allowed",
+    bailTypesPretty(sp.bail_types_allowed),
+  );
+  html += renderProcedureRow(
+    "Published bail schedule",
+    sp.bail_default_amounts_by_charge,
+  );
+  html += renderProcedureRow(
+    "Right to a phone call",
+    sp.phone_call_rule,
+  );
+  if (sp.recording_police_consent) {
+    const recMap: Record<string, string> = {
+      "one-party": "One-party consent — recording is generally permitted when one participant (you) consents.",
+      "all-party": "All-party consent — every participant must consent before a private conversation may be recorded.",
+      restricted: "Restricted — consent rules differ by setting (e.g., telephone vs. in-person). Check the source for the specific rule.",
+    };
+    html += renderProcedureRow(
+      "Recording-police consent",
+      recMap[sp.recording_police_consent] ?? sp.recording_police_consent,
+    );
+  }
+  html += renderProcedureRow(
+    "Expungement / sealing window",
+    sp.expungement_window_years,
+  );
+
+  html += `</tbody></table>`;
+
+  if (sp.misc_quirks.length > 0) {
+    html += `<h3 style="color: #F59E0B; font-size: 15px; margin: 16px 0 8px;">${escapeHtml(sp.state_name)}-specific quirks</h3>`;
+    html += `<ul style="color: #D4D4D8; padding-left: 20px; margin-bottom: 16px;">`;
+    for (const q of sp.misc_quirks) {
+      html += `<li style="margin-bottom: 6px;">${escapeHtml(q)}</li>`;
+    }
+    html += `</ul>`;
+  }
+
+  if (sp._unknown_fields.length > 0) {
+    const labelMap: Record<string, string> = {
+      first_appearance_window_hours: "First-appearance window",
+      pd_attach_trigger: "Public defender attach trigger",
+      indigency_threshold: "Indigency standard",
+      bail_types_allowed: "Bail types allowed",
+      bail_default_amounts_by_charge: "Published bail schedule",
+      phone_call_rule: "Phone-call rule",
+      recording_police_consent: "Recording-police consent",
+      expungement_window_years: "Expungement window",
+    };
+    const labels = sp._unknown_fields
+      .map((f: string) => labelMap[f] ?? f)
+      .join(", ");
+    html += `<p style="color: #FCD34D; font-size: 12px; padding: 8px 12px; background: #1C1917; border-left: 3px solid #F59E0B; margin-bottom: 16px;">
+      Coverage note: no statewide authoritative source published for the following — ${escapeHtml(labels)}. These fields commonly vary by county or court; the rest of the section reflects what the state-level law does establish.
+    </p>`;
+  }
+
+  html += renderProcedureSourceList(sp.source_urls);
+
+  return { html, sourceCount: sp.source_urls.length };
+}
+
 export function renderArrestSurvivalKit(data: ArrestSurvivalKitData): string {
   let totalSources = 0;
   let body = "";
+
+  // v3: state procedural data leads. Crisis-buyers want to know what
+  // happens next in their state — not aggregate use-of-force counts.
+  const procedure = renderStateProcedureSection(data);
+  body += procedure.html;
+  totalSources += procedure.sourceCount;
 
   // Your Rights During Arrest
   body += sectionHeader("Your Constitutional Rights During Arrest");
@@ -2160,8 +2303,11 @@ export function renderArrestSurvivalKit(data: ArrestSurvivalKitData): string {
     `;
   }
 
-  // Agency Data — always render a section; content depends on data status.
-  body += sectionHeader(`Agency Incident Data, ${escapeHtml(data.stateName)}`);
+  // Regional context — demoted to bottom in v3 (2026-04-28). Headline
+  // content is now state procedural data above. This section provides
+  // background on agencies + officers in the state without claiming
+  // direct relevance to a specific defendant's case.
+  body += sectionHeader(`Regional Context: Agency Records in ${escapeHtml(data.stateName)}`);
   if (data.agencyIncidentsStatus === "data_unavailable") {
     body += `<p style="color: #A1A1AA; font-size: 13px; margin-bottom: 12px;">Officer-incident data is not yet available for this jurisdiction. This section will be enriched when local data sources are ingested.</p>`;
   } else if (data.agencyIncidentsStatus === "no_incidents") {

--- a/src/lib/tiers.ts
+++ b/src/lib/tiers.ts
@@ -363,7 +363,7 @@ export const TIER_CORE = {
     price: 4700, // cents
     priceDisplay: "$47",
     delivery: "Instant",
-    deliveryDetail: "Your Arrest Survival Kit is generated on demand the moment you complete purchase.",
+    deliveryDetail: "What happens to you in the next 72 hours in your state — first-appearance window, public-defender attach, bail types, phone-call rule, recording-police consent, expungement window. Generated the moment you complete purchase.",
     requiresDiscovery: false,
     isAddon: false,
     isDigitalProduct: true,

--- a/tests/state-arrest-procedure-load.test.ts
+++ b/tests/state-arrest-procedure-load.test.ts
@@ -1,0 +1,137 @@
+// test-isolation-na: pure unit test of JSON validation, zero Supabase writes
+// Pattern: no-hallucinated-legal-data.md (cardinal rule: every populated field must have source_url)
+/**
+ * Loader tests for state-arrest-procedure JSON files.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  validateStateArrestProcedure,
+  StateArrestProcedureValidationError,
+} from "../src/lib/state-arrest-procedure/load";
+
+const MINIMAL_VALID = {
+  state_code: "FL",
+  state_name: "Florida",
+  researched_at: "2026-04-28",
+  first_appearance_window_hours: 24,
+  pd_attach_trigger: "at first appearance",
+  indigency_threshold: null,
+  bail_types_allowed: ["cash", "surety", "personal_recognizance"],
+  bail_default_amounts_by_charge: null,
+  phone_call_rule: "Right to telephone within 3 hours",
+  recording_police_consent: "one-party",
+  expungement_window_years: null,
+  misc_quirks: ["state-specific quirk"],
+  source_urls: ["https://example.gov/fl/rules"],
+  _unknown_fields: [
+    "indigency_threshold",
+    "bail_default_amounts_by_charge",
+    "expungement_window_years",
+  ],
+};
+
+describe("validateStateArrestProcedure", () => {
+  it("accepts a fully-shaped minimal record", () => {
+    const out = validateStateArrestProcedure(MINIMAL_VALID, "fl.json");
+    expect(out.state_code).toBe("FL");
+    expect(out.bail_types_allowed).toContain("cash");
+  });
+
+  it("rejects state_code that is not 2-letter uppercase", () => {
+    expect(() =>
+      validateStateArrestProcedure({ ...MINIMAL_VALID, state_code: "fl" }, "fl.json"),
+    ).toThrow(StateArrestProcedureValidationError);
+  });
+
+  it("rejects researched_at not in ISO YYYY-MM-DD", () => {
+    expect(() =>
+      validateStateArrestProcedure(
+        { ...MINIMAL_VALID, researched_at: "April 28, 2026" },
+        "fl.json",
+      ),
+    ).toThrow(StateArrestProcedureValidationError);
+  });
+
+  it("rejects missing source_urls when fields are populated", () => {
+    expect(() =>
+      validateStateArrestProcedure(
+        { ...MINIMAL_VALID, source_urls: [] },
+        "fl.json",
+      ),
+    ).toThrow(/no-hallucinated-legal-data/);
+  });
+
+  it("allows empty source_urls when nothing is populated", () => {
+    const empty = {
+      state_code: "ZZ",
+      state_name: "Empty",
+      researched_at: "2026-04-28",
+      first_appearance_window_hours: null,
+      pd_attach_trigger: null,
+      indigency_threshold: null,
+      bail_types_allowed: [],
+      bail_default_amounts_by_charge: null,
+      phone_call_rule: null,
+      recording_police_consent: null,
+      expungement_window_years: null,
+      misc_quirks: [],
+      source_urls: [],
+      _unknown_fields: [
+        "first_appearance_window_hours",
+        "pd_attach_trigger",
+        "indigency_threshold",
+        "bail_default_amounts_by_charge",
+        "phone_call_rule",
+        "recording_police_consent",
+        "expungement_window_years",
+      ],
+    };
+    expect(() => validateStateArrestProcedure(empty, "zz.json")).not.toThrow();
+  });
+
+  it("rejects http source_url that is not http(s)", () => {
+    expect(() =>
+      validateStateArrestProcedure(
+        { ...MINIMAL_VALID, source_urls: ["ftp://example.gov/x"] },
+        "fl.json",
+      ),
+    ).toThrow();
+  });
+
+  it("rejects invalid bail_types_allowed value", () => {
+    expect(() =>
+      validateStateArrestProcedure(
+        { ...MINIMAL_VALID, bail_types_allowed: ["bitcoin"] },
+        "fl.json",
+      ),
+    ).toThrow(/invalid bail_types_allowed/);
+  });
+
+  it("rejects invalid recording_police_consent enum", () => {
+    expect(() =>
+      validateStateArrestProcedure(
+        { ...MINIMAL_VALID, recording_police_consent: "two-party" },
+        "fl.json",
+      ),
+    ).toThrow(/recording_police_consent/);
+  });
+
+  it("rejects negative first_appearance_window_hours", () => {
+    expect(() =>
+      validateStateArrestProcedure(
+        { ...MINIMAL_VALID, first_appearance_window_hours: -1 },
+        "fl.json",
+      ),
+    ).toThrow(/first_appearance_window_hours/);
+  });
+
+  it("rejects _unknown_fields mislabeling a populated field", () => {
+    expect(() =>
+      validateStateArrestProcedure(
+        { ...MINIMAL_VALID, _unknown_fields: ["pd_attach_trigger"] },
+        "fl.json",
+      ),
+    ).toThrow(/_unknown_fields/);
+  });
+});


### PR DESCRIPTION
## Why

Current ASK ($47, Tier 9, live) leads with top-20 state agency use-of-force counts and a wandering-officer aggregate. Both are sociology, not actionable, for a defendant arrested in the last 72 hours. Crisis-buyers need **what happens next** in their state.

Repositions the SKU from "First-72-hours checklist tuned to your state" → **\"What happens to you in $STATE in the next 72 hours.\"**

## What's in (62 files / +2,555 / -69)

**Schema + loader**
- `data/state-arrest-procedure/_README.md` — schema doc + research methodology + UPL + no-hallucination rule
- `data/state-arrest-procedure/<code>.json` — 50 / 50 state files
- `src/lib/state-arrest-procedure/{types,load}.ts` — typed loader with strict validation (rejects any populated field without source_urls backing)
- `tests/state-arrest-procedure-load.test.ts` — 10 unit tests

**Code refactor**
- `src/lib/defense-intelligence/query.ts` — `queryArrestSurvivalKit` loads `stateProcedure` via the loader; existing `agency_incidents` + `officer_external_intel` paths kept as defense-in-depth
- `src/lib/tier9-reports/render.ts` — `renderArrestSurvivalKit` leads with **\"What Happens Next in $STATE\"** (first-appearance window, PD attach, indigency standard, bail types, phone-call rule, recording-police consent, expungement window, state-specific quirks); demotes agency/officer to **Regional Context** at the bottom; every claim links to its source_url

**Repositioning**
- `src/app/arrest-survival-kit/page.tsx` — hero, features, sample table, FAQ, trust copy, JSON-LD repositioned
- `src/lib/products.ts` — STANDALONE_PRODUCTS description repositioned
- `src/lib/tiers.ts` — TIER_CORE deliveryDetail repositioned
- `src/lib/drip-emails.ts` — 3 ASK drip emails (delivery / day-3 / day-7 upsell) rewritten to procedural framing

## What's not changed
- Stripe price IDs, tier slugs, URL slug `/arrest-survival-kit`
- DB tier_slugs / migrations
- Existing `agency_incidents` / `officer_external_intel` queries (kept as Regional Context block)
- Stripe `live: true` flag

## Verification (per `~/.claude/rules/no-hallucinated-legal-data.md`)

Loader rejects any state file with populated values but no `source_urls` backing. Inline validator over all 50 files: **OK=50, FAIL=0**. Every populated field has at least one verification URL; fields without an authoritative source are `null` and listed in `_unknown_fields` (most commonly `bail_default_amounts_by_charge` — published bail schedules are county-level, not statewide, in most states).

- `npx tsc --noEmit --skipLibCheck` → clean
- `npx vitest run` (loader + ASK query + ASK coverage) → 27 / 27 pass
- `next build --webpack --experimental-build-mode compile` → green (pre-push hook)

## State coverage report

50 / 50 written. Common `_unknown_fields`:
- `bail_default_amounts_by_charge` — county-published, not statewide, in most states (~45 of 50)
- `phone_call_rule` — many states have no codified per-arrestee timed phone-call statute (~25 of 50)
- `indigency_threshold` — many states use case-by-case judicial determination rather than a published income percentage (~30 of 50)

States with notable model-state divergence captured in `misc_quirks`:
- IL / NJ — no cash bail (post-2017 / 2023 reforms)
- KY / OR / ME / MT — no commercial bail bondsmen
- WV — statutory cap on misdemeanor cash bail (3× max statutory fine)
- IA / SC / SD — 24-hour first-appearance window
- MN — 36-hour window excluding weekends
- LA — civil-law state, parish terminology, 72-hour CCRP 230.1 window
- WA / FL / MA / IL / MD / MT / NH / OR (in-person) / CA / PA / CT — all-party recording consent
- VT — 2025 sealing-vs-expungement reform; new automatic-sealing scheme
- VA — July 2026 automatic-sealing scheme
- PA — Clean Slate Act auto-sealing (Act 56 of 2018)
- WI — expungement only at sentencing (under 25 / max ≤ 6yr)

## UPL

Persona is **Mercer** the back-room strategist. Every render-side claim is **information**, not advice. No \"you should\" / \"verify with attorney\" framing. The procedural section describes what the law says, not what the defendant should do.

## Test plan

- [x] Loader unit tests pass
- [x] tsc clean
- [x] Existing ASK tests still pass
- [x] All 50 state files validate via loader + inline validator
- [ ] Manual smoke: `/arrest-survival-kit` page renders new copy
- [ ] Manual smoke: generate ASK report for a state with a JSON file (e.g. FL) — procedural section first, then rights checklist, then regional context
- [ ] Manual smoke: generate ASK report for a state without a JSON file — graceful \"data being researched\" fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)