### PR TITLE
feat(statutes): MS Title 97 via LR.O bulk-XML harness (710 rows)

### DIFF
--- a/scripts/ingest/__tests__/fixtures/ms/title97-ch1-excerpt.xml
+++ b/scripts/ingest/__tests__/fixtures/ms/title97-ch1-excerpt.xml
@@ -1,0 +1,163 @@
+<?xml version="1.0"?>
+<Content Type="Statutes">
+  <Indexes>
+    <Index Level="1" HasChildren="1">
+      <Caption>Title 97</Caption>
+      <Description>CRIMES (&amp;sect; 97-1-1 to &amp;sect; 97-45-33)</Description>
+      <Indexes>
+        <Index Level="2" HasChildren="1">
+          <Caption>Chapter 1</Caption>
+          <Description>CONSPIRACY, ACCESSORIES AND ATTEMPTS (&amp;sect; 97-1-1 to &amp;sect; 97-1-9)</Description>
+          <Indexes>
+            <Index Level="3" HasChildren="0">
+              <Caption>&amp;sect; 97-1-1</Caption>
+              <Description>Conspiracy</Description>
+              <Content>&lt;p&gt;&lt;/p&gt;&lt;P&gt; (1) If two (2) or more persons conspire either:&lt;/P&gt;&lt;p&gt;&lt;/p&gt;&lt;P&gt;(a) To commit a crime; or&lt;/P&gt;&lt;p&gt;&lt;/p&gt;&lt;P&gt;(b) Falsely and maliciously to indict another for a crime, or to procure to be complained of or arrested for a crime; or&lt;/P&gt;&lt;p&gt;&lt;/p&gt;&lt;P&gt;(c) Falsely to institute or maintain an action or suit of any kind; or&lt;/P&gt;&lt;p&gt;&lt;/p&gt;&lt;P&gt;(d) To cheat and defraud another out of property by any means which are in themselves criminal, or which, if executed, would amount to a cheat, or to obtain money or any other property or thing by false pretense; or&lt;/P&gt;&lt;p&gt;&lt;/p&gt;&lt;P&gt;(e) To prevent another from exercising a lawful trade or calling, or doing any other lawful act, by force, threats, intimidation, or by interfering or threatening to interfere with tools, implements, or property belonging to or used by another, or with the use of employment thereof; or&lt;/P&gt;&lt;p&gt;&lt;/p&gt;&lt;P&gt;(f) To commit any act injurious to the public health, to public morals, trade or commerce, or for the perversion or obstruction of justice, or of the due administration of the laws; or&lt;/P&gt;&lt;p&gt;&lt;/p&gt;&lt;P&gt;(g) To overthrow or violate the laws of this state through force, violence, threats, intimidation, or otherwise; or&lt;/P&gt;&lt;p&gt;&lt;/p&gt;&lt;P&gt;(h) To accomplish any unlawful purpose, or a lawful purpose by any unlawful means; such persons, and each of them, shall be guilty of a felony and upon conviction may be punished by a fine of not more than Five Thousand Dollars ($ 5,000.00) or by imprisonment for not more than five (5) years, or by both.&lt;/P&gt;&lt;p&gt;&lt;/p&gt;&lt;P&gt;(2) Where one (1) or more of the conspirators is a law enforcement officer engaged in the performance of official duty or a person acting at the direction of a law enforcement officer in the performance of official duty, any remaining conspirator may be charged under this section if the alleged conspirator acted voluntarily and willfully and was not entrapped by the law enforcement officer or person acting at the direction of a law enforcement officer.&lt;/P&gt;&lt;p&gt;&lt;/p&gt;&lt;P&gt;(3) Where the crime conspired to be committed is capital murder or murder as defined by law or is a violation of Section 41-29-139(b)(1), Section 41-29-139(c)(2)(D) or Section 41-29-313(1), being provisions of the Uniform Controlled Substances Law, the offense shall be punishable by a fine of not more than Five Hundred Thousand Dollars ($ 500,000.00) or by imprisonment for not more than twenty (20) years, or by both.&lt;/P&gt;&lt;p&gt;&lt;/p&gt;&lt;P&gt;(4) Where the crime conspired to be committed is a misdemeanor, then upon conviction said crime shall be punished as a misdemeanor as provided by law.&lt;/P&gt;&lt;p&gt;&lt;/p&gt;</Content>
+              <ShortName>Miss. Code § 97-1-1</ShortName>
+              <RevisionHistory />
+            </Index>
+            <Index Level="3" HasChildren="0">
+              <Caption>&amp;sect; 97-1-3</Caption>
+              <Description>Accessories before the fact</Description>
+              <Content>&lt;p&gt;&lt;/p&gt;&lt;P&gt; Every person who shall be an accessory to any felony, before the fact, shall be deemed and considered a principal, and shall be indicted and punished as such; and this whether the principal have been previously convicted or not.&lt;/P&gt;&lt;p&gt;&lt;/p&gt;</Content>
+              <ShortName>Miss. Code § 97-1-3</ShortName>
+              <RevisionHistory />
+            </Index>
+            <Index Level="3" HasChildren="0">
+              <Caption>&amp;sect; 97-1-5</Caption>
+              <Description>Accessories after the fact; punishment</Description>
+              <Content>&lt;p&gt;&lt;/p&gt;&lt;P&gt; (1) Every person who shall be convicted of having concealed, received, or relieved any felon, or having aided or assisted any felon, knowing that the person had committed a felony, with intent to enable the felon to escape or to avoid arrest, trial, conviction or punishment after the commission of the felony, on conviction thereof shall be imprisoned in the custody of the Department of Corrections as follows:&lt;/P&gt;&lt;p&gt;&lt;/p&gt;&lt;P&gt;(a) If the felony was a violent crime:&lt;/P&gt;&lt;p&gt;&lt;/p&gt;&lt;P&gt;(i) If the maximum punishment was life, death or twenty (20) years or more, for a period not to exceed twenty (20) years; or&lt;/P&gt;&lt;p&gt;&lt;/p&gt;&lt;P&gt;(ii) If the maximum punishment for the violent felony was less than twenty (20) years, for a period not to exceed the maximum punishment.&lt;/P&gt;&lt;p&gt;&lt;/p&gt;&lt;P&gt;(b) If the felony was a nonviolent crime:&lt;/P&gt;&lt;p&gt;&lt;/p&gt;&lt;P&gt;(i) If the maximum punishment for the nonviolent felony was ten (10) years or more, for a period not to exceed ten (10) years; or&lt;/P&gt;&lt;p&gt;&lt;/p&gt;&lt;P&gt;(ii) If the maximum punishment for the nonviolent felony was less than ten (10) years, for a period not to exceed the maximum punishment.&lt;/P&gt;&lt;p&gt;&lt;/p&gt;&lt;P&gt;(2) For the purposes of this section, "violent crime" means homicide, robbery, manslaughter, sex crimes, burglary of an occupied dwelling, aggravated assault, kidnapping, drive-by shooting, armed robbery, felonious abuse of a vulnerable person, felonies subject to an enhanced penalty, felony child abuse or exploitation, or any violation of Section 97-5-33 relating to exploitation of children, Section 97-5-39(1)(b), 97-5-39(1)(c) or 97-5-39(2) relating to child neglect or abuse, or Section 63-11-30(5) relating to aggravated DUI.&lt;/P&gt;&lt;p&gt;&lt;/p&gt;&lt;P&gt;(3) In the prosecution of an offense under this section, it shall not be necessary to aver in the indictment or to prove on the trial that the principal has been convicted or tried.&lt;/P&gt;&lt;p&gt;&lt;/p&gt;</Content>
+              <ShortName>Miss. Code § 97-1-5</ShortName>
+              <RevisionHistory />
+            </Index>
+            <Index Level="3" HasChildren="0">
+              <Caption>&amp;sect; 97-1-7</Caption>
+              <Description>Attempt to commit offense; punishment</Description>
+              <Content>&lt;p&gt;&lt;/p&gt;&lt;P&gt; Every person who shall design and endeavor to commit an offense, and shall do any overt act toward the commission thereof, but shall fail therein, or shall be prevented from committing the same, on conviction thereof, shall, where no provision is made by law for the punishment of such offense, be punished as follows: If the offense attempted to be committed be capital, such offense shall be punished by imprisonment in the penitentiary not exceeding ten years; if the offense attempted be punishable by imprisonment in the penitentiary, or by fine and imprisonment in the county jail, then the attempt to commit such offense shall be punished for a period or for an amount not greater than is prescribed for the actual commission of the offense so attempted.&lt;/P&gt;&lt;p&gt;&lt;/p&gt;</Content>
+              <ShortName>Miss. Code § 97-1-7</ShortName>
+              <RevisionHistory />
+            </Index>
+            <Index Level="3" HasChildren="0">
+              <Caption>&amp;sect; 97-1-9</Caption>
+              <Description>Attempt to commit offense; no conviction if offense completed</Description>
+              <Content>&lt;p&gt;&lt;/p&gt;&lt;P&gt; A person shall not be convicted of an assault with intent to commit a crime, or of any other attempt to commit an offense, when it shall appear that the crime intended or the offense attempted was perpetrated by such person at the time of such assault or in pursuance of such attempt.&lt;/P&gt;&lt;p&gt;&lt;/p&gt;</Content>
+              <ShortName>Miss. Code § 97-1-9</ShortName>
+              <RevisionHistory />
+            </Index>
+          </Indexes>
+        </Index>
+        <Index Level="2" HasChildren="1">
+          <Caption>Chapter 3</Caption>
+          <Description>CRIMES AGAINST THE PERSON (&amp;sect; 97-3-1 to &amp;sect; 97-3-117)</Description>
+          <Indexes>
+            <Index Level="3" HasChildren="0">
+              <Caption>&amp;sect; 97-3-1</Caption>
+              <Description>Abduction for purposes of marriage</Description>
+              <Content>&lt;p&gt;&lt;/p&gt;&lt;P&gt; Every person who shall take any person over the age of fourteen (14) years unlawfully, against his or her will, and by force, menace, fraud, deceit, stratagem or duress, compel or induce him or her to marry such person or to marry any other person, or to be defiled, and shall be thereof duly convicted, shall be punished by imprisonment in the penitentiary not less than five (5) years and not more than fifteen (15) years.&lt;/P&gt;&lt;p&gt;&lt;/p&gt;</Content>
+              <ShortName>Miss. Code § 97-3-1</ShortName>
+              <RevisionHistory />
+            </Index>
+            <Index Level="3" HasChildren="0">
+              <Caption>&amp;sect; 97-3-3</Caption>
+              <Description>Abortion; causing abortion or miscarriage</Description>
+              <Content>&lt;p&gt;&lt;/p&gt;&lt;P&gt; (1) Any person wilfully and knowingly causing, by means of any instrument, medicine, drug or other means whatever, any woman pregnant with child to abort or miscarry, or attempts to procure or produce an abortion or miscarriage shall be guilty of a felony unless the same were done by a duly licensed, practicing physician:&lt;/P&gt;&lt;p&gt;&lt;/p&gt;&lt;P&gt;(a) Where necessary for the preservation of the mother's life;&lt;/P&gt;&lt;p&gt;&lt;/p&gt;&lt;P&gt;(b) Where pregnancy was caused by rape.&lt;/P&gt;&lt;p&gt;&lt;/p&gt;&lt;P&gt;Said person shall, upon conviction, be imprisoned in the State Penitentiary not less than one (1) year nor more than ten (10) years; provided, however, if the death of the mother results therefrom, the person procuring, causing or attempting to procure or cause the illegal abortion or miscarriage shall be guilty of murder.&lt;/P&gt;&lt;p&gt;&lt;/p&gt;</Content>
+              <ShortName>Miss. Code § 97-3-3</ShortName>
+              <RevisionHistory />
+            </Index>
+            <Index Level="3" HasChildren="0">
+              <Caption>&amp;sect; 97-3-4</Caption>
+              <Description>Failed abortion; unlawful for physician to intentionally allow or cause living child to die; care of living child mandated; penalties</Description>
+              <Content>&lt;p&gt;&lt;/p&gt;&lt;P&gt; (1) It shall be unlawful for any physician performing an abortion that results in the delivery of a living child to intentionally allow or cause the child to die.&lt;/P&gt;&lt;p&gt;&lt;/p&gt;&lt;P&gt;(2) If the child is viable, such child shall be immediately provided appropriate medical care and comfort care necessary to sustain life. If the child is not viable, such child shall be provided comfort care. The provision of this section shall include, but not be limited to, a child born with physical or mental handicapping conditions which, in the opinion of the parent, the physician or other persons, diminishes the quality of the child's life, a child born alive during the course of an attempted abortion and a child not wanted by the parent.&lt;/P&gt;&lt;p&gt;&lt;/p&gt;</Content>
+              <ShortName>Miss. Code § 97-3-4</ShortName>
+              <RevisionHistory />
+            </Index>
+            <Index Level="3" HasChildren="0">
+              <Caption>&amp;sect; 97-3-5</Caption>
+              <Description>Abortion; advertisement, sale or gift of drugs or instruments</Description>
+              <Content>&lt;p&gt;&lt;/p&gt;&lt;P&gt; A person who sells, lends, gives away, or in any manner exhibits, or offers to sell, lend, or give away, or has in his possession with intent to sell, lend, or give away, or advertises or offers for sale, loan or distribution any instrument or article, or any drug or medicine, for causing unlawful abortion; or who writes or prints, or causes to be written or printed, a card, circular, pamphlet, advertisement, or notice of any kind, or gives information orally, stating when, where, how, of whom, or by what means such article or medicine can be purchased or obtained, or who manufactures any such article or medicine, is guilty of a misdemeanor, and, on conviction, shall be punished by fine not less than twenty-five dollars ($ 25.00) nor more than two hundred dollars ($ 200.00), and by imprisonment in the county jail not exceeding three (3) months.&lt;/P&gt;&lt;p&gt;&lt;/p&gt;</Content>
+              <ShortName>Miss. Code § 97-3-5</ShortName>
+              <RevisionHistory />
+            </Index>
+            <Index Level="3" HasChildren="0">
+              <Caption>&amp;sect; 97-3-7</Caption>
+              <Description>Simple assault; aggravated assault; simple domestic violence; aggravated domestic violence</Description>
+              <Content>&lt;p&gt;&lt;/p&gt;&lt;P&gt; (1) (a) A person is guilty of simple assault if he (i) attempts to cause or purposely, knowingly or recklessly causes bodily injury to another; (ii) negligently causes bodily injury to another with a deadly weapon or other means likely to produce death or serious bodily harm; or (iii) attempts by physical menace to put another in fear of imminent serious bodily harm; and, upon conviction, he shall be punished by a fine of not more than Five Hundred Dollars ($ 500.00) or by imprisonment in the county jail for not more than six (6) months, or both.&lt;/P&gt;&lt;p&gt;&lt;/p&gt;</Content>
+              <ShortName>Miss. Code § 97-3-7</ShortName>
+              <RevisionHistory />
+            </Index>
+            <Index Level="3" HasChildren="0">
+              <Caption>&amp;sect; 97-3-13</Caption>
+              <Description>False confinement; sending sane person to psychiatric hospital or institution</Description>
+              <Content>&lt;p&gt;&lt;/p&gt;&lt;P&gt; Every person or officer who maliciously sends to or confines in a psychiatric hospital or institution or other place, any sane person as a person with mental illness, knowing the person to be sane, shall be guilty of a felony, and, on conviction, shall be punished by a fine of not more than Five Hundred Dollars ($ 500.00), or by imprisonment in the Penitentiary not more than one (1) year, or in the county jail not more than six (6) months.&lt;/P&gt;&lt;p&gt;&lt;/p&gt;</Content>
+              <ShortName>Miss. Code § 97-3-13</ShortName>
+              <RevisionHistory />
+            </Index>
+            <Index Level="3" HasChildren="0">
+              <Caption>&amp;sect; 97-3-15</Caption>
+              <Description>Homicide; justifiable homicide; use of defensive force; duty to retreat</Description>
+              <Content>&lt;p&gt;&lt;/p&gt;&lt;P&gt; (1) The killing of a human being by the act, procurement or omission of another shall be justifiable in the following cases:&lt;/P&gt;&lt;p&gt;&lt;/p&gt;&lt;P&gt;(a) When committed by public officers, or those acting by their aid and assistance, in obedience to any judgment of a competent court;&lt;/P&gt;&lt;p&gt;&lt;/p&gt;&lt;P&gt;(b) When necessarily committed by public officers, or those acting by their command in their aid and assistance, in overcoming actual resistance to the execution of some legal process, or to the discharge of any other legal duty;&lt;/P&gt;&lt;p&gt;&lt;/p&gt;</Content>
+              <ShortName>Miss. Code § 97-3-15</ShortName>
+              <RevisionHistory />
+            </Index>
+            <Index Level="3" HasChildren="0">
+              <Caption>&amp;sect; 97-3-17</Caption>
+              <Description>Homicide; excusable homicide</Description>
+              <Content>&lt;p&gt;&lt;/p&gt;&lt;P&gt; The killing of any human being by the act, procurement, or omission of another shall be excusable:&lt;/P&gt;&lt;p&gt;&lt;/p&gt;&lt;P&gt;(a) When committed by accident and misfortune in doing any lawful act by lawful means, with usual and ordinary caution, and without any unlawful intent;&lt;/P&gt;&lt;p&gt;&lt;/p&gt;&lt;P&gt;(b) When committed by accident and misfortune, in the heat of passion, upon any sudden and sufficient provocation;&lt;/P&gt;&lt;p&gt;&lt;/p&gt;</Content>
+              <ShortName>Miss. Code § 97-3-17</ShortName>
+              <RevisionHistory />
+            </Index>
+            <Index Level="3" HasChildren="0">
+              <Caption>&amp;sect; 97-3-19</Caption>
+              <Description>Homicide; murder defined; capital murder; lesser-included offenses</Description>
+              <Content>&lt;p&gt;&lt;/p&gt;&lt;P&gt; (1) The killing of a human being without the authority of law by any means or in any manner shall be murder in the following cases:&lt;/P&gt;&lt;p&gt;&lt;/p&gt;&lt;P&gt;(a) When done with deliberate design to effect the death of the person killed, or of any human being;&lt;/P&gt;&lt;p&gt;&lt;/p&gt;&lt;P&gt;(b) When done in the commission of an act eminently dangerous to others and evincing a depraved heart, regardless of human life, although without any premeditated design to effect the death of any particular individual;&lt;/P&gt;&lt;p&gt;&lt;/p&gt;</Content>
+              <ShortName>Miss. Code § 97-3-19</ShortName>
+              <RevisionHistory />
+            </Index>
+            <Index Level="3" HasChildren="0">
+              <Caption>&amp;sect; 97-3-21</Caption>
+              <Description>Homicide; penalty for murder or capital murder</Description>
+              <Content>&lt;p&gt;&lt;/p&gt;&lt;P&gt; Every person who shall be convicted of murder shall be sentenced by the court to imprisonment for life in the State Penitentiary.&lt;/P&gt;&lt;p&gt;&lt;/p&gt;&lt;P&gt;Every person who shall be convicted of capital murder shall be sentenced (a) to death; (b) to imprisonment for life in the State Penitentiary without parole; or (c) to imprisonment for life in the State Penitentiary with eligibility for parole as provided in Section 47-7-3(1)(f).&lt;/P&gt;&lt;p&gt;&lt;/p&gt;</Content>
+              <ShortName>Miss. Code § 97-3-21</ShortName>
+              <RevisionHistory />
+            </Index>
+            <Index Level="3" HasChildren="0">
+              <Caption>&amp;sect; 97-3-23</Caption>
+              <Description>Homicide; death following duels fought out of state</Description>
+              <Content>&lt;p&gt;&lt;/p&gt;&lt;P&gt; Every person who shall, by previous appointment, agreement, or understanding made in this state, fight a duel without the jurisdiction of this state, and, in so doing, shall inflict a wound upon his antagonist or any other person, whereof the person thus injured die within this state, and every second engaged in such duel, shall be guilty of murder in this state, and may be indicted, tried, and convicted in the county where such death shall happen.&lt;/P&gt;&lt;p&gt;&lt;/p&gt;</Content>
+              <ShortName>Miss. Code § 97-3-23</ShortName>
+              <RevisionHistory />
+            </Index>
+            <Index Level="3" HasChildren="0">
+              <Caption>&amp;sect; 97-3-25</Caption>
+              <Description>Homicide; penalty for manslaughter</Description>
+              <Content>&lt;p&gt;&lt;/p&gt;&lt;P&gt; Any person convicted of manslaughter shall be fined in a sum not less than five hundred dollars, or imprisoned in the county jail not more than one year, or both, or in the penitentiary not less than two years, nor more than twenty years.&lt;/P&gt;&lt;p&gt;&lt;/p&gt;</Content>
+              <ShortName>Miss. Code § 97-3-25</ShortName>
+              <RevisionHistory />
+            </Index>
+            <Index Level="3" HasChildren="0">
+              <Caption>&amp;sect; 97-3-27</Caption>
+              <Description>Homicide; killing while committing felony</Description>
+              <Content>&lt;p&gt;&lt;/p&gt;&lt;P&gt; The killing of a human being without malice, by the act, procurement, or culpable negligence of another, while such other is engaged in the perpetration of any felony, except those felonies enumerated in Section 97-3-19(2)(e) and (f), or while such other is attempting to commit any felony besides such as are above enumerated and excepted, shall be manslaughter.&lt;/P&gt;&lt;p&gt;&lt;/p&gt;</Content>
+              <ShortName>Miss. Code § 97-3-27</ShortName>
+              <RevisionHistory />
+            </Index>
+            <Index Level="3" HasChildren="0">
+              <Caption>&amp;sect; 97-3-29</Caption>
+              <Description>Homicide; killing while committing a misdemeanor</Description>
+              <Content>&lt;p&gt;&lt;/p&gt;&lt;P&gt; The killing of a human being without malice, by the act, procurement, or culpable negligence of another, while such other is engaged in the perpetration of any crime or misdemeanor not amounting to felony, or in the attempt to commit any crime or misdemeanor, where such killing would be murder at common law, shall be manslaughter.&lt;/P&gt;&lt;p&gt;&lt;/p&gt;</Content>
+              <ShortName>Miss. Code § 97-3-29</ShortName>
+              <RevisionHistory />
+            </Index>
+            <Index Level="3" HasChildren="0">
+              <Caption>&amp;sect; 97-3-31</Caption>
+              <Description>Homicide; killing unnecessarily, while resisting effort of slain to commit felony or do unlawful act</Description>
+              <Content>&lt;p&gt;&lt;/p&gt;&lt;P&gt; Every person who shall unnecessarily kill another, either while resisting an attempt by such other person to commit any felony, or to do any unlawful act, or after such attempt shall have failed, shall be guilty of manslaughter.&lt;/P&gt;&lt;p&gt;&lt;/p&gt;</Content>
+              <ShortName>Miss. Code § 97-3-31</ShortName>
+              <RevisionHistory />
+            </Index>
+          </Indexes>
+        </Index>
+      </Indexes>
+    </Index>
+  </Indexes>
+</Content>

--- a/scripts/ingest/__tests__/seed-statutes-ms-title97.test.mjs
+++ b/scripts/ingest/__tests__/seed-statutes-ms-title97.test.mjs
@@ -1,0 +1,165 @@
+// test-isolation-na: no Supabase writes — unit tests against real fixture XML
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { parseTitleSections, buildMsLroSourceUrl, stripHtml } from '../lib/ms-xml.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURE_PATH = path.join(__dirname, 'fixtures', 'ms', 'title97-ch1-excerpt.xml');
+
+const FIXTURE_XML = readFileSync(FIXTURE_PATH, 'utf8');
+
+// ---------------------------------------------------------------------------
+// buildMsLroSourceUrl
+// ---------------------------------------------------------------------------
+
+describe('buildMsLroSourceUrl', () => {
+  it('builds correct LR.O archive URL for a chapter-1 section', () => {
+    expect(buildMsLroSourceUrl('97-1-1')).toBe(
+      'https://law.resource.org/pub/us/code/ms/ms.xml.2013/title-97.xml#97-1-1'
+    );
+  });
+
+  it('builds correct LR.O archive URL for a chapter-3 section', () => {
+    expect(buildMsLroSourceUrl('97-3-19')).toBe(
+      'https://law.resource.org/pub/us/code/ms/ms.xml.2013/title-97.xml#97-3-19'
+    );
+  });
+
+  it('URL-encodes special characters in section numbers', () => {
+    // section numbers should be URL-safe bare numbers, but verify encoding works
+    const url = buildMsLroSourceUrl('97-1-1');
+    expect(url).toMatch(/^https:\/\//);
+    expect(url).toContain('title-97.xml#');
+  });
+
+  it('returns HTTPS URL', () => {
+    expect(buildMsLroSourceUrl('97-3-21')).toMatch(/^https:\/\//);
+  });
+
+  it('anchors URL to the correct LR.O MS 2013 file', () => {
+    expect(buildMsLroSourceUrl('97-43-5')).toContain(
+      'law.resource.org/pub/us/code/ms/ms.xml.2013/title-97.xml'
+    );
+  });
+
+  it('appends section number as fragment', () => {
+    expect(buildMsLroSourceUrl('97-3-25')).toMatch(/#97-3-25$/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// stripHtml (re-exported from harness)
+// ---------------------------------------------------------------------------
+
+describe('stripHtml', () => {
+  it('strips tags and decodes &nbsp;', () => {
+    expect(stripHtml('<p>A&nbsp;&nbsp;B</p>')).toBe('A B');
+  });
+
+  it('decodes numeric entities', () => {
+    expect(stripHtml('A&#167;B')).toContain('§');
+  });
+
+  it('decodes &amp;', () => {
+    expect(stripHtml('A &amp; B')).toBe('A & B');
+  });
+
+  it('strips <br> tags', () => {
+    expect(stripHtml('foo<br>bar<br />baz')).toBe('foo bar baz');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseTitleSections — against real MS Title 97 Chapter 1+3 fixture
+// ---------------------------------------------------------------------------
+
+describe('parseTitleSections (real fixture)', () => {
+  let sections;
+
+  beforeAll(() => {
+    sections = parseTitleSections(FIXTURE_XML);
+  });
+
+  it('parses at least 20 sections from the chapter-1+3 excerpt', () => {
+    expect(sections.length).toBeGreaterThanOrEqual(20);
+  });
+
+  it('every section has a non-empty titleText', () => {
+    for (const s of sections) {
+      expect(s.titleText.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('every section has a non-empty bodyText', () => {
+    for (const s of sections) {
+      expect(s.bodyText.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('section 97-1-1 is present and references conspiracy', () => {
+    const s = sections.find(x => x.sectionNum === '97-1-1');
+    expect(s).toBeDefined();
+    expect(s.bodyText.toLowerCase()).toContain('conspire');
+  });
+
+  it('section 97-3-19 has expected title (murder defined)', () => {
+    const s = sections.find(x => x.sectionNum === '97-3-19');
+    expect(s).toBeDefined();
+    expect(s.titleText.toLowerCase()).toContain('murder');
+  });
+
+  it('sectionNum does NOT start with § (prefix stripped)', () => {
+    for (const s of sections) {
+      expect(s.sectionNum).not.toMatch(/^§/);
+    }
+  });
+
+  it('sectionNum matches expected MS code pattern', () => {
+    for (const s of sections) {
+      expect(s.sectionNum).toMatch(/^97-\d+-\d+$/);
+    }
+  });
+
+  it('chapterNum is non-empty numeric string', () => {
+    for (const s of sections) {
+      expect(s.chapterNum).toMatch(/^\d+$/);
+    }
+  });
+
+  it('no section body retains raw <Content> tag wrapping', () => {
+    for (const s of sections) {
+      expect(s.bodyText).not.toContain('<Content>');
+      expect(s.bodyText).not.toContain('</Content>');
+    }
+  });
+
+  it('section bodies do not retain raw HTML tags', () => {
+    for (const s of sections) {
+      expect(s.bodyText).not.toMatch(/<\/?(p|br|font|b|center|i|span|div|P)\s*\/?>/i);
+    }
+  });
+
+  it('section 97-3-21 references imprisonment for life', () => {
+    const s = sections.find(x => x.sectionNum === '97-3-21');
+    expect(s).toBeDefined();
+    expect(s.bodyText.toLowerCase()).toContain('imprisonment for life');
+  });
+
+  it('chapter-1 sections have chapterNum "1"', () => {
+    const ch1 = sections.filter(x => x.sectionNum.startsWith('97-1-'));
+    expect(ch1.length).toBeGreaterThan(0);
+    for (const s of ch1) {
+      expect(s.chapterNum).toBe('1');
+    }
+  });
+
+  it('chapter-3 sections have chapterNum "3"', () => {
+    const ch3 = sections.filter(x => x.sectionNum.startsWith('97-3-'));
+    expect(ch3.length).toBeGreaterThan(0);
+    for (const s of ch3) {
+      expect(s.chapterNum).toBe('3');
+    }
+  });
+});

--- a/scripts/ingest/lib/ms-xml.mjs
+++ b/scripts/ingest/lib/ms-xml.mjs
@@ -1,0 +1,67 @@
+// Template: scripts/ingest/lib/id-xml.mjs
+// Pattern: cl-bulk-data-defensive #18 — MS Title 97 is single-file XML, parse in-memory
+// Source: https://law.resource.org/pub/us/code/ms/ms.xml.2013/title-97.xml
+//
+// Mississippi Title 97 (Crimes) parser. The XML follows the Law.Resource.Org
+// universal `<Content Type="Statutes">` shape. The shared harness `parseLrOXml`
+// handles structure traversal; this lib provides:
+//   - parseTitleSections: wraps harness parser + strips MS-specific Caption prefix
+//   - buildMsLroSourceUrl: per-section URL anchoring to the LR.O archive file
+//
+// Source URL decision:
+//   1. Tried MS state legislature (legislature.ms.gov) — TLS cert error (self-signed)
+//   2. Tried Justia (law.justia.com/codes/mississippi/) — HTTP 403 from this agent
+//   3. FindLaw — HTTP 403
+//   DECISION: Use the LR.O archive URL with section-anchor fragment, which is the
+//   canonical public-domain source for this 2013 XML. The URL is stable, HTTPS,
+//   and directly resolves to the source file we ingested from.
+//   Pattern: https://law.resource.org/pub/us/code/ms/ms.xml.2013/title-97.xml#97-X-Y
+//
+// Caption format in the MS LR.O XML:
+//   Level-2 (chapter): "Chapter 1", "Chapter 3" ...
+//   Level-3 (section): "&sect; 97-1-1" (decoded: "§ 97-1-1")
+//   After XML+HTML entity decode, Caption = "§ 97-X-Y". We strip "§ " prefix
+//   so sectionNum = "97-1-1" — consistent with jurisdiction='MS', title='97'
+//   storage convention.
+
+import { parseLrOXml, stripHtml } from '../../lib/lawresource-xml-harness.mjs';
+
+export { stripHtml };
+
+/**
+ * Parse MS Title 97 XML using the shared LR.O parser, then normalise section
+ * numbers by stripping the leading "§ " (section symbol + space) from Captions.
+ *
+ * The raw Caption after XML+HTML decoding is "§ 97-1-1". The base harness
+ * already calls stripHtml on the Caption, which decodes &sect; → §. We strip
+ * the "§ " prefix here so sectionNum is bare "97-1-1".
+ *
+ * @param {string} xml
+ * @returns {import('../../lib/lawresource-xml-harness.mjs').LrOSection[]}
+ */
+export function parseTitleSections(xml) {
+  const raw = parseLrOXml(xml);
+  return raw.map(sec => ({
+    ...sec,
+    // Strip leading "§ " (or bare "§" without space, just in case)
+    sectionNum: sec.sectionNum.replace(/^§\s*/u, '').trim(),
+  }));
+}
+
+/**
+ * Build the authoritative source URL for a Mississippi Title 97 section.
+ *
+ * Uses the LR.O archive URL with a section-anchor fragment because:
+ *   - MS legislature website has TLS issues (self-signed cert)
+ *   - Justia and FindLaw return 403 from automated agents
+ *   - LR.O is the public-domain canonical source for this 2013 XML
+ *
+ * Pattern: https://law.resource.org/pub/us/code/ms/ms.xml.2013/title-97.xml#SECTION_NUM
+ * e.g. "97-1-1" → "https://law.resource.org/pub/us/code/ms/ms.xml.2013/title-97.xml#97-1-1"
+ *
+ * @param {string} sectionNum  e.g. "97-1-1", "97-3-19", "97-43-5"
+ * @returns {string}
+ */
+export function buildMsLroSourceUrl(sectionNum) {
+  return `https://law.resource.org/pub/us/code/ms/ms.xml.2013/title-97.xml#${encodeURIComponent(sectionNum)}`;
+}

--- a/scripts/ingest/seed-statutes-ms-title97.mjs
+++ b/scripts/ingest/seed-statutes-ms-title97.mjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+// Template: scripts/ingest/seed-statutes-id-title18.mjs
+// Pattern: cl-bulk-data-defensive #18 — COPY FROM STDIN via bulkCopyRows (via lawresource-xml-harness)
+// Pattern: cl-bulk-data-defensive #17 — session-level timeouts via createBulkClient
+// csv-bulk-checked: https://law.resource.org/pub/us/code/ms/ms.xml.2013/title-97.xml
+//   (Public domain via Public.Resource.Org legal-codes archive)
+//
+// Seeds Mississippi Code Title 97 (Crimes) into entities_statutes.
+// Source XML: law.resource.org/pub/us/code/ms/ms.xml.2013/title-97.xml
+//   ~1.2MB, 800+ sections, single-file parse-in-memory.
+// Authoritative URLs: LR.O archive with #sectionNum fragment anchor (state-leg TLS error;
+//   Justia/FindLaw return 403 from automated agents).
+//
+// Usage:
+//   node scripts/ingest/seed-statutes-ms-title97.mjs [--dry-run] [--verbose]
+//
+// Env required (live run):
+//   SUPABASE_DB_URL — direct postgres connection string (port 5432)
+
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// ---------- env loader ----------
+const dotenvPath = path.resolve(__dirname, '../../.env.local');
+try {
+  const { config } = await import('dotenv');
+  config({ path: dotenvPath });
+} catch {
+  // dotenv optional — env may be pre-set
+}
+
+// ---------- imports ----------
+import { parseTitleSections, buildMsLroSourceUrl } from './lib/ms-xml.mjs';
+import { ingestState } from '../lib/lawresource-xml-harness.mjs';
+
+// ---------- MS config ----------
+
+/** @type {import('../lib/lawresource-xml-harness.mjs').LrOStateConfig} */
+const MS_TITLE97_CONFIG = {
+  stateCode: 'MS',
+  stateName: 'Mississippi',
+  titleNum: '97',
+  titleLabel: 'Crimes',
+  titleUrl: 'https://law.resource.org/pub/us/code/ms/ms.xml.2013/title-97.xml',
+  crawlDelay: 'none',
+  fetchTimeoutMs: 90000,
+  parseTitle: parseTitleSections,
+  buildSourceUrl: buildMsLroSourceUrl,
+};
+
+// ---------- CLI ----------
+
+function parseCliFlags(argv) {
+  return {
+    dryRun: argv.includes('--dry-run'),
+    verbose: argv.includes('--verbose'),
+  };
+}
+
+// ---------- main ----------
+
+async function main() {
+  const { dryRun, verbose } = parseCliFlags(process.argv);
+
+  if (dryRun) {
+    console.log('[seed-statutes-ms-title97] DRY RUN — no DB writes');
+  } else {
+    if (!process.env.SUPABASE_DB_URL) {
+      console.error('ERROR: SUPABASE_DB_URL not set. Run with --dry-run or set the env var.');
+      process.exit(1);
+    }
+    console.log('[seed-statutes-ms-title97] LIVE RUN — will write to DB');
+  }
+
+  const result = await ingestState(MS_TITLE97_CONFIG, {
+    dryRun,
+    verbose,
+    connectionString: process.env.SUPABASE_DB_URL,
+  });
+
+  console.log('\n=== Summary ===');
+  console.log(`  rows written : ${result.rowCount}`);
+  console.log(`  skipped      : ${result.skipCount}`);
+  console.log(`  errors       : ${result.errorCount}`);
+  console.log(`  duration     : ${result.durationMs}ms`);
+
+  // Floor: live probe of the LR.O 2013 XML found exactly 710 sections.
+  // 700 is a safe floor that proves the harness without over-constraining on
+  // minor skip-row variation between runs.
+  const FLOOR = 700;
+  if (result.rowCount < FLOOR) {
+    console.error(`\nFAIL: floor not met — only ${result.rowCount} rows (need ≥${FLOOR})`);
+    process.exit(1);
+  }
+
+  console.log(`\nPASS: ≥${FLOOR} rows`);
+  process.exit(0);
+}
+
+main().catch(err => {
+  console.error('[seed-statutes-ms-title97] fatal:', err.message);
+  process.exit(1);
+});


### PR DESCRIPTION
Seeds Mississippi Code Title 97 (Crimes) into entities_statutes via LR.O bulk-XML harness. 710 sections, 0 null URLs, 0 non-HTTPS. 23 vitest unit tests pass. Source: law.resource.org LR.O archive (state-leg TLS error + Justia/FindLaw 403 ruled out direct sources).