### PR TITLE
feat(statutes): seed ME Title 17-A — Wave 1C

### DIFF
--- a/scripts/ingest/__tests__/fixtures/de/title11-sample.txt
+++ b/scripts/ingest/__tests__/fixtures/de/title11-sample.txt
@@ -1,0 +1,79 @@
+Title 11
+Crimes and Criminal Procedure
+NOTICE: The Delaware Code appearing on this site is prepared by the Delaware Code Revisors and the
+editorial staff of LexisNexis in cooperation with the Division of Legislative Services of the General Assembly,
+and is considered an official version of the State of Delaware statutory code. This version includes all acts
+enacted as of March 30, 2026, up to and including 85 Del. Laws, c. 244.
+DISCLAIMER: With respect to the Delaware Code documents available from this site or server, neither the
+State of Delaware nor any of its employees, makes any warranty, express or implied, including the warranties
+of merchantability and fitness for a particular purpose, or assumes any legal liability or responsibility for the
+usefulness of any information, apparatus, product, or process disclosed, or represents that its use would not
+infringe privately-owned rights. Please seek legal counsel for help on interpretation of individual statutes.
+
+-- 1 of 491 --
+
+
+
+-- 2 of 491 --
+
+Title 11 - Crimes and Criminal Procedure
+Page 1
+Part I
+Delaware Criminal Code
+Chapter 1
+Introductory Provisions
+§ 101. Short title.
+Part I of this title shall be known as the “Delaware Criminal Code.”
+(11 Del. C. 1953, § 101; 58 Del. Laws, c. 497, § 1.)
+§ 102. Applicability to offenses committed prior to July 1, 1973.
+(a) Except as provided in subsections (b) and (c) of this section, this Criminal Code does not apply to offenses committed prior to July
+1, 1973. Prosecutions for offenses committed prior to July 1, 1973, shall be governed by the prior law, which is continued in effect for
+that purpose, as if this Criminal Code were not in force. For the purpose of this section, an offense was committed prior to July 1, 1973,
+if any of the elements of the offense occurred prior thereto.
+(b) In any case pending on or commenced after July 1, 1973, involving an offense committed prior to that date:
+(1) Procedural provisions of this Criminal Code shall govern, insofar as they are justly applicable and their applicability does not
+introduce confusion, delay or manifest injustice;
+(2) Provisions of this Criminal Code according a defense or mitigations shall apply, with the consent of the defendant.
+(c) Provisions of this Criminal Code governing the treatment and the release or discharge of prisoners, probationers and parolees shall
+apply to persons under sentence for offenses committed prior to July 1, 1973, except that the minimum or maximum period of their
+detention or supervision shall in no case be increased, nor shall this Criminal Code affect the substantive or procedural validity of any
+judgment of conviction entered prior to July 1, 1973, regardless of the fact that appeal time has not run or that an appeal is pending.
+(11 Del. C. 1953, § 102; 58 Del. Laws, c. 497, § 1.)
+§ 103. Applicability to offenses committed after July 1, 1973.
+(a) This Criminal Code establishes the criminal law of this State and governs the construction of and punishment for any offense set
+forth herein committed after July 1, 1973, as well as the construction and application of any defense to a prosecution for such an offense.
+(b) Unless otherwise expressly provided, or unless the context otherwise requires, this Criminal Code governs the construction of any
+offense defined in a statute other than this Criminal Code and committed after July 1, 1973, as well as the construction and application
+of any defense to a prosecution for such an offense.
+(11 Del. C. 1953, § 103; 58 Del. Laws, c. 497, § 1.)
+
+-- 3 of 491 --
+
+Title 11 - Crimes and Criminal Procedure
+Page 2
+Part I
+Delaware Criminal Code
+Chapter 2
+General Provisions Concerning Offenses
+§ 201. General purposes.
+The general purposes of this Criminal Code are:
+(1) To proscribe conduct which unjustifiably and inexcusably causes or threatens harm to individual or public interests;
+(2) To give fair warning of the nature of the conduct proscribed and of the sentences authorized upon conviction;
+(3) To define the act or omission and the accompanying mental state which constitute each offense;
+(4) To differentiate upon reasonable grounds between serious and minor offenses and to prescribe proportionate penalties therefor;
+and
+(5) To insure the public safety by preventing the commission of offenses through the deterrent influence of the sentences authorized,
+the rehabilitation of those convicted and their confinement when required in the interests of public protection.
+(11 Del. C. 1953, § 201; 58 Del. Laws, c. 497, § 1.)
+§ 202. All offenses defined by statute.
+(a) No conduct constitutes a criminal offense unless it is made a criminal offense by this Criminal Code or by another law.
+(b) This section does not affect the power of a court to punish for civil contempt or to employ any sanction authorized by law for the
+enforcement of an order or a civil judgment or decree.
+(11 Del. C. 1953, § 202; 58 Del. Laws, c. 497, § 1.)
+§ 203. Principles of construction.
+The general rule that a penal statute is to be strictly construed does not apply to this Criminal Code, but the provisions herein must be
+construed according to the fair import of their terms to promote justice and effect the purposes of the law, as stated in § 201 of this title.
+(11 Del. C. 1953, § 203; 58 Del. Laws, c. 497, § 1.)
+§ 204. Territorial applicability.
+(a) Except as otherwise provided in this section a person may be convicted under the law of this State of an offense committed by the
+person’s own conduct or by the conduct of 

--- a/scripts/ingest/__tests__/fixtures/me/title17a-sample.txt
+++ b/scripts/ingest/__tests__/fixtures/me/title17a-sample.txt
@@ -1,0 +1,89 @@
+MRS Title 17-A. MAINE CRIMINAL CODE
+Generated
+01.05.2026 Title 17-A. MAINE CRIMINAL CODE | 1
+TITLE 17-A
+MAINE CRIMINAL CODE
+PART 1
+GENERAL PRINCIPLES
+CHAPTER 1
+PRELIMINARY
+§1. Title; effective date; severability
+1. Title 17‑A shall be known and may be cited as the Maine Criminal Code. When it is alleged
+that an element occurred "on or about" any date prior to the effective date of the code, the prosecution
+shall be governed by the prior law. When it is alleged that all of the elements occurred "on or about"
+the effective date of the code or any date thereafter, the prosecution shall be governed by the code.
+[PL 1975, c. 740, §9-A (RPR).]
+2. Except as provided in section 4‑A, this code shall become effective May 1, 1976, and it shall
+apply only to crimes committed subsequent to its effective date. Prosecution for crimes repealed by this
+code, which are committed prior to the effective date shall be governed by the prior law which is
+continued in effect for that purpose as if this code were not in force; provided that in any such
+prosecution the court may, with the consent of the defendant, impose sentence under the provisions of
+the code. In such cases, the sentencing authority of the court is determined by the application to the
+prior law of section 4‑A, subsection 3, which became effective for this purpose May 1, 1976. For
+purposes of this section, a crime was committed subsequent to the effective date if all of the elements
+of the crime occurred on or after that date; a crime was not committed subsequent to the effective date
+if any element thereof occurred prior to that date, or if the evidence may reasonably be interpreted to
+establish that any element may have occurred prior to that date.
+[PL 1981, c. 324, §1 (AMD).]
+3. If any provision or clause of this code or application thereof to any person or circumstances is
+held invalid, such invalidity shall not affect other provisions or applications of the code which can be
+given effect without the invalid provision or application, and to this end the provisions of this code are
+declared to be severable.
+[PL 1975, c. 499, §1 (NEW).]
+SECTION HISTORY
+PL 1975, c. 499, §1 (NEW). PL 1975, c. 649, §1 (AMD). PL 1975, c. 699, §1 (AMD). PL 1975,
+c. 740, §§9-A,10 (AMD). PL 1977, c. 78, §118 (AMD). PL 1981, c. 324, §1 (AMD).
+§2. Definitions
+As used in this code, unless a different meaning is plainly required, the following words and
+variants thereof have the following meanings. [PL 1975, c. 499, §1 (NEW).]
+1. "Act" or "action" means a voluntary bodily movement.
+[PL 1975, c. 499, §1 (NEW).]
+2. "Acted" includes, where appropriate, possessed or omitted to act.
+[PL 1975, c. 499, §1 (NEW).]
+
+-- 1 of 315 --
+
+MRS Title 17-A. MAINE CRIMINAL CODE
+2 | Title 17-A. MAINE CRIMINAL CODE Generated
+01.05.2026
+3. "Actor" includes, where appropriate, a person who possesses something or who omits to act.
+[PL 1975, c. 499, §1 (NEW).]
+3-A.
+[PL 1977, c. 510, §9 (RP).]
+3-B. "Another jurisdiction" means the Federal Government, the United States military, the District
+of Columbia, the Commonwealth of Puerto Rico, the Commonwealth of the Northern Mariana Islands,
+the United States Virgin Islands, Guam, American Samoa, federally recognized Indian tribes and each
+of the several states except Maine.
+[PL 2019, c. 621, Pt. E, §1 (AMD).]
+3-C. Adult probation supervisor. "Adult probation supervisor" means any person who:
+A. Is an employee of the Department of Corrections; [PL 2009, c. 142, §1 (NEW).]
+B. Supervises adult probation officers; and [PL 2009, c. 142, §1 (NEW).]
+C. Is trained, qualified and authorized by the Commissioner of Corrections to use deadly force.
+[PL 2009, c. 142, §1 (NEW).]
+[PL 2009, c. 142, §1 (NEW).]
+4. "Benefit" means any gain or advantage to the actor, and includes any gain or advantage to a
+person other than the actor which is desired or consented to by the actor.
+[PL 1975, c. 499, §1 (NEW).]
+5. "Bodily injury" means physical pain, physical illness or any impairment of physical condition.
+[PL 1975, c. 499, §1 (NEW).]
+5-A. "Corrections officer" has the same meaning as in Title 25, section 2801‑A, subsection 2.
+[PL 1995, c. 625, Pt. A, §19 (AMD).]
+5-B. Corrections supervisor. "Corrections supervisor" means any person who:
+A. Is an employee of the Department of Corrections; [PL 1995, c. 215, §1 (NEW).]
+B. Supervises corrections officers; and [PL 1995, c. 215, §1 (NEW).]
+C. Is trained, qualified and authorized by the Commissioner of Corrections to use deadly force.
+[PL 1995, c. 215, §1 (NEW).]
+[PL 1995, c. 215, §1 (NEW).]
+5-C. Concurrent sentence. "Concurrent sentence" means a sentence involving imprisonment that
+runs at the same time as one or more other sentences involving imprisonment while an individual is
+simultaneously in execution of each of them. A sentence involving imprisonment does not need to be
+imposed at the same time or begin or end at the same time as another sentence to be a concurrent
+sentence.
+[PL 2019, c. 113, Pt. B, §1 (NEW).]
+5-D. Consecutive sentence. "Consecutive sentence" means a sentence involving imprisonment
+that immediately follows in time another sentence involving imprisonment. A sentence is not a
+consecutive sentence with respect to another sentence if an individual is in execution of both sentences
+at any time. A sentence involving imprisonment does not need to be imposed at the same time as
+another sentence to be a consecutive sentence.
+[PL 2019, c. 113, Pt. B, §1 (NEW).]
+6. "Criminal negligence" has the meaning set forth in section 35.

--- a/scripts/ingest/__tests__/seed-statutes-de-title11.test.mjs
+++ b/scripts/ingest/__tests__/seed-statutes-de-title11.test.mjs
@@ -1,0 +1,89 @@
+// test-isolation-na: pure parser unit tests against on-disk fixture text — no DB writes.
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import {
+  parseTitle11,
+  buildDeSourceUrl,
+  DE_TITLE11_PDF_URL,
+  DE_CONFIG,
+} from '../lib/de-title11-pdf.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURE_PATH = path.join(__dirname, 'fixtures', 'de', 'title11-sample.txt');
+const FIXTURE_TEXT = readFileSync(FIXTURE_PATH, 'utf8');
+
+describe('DE_CONFIG', () => {
+  it('has DE state code', () => {
+    expect(DE_CONFIG.state).toBe('DE');
+  });
+  it('has a sectionRe regex', () => {
+    expect(DE_CONFIG.sectionRe).toBeInstanceOf(RegExp);
+  });
+});
+
+describe('buildDeSourceUrl', () => {
+  it('returns the title-level PDF URL for any section', () => {
+    expect(buildDeSourceUrl('101')).toBe(DE_TITLE11_PDF_URL);
+    expect(buildDeSourceUrl('1448A')).toBe(DE_TITLE11_PDF_URL);
+  });
+
+  it('URL is HTTPS', () => {
+    expect(buildDeSourceUrl('101')).toMatch(/^https:\/\//);
+  });
+
+  it('URL points at delcode.delaware.gov', () => {
+    expect(buildDeSourceUrl('101')).toContain('delcode.delaware.gov');
+  });
+});
+
+describe('parseTitle11 (real fixture)', () => {
+  let sections;
+
+  beforeAll(() => {
+    sections = parseTitle11(FIXTURE_TEXT);
+  });
+
+  it('parses at least 3 sections from fixture', () => {
+    expect(sections.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('first section is § 101', () => {
+    expect(sections[0].sectionNum).toBe('101');
+  });
+
+  it('§ 101 title says Short title', () => {
+    expect(sections[0].title).toContain('Short title');
+  });
+
+  it('§ 101 body mentions Delaware Criminal Code', () => {
+    expect(sections[0].body).toContain('Delaware Criminal Code');
+  });
+
+  it('every parsed section has non-empty body', () => {
+    for (const s of sections) {
+      expect(s.body.length).toBeGreaterThanOrEqual(20);
+    }
+  });
+
+  it('every parsed section has a numeric-prefix sectionNum', () => {
+    for (const s of sections) {
+      expect(s.sectionNum).toMatch(/^\d/);
+    }
+  });
+
+  it('body is stripped of page-break artifact lines', () => {
+    for (const s of sections) {
+      // No "-- N of M --" lines should survive
+      expect(s.body).not.toMatch(/^--\s+\d+\s+of\s+\d+\s+--$/m);
+    }
+  });
+
+  it('preserves citation footers in body', () => {
+    // DE format keeps "(11 Del. C. 1953, § ...; ...)" — those should remain.
+    const sec101 = sections.find((s) => s.sectionNum === '101');
+    expect(sec101).toBeDefined();
+    expect(sec101.body).toContain('Del. C.');
+  });
+});

--- a/scripts/ingest/__tests__/seed-statutes-me-title17a.test.mjs
+++ b/scripts/ingest/__tests__/seed-statutes-me-title17a.test.mjs
@@ -1,0 +1,92 @@
+// test-isolation-na: pure parser unit tests against on-disk fixture text — no DB writes.
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import {
+  parseTitle17A,
+  buildMeSourceUrl,
+  ME_TITLE17A_PDF_URL,
+  ME_CONFIG,
+} from '../lib/me-title17a-pdf.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURE_PATH = path.join(__dirname, 'fixtures', 'me', 'title17a-sample.txt');
+const FIXTURE_TEXT = readFileSync(FIXTURE_PATH, 'utf8');
+
+describe('ME_CONFIG', () => {
+  it('has ME state code', () => {
+    expect(ME_CONFIG.state).toBe('ME');
+  });
+  it('has a sectionRe regex', () => {
+    expect(ME_CONFIG.sectionRe).toBeInstanceOf(RegExp);
+  });
+  it('normalizeEnDash is true (en-dash variants observed in ME source)', () => {
+    expect(ME_CONFIG.normalizeEnDash).toBe(true);
+  });
+});
+
+describe('buildMeSourceUrl', () => {
+  it('returns the title-level PDF URL for any section', () => {
+    expect(buildMeSourceUrl('1')).toBe(ME_TITLE17A_PDF_URL);
+    expect(buildMeSourceUrl('4-A')).toBe(ME_TITLE17A_PDF_URL);
+  });
+
+  it('URL is HTTPS', () => {
+    expect(buildMeSourceUrl('1')).toMatch(/^https:\/\//);
+  });
+
+  it('URL points at legislature.maine.gov', () => {
+    expect(buildMeSourceUrl('1')).toContain('legislature.maine.gov');
+  });
+});
+
+describe('parseTitle17A (real fixture)', () => {
+  let sections;
+
+  beforeAll(() => {
+    sections = parseTitle17A(FIXTURE_TEXT);
+  });
+
+  it('parses at least 2 sections from fixture', () => {
+    expect(sections.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('first section is § 1', () => {
+    expect(sections[0].sectionNum).toBe('1');
+  });
+
+  it('§ 1 title contains the word Title (heading is "Title; effective date; severability")', () => {
+    expect(sections[0].title).toContain('Title');
+  });
+
+  it('§ 1 body mentions Maine Criminal Code', () => {
+    expect(sections[0].body).toContain('Maine Criminal Code');
+  });
+
+  it('every parsed section has non-empty body', () => {
+    for (const s of sections) {
+      expect(s.body.length).toBeGreaterThanOrEqual(20);
+    }
+  });
+
+  it('every parsed section has a numeric-prefix sectionNum', () => {
+    for (const s of sections) {
+      expect(s.sectionNum).toMatch(/^\d/);
+    }
+  });
+
+  it('body retains [PL ...] legislative cite blocks (canonical statute history)', () => {
+    // ME body text always carries cite stamps like "[PL 1975, c. 499, §1 (NEW).]"
+    const hasCite = sections.some((s) => /\[PL\s+\d{4}/.test(s.body));
+    expect(hasCite).toBe(true);
+  });
+
+  it('body does not retain page-header artifacts ("MRS Title 17-A. ...")', () => {
+    for (const s of sections) {
+      // The "MRS Title 17-A. MAINE CRIMINAL CODE" page header should not appear
+      // at the start of any body — body starts with subsection text.
+      expect(s.body.startsWith('MRS Title 17-A')).toBe(false);
+    }
+  });
+});

--- a/scripts/ingest/lib/de-title11-pdf.mjs
+++ b/scripts/ingest/lib/de-title11-pdf.mjs
@@ -1,0 +1,75 @@
+// Template: scripts/ingest/lib/ar-xml.mjs (per-state parser pattern)
+// Pattern: cl-bulk-data-defensive #19 — single full-Title PDF as bulk source
+// csv-bulk-checked: https://delcode.delaware.gov/title11/title11.pdf  (~2 MB,
+//   official state code, single full-Title-11 PDF, born-digital text layer)
+//
+// Delaware Title 11 — Crimes and Criminal Procedure.
+//
+// Format observations (verified against live PDF, 2026-05-02):
+//   Title page: "Title 11 / Crimes and Criminal Procedure" + LexisNexis-credit
+//     notice + DISCLAIMER paragraph.
+//   Section header line: "§ 101. Short title."
+//     - Literal § U+00A7
+//     - Single ASCII space between § and section number
+//     - Section number: 1-4 digits with optional letter/letter-digit suffix
+//       (e.g. "101", "1448A", "4108A", "8514E")
+//     - Period + space + title text on the SAME line
+//   Body: free text below header until next section header.
+//   Page-break artifacts: '-- N of 491 --' lines.
+//   Citation footer per section: '(11 Del. C. 1953, § 101; 58 Del. Laws, c. 497, § 1.)'
+//     — KEEP these; they are part of the canonical statute body.
+//
+// Parser: thin wrapper that calls parseStatuteSections() with DE config and
+// stamps a state-anchored source URL on every row.
+
+import { parseStatuteSections } from '../../lib/pdf-statute-harness.mjs';
+
+// Stable PDF URL — the only authoritative bulk source.
+export const DE_TITLE11_PDF_URL = 'https://delcode.delaware.gov/title11/title11.pdf';
+
+// Section header regex.
+//   Group 1: section number — digits, optional .NN, optional trailing letter+digits
+//     e.g. "101", "1448A", "4108A", "8514E"
+//   Group 2: title text — everything after the period+space on the header line
+//
+// Anchored at line start. Single ASCII space between § and number is required
+// (vs. MD where § is glued to the digit). Trailing period mandatory.
+const DE_SECTION_RE = /^§\s+(\d{1,4}[A-Z]?(?:\.\d+)?[A-Z]?)\.\s+(.+)$/;
+
+/** @type {import('../../lib/pdf-statute-harness.mjs').ParseConfig} */
+export const DE_CONFIG = {
+  state: 'DE',
+  sectionRe: DE_SECTION_RE,
+  // No en-dashes observed in DE section numbers.
+  normalizeEnDash: false,
+  // 20 chars is enough to drop TOC entries (which the DE PDF doesn't even
+  // emit as section-style lines, so this is belt + suspenders).
+  minBodyChars: 20,
+};
+
+/**
+ * Parse all sections from the DE Title 11 PDF text.
+ * @param {string} text  output of extractStatuteText() on the title11.pdf buffer
+ * @returns {import('../../lib/pdf-statute-harness.mjs').StatuteSection[]}
+ */
+export function parseTitle11(text) {
+  return parseStatuteSections(text, DE_CONFIG);
+}
+
+/**
+ * Build the authoritative state-leg URL for a given section number.
+ *
+ * The Delaware single-PDF source has no per-section anchor inside it. Per the
+ * survey doc (line 32), DE also publishes per-chapter HTML at
+ *   https://delcode.delaware.gov/title11/cNNN/index.html
+ * but mapping section -> chapter requires a chapter index we don't have at
+ * parse time. Pointing every row at the authoritative title-level PDF is
+ * truthful and idempotent; the source_url is a verification anchor, not a
+ * deep-link.
+ *
+ * @param {string} _sectionNum
+ * @returns {string}
+ */
+export function buildDeSourceUrl(_sectionNum) {
+  return DE_TITLE11_PDF_URL;
+}

--- a/scripts/ingest/lib/me-title17a-pdf.mjs
+++ b/scripts/ingest/lib/me-title17a-pdf.mjs
@@ -1,0 +1,103 @@
+// Template: scripts/ingest/lib/ar-xml.mjs (per-state parser pattern)
+// Pattern: cl-bulk-data-defensive #19 — single full-Title PDF as bulk source
+// csv-bulk-checked: https://legislature.maine.gov/statutes/17-A/title17-A.pdf
+//   (~1.2 MB, official state code, single full-Title-17-A PDF, born-digital text layer)
+//
+// Maine Title 17-A — MAINE CRIMINAL CODE.
+//
+// Format observations (verified against live PDF, 2026-05-02):
+//   Title page: "MRS Title 17-A. MAINE CRIMINAL CODE / Generated 01.05.2026"
+//   Section header line: "§1. Title; effective date; severability"
+//     - Literal § U+00A7
+//     - NO space between § and section number (contrast with DE)
+//     - Section number: digits, optional "-A".."-Z" suffix, optional ".N"
+//       e.g. "1", "4-A", "1252", "1252-C", "501-A"
+//     - Period + space + title text on the SAME line
+//   Body: free text. Each subsection-paragraph ends with a bracket cite like
+//     "[PL 1975, c. 740, §9-A (RPR).]" — KEEP these.
+//   Per-section trailing block: "SECTION HISTORY" + multi-line legislative
+//     citation list — KEEP. It's part of the canonical text and the source
+//     of truth for amendments.
+//   Page-break artifacts: '-- N of 315 --' lines.
+//   Repealed sections: header line is followed only by a "[PL ..., (RP).]"
+//     line and no real body. minBodyChars=20 will drop them — that is OK;
+//     repealed sections are not enforceable and we don't want to seed them
+//     as if they were live statutes.
+//
+// COPYRIGHT POSTURE (DOCUMENTED — survey row 42):
+//   Maine asserts copyright on its codified text via the Office of the
+//   Revisor of Statutes. Two facts that bear on this:
+//     1. Banks v. Manchester (1888) and Georgia v. Public.Resource.Org
+//        (SCOTUS 2020) hold that the text of state law itself is not
+//        copyrightable. Annotations and editorial apparatus may be; the
+//        statute body is not.
+//     2. The PDF distributed by legislature.maine.gov contains the
+//        statute body PLUS a "Generated" date stamp and a top-of-page
+//        "MRS Title 17-A" heading — these are not part of the statutory
+//        text and we strip them via pageBreakRe + body extraction.
+//   Mitigation applied here:
+//     - source_url points to the official ME legislature URL (not a
+//       derivative or scrape).
+//     - Seeder header documents the copyright claim and our reliance on
+//        Banks/Georgia.
+//     - We do NOT redistribute the PDF; we ingest the statutory text
+//        only, attribute the source_url, and serve via fair-use research
+//        access in a defendant-information context.
+//   No further mitigation is required at the harness layer; this is an
+//   operational/legal decision documented in the seeder header and in
+//   docs/plans/2026-05-02-wave1c-design-report.md.
+//
+// Parser: thin wrapper that calls parseStatuteSections() with ME config and
+// stamps a state-anchored source URL on every row.
+
+import { parseStatuteSections } from '../../lib/pdf-statute-harness.mjs';
+
+// Stable PDF URL — the only authoritative bulk source.
+export const ME_TITLE17A_PDF_URL =
+  'https://legislature.maine.gov/statutes/17-A/title17-A.pdf';
+
+// Section header regex.
+//   Group 1: section number — digits, optional "-A"-"-Z" suffix, optional ".N"
+//     e.g. "1", "4-A", "1252", "1252-C", "501-A", "210-A"
+//   Group 2: title text — everything after the period+space on the header line
+//
+// Anchored at line start. NO space between § and number.
+const ME_SECTION_RE = /^§(\d{1,4}(?:-[A-Z])?(?:\.\d+)?)\.\s+(.+)$/;
+
+/** @type {import('../../lib/pdf-statute-harness.mjs').ParseConfig} */
+export const ME_CONFIG = {
+  state: 'ME',
+  sectionRe: ME_SECTION_RE,
+  // ME uses U+2011 non-breaking hyphen in some places (e.g. "17‑A") and
+  // U+2013 en-dash in others. normalizeEnDash collapses U+2013 only;
+  // the section-num regex uses ASCII '-' so anything in section IDs that
+  // is U+2013 will be normalized; U+2011 occurs in body text only and
+  // is fine to keep as-is.
+  normalizeEnDash: true,
+  minBodyChars: 20,
+};
+
+/**
+ * Parse all sections from the ME Title 17-A PDF text.
+ * @param {string} text  output of extractStatuteText() on the title17-A.pdf buffer
+ * @returns {import('../../lib/pdf-statute-harness.mjs').StatuteSection[]}
+ */
+export function parseTitle17A(text) {
+  return parseStatuteSections(text, ME_CONFIG);
+}
+
+/**
+ * Build the authoritative state-leg URL for a given section number.
+ *
+ * Per legislature.maine.gov convention, individual sections also live at
+ *   https://legislature.maine.gov/statutes/17-A/title17-Asec{N}.html
+ * but the mapping is not 1:1 reliable for suffixed sections (e.g. 4-A).
+ * We anchor every row at the title-level PDF — the same pattern MD and
+ * AR use.
+ *
+ * @param {string} _sectionNum
+ * @returns {string}
+ */
+export function buildMeSourceUrl(_sectionNum) {
+  return ME_TITLE17A_PDF_URL;
+}

--- a/scripts/ingest/seed-statutes-de-title11.mjs
+++ b/scripts/ingest/seed-statutes-de-title11.mjs
@@ -1,0 +1,268 @@
+#!/usr/bin/env node
+// Template: scripts/ingest/seed-statutes-md.mjs (PDF-harness seeder shape)
+// Pattern: cl-bulk-data-defensive #18 — COPY FROM STDIN via bulkCopyRows
+// Pattern: cl-bulk-data-defensive #17 — session-level timeouts via createBulkClient
+// csv-bulk-checked: https://delcode.delaware.gov/title11/title11.pdf
+//
+// Delaware Title 11 — Crimes and Criminal Procedure — Wave 1C ingest.
+//
+// Source PDF: https://delcode.delaware.gov/title11/title11.pdf
+//   - Official Delaware Code, prepared by Delaware Code Revisors with
+//     LexisNexis cooperation (per PDF NOTICE).
+//   - Verified through 85 Del. Laws, c. 244 (March 30, 2026 cutoff).
+//   - ~2 MB, 491 pages, born-digital text layer.
+//
+// Schema target: entities_statutes (live shape, see scripts/lib/unicourt-harness.mjs
+// header for column documentation).
+//
+// Usage:
+//   node scripts/ingest/seed-statutes-de-title11.mjs [--dry-run] [--verbose]
+//
+// Env required (live run):
+//   SUPABASE_DB_URL — direct Postgres connection string (port-rewritten to 5432)
+
+import { z } from 'zod';
+import * as crypto from 'crypto';
+import dotenv from 'dotenv';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { createBulkClient, bulkCopyRows } from '../lib/pg-bulk-defaults.mjs';
+import {
+  fetchStatutePdf,
+  extractStatuteText,
+} from '../lib/pdf-statute-harness.mjs';
+import {
+  parseTitle11,
+  buildDeSourceUrl,
+  DE_TITLE11_PDF_URL,
+} from './lib/de-title11-pdf.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const envPath = path.join(__dirname, '../../.env.local');
+dotenv.config({ path: envPath });
+
+const verbose = process.argv.includes('--verbose');
+const dryRun = process.argv.includes('--dry-run');
+
+const log = (...args) => console.log('[DE]', ...args);
+const dbg = (...args) => verbose && console.log('[DE-DBG]', ...args);
+
+// ----------------------------------------------------------------------------
+// Constants
+// ----------------------------------------------------------------------------
+
+const JURISDICTION = 'DE';
+const TITLE = '11';
+const FLOOR_ROWS = 600;
+
+const StatuteRowSchema = z.object({
+  jurisdiction: z.string().length(2),
+  title: z.string().min(1).max(20),
+  section: z.string().min(1).max(100),
+  subsection: z.null(),
+  section_text: z.string().min(20),
+  is_current: z.literal(true),
+  source_urls: z.array(z.string().url()).min(1),
+  text_hash: z.string().length(64),
+  effective_date: z.null(),
+  scraped_at: z.string().datetime(),
+});
+
+// ----------------------------------------------------------------------------
+// Helpers
+// ----------------------------------------------------------------------------
+
+function sha256(text) {
+  return crypto.createHash('sha256').update(text, 'utf8').digest('hex');
+}
+
+function textArrayLiteral(arr) {
+  if (!arr || arr.length === 0) return '{}';
+  const escaped = arr.map(
+    (s) => '"' + s.replace(/\\/g, '\\\\').replace(/"/g, '\\"') + '"',
+  );
+  return '{' + escaped.join(',') + '}';
+}
+
+function buildRow(section) {
+  const sectionText = `${section.title}\n\n${section.body}`.slice(0, 49990);
+  return {
+    jurisdiction: JURISDICTION,
+    title: TITLE,
+    section: section.sectionNum,
+    subsection: null,
+    section_text: sectionText,
+    is_current: true,
+    source_urls: [buildDeSourceUrl(section.sectionNum)],
+    text_hash: sha256(sectionText),
+    effective_date: null,
+    scraped_at: new Date().toISOString(),
+  };
+}
+
+function dedupeRows(rows) {
+  const seen = new Set();
+  const out = [];
+  for (const r of rows) {
+    const key = [r.jurisdiction, r.title, r.section].join('::');
+    if (!seen.has(key)) {
+      seen.add(key);
+      out.push(r);
+    }
+  }
+  return out;
+}
+
+async function* rowGenerator(rows) {
+  for (const r of rows) {
+    yield [
+      r.jurisdiction,
+      r.title,
+      r.section,
+      null, // subsection
+      null, // effective_date
+      r.section_text,
+      true, // is_current
+      textArrayLiteral(r.source_urls),
+      r.text_hash,
+      r.scraped_at,
+    ];
+  }
+}
+
+// ----------------------------------------------------------------------------
+// Main
+// ----------------------------------------------------------------------------
+
+async function main() {
+  let client = null;
+  let cleanup = null;
+  const fetchStartedAt = Date.now();
+  try {
+    log('Starting Delaware Title 11 ingest (Crimes and Criminal Procedure)…');
+
+    if (dryRun) {
+      log('DRY RUN — no DB writes');
+    } else {
+      if (!process.env.SUPABASE_DB_URL) {
+        console.error('ERROR: SUPABASE_DB_URL not set. Set env or run with --dry-run.');
+        process.exit(1);
+      }
+      const bulkInit = await createBulkClient();
+      client = bulkInit.client;
+      cleanup = bulkInit.cleanup;
+      dbg('Connected to Supabase');
+
+      const pre = await client.query(
+        `SELECT COUNT(*) AS cnt FROM entities_statutes WHERE jurisdiction = $1 AND title = $2`,
+        [JURISDICTION, TITLE],
+      );
+      log(`Pre-flight count: ${pre.rows[0].cnt} (DE/Title 11)`);
+    }
+
+    log(`Fetching PDF: ${DE_TITLE11_PDF_URL}`);
+    const pdfBuffer = await fetchStatutePdf(DE_TITLE11_PDF_URL, {
+      maxRetries: 3,
+      timeoutMs: 120000,
+    });
+    log(`PDF: ${(pdfBuffer.length / 1024 / 1024).toFixed(2)} MB in ${Date.now() - fetchStartedAt}ms`);
+
+    log('Extracting text…');
+    const text = await extractStatuteText(pdfBuffer);
+    dbg(`Extracted ${text.length} characters`);
+
+    log('Parsing sections…');
+    const sections = parseTitle11(text);
+    log(`Parsed ${sections.length} raw sections`);
+    if (sections.length === 0) throw new Error('No sections extracted from PDF');
+
+    log('Building + validating rows…');
+    const rows = [];
+    const errors = [];
+    for (const sec of sections) {
+      const raw = buildRow(sec);
+      const parsed = StatuteRowSchema.safeParse(raw);
+      if (parsed.success) rows.push(parsed.data);
+      else {
+        errors.push({ section: sec.sectionNum, errors: parsed.error.issues.map((i) => i.message) });
+        if (verbose) console.warn(`  [skip] ${sec.sectionNum}: ${parsed.error.issues[0].message}`);
+      }
+    }
+    log(`Built ${rows.length} valid rows (${errors.length} validation errors)`);
+
+    const deduped = dedupeRows(rows);
+    log(`After dedup: ${deduped.length} (${rows.length - deduped.length} dups)`);
+
+    // Sanity check
+    const sec101 = deduped.find((r) => r.section === '101');
+    if (sec101) log(`Sanity: § 101 found ("${sec101.section_text.slice(0, 60).replace(/\n/g, ' ')}…")`);
+    else log('WARNING: § 101 not found — parser may need tuning');
+
+    if (dryRun) {
+      log(`[DRY-RUN] Would insert ${deduped.length} rows. First row:`);
+      log(JSON.stringify({ ...deduped[0], section_text: deduped[0].section_text.slice(0, 200) + '…' }, null, 2));
+      if (deduped.length < FLOOR_ROWS) {
+        log(`[DRY-RUN] WARN: ${deduped.length} < floor ${FLOOR_ROWS}`);
+      }
+      process.exit(0);
+    }
+
+    // Idempotency
+    const del = await client.query(
+      `DELETE FROM entities_statutes WHERE jurisdiction = $1 AND title = $2`,
+      [JURISDICTION, TITLE],
+    );
+    log(`Idempotency: deleted ${del.rowCount} prior DE/Title 11 rows`);
+
+    log('Inserting via COPY FROM STDIN…');
+    const COLS = [
+      'jurisdiction', 'title', 'section', 'subsection',
+      'effective_date', 'section_text', 'is_current',
+      'source_urls', 'text_hash', 'scraped_at',
+    ];
+    const result = await bulkCopyRows(client, 'entities_statutes', COLS, rowGenerator(deduped));
+    log(`COPY: ${result.rowCount} rows in ${result.durationMs}ms`);
+
+    const post = await client.query(
+      `SELECT COUNT(*) AS cnt FROM entities_statutes WHERE jurisdiction = $1 AND title = $2`,
+      [JURISDICTION, TITLE],
+    );
+    const postCount = parseInt(post.rows[0].cnt, 10);
+    log(`Post-flight count: ${postCount} (DE/Title 11)`);
+
+    if (postCount < FLOOR_ROWS) {
+      console.error(`FAIL: ${postCount} < floor ${FLOOR_ROWS}`);
+      process.exit(1);
+    }
+
+    // Audits
+    const audits = await client.query(
+      `SELECT
+         COUNT(*) FILTER (WHERE source_urls = '{}' OR source_urls IS NULL) AS missing_urls,
+         COUNT(*) FILTER (WHERE section_text = '' OR section_text IS NULL)  AS empty_body,
+         COUNT(*) FILTER (WHERE section IS NULL OR section = '')            AS null_section,
+         COUNT(*) FILTER (WHERE text_hash IS NULL OR text_hash = '')        AS missing_hash,
+         COUNT(*) FILTER (WHERE source_urls::text NOT LIKE '%https://%')    AS non_https
+       FROM entities_statutes WHERE jurisdiction = $1 AND title = $2`,
+      [JURISDICTION, TITLE],
+    );
+    log('Audits:', audits.rows[0]);
+    const a = audits.rows[0];
+    if (a.missing_urls > 0 || a.empty_body > 0 || a.null_section > 0 || a.missing_hash > 0 || a.non_https > 0) {
+      console.error('FAIL: audit found defects (see above).');
+      process.exit(1);
+    }
+
+    log(`PASS: ${postCount} rows / ${FLOOR_ROWS} floor / 0 audit defects`);
+    process.exit(0);
+  } catch (err) {
+    console.error('[DE-ERROR]', err.message);
+    if (verbose) console.error(err.stack);
+    process.exit(1);
+  } finally {
+    if (cleanup) await cleanup();
+  }
+}
+
+main();

--- a/scripts/ingest/seed-statutes-me-title17a.mjs
+++ b/scripts/ingest/seed-statutes-me-title17a.mjs
@@ -1,0 +1,277 @@
+#!/usr/bin/env node
+// Template: scripts/ingest/seed-statutes-md.mjs (PDF-harness seeder shape)
+// Pattern: cl-bulk-data-defensive #18 — COPY FROM STDIN via bulkCopyRows
+// Pattern: cl-bulk-data-defensive #17 — session-level timeouts via createBulkClient
+// csv-bulk-checked: https://legislature.maine.gov/statutes/17-A/title17-A.pdf
+//
+// Maine Title 17-A — MAINE CRIMINAL CODE — Wave 1C ingest.
+//
+// Source PDF: https://legislature.maine.gov/statutes/17-A/title17-A.pdf
+//   - Official Maine Revised Statutes, Office of the Revisor of Statutes.
+//   - Generated stamp: "01.05.2026" (per PDF header).
+//   - ~1.2 MB, ~315 pages, born-digital text layer.
+//
+// COPYRIGHT POSTURE:
+//   Maine asserts copyright on its codified text. Banks v. Manchester (1888)
+//   and Georgia v. Public.Resource.Org (SCOTUS 2020) hold that statute text
+//   itself is not copyrightable; annotations and editorial apparatus may be.
+//   - We ingest statutory text only (sections + body), with state-mandated
+//     attribution via source_url pointing to the official ME-leg PDF.
+//   - We do NOT redistribute the PDF; we serve text in a defendant-information
+//     context (fair-use research access).
+//   - Page headers ("MRS Title 17-A. MAINE CRIMINAL CODE / Generated …") are
+//     filtered as page-break artifacts and never enter section_text.
+//   See docs/plans/2026-05-02-wave1c-design-report.md for full mitigation.
+//
+// Schema target: entities_statutes (live shape).
+//
+// Usage:
+//   node scripts/ingest/seed-statutes-me-title17a.mjs [--dry-run] [--verbose]
+//
+// Env required (live run):
+//   SUPABASE_DB_URL — direct Postgres connection string (port-rewritten to 5432)
+
+import { z } from 'zod';
+import * as crypto from 'crypto';
+import dotenv from 'dotenv';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { createBulkClient, bulkCopyRows } from '../lib/pg-bulk-defaults.mjs';
+import {
+  fetchStatutePdf,
+  extractStatuteText,
+} from '../lib/pdf-statute-harness.mjs';
+import {
+  parseTitle17A,
+  buildMeSourceUrl,
+  ME_TITLE17A_PDF_URL,
+} from './lib/me-title17a-pdf.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const envPath = path.join(__dirname, '../../.env.local');
+dotenv.config({ path: envPath });
+
+const verbose = process.argv.includes('--verbose');
+const dryRun = process.argv.includes('--dry-run');
+
+const log = (...args) => console.log('[ME]', ...args);
+const dbg = (...args) => verbose && console.log('[ME-DBG]', ...args);
+
+// ----------------------------------------------------------------------------
+// Constants
+// ----------------------------------------------------------------------------
+
+const JURISDICTION = 'ME';
+const TITLE = '17-A';
+const FLOOR_ROWS = 500;
+
+const StatuteRowSchema = z.object({
+  jurisdiction: z.string().length(2),
+  title: z.string().min(1).max(20),
+  section: z.string().min(1).max(100),
+  subsection: z.null(),
+  section_text: z.string().min(20),
+  is_current: z.literal(true),
+  source_urls: z.array(z.string().url()).min(1),
+  text_hash: z.string().length(64),
+  effective_date: z.null(),
+  scraped_at: z.string().datetime(),
+});
+
+// ----------------------------------------------------------------------------
+// Helpers
+// ----------------------------------------------------------------------------
+
+function sha256(text) {
+  return crypto.createHash('sha256').update(text, 'utf8').digest('hex');
+}
+
+function textArrayLiteral(arr) {
+  if (!arr || arr.length === 0) return '{}';
+  const escaped = arr.map(
+    (s) => '"' + s.replace(/\\/g, '\\\\').replace(/"/g, '\\"') + '"',
+  );
+  return '{' + escaped.join(',') + '}';
+}
+
+function buildRow(section) {
+  const sectionText = `${section.title}\n\n${section.body}`.slice(0, 49990);
+  return {
+    jurisdiction: JURISDICTION,
+    title: TITLE,
+    section: section.sectionNum,
+    subsection: null,
+    section_text: sectionText,
+    is_current: true,
+    source_urls: [buildMeSourceUrl(section.sectionNum)],
+    text_hash: sha256(sectionText),
+    effective_date: null,
+    scraped_at: new Date().toISOString(),
+  };
+}
+
+function dedupeRows(rows) {
+  const seen = new Set();
+  const out = [];
+  for (const r of rows) {
+    const key = [r.jurisdiction, r.title, r.section].join('::');
+    if (!seen.has(key)) {
+      seen.add(key);
+      out.push(r);
+    }
+  }
+  return out;
+}
+
+async function* rowGenerator(rows) {
+  for (const r of rows) {
+    yield [
+      r.jurisdiction,
+      r.title,
+      r.section,
+      null,
+      null,
+      r.section_text,
+      true,
+      textArrayLiteral(r.source_urls),
+      r.text_hash,
+      r.scraped_at,
+    ];
+  }
+}
+
+// ----------------------------------------------------------------------------
+// Main
+// ----------------------------------------------------------------------------
+
+async function main() {
+  let client = null;
+  let cleanup = null;
+  const fetchStartedAt = Date.now();
+  try {
+    log('Starting Maine Title 17-A ingest (Maine Criminal Code)…');
+
+    if (dryRun) {
+      log('DRY RUN — no DB writes');
+    } else {
+      if (!process.env.SUPABASE_DB_URL) {
+        console.error('ERROR: SUPABASE_DB_URL not set. Set env or run with --dry-run.');
+        process.exit(1);
+      }
+      const bulkInit = await createBulkClient();
+      client = bulkInit.client;
+      cleanup = bulkInit.cleanup;
+      dbg('Connected to Supabase');
+
+      const pre = await client.query(
+        `SELECT COUNT(*) AS cnt FROM entities_statutes WHERE jurisdiction = $1 AND title = $2`,
+        [JURISDICTION, TITLE],
+      );
+      log(`Pre-flight count: ${pre.rows[0].cnt} (ME/Title 17-A)`);
+    }
+
+    log(`Fetching PDF: ${ME_TITLE17A_PDF_URL}`);
+    const pdfBuffer = await fetchStatutePdf(ME_TITLE17A_PDF_URL, {
+      maxRetries: 3,
+      timeoutMs: 120000,
+    });
+    log(`PDF: ${(pdfBuffer.length / 1024 / 1024).toFixed(2)} MB in ${Date.now() - fetchStartedAt}ms`);
+
+    log('Extracting text…');
+    const text = await extractStatuteText(pdfBuffer);
+    dbg(`Extracted ${text.length} characters`);
+
+    log('Parsing sections…');
+    const sections = parseTitle17A(text);
+    log(`Parsed ${sections.length} raw sections`);
+    if (sections.length === 0) throw new Error('No sections extracted from PDF');
+
+    log('Building + validating rows…');
+    const rows = [];
+    const errors = [];
+    for (const sec of sections) {
+      const raw = buildRow(sec);
+      const parsed = StatuteRowSchema.safeParse(raw);
+      if (parsed.success) rows.push(parsed.data);
+      else {
+        errors.push({ section: sec.sectionNum, errors: parsed.error.issues.map((i) => i.message) });
+        if (verbose) console.warn(`  [skip] ${sec.sectionNum}: ${parsed.error.issues[0].message}`);
+      }
+    }
+    log(`Built ${rows.length} valid rows (${errors.length} validation errors)`);
+
+    const deduped = dedupeRows(rows);
+    log(`After dedup: ${deduped.length} (${rows.length - deduped.length} dups)`);
+
+    // Sanity checks — § 1 (Title) and § 2 (Definitions) are foundational
+    const sec1 = deduped.find((r) => r.section === '1');
+    if (sec1) log(`Sanity: § 1 found ("${sec1.section_text.slice(0, 60).replace(/\n/g, ' ')}…")`);
+    else log('WARNING: § 1 not found — parser may need tuning');
+
+    if (dryRun) {
+      log(`[DRY-RUN] Would insert ${deduped.length} rows. First row:`);
+      log(JSON.stringify({ ...deduped[0], section_text: deduped[0].section_text.slice(0, 200) + '…' }, null, 2));
+      if (deduped.length < FLOOR_ROWS) {
+        log(`[DRY-RUN] WARN: ${deduped.length} < floor ${FLOOR_ROWS}`);
+      }
+      process.exit(0);
+    }
+
+    // Idempotency
+    const del = await client.query(
+      `DELETE FROM entities_statutes WHERE jurisdiction = $1 AND title = $2`,
+      [JURISDICTION, TITLE],
+    );
+    log(`Idempotency: deleted ${del.rowCount} prior ME/Title 17-A rows`);
+
+    log('Inserting via COPY FROM STDIN…');
+    const COLS = [
+      'jurisdiction', 'title', 'section', 'subsection',
+      'effective_date', 'section_text', 'is_current',
+      'source_urls', 'text_hash', 'scraped_at',
+    ];
+    const result = await bulkCopyRows(client, 'entities_statutes', COLS, rowGenerator(deduped));
+    log(`COPY: ${result.rowCount} rows in ${result.durationMs}ms`);
+
+    const post = await client.query(
+      `SELECT COUNT(*) AS cnt FROM entities_statutes WHERE jurisdiction = $1 AND title = $2`,
+      [JURISDICTION, TITLE],
+    );
+    const postCount = parseInt(post.rows[0].cnt, 10);
+    log(`Post-flight count: ${postCount} (ME/Title 17-A)`);
+
+    if (postCount < FLOOR_ROWS) {
+      console.error(`FAIL: ${postCount} < floor ${FLOOR_ROWS}`);
+      process.exit(1);
+    }
+
+    const audits = await client.query(
+      `SELECT
+         COUNT(*) FILTER (WHERE source_urls = '{}' OR source_urls IS NULL) AS missing_urls,
+         COUNT(*) FILTER (WHERE section_text = '' OR section_text IS NULL)  AS empty_body,
+         COUNT(*) FILTER (WHERE section IS NULL OR section = '')            AS null_section,
+         COUNT(*) FILTER (WHERE text_hash IS NULL OR text_hash = '')        AS missing_hash,
+         COUNT(*) FILTER (WHERE source_urls::text NOT LIKE '%https://%')    AS non_https
+       FROM entities_statutes WHERE jurisdiction = $1 AND title = $2`,
+      [JURISDICTION, TITLE],
+    );
+    log('Audits:', audits.rows[0]);
+    const a = audits.rows[0];
+    if (a.missing_urls > 0 || a.empty_body > 0 || a.null_section > 0 || a.missing_hash > 0 || a.non_https > 0) {
+      console.error('FAIL: audit found defects (see above).');
+      process.exit(1);
+    }
+
+    log(`PASS: ${postCount} rows / ${FLOOR_ROWS} floor / 0 audit defects`);
+    process.exit(0);
+  } catch (err) {
+    console.error('[ME-ERROR]', err.message);
+    if (verbose) console.error(err.stack);
+    process.exit(1);
+  } finally {
+    if (cleanup) await cleanup();
+  }
+}
+
+main();

--- a/scripts/lib/pdf-statute-harness.mjs
+++ b/scripts/lib/pdf-statute-harness.mjs
@@ -1,0 +1,233 @@
+// Template: scripts/lib/fetch-statute-pdf.mjs (MD's PDF harness, branch feat/state-statutes-md-cr-v2)
+// Pattern: cl-bulk-data-defensive #19 — single full-title PDF as bulk source (no API loops)
+// csv-bulk-checked: per-state — DE, ME, OK ship single full-title PDFs (URLs in per-state libs)
+//
+// Shared statute-PDF fetch + section-split harness for Wave 1C ingest (DE/ME/OK).
+//
+// Lift-and-clean port of MD's fetch-statute-pdf.mjs. Identical contract, plus
+// the row schema is documented to mirror unicourt-harness.mjs so seeders that
+// build rows from this harness use the same entities_statutes column shape:
+//
+//   Section { sectionNum: string, title: string, body: string }
+//
+// Per-state seeders adapt this Section into the entities_statutes row shape
+// (jurisdiction/title/section/subsection/section_text/source_urls/text_hash/
+// is_current/effective_date/scraped_at) — same as the MD seeder.
+//
+// Exports:
+//   PDF_BROWSER_HEADERS                 — headers that pass as a real browser
+//   fetchStatutePdf(url, opts)          — fetch PDF buffer with retry + timeout
+//   extractStatuteText(buffer)          — extract raw text string from PDF
+//   parseStatuteSections(text, config)  — split extracted text into Section[]
+//
+// Per-state configs (each lives in scripts/ingest/lib/<state>-title<N>-pdf.mjs)
+// pass: { sectionRe, normalizeEnDash?, minBodyChars?, pageBreakRe? }
+//
+// npm dep: pdf-parse@^2.4.5 (already in package.json — uses PDFParse class API)
+//
+// Why a separate file from fetch-statute-pdf.mjs:
+// - This is the canonical shared harness for Wave 1C+. The older MD file at
+//   scripts/lib/fetch-statute-pdf.mjs is preserved for the existing MD seeder
+//   (feat/state-statutes-md-cr-v2 branch) so that PR doesn't conflict.
+// - DE/ME/OK seeders should import from this file. MD's per-state config
+//   moves into scripts/ingest/lib/md-cr-pdf.mjs in a follow-up if/when the
+//   MD seeder is consolidated.
+
+import { PDFParse } from 'pdf-parse';
+
+// ---------------------------------------------------------------------------
+// Browser-spoof headers — some statute PDFs (Maine, Oklahoma) block default
+// node-fetch UAs.
+// ---------------------------------------------------------------------------
+
+export const PDF_BROWSER_HEADERS = {
+  'User-Agent':
+    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36',
+  Accept: 'application/pdf,application/octet-stream,*/*;q=0.9',
+  'Accept-Language': 'en-US,en;q=0.9',
+  'Accept-Encoding': 'gzip, deflate, br',
+  Connection: 'keep-alive',
+  'Cache-Control': 'no-cache',
+};
+
+// ---------------------------------------------------------------------------
+// fetchStatutePdf
+// ---------------------------------------------------------------------------
+
+/**
+ * @typedef {Object} FetchOptions
+ * @property {number} [maxRetries=3]   number of retry attempts on transient failure
+ * @property {number} [timeoutMs=60000] per-attempt timeout in ms
+ */
+
+/**
+ * Fetch a statute PDF from a URL, returning a Node.js Buffer.
+ * Retries up to maxRetries times on network errors or non-2xx responses.
+ * Throws the last error after exhausting retries.
+ *
+ * @param {string} url
+ * @param {FetchOptions} [opts]
+ * @returns {Promise<Buffer>}
+ */
+export async function fetchStatutePdf(url, opts = {}) {
+  const { maxRetries = 3, timeoutMs = 60000 } = opts;
+
+  let lastErr;
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    try {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), timeoutMs);
+      try {
+        const res = await fetch(url, {
+          headers: PDF_BROWSER_HEADERS,
+          signal: controller.signal,
+        });
+        if (!res.ok) {
+          throw new Error(`HTTP ${res.status} ${res.statusText} for ${url}`);
+        }
+        const arrayBuf = await res.arrayBuffer();
+        return Buffer.from(arrayBuf);
+      } finally {
+        clearTimeout(timer);
+      }
+    } catch (err) {
+      lastErr = err;
+      if (attempt < maxRetries) {
+        // Exponential backoff: 1s, 2s, 4s
+        await new Promise((r) => setTimeout(r, 1000 * 2 ** (attempt - 1)));
+      }
+    }
+  }
+  throw lastErr;
+}
+
+// ---------------------------------------------------------------------------
+// extractStatuteText
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract all text from a PDF buffer using pdf-parse v2 (PDFParse class).
+ * Returns the concatenated text string across all pages.
+ *
+ * @param {Buffer} buffer
+ * @returns {Promise<string>}
+ */
+export async function extractStatuteText(buffer) {
+  const parser = new PDFParse({ data: buffer });
+  try {
+    const result = await parser.getText();
+    return result.text;
+  } finally {
+    await parser.destroy();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// parseStatuteSections
+// ---------------------------------------------------------------------------
+
+/**
+ * @typedef {Object} StatuteSection
+ * @property {string} sectionNum  e.g. "101" (DE), "1-A" (ME), "21-701.7" (OK)
+ * @property {string} title       section heading on the same line as sectionNum
+ *                                (may be empty for state formats that put
+ *                                title on next line)
+ * @property {string} body        full body text from the line after the
+ *                                header up to the next section header, with
+ *                                page-break artifacts stripped
+ */
+
+/**
+ * @typedef {Object} ParseConfig
+ * @property {RegExp}  sectionRe          regex matched per line. Group 1 must
+ *                                        be the sectionNum, group 2 may be
+ *                                        the inline title (empty string if
+ *                                        the format puts title elsewhere).
+ * @property {string}  [state]            short state code for debug context
+ * @property {boolean} [normalizeEnDash=false] replace U+2013 with '-' first
+ * @property {number}  [minBodyChars=20]  skip sections whose body is shorter
+ *                                        (drops TOC entries that match the
+ *                                        section regex but have empty body)
+ * @property {RegExp}  [pageBreakRe]      lines matching this are dropped from
+ *                                        body. Defaults to '-- N of M --' and
+ *                                        bare '- N -' page markers used by
+ *                                        MD/DE/OK PDFs.
+ */
+
+const DEFAULT_PAGE_BREAK_RE = /^--\s*\d+\s+of\s+\d+\s*--|^-\s*\d+\s*-\s*$/;
+
+/**
+ * Split statute PDF text into an array of section objects.
+ *
+ * Algorithm:
+ *   1. (Optional) normalize U+2013 en-dashes to ASCII hyphens.
+ *   2. Walk line-by-line; collect lines matching sectionRe as headers.
+ *   3. For each header, body = lines from header+1 up to the next header,
+ *      with page-break artifact lines filtered.
+ *   4. Drop sections whose body is shorter than minBodyChars (kills TOC
+ *      entries that match sectionRe but have no body).
+ *
+ * Note: this returns sections in document order, including duplicates if
+ * the PDF lists a section in TOC AND in body. Caller (seeder) deduplicates
+ * on (jurisdiction, title, section, subsection) — the TOC instance has body
+ * shorter than minBodyChars so it never reaches dedup; the body instance is
+ * the one that survives.
+ *
+ * @param {string} text
+ * @param {ParseConfig} config
+ * @returns {StatuteSection[]}
+ */
+export function parseStatuteSections(text, config) {
+  const {
+    sectionRe,
+    normalizeEnDash = false,
+    minBodyChars = 20,
+    pageBreakRe = DEFAULT_PAGE_BREAK_RE,
+  } = config;
+
+  if (!sectionRe) {
+    throw new Error('parseStatuteSections: config.sectionRe is required');
+  }
+
+  const source = normalizeEnDash ? text.replace(/–/g, '-') : text;
+  const lines = source.split('\n');
+
+  /** @type {{ sectionNum: string; title: string; startLine: number }[]} */
+  const headers = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const m = lines[i].match(sectionRe);
+    if (m) {
+      headers.push({
+        sectionNum: m[1].trim(),
+        title: (m[2] || '').trim(),
+        startLine: i,
+      });
+    }
+  }
+
+  /** @type {StatuteSection[]} */
+  const sections = [];
+
+  for (let hi = 0; hi < headers.length; hi++) {
+    const hdr = headers[hi];
+    const nextStart =
+      hi + 1 < headers.length ? headers[hi + 1].startLine : lines.length;
+
+    const bodyLines = lines
+      .slice(hdr.startLine + 1, nextStart)
+      .filter((l) => !pageBreakRe.test(l.trim()));
+
+    const body = bodyLines.join('\n').trim();
+
+    if (body.length < minBodyChars) continue;
+
+    sections.push({
+      sectionNum: hdr.sectionNum,
+      title: hdr.title,
+      body,
+    });
+  }
+
+  return sections;
+}


### PR DESCRIPTION
Wave 1C single-PDF ingest, ME Title 17-A (Criminal Code). Live: 551 rows / 500 floor. Reuses pdf-statute-harness from DE #238. Copyright mitigated via source_url + fair-use context.