### PR TITLE
feat(ussc): shared freshness/audit pattern adoption (cross-project plan phase 2)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -537,6 +537,21 @@ All vars verified present in `src/` via `process.env.*` grep. Common trap: the c
 | `ENGINE_DISPATCH_PAT` | cron/generate-backup | GitHub PAT to dispatch engine workflow |
 | `VERCEL_TOKEN` | scripts, CLI | Vercel API/CLI auth |
 
+## Shared analytical layer (cross-project)
+
+`public.ussc_codebook_meta` and `public.ussc_matview_meta` are SHARED tables in
+the public schema. They're consumed by both INAA's USSC similar-cases stack
+and a sister analytical product on the same Supabase project. Do not add
+tenant-prefixes to these tables; do not write tenant-prefixed CHECK
+constraints. The freshness audit log (`ussc_matview_meta`) currently records
+refreshes from the sister project's matview (`ussc_similar_cases`) and will
+also record INAA's matview (`ussc_similar_cases_summary`) once Phase 1 of
+the shared-USSC plan ships.
+
+INAA's freshness gate reads the latest row across all matview refreshes;
+30-day floor matches the sister project's published commitment. Source plan:
+`C:\Users\email\projects\bench-recon-web\docs\plans\2026-04-30-shared-ussc-data-layer-cross-project.md`
+
 ## Deployment
 
 - **Trigger:** `git push origin master` → GitHub integration → Vercel auto-deploy

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -552,6 +552,17 @@ INAA's freshness gate reads the latest row across all matview refreshes;
 30-day floor matches the sister project's published commitment. Source plan:
 `C:\Users\email\projects\bench-recon-web\docs\plans\2026-04-30-shared-ussc-data-layer-cross-project.md`
 
+### Deferred: per-matview refresh RPC for INAA's summary matview
+
+`refresh_ussc_similar_cases_with_lock` (sister project's RPC, READ-ONLY
+reference at sister-repo `supabase/migrations/20260430c` — refreshes one
+specific matview) will get an INAA equivalent
+(`refresh_ussc_similar_cases_summary_with_lock`) when
+`ussc_similar_cases_summary` lands in Phase 1 of the shared-USSC plan.
+Per plan §Decision 4, parameterization into a single multi-matview RPC
+is deferred to Phase 4. Tracking:
+`C:\Users\email\projects\bench-recon-web\docs\plans\2026-04-30-shared-ussc-data-layer-cross-project.md` (Phases 1, 4).
+
 ## Deployment
 
 - **Trigger:** `git push origin master` → GitHub integration → Vercel auto-deploy

--- a/src/app/api/data-status/route.ts
+++ b/src/app/api/data-status/route.ts
@@ -1,0 +1,125 @@
+// Pattern: cross-project Phase 2 — adopted from sister analytical product's
+//   src/app/api/data-status/route.ts (READ-ONLY reference). Plan path:
+//   C:\Users\email\projects\bench-recon-web\docs\plans\2026-04-30-shared-ussc-data-layer-cross-project.md
+//
+// Public USSC freshness endpoint.
+// Reads the latest public.ussc_matview_meta row (a SHARED table populated
+// today by the sister project's matview refresh; INAA's own matview will
+// also populate it once Phase 1 of the shared-USSC plan ships) and returns
+// a stable JSON shape. 60s private cache so anonymous pollers don't hammer
+// the meta table; service-role consumers (queryBucket's freshness gate)
+// have their own freshness check on the same rows.
+
+import { NextResponse } from "next/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// 30-day stale floor — matches the sister project's published commitment
+// and the queryBucket pre-flight gate in src/lib/ussc-similar-cases.ts.
+const STALE_FLOOR_DAYS = 30;
+const STALE_FLOOR_MS = STALE_FLOOR_DAYS * 24 * 60 * 60 * 1000;
+
+interface UsscFreshness {
+  refreshed_at: string | null;
+  codebook_version: string | null;
+  freshness_floor_fy: number | null;
+  source_datafile_url: string | null;
+  /**
+   * Approximate row count — rounded to the nearest 1000 to avoid disclosing
+   * the exact size of the upstream analytical filter stack to anonymous
+   * pollers. Exact count remains available to service-role consumers via
+   * direct ussc_matview_meta select.
+   */
+  row_count_approx: number | null;
+  is_stale: boolean;
+  /** Distance from now to refreshed_at, in days. null when refreshed_at is null. */
+  days_since_refresh: number | null;
+}
+
+interface DataStatusResponse {
+  ussc: UsscFreshness;
+  fetched_at: string;
+}
+
+function roundToThousand(n: number | null | undefined): number | null {
+  if (n == null || !Number.isFinite(n)) return null;
+  return Math.round(n / 1000) * 1000;
+}
+
+const EMPTY_USSC: UsscFreshness = {
+  refreshed_at: null,
+  codebook_version: null,
+  freshness_floor_fy: null,
+  source_datafile_url: null,
+  row_count_approx: null,
+  is_stale: true,
+  days_since_refresh: null,
+};
+
+function jsonStatus(ussc: UsscFreshness, cache: "cache" | "no-cache" = "cache") {
+  const headers: Record<string, string> =
+    cache === "cache"
+      ? { "Cache-Control": "private, max-age=60, must-revalidate" }
+      : { "Cache-Control": "no-store, no-cache, must-revalidate" };
+  return NextResponse.json(
+    {
+      ussc,
+      fetched_at: new Date().toISOString(),
+    } satisfies DataStatusResponse,
+    { status: 200, headers },
+  );
+}
+
+export async function GET() {
+  try {
+    const supabase = createAdminClient();
+
+    const { data: meta, error: metaErr } = await supabase
+      .from("ussc_matview_meta")
+      .select(
+        "refreshed_at,codebook_version,freshness_floor_fy,source_datafile_url,row_count",
+      )
+      .order("refreshed_at", { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    if (metaErr) {
+      // Relation-missing is treated as "no data yet" — public endpoint stays
+      // 200 so anonymous pollers don't see 5xx pre-Phase-1. is_stale stays
+      // true so any operator-side surface still shows the warning.
+      const benign =
+        metaErr.code === "42P01" ||
+        metaErr.code === "PGRST205" ||
+        metaErr.code === "PGRST204" ||
+        /not found|does not exist/i.test(metaErr.message ?? "");
+      if (!benign) {
+        console.warn("[data-status] ussc_matview_meta query failed", metaErr);
+      }
+      return jsonStatus(EMPTY_USSC);
+    }
+
+    if (!meta) {
+      return jsonStatus(EMPTY_USSC);
+    }
+
+    const refreshedAt = new Date(meta.refreshed_at);
+    const ageMs = Date.now() - refreshedAt.getTime();
+    const isStale = ageMs > STALE_FLOOR_MS;
+    const daysSince = Math.max(0, Math.floor(ageMs / (24 * 60 * 60 * 1000)));
+
+    return jsonStatus({
+      refreshed_at: meta.refreshed_at,
+      codebook_version: meta.codebook_version ?? null,
+      freshness_floor_fy: meta.freshness_floor_fy ?? null,
+      source_datafile_url: meta.source_datafile_url ?? null,
+      row_count_approx: roundToThousand(meta.row_count ?? null),
+      is_stale: isStale,
+      days_since_refresh: daysSince,
+    });
+  } catch (e) {
+    console.error("[data-status] uncaught", e);
+    return jsonStatus(EMPTY_USSC, "no-cache");
+  }
+}

--- a/src/lib/ussc-similar-cases.ts
+++ b/src/lib/ussc-similar-cases.ts
@@ -20,6 +20,105 @@
  */
 import type { SupabaseClient } from "@supabase/supabase-js";
 
+// 30-day stale floor — matches the sister analytical product's published
+// freshness commitment on the shared `public.ussc_matview_meta` audit log.
+// Beyond this, `queryBucket` short-circuits to `insufficient_data` with
+// `stale: true` so the caller can route to refund-pending UI rather than
+// surface old distributions. Source plan:
+//   C:\Users\email\projects\bench-recon-web\docs\plans\2026-04-30-shared-ussc-data-layer-cross-project.md
+const STALE_FLOOR_DAYS = 30;
+const STALE_FLOOR_MS = STALE_FLOOR_DAYS * 24 * 60 * 60 * 1000;
+
+export interface UsscFreshnessGate {
+  is_stale: boolean;
+  refreshed_at: string | null;
+  days_old: number | null;
+  reason: "fresh" | "stale-data" | "no-meta" | "meta-missing";
+}
+
+/**
+ * Read the latest `public.ussc_matview_meta` row and classify freshness.
+ *
+ * Decision matrix:
+ *   - `fresh`         — refreshed within 30 days. Caller proceeds.
+ *   - `stale-data`    — meta row exists but >30 days old. Caller short-circuits.
+ *   - `no-meta`       — table exists, zero rows. Pre-Phase-1 INAA matview state;
+ *                       caller degrades open (proceeds with query) to avoid
+ *                       false-positive refund storms before INAA's own matview
+ *                       lands.
+ *   - `meta-missing`  — table itself is missing or any other transport error.
+ *                       Caller degrades open. We deliberately do NOT throw here;
+ *                       the caller decides how to react to each `reason`.
+ *
+ * The whole body is wrapped in try/catch so that supabase-js client variants
+ * that don't support `.order/.limit/.maybeSingle` (e.g. test mocks) collapse
+ * to `meta-missing` rather than blowing up the calling RPC route.
+ */
+export async function checkUsscFreshness(
+  sb: SupabaseClient,
+): Promise<UsscFreshnessGate> {
+  try {
+    const { data, error } = await sb
+      .from("ussc_matview_meta")
+      .select("refreshed_at")
+      .order("refreshed_at", { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    if (error) {
+      const benign =
+        error.code === "42P01" ||
+        error.code === "PGRST205" ||
+        error.code === "PGRST204" ||
+        /not found|does not exist/i.test(error.message ?? "");
+      if (benign) {
+        return {
+          is_stale: true,
+          refreshed_at: null,
+          days_old: null,
+          reason: "meta-missing",
+        };
+      }
+      // Unknown error — log and degrade open (treat as meta-missing).
+      console.error("[ussc-similar-cases] freshness check error:", error);
+      return {
+        is_stale: true,
+        refreshed_at: null,
+        days_old: null,
+        reason: "meta-missing",
+      };
+    }
+
+    if (!data?.refreshed_at) {
+      return {
+        is_stale: true,
+        refreshed_at: null,
+        days_old: null,
+        reason: "no-meta",
+      };
+    }
+
+    const ageMs = Date.now() - new Date(data.refreshed_at).getTime();
+    const days_old = Math.max(0, Math.floor(ageMs / (24 * 60 * 60 * 1000)));
+    const is_stale = ageMs > STALE_FLOOR_MS;
+    return {
+      is_stale,
+      refreshed_at: data.refreshed_at,
+      days_old,
+      reason: is_stale ? "stale-data" : "fresh",
+    };
+  } catch (e) {
+    // Includes test-mock variants whose chain lacks .order/.limit/.maybeSingle.
+    console.error("[ussc-similar-cases] freshness check threw:", e);
+    return {
+      is_stale: true,
+      refreshed_at: null,
+      days_old: null,
+      reason: "meta-missing",
+    };
+  }
+}
+
 export type AgeBucket = "<25" | "25-34" | "35-44" | "45-54" | "55+" | "UNK";
 
 export interface BucketInput {
@@ -72,6 +171,17 @@ export interface SimilarCasesResponse {
   total_cases: number;
   /** "Based on N cases FY<earliest>-FY<latest>." Empty when insufficient_data. */
   sample_size_caveat: string;
+  /**
+   * True when the matview audit log says the data is older than the 30-day
+   * stale floor. Only set when the freshness gate short-circuits the query
+   * (match_depth = "insufficient_data"). Surfaced for refund-pending UI.
+   */
+  stale?: boolean;
+  /**
+   * ISO timestamp of the last `public.ussc_matview_meta` refresh, when known.
+   * Only set when the freshness gate short-circuits the query.
+   */
+  refreshed_at?: string | null;
 }
 
 /**
@@ -152,6 +262,30 @@ export async function queryBucket(
   sb: SupabaseClient,
   input: BucketInput,
 ): Promise<SimilarCasesResponse> {
+  // Pre-flight freshness gate. Only `stale-data` short-circuits; the other
+  // reasons (`no-meta`, `meta-missing`) degrade open and let the existing
+  // widening pipeline run. Pre-Phase-1 INAA's matview doesn't write meta
+  // rows yet, so blocking on missing rows would refund-storm the customer.
+  const freshness = await checkUsscFreshness(sb);
+  if (freshness.reason === "stale-data" && freshness.is_stale) {
+    return {
+      match_depth: "insufficient_data",
+      widening_note:
+        "Federal sentencing data has not been refreshed within the last 30 days. " +
+        "Skipping distribution to avoid surfacing stale outcomes.",
+      rows: [],
+      total_cases: 0,
+      sample_size_caveat: "",
+      stale: true,
+      refreshed_at: freshness.refreshed_at,
+    };
+  }
+  if (freshness.reason === "no-meta" || freshness.reason === "meta-missing") {
+    console.warn(
+      `[ussc-similar-cases] freshness meta unavailable (${freshness.reason}); degrading open.`,
+    );
+  }
+
   const hasDistrict = isNonEmptyString(input.district);
   const hasCitizen = isNonEmptyString(input.citizen);
   const hasAgeBucket = isNonEmptyString(input.age_bucket);


### PR DESCRIPTION
## Summary

Phase 2 of the cross-project shared-USSC data-layer plan. Adopts the existing freshness/audit pattern on the SHARED `public.ussc_matview_meta` table (sister analytical product on the same Supabase project already populates it; INAA's own matview will populate it once Phase 1 lands). Cascades:

- **Sub-task 1** — `ARCHITECTURE.md` gains a Shared Analytical Layer section: cross-project semantics of `public.ussc_codebook_meta` + `public.ussc_matview_meta`, no-tenant-prefix rule, 30-day stale floor.
- **Sub-task 2** — `src/lib/ussc-similar-cases.ts` exports `checkUsscFreshness()` and wires it as a pre-flight inside `queryBucket`. `stale-data` short-circuits to `insufficient_data` with new optional `stale` + `refreshed_at` fields for refund-pending UI. `no-meta` and `meta-missing` degrade open with a `console.warn` so pre-Phase-1 INAA's matview (no meta rows yet) doesn't trigger refund storms. Body is `try/catch`-wrapped so existing test mocks (which lack `.order/.limit/.maybeSingle`) collapse to `meta-missing` instead of throwing.
- **Sub-task 3** — `GET /api/data-status` returns the latest meta row in the shape `{ ussc: { refreshed_at, codebook_version, freshness_floor_fy, source_datafile_url, row_count_approx, is_stale, days_since_refresh }, fetched_at }`. 60s `private` cache. `row_count` rounded to nearest 1000 to avoid disclosing upstream filter-stack size to anonymous pollers. Relation-missing returns 200 with `EMPTY_USSC` so the public surface stays available pre-Phase-1.
- **Sub-task 4** — Documents the deferred `refresh_ussc_similar_cases_summary_with_lock` RPC in `ARCHITECTURE.md` (matview prereq belongs to Phase 1; multi-matview parameterization is plan §Decision 4 → Phase 4).

Parent plan: `C:\Users\email\projects\bench-recon-web\docs\plans\2026-04-30-shared-ussc-data-layer-cross-project.md` (Phase 2)

## Diff

```
ARCHITECTURE.md                  |  26 ++++++++
src/app/api/data-status/route.ts | 125 ++++++++++++++++++++++++++++++++++++
src/lib/ussc-similar-cases.ts    | 134 +++++++++++++++++++++++++++++++++++++++
3 files changed, 285 insertions(+)
```

## Deferred (out of Phase 2 scope, surfaced in PR body per plan)

- **Methodology / transparency page wire-up.** INAA-web has no `src/app/methodology` or `src/app/transparency` page today (verified via Glob). The SSR consumer described in the plan (server-side fetch + warning banner + `refreshed_at` display) is not creatable as part of Phase 2 because creating a brand-new public page is out of the Phase 2 mandate. Suggested follow-up: open a separate PR that adds the methodology page using `/api/data-status` as its data source.
- **`refresh_ussc_similar_cases_summary_with_lock` RPC.** Pending matview creation in Phase 1; documented as deferred in `ARCHITECTURE.md` rather than written against a missing relation.

## Pre-existing issues (NOT caused by this PR)

- `npx vitest run` (full suite) reports 51 failed suites under `scripts/lib/test-db.test.mjs` and `scripts/ingest/__tests__/scrape-*-discipline.test.mjs` + `scripts/ingest/__tests__/seed-statutes-*.test.mjs`. All are `node:test`-style files vitest can't parse (`Error: No test suite found in file`) — they exist on `master` before this branch. Confirmed via clean checkout of `origin/master`. Out of scope here.
- `npm run build` emits a Turbopack NFT warning about `next.config.ts` and the `security-scan` cron route (pre-existing) and a Next 16 deprecation warning about `middleware.ts` → `proxy.ts` (pre-existing). 60+ blog QA warnings (`failing quality gates: slop, upl, dna (non-blocking)`) are gated as non-blocking by the existing pipeline.

## Test plan

- [x] `npx tsc --noEmit --skipLibCheck` — clean per commit (also enforced by `prepare-commit` hook).
- [x] `npx eslint src/app/api/data-status/route.ts src/lib/ussc-similar-cases.ts` — no issues.
- [x] `npx vitest run tests/lib/ussc-similar-cases.test.ts` — 18 / 18 pass (existing tests unchanged; freshness gate degrades open under the test mock).
- [x] `npm run build` — exits 0 with only the pre-existing warnings noted above.
- [ ] Smoke `curl https://imnotanattorney.com/api/data-status` after deploy and confirm `{ ussc: { ... }, fetched_at }` shape (200, `Cache-Control: private, max-age=60`).
- [ ] Confirm `queryBucket` against the live shared `public.ussc_matview_meta` returns `match_depth !== "insufficient_data"` (today's row is fresh; verifies the gate doesn't false-positive on a healthy meta).

🤖 Generated with [Claude Code](https://claude.com/claude-code)