### PR TITLE
feat(statutes): seed OK Title 21 — Wave 1C

### DIFF
--- a/scripts/ingest/__tests__/fixtures/de/title11-sample.txt
+++ b/scripts/ingest/__tests__/fixtures/de/title11-sample.txt
@@ -1,0 +1,79 @@
+Title 11
+Crimes and Criminal Procedure
+NOTICE: The Delaware Code appearing on this site is prepared by the Delaware Code Revisors and the
+editorial staff of LexisNexis in cooperation with the Division of Legislative Services of the General Assembly,
+and is considered an official version of the State of Delaware statutory code. This version includes all acts
+enacted as of March 30, 2026, up to and including 85 Del. Laws, c. 244.
+DISCLAIMER: With respect to the Delaware Code documents available from this site or server, neither the
+State of Delaware nor any of its employees, makes any warranty, express or implied, including the warranties
+of merchantability and fitness for a particular purpose, or assumes any legal liability or responsibility for the
+usefulness of any information, apparatus, product, or process disclosed, or represents that its use would not
+infringe privately-owned rights. Please seek legal counsel for help on interpretation of individual statutes.
+
+-- 1 of 491 --
+
+
+
+-- 2 of 491 --
+
+Title 11 - Crimes and Criminal Procedure
+Page 1
+Part I
+Delaware Criminal Code
+Chapter 1
+Introductory Provisions
+§ 101. Short title.
+Part I of this title shall be known as the “Delaware Criminal Code.”
+(11 Del. C. 1953, § 101; 58 Del. Laws, c. 497, § 1.)
+§ 102. Applicability to offenses committed prior to July 1, 1973.
+(a) Except as provided in subsections (b) and (c) of this section, this Criminal Code does not apply to offenses committed prior to July
+1, 1973. Prosecutions for offenses committed prior to July 1, 1973, shall be governed by the prior law, which is continued in effect for
+that purpose, as if this Criminal Code were not in force. For the purpose of this section, an offense was committed prior to July 1, 1973,
+if any of the elements of the offense occurred prior thereto.
+(b) In any case pending on or commenced after July 1, 1973, involving an offense committed prior to that date:
+(1) Procedural provisions of this Criminal Code shall govern, insofar as they are justly applicable and their applicability does not
+introduce confusion, delay or manifest injustice;
+(2) Provisions of this Criminal Code according a defense or mitigations shall apply, with the consent of the defendant.
+(c) Provisions of this Criminal Code governing the treatment and the release or discharge of prisoners, probationers and parolees shall
+apply to persons under sentence for offenses committed prior to July 1, 1973, except that the minimum or maximum period of their
+detention or supervision shall in no case be increased, nor shall this Criminal Code affect the substantive or procedural validity of any
+judgment of conviction entered prior to July 1, 1973, regardless of the fact that appeal time has not run or that an appeal is pending.
+(11 Del. C. 1953, § 102; 58 Del. Laws, c. 497, § 1.)
+§ 103. Applicability to offenses committed after July 1, 1973.
+(a) This Criminal Code establishes the criminal law of this State and governs the construction of and punishment for any offense set
+forth herein committed after July 1, 1973, as well as the construction and application of any defense to a prosecution for such an offense.
+(b) Unless otherwise expressly provided, or unless the context otherwise requires, this Criminal Code governs the construction of any
+offense defined in a statute other than this Criminal Code and committed after July 1, 1973, as well as the construction and application
+of any defense to a prosecution for such an offense.
+(11 Del. C. 1953, § 103; 58 Del. Laws, c. 497, § 1.)
+
+-- 3 of 491 --
+
+Title 11 - Crimes and Criminal Procedure
+Page 2
+Part I
+Delaware Criminal Code
+Chapter 2
+General Provisions Concerning Offenses
+§ 201. General purposes.
+The general purposes of this Criminal Code are:
+(1) To proscribe conduct which unjustifiably and inexcusably causes or threatens harm to individual or public interests;
+(2) To give fair warning of the nature of the conduct proscribed and of the sentences authorized upon conviction;
+(3) To define the act or omission and the accompanying mental state which constitute each offense;
+(4) To differentiate upon reasonable grounds between serious and minor offenses and to prescribe proportionate penalties therefor;
+and
+(5) To insure the public safety by preventing the commission of offenses through the deterrent influence of the sentences authorized,
+the rehabilitation of those convicted and their confinement when required in the interests of public protection.
+(11 Del. C. 1953, § 201; 58 Del. Laws, c. 497, § 1.)
+§ 202. All offenses defined by statute.
+(a) No conduct constitutes a criminal offense unless it is made a criminal offense by this Criminal Code or by another law.
+(b) This section does not affect the power of a court to punish for civil contempt or to employ any sanction authorized by law for the
+enforcement of an order or a civil judgment or decree.
+(11 Del. C. 1953, § 202; 58 Del. Laws, c. 497, § 1.)
+§ 203. Principles of construction.
+The general rule that a penal statute is to be strictly construed does not apply to this Criminal Code, but the provisions herein must be
+construed according to the fair import of their terms to promote justice and effect the purposes of the law, as stated in § 201 of this title.
+(11 Del. C. 1953, § 203; 58 Del. Laws, c. 497, § 1.)
+§ 204. Territorial applicability.
+(a) Except as otherwise provided in this section a person may be convicted under the law of this State of an offense committed by the
+person’s own conduct or by the conduct of 

--- a/scripts/ingest/__tests__/fixtures/ok/title21-sample.txt
+++ b/scripts/ingest/__tests__/fixtures/ok/title21-sample.txt
@@ -1,0 +1,118 @@
+........ 883
+§21-1. Title of code.
+This chapter shall be known as the penal code of the State of
+Oklahoma.
+R.L.1910, § 2082.
+§21-2. Criminal acts are only those prescribed - "This code"
+defined.
+No act or omission shall be deemed criminal or punishable except
+as prescribed or authorized by this code. The words "this code" as
+used in the "penal code" shall be construed to mean "Statutes of
+this State."
+R.L.1910, § 2083.
+§21-3. Crime and public offense defined.
+A crime or public offense is an act or omission forbidden by
+law, and to which is annexed, upon conviction, either of the
+following punishments:
+1. Death;
+2. Imprisonment;
+3. Fine;
+4. Removal from office; or
+
+-- 33 of 884 --
+
+Oklahoma Statutes - Title 21. Crimes and Punishments Page 34
+5. Disqualification to hold and enjoy any office of honor,
+trust, or profit, under this state.
+R.L. 1910, § 2084. Amended by Laws 1997, c. 133, § 10, eff. July 1,
+1999; Laws 1999, 1st Ex.Sess., c. 5, § 1, eff. July 1, 1999.
+NOTE: Laws 1998, 1st Ex.Sess., c. 2, § 23 amended the effective
+date of Laws 1997, c. 133, § 10 from July 1, 1998, to July 1, 1999.
+§21-4. Crimes classified.
+Crimes are divided into:
+1. Felonies;
+2. Misdemeanors.
+R.L.1910, § 2085.
+§21-5. Felony defined.
+A felony is a crime which is, or may be, punishable with death,
+or by imprisonment in the penitentiary.
+R.L. 1910, § 2086. Amended by Laws 1997, c. 133, § 11, eff. July 1,
+1999; Laws 1999, 1st Ex.Sess., c. 5, § 2, eff. July 1, 1999.
+NOTE: Laws 1998, 1st Ex.Sess., c. 2, § 23 amended the effective
+date of Laws 1997, c. 133, § 11 from July 1, 1998, to July 1, 1999.
+§21-6. Misdemeanor defined.
+Every other crime is a misdemeanor.
+R.L.1910, § 2087. R.L.1910, § 2087.
+§21-7. Objects of penal code.
+This title specifies the classes of persons who are deemed
+capable of crimes, and liable to punishment therefor. This title
+defines the nature of various crimes and prescribes the kind and
+measure of punishment to be inflicted for each. The manner of
+prosecuting and convicting criminals is regulated by the code of
+criminal procedure.
+R.L. 1910, § 2088. Amended by Laws 1997, c. 133, § 12, eff. July 1,
+1999; Laws 1999, 1st Ex.Sess., c. 5, § 3, eff. July 1, 1999.
+NOTE: Laws 1998, 1st Ex.Sess., c. 2, § 23 amended the effective
+date of Laws 1997, c. 133, § 12 from July 1, 1998, to July 1, 1999.
+§21-8. Conviction must precede punishment.
+The punishments prescribed by this chapter can be inflicted only
+upon a legal conviction in a court having jurisdiction.
+R.L.1910, § 2090.
+§21-9. Punishment of felonies.
+Except in cases where a different punishment is prescribed by
+this title, or by some existing provision of law, every offense
+declared to be a felony is punishable by a fine not exceeding One
+Thousand Dollars ($1,000.00), or by imprisonment in the State
+
+-- 34 of 884 --
+
+Oklahoma Statutes - Title 21. Crimes and Punishments Page 35
+Penitentiary not exceeding two (2) years, or by both such fine and
+imprisonment.
+R.L. 1910, § 2090. Amended by Laws 1997, c. 133, § 13, eff. July 1,
+1999; Laws 1998, 1st Ex.Sess., c. 2, § 1, emerg. eff. June 19, 1998;
+Laws 1999, 1st Ex.Sess., c. 5, § 4, eff. July 1, 1999.
+NOTE: Laws 1998, 1st Ex.Sess., c. 2, § 23 amended the effective
+date of Laws 1997, c. 133, § 13 from July 1, 1998, to July 1, 1999.
+§21-10. Punishment of misdemeanor.
+Except in cases where a different punishment is prescribed by
+this chapter or by some existing provisions of law, every offense
+declared to be a misdemeanor is punishable by imprisonment in the
+county jail not exceeding one year or by a fine not exceeding five
+hundred dollars, or both such fine and imprisonment.
+R.L.1910, § 2091.
+§21-11. Special provisions as governing - Acts punishable in
+different ways.
+If there be in any other provision of the laws of this state a
+provision making any specific act or omission criminal and providing
+the punishment therefor, and there be in this title any provision or
+section making the same act or omission a criminal offense or
+prescribing the punishment therefor, that offense and the punishment
+thereof, shall be governed by the special provisions made in
+relation thereto, and not by the provisions of this title. But an
+act or omission which is made punishable in different ways by
+different provisions of this title may be punished under any of such
+provisions, except that in cases specified in Sections 51.1 and 54
+of this title, the punishments therein prescribed are substituted
+for those prescribed for a first offense, but in no case can a
+criminal act or omission be punished under more than one section of
+law; and an acquittal or conviction and sentence under one section
+of law, bars the prosecution for the same act or omission under any
+other section of law.
+R.L. 1910, § 2092. Amended by Laws 1970, c. 199, § 1; Laws 1987, c.
+226, § 1, operative July 1, 1987; Laws 1997, c. 133, § 14, eff. July
+1, 1999; Laws 1999, 1st Ex. Sess., c. 5, § 5, eff. July 1, 1999;
+Laws 2019, c. 227, § 1, eff. Nov. 1, 2019.
+NOTE: Laws 1998, 1st Ex. Sess., c. 2, § 23 amended the effective
+date of Laws 1997, c. 133, § 14 from July 1, 1998, to July 1, 1999.
+§21-12. Repealed by Laws 1999, 1st Ex.Sess., c. 5, § 452, eff. July
+1, 1999.
+§21-12.1. Required service of minimum percentage of sentence –
+Effective date.
+
+-- 35 of 884 --
+
+Oklahoma Statutes - Title 21. Crimes and Punishments Page 36
+A person committing a felony offense listed in Section 30 of
+this act on or after March 1, 2000, and convicted of the offense
+shall serve not less than eighty-f

--- a/scripts/ingest/__tests__/seed-statutes-de-title11.test.mjs
+++ b/scripts/ingest/__tests__/seed-statutes-de-title11.test.mjs
@@ -1,0 +1,89 @@
+// test-isolation-na: pure parser unit tests against on-disk fixture text — no DB writes.
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import {
+  parseTitle11,
+  buildDeSourceUrl,
+  DE_TITLE11_PDF_URL,
+  DE_CONFIG,
+} from '../lib/de-title11-pdf.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURE_PATH = path.join(__dirname, 'fixtures', 'de', 'title11-sample.txt');
+const FIXTURE_TEXT = readFileSync(FIXTURE_PATH, 'utf8');
+
+describe('DE_CONFIG', () => {
+  it('has DE state code', () => {
+    expect(DE_CONFIG.state).toBe('DE');
+  });
+  it('has a sectionRe regex', () => {
+    expect(DE_CONFIG.sectionRe).toBeInstanceOf(RegExp);
+  });
+});
+
+describe('buildDeSourceUrl', () => {
+  it('returns the title-level PDF URL for any section', () => {
+    expect(buildDeSourceUrl('101')).toBe(DE_TITLE11_PDF_URL);
+    expect(buildDeSourceUrl('1448A')).toBe(DE_TITLE11_PDF_URL);
+  });
+
+  it('URL is HTTPS', () => {
+    expect(buildDeSourceUrl('101')).toMatch(/^https:\/\//);
+  });
+
+  it('URL points at delcode.delaware.gov', () => {
+    expect(buildDeSourceUrl('101')).toContain('delcode.delaware.gov');
+  });
+});
+
+describe('parseTitle11 (real fixture)', () => {
+  let sections;
+
+  beforeAll(() => {
+    sections = parseTitle11(FIXTURE_TEXT);
+  });
+
+  it('parses at least 3 sections from fixture', () => {
+    expect(sections.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('first section is § 101', () => {
+    expect(sections[0].sectionNum).toBe('101');
+  });
+
+  it('§ 101 title says Short title', () => {
+    expect(sections[0].title).toContain('Short title');
+  });
+
+  it('§ 101 body mentions Delaware Criminal Code', () => {
+    expect(sections[0].body).toContain('Delaware Criminal Code');
+  });
+
+  it('every parsed section has non-empty body', () => {
+    for (const s of sections) {
+      expect(s.body.length).toBeGreaterThanOrEqual(20);
+    }
+  });
+
+  it('every parsed section has a numeric-prefix sectionNum', () => {
+    for (const s of sections) {
+      expect(s.sectionNum).toMatch(/^\d/);
+    }
+  });
+
+  it('body is stripped of page-break artifact lines', () => {
+    for (const s of sections) {
+      // No "-- N of M --" lines should survive
+      expect(s.body).not.toMatch(/^--\s+\d+\s+of\s+\d+\s+--$/m);
+    }
+  });
+
+  it('preserves citation footers in body', () => {
+    // DE format keeps "(11 Del. C. 1953, § ...; ...)" — those should remain.
+    const sec101 = sections.find((s) => s.sectionNum === '101');
+    expect(sec101).toBeDefined();
+    expect(sec101.body).toContain('Del. C.');
+  });
+});

--- a/scripts/ingest/__tests__/seed-statutes-ok-title21.test.mjs
+++ b/scripts/ingest/__tests__/seed-statutes-ok-title21.test.mjs
@@ -1,0 +1,89 @@
+// test-isolation-na: pure parser unit tests against on-disk fixture text — no DB writes.
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import {
+  parseTitle21,
+  buildOkSourceUrl,
+  OK_TITLE21_PDF_URL,
+  OK_CONFIG,
+} from '../lib/ok-title21-pdf.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURE_PATH = path.join(__dirname, 'fixtures', 'ok', 'title21-sample.txt');
+const FIXTURE_TEXT = readFileSync(FIXTURE_PATH, 'utf8');
+
+describe('OK_CONFIG', () => {
+  it('has OK state code', () => {
+    expect(OK_CONFIG.state).toBe('OK');
+  });
+  it('has a sectionRe regex', () => {
+    expect(OK_CONFIG.sectionRe).toBeInstanceOf(RegExp);
+  });
+});
+
+describe('buildOkSourceUrl', () => {
+  it('returns the title-level PDF URL for any section', () => {
+    expect(buildOkSourceUrl('21-1')).toBe(OK_TITLE21_PDF_URL);
+    expect(buildOkSourceUrl('21-540A')).toBe(OK_TITLE21_PDF_URL);
+    expect(buildOkSourceUrl('21-13.1v1')).toBe(OK_TITLE21_PDF_URL);
+  });
+
+  it('URL is HTTPS', () => {
+    expect(buildOkSourceUrl('21-1')).toMatch(/^https:\/\//);
+  });
+
+  it('URL points at oklegislature.gov', () => {
+    expect(buildOkSourceUrl('21-1')).toContain('oklegislature.gov');
+  });
+});
+
+describe('parseTitle21 (real fixture, body slice past TOC)', () => {
+  let sections;
+
+  beforeAll(() => {
+    sections = parseTitle21(FIXTURE_TEXT);
+  });
+
+  it('parses at least 4 sections from fixture', () => {
+    expect(sections.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it('first section is § 21-1', () => {
+    expect(sections[0].sectionNum).toBe('21-1');
+  });
+
+  it('§ 21-1 title says Title of code', () => {
+    expect(sections[0].title).toContain('Title of code');
+  });
+
+  it('§ 21-1 body mentions penal code of the State of Oklahoma', () => {
+    expect(sections[0].body).toMatch(/penal code of the State of\s+Oklahoma/);
+  });
+
+  it('every parsed section has non-empty body', () => {
+    for (const s of sections) {
+      expect(s.body.length).toBeGreaterThanOrEqual(20);
+    }
+  });
+
+  it('every parsed section has the OK title-prefix "21-" in sectionNum', () => {
+    for (const s of sections) {
+      expect(s.sectionNum).toMatch(/^21-/);
+    }
+  });
+
+  it('body is stripped of page-break artifact lines', () => {
+    for (const s of sections) {
+      expect(s.body).not.toMatch(/^--\s+\d+\s+of\s+\d+\s+--$/m);
+    }
+  });
+
+  it('preserves R.L. legislative cite stamps in body', () => {
+    // OK body retains "R.L.1910, § 2082." style cites.
+    const sec1 = sections.find((s) => s.sectionNum === '21-1');
+    expect(sec1).toBeDefined();
+    expect(sec1.body).toMatch(/R\.L\.?\s*1910/);
+  });
+});

--- a/scripts/ingest/lib/de-title11-pdf.mjs
+++ b/scripts/ingest/lib/de-title11-pdf.mjs
@@ -1,0 +1,75 @@
+// Template: scripts/ingest/lib/ar-xml.mjs (per-state parser pattern)
+// Pattern: cl-bulk-data-defensive #19 — single full-Title PDF as bulk source
+// csv-bulk-checked: https://delcode.delaware.gov/title11/title11.pdf  (~2 MB,
+//   official state code, single full-Title-11 PDF, born-digital text layer)
+//
+// Delaware Title 11 — Crimes and Criminal Procedure.
+//
+// Format observations (verified against live PDF, 2026-05-02):
+//   Title page: "Title 11 / Crimes and Criminal Procedure" + LexisNexis-credit
+//     notice + DISCLAIMER paragraph.
+//   Section header line: "§ 101. Short title."
+//     - Literal § U+00A7
+//     - Single ASCII space between § and section number
+//     - Section number: 1-4 digits with optional letter/letter-digit suffix
+//       (e.g. "101", "1448A", "4108A", "8514E")
+//     - Period + space + title text on the SAME line
+//   Body: free text below header until next section header.
+//   Page-break artifacts: '-- N of 491 --' lines.
+//   Citation footer per section: '(11 Del. C. 1953, § 101; 58 Del. Laws, c. 497, § 1.)'
+//     — KEEP these; they are part of the canonical statute body.
+//
+// Parser: thin wrapper that calls parseStatuteSections() with DE config and
+// stamps a state-anchored source URL on every row.
+
+import { parseStatuteSections } from '../../lib/pdf-statute-harness.mjs';
+
+// Stable PDF URL — the only authoritative bulk source.
+export const DE_TITLE11_PDF_URL = 'https://delcode.delaware.gov/title11/title11.pdf';
+
+// Section header regex.
+//   Group 1: section number — digits, optional .NN, optional trailing letter+digits
+//     e.g. "101", "1448A", "4108A", "8514E"
+//   Group 2: title text — everything after the period+space on the header line
+//
+// Anchored at line start. Single ASCII space between § and number is required
+// (vs. MD where § is glued to the digit). Trailing period mandatory.
+const DE_SECTION_RE = /^§\s+(\d{1,4}[A-Z]?(?:\.\d+)?[A-Z]?)\.\s+(.+)$/;
+
+/** @type {import('../../lib/pdf-statute-harness.mjs').ParseConfig} */
+export const DE_CONFIG = {
+  state: 'DE',
+  sectionRe: DE_SECTION_RE,
+  // No en-dashes observed in DE section numbers.
+  normalizeEnDash: false,
+  // 20 chars is enough to drop TOC entries (which the DE PDF doesn't even
+  // emit as section-style lines, so this is belt + suspenders).
+  minBodyChars: 20,
+};
+
+/**
+ * Parse all sections from the DE Title 11 PDF text.
+ * @param {string} text  output of extractStatuteText() on the title11.pdf buffer
+ * @returns {import('../../lib/pdf-statute-harness.mjs').StatuteSection[]}
+ */
+export function parseTitle11(text) {
+  return parseStatuteSections(text, DE_CONFIG);
+}
+
+/**
+ * Build the authoritative state-leg URL for a given section number.
+ *
+ * The Delaware single-PDF source has no per-section anchor inside it. Per the
+ * survey doc (line 32), DE also publishes per-chapter HTML at
+ *   https://delcode.delaware.gov/title11/cNNN/index.html
+ * but mapping section -> chapter requires a chapter index we don't have at
+ * parse time. Pointing every row at the authoritative title-level PDF is
+ * truthful and idempotent; the source_url is a verification anchor, not a
+ * deep-link.
+ *
+ * @param {string} _sectionNum
+ * @returns {string}
+ */
+export function buildDeSourceUrl(_sectionNum) {
+  return DE_TITLE11_PDF_URL;
+}

--- a/scripts/ingest/lib/ok-title21-pdf.mjs
+++ b/scripts/ingest/lib/ok-title21-pdf.mjs
@@ -1,0 +1,80 @@
+// Template: scripts/ingest/lib/ar-xml.mjs (per-state parser pattern)
+// Pattern: cl-bulk-data-defensive #19 — single full-Title PDF as bulk source
+// csv-bulk-checked: https://www.oklegislature.gov/OK_Statutes/CompleteTitles/os21.pdf
+//   (~3.5 MB / 884 pages, official state code, single full-Title-21 PDF,
+//    born-digital text layer, public-domain via state authorship)
+//
+// Oklahoma Title 21 — Crimes and Punishments.
+//
+// Format observations (verified against live PDF, 2026-05-02):
+//   Title page: "OKLAHOMA STATUTES / TITLE 21. CRIMES AND PUNISHMENTS"
+//   First ~50k chars: TABLE OF CONTENTS — every line matches the section
+//     regex but trailing dot leaders take the place of the title text and
+//     body is empty. minBodyChars=20 drops these. Seeder dedup keeps the
+//     real (longer-body) instance found later in the document.
+//   Section header line: "§21-1. Title of code."
+//     - Literal § U+00A7
+//     - NO space between § and section number
+//     - Section number always starts with title prefix "21-"
+//     - Section can have:
+//         * decimal subsection: "21-13.1"
+//         * versioned: "21-13.1v1", "21-13.1v2"
+//         * letter suffix: "21-540A", "21-540B", "21-20A"
+//         * compound: "21-1289.16-1" (range markers)
+//     - Period + space + title text on the SAME line
+//   Body: free text, sometimes with bracket cites like "Added by Laws 2024,
+//     c. 12, § 1, eff. Nov. 1, 2024."
+//   Page-break artifacts: '-- N of 884 --' lines.
+//   Repealed sections: title line says "Repealed by Laws YYYY, ..." with
+//     no real body. minBodyChars=20 drops most; the ones that DO have body
+//     usually contain the repealing-act citation only — that is acceptable
+//     statutory text.
+//
+// Parser: thin wrapper that calls parseStatuteSections() with OK config and
+// stamps a state-anchored source URL on every row.
+
+import { parseStatuteSections } from '../../lib/pdf-statute-harness.mjs';
+
+// Stable PDF URL — the only authoritative bulk source.
+export const OK_TITLE21_PDF_URL =
+  'https://www.oklegislature.gov/OK_Statutes/CompleteTitles/os21.pdf';
+
+// Section header regex.
+//   Group 1: section number — full form "21-N[.M][vK][-J]" with optional letter
+//     suffix variants. Mirrors the OK_CONFIG that already lives in the legacy
+//     fetch-statute-pdf.mjs harness; ported verbatim.
+//   Group 2: title text — everything after the period+space on the header line
+const OK_SECTION_RE = /^§(\d+[-–]\d+(?:\.\d+)*[A-Z]?(?:v\d+)?(?:-\d+)?)\.\s+(.+)$/;
+
+/** @type {import('../../lib/pdf-statute-harness.mjs').ParseConfig} */
+export const OK_CONFIG = {
+  state: 'OK',
+  sectionRe: OK_SECTION_RE,
+  // OK uses ASCII hyphens in section numbers; en-dash never observed.
+  normalizeEnDash: false,
+  minBodyChars: 20,
+};
+
+/**
+ * Parse all sections from the OK Title 21 PDF text.
+ * @param {string} text  output of extractStatuteText() on the os21.pdf buffer
+ * @returns {import('../../lib/pdf-statute-harness.mjs').StatuteSection[]}
+ */
+export function parseTitle21(text) {
+  return parseStatuteSections(text, OK_CONFIG);
+}
+
+/**
+ * Build the authoritative state-leg URL for a given section number.
+ *
+ * Oklahoma's online statute UI exists at oscn.net but the URL grammar is
+ * dynamic-form-only (token=...). The single-PDF source is the only stable
+ * authoritative deep-link, so every row anchors there — same pattern as
+ * MD/DE/ME.
+ *
+ * @param {string} _sectionNum
+ * @returns {string}
+ */
+export function buildOkSourceUrl(_sectionNum) {
+  return OK_TITLE21_PDF_URL;
+}

--- a/scripts/ingest/seed-statutes-de-title11.mjs
+++ b/scripts/ingest/seed-statutes-de-title11.mjs
@@ -1,0 +1,268 @@
+#!/usr/bin/env node
+// Template: scripts/ingest/seed-statutes-md.mjs (PDF-harness seeder shape)
+// Pattern: cl-bulk-data-defensive #18 — COPY FROM STDIN via bulkCopyRows
+// Pattern: cl-bulk-data-defensive #17 — session-level timeouts via createBulkClient
+// csv-bulk-checked: https://delcode.delaware.gov/title11/title11.pdf
+//
+// Delaware Title 11 — Crimes and Criminal Procedure — Wave 1C ingest.
+//
+// Source PDF: https://delcode.delaware.gov/title11/title11.pdf
+//   - Official Delaware Code, prepared by Delaware Code Revisors with
+//     LexisNexis cooperation (per PDF NOTICE).
+//   - Verified through 85 Del. Laws, c. 244 (March 30, 2026 cutoff).
+//   - ~2 MB, 491 pages, born-digital text layer.
+//
+// Schema target: entities_statutes (live shape, see scripts/lib/unicourt-harness.mjs
+// header for column documentation).
+//
+// Usage:
+//   node scripts/ingest/seed-statutes-de-title11.mjs [--dry-run] [--verbose]
+//
+// Env required (live run):
+//   SUPABASE_DB_URL — direct Postgres connection string (port-rewritten to 5432)
+
+import { z } from 'zod';
+import * as crypto from 'crypto';
+import dotenv from 'dotenv';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { createBulkClient, bulkCopyRows } from '../lib/pg-bulk-defaults.mjs';
+import {
+  fetchStatutePdf,
+  extractStatuteText,
+} from '../lib/pdf-statute-harness.mjs';
+import {
+  parseTitle11,
+  buildDeSourceUrl,
+  DE_TITLE11_PDF_URL,
+} from './lib/de-title11-pdf.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const envPath = path.join(__dirname, '../../.env.local');
+dotenv.config({ path: envPath });
+
+const verbose = process.argv.includes('--verbose');
+const dryRun = process.argv.includes('--dry-run');
+
+const log = (...args) => console.log('[DE]', ...args);
+const dbg = (...args) => verbose && console.log('[DE-DBG]', ...args);
+
+// ----------------------------------------------------------------------------
+// Constants
+// ----------------------------------------------------------------------------
+
+const JURISDICTION = 'DE';
+const TITLE = '11';
+const FLOOR_ROWS = 600;
+
+const StatuteRowSchema = z.object({
+  jurisdiction: z.string().length(2),
+  title: z.string().min(1).max(20),
+  section: z.string().min(1).max(100),
+  subsection: z.null(),
+  section_text: z.string().min(20),
+  is_current: z.literal(true),
+  source_urls: z.array(z.string().url()).min(1),
+  text_hash: z.string().length(64),
+  effective_date: z.null(),
+  scraped_at: z.string().datetime(),
+});
+
+// ----------------------------------------------------------------------------
+// Helpers
+// ----------------------------------------------------------------------------
+
+function sha256(text) {
+  return crypto.createHash('sha256').update(text, 'utf8').digest('hex');
+}
+
+function textArrayLiteral(arr) {
+  if (!arr || arr.length === 0) return '{}';
+  const escaped = arr.map(
+    (s) => '"' + s.replace(/\\/g, '\\\\').replace(/"/g, '\\"') + '"',
+  );
+  return '{' + escaped.join(',') + '}';
+}
+
+function buildRow(section) {
+  const sectionText = `${section.title}\n\n${section.body}`.slice(0, 49990);
+  return {
+    jurisdiction: JURISDICTION,
+    title: TITLE,
+    section: section.sectionNum,
+    subsection: null,
+    section_text: sectionText,
+    is_current: true,
+    source_urls: [buildDeSourceUrl(section.sectionNum)],
+    text_hash: sha256(sectionText),
+    effective_date: null,
+    scraped_at: new Date().toISOString(),
+  };
+}
+
+function dedupeRows(rows) {
+  const seen = new Set();
+  const out = [];
+  for (const r of rows) {
+    const key = [r.jurisdiction, r.title, r.section].join('::');
+    if (!seen.has(key)) {
+      seen.add(key);
+      out.push(r);
+    }
+  }
+  return out;
+}
+
+async function* rowGenerator(rows) {
+  for (const r of rows) {
+    yield [
+      r.jurisdiction,
+      r.title,
+      r.section,
+      null, // subsection
+      null, // effective_date
+      r.section_text,
+      true, // is_current
+      textArrayLiteral(r.source_urls),
+      r.text_hash,
+      r.scraped_at,
+    ];
+  }
+}
+
+// ----------------------------------------------------------------------------
+// Main
+// ----------------------------------------------------------------------------
+
+async function main() {
+  let client = null;
+  let cleanup = null;
+  const fetchStartedAt = Date.now();
+  try {
+    log('Starting Delaware Title 11 ingest (Crimes and Criminal Procedure)…');
+
+    if (dryRun) {
+      log('DRY RUN — no DB writes');
+    } else {
+      if (!process.env.SUPABASE_DB_URL) {
+        console.error('ERROR: SUPABASE_DB_URL not set. Set env or run with --dry-run.');
+        process.exit(1);
+      }
+      const bulkInit = await createBulkClient();
+      client = bulkInit.client;
+      cleanup = bulkInit.cleanup;
+      dbg('Connected to Supabase');
+
+      const pre = await client.query(
+        `SELECT COUNT(*) AS cnt FROM entities_statutes WHERE jurisdiction = $1 AND title = $2`,
+        [JURISDICTION, TITLE],
+      );
+      log(`Pre-flight count: ${pre.rows[0].cnt} (DE/Title 11)`);
+    }
+
+    log(`Fetching PDF: ${DE_TITLE11_PDF_URL}`);
+    const pdfBuffer = await fetchStatutePdf(DE_TITLE11_PDF_URL, {
+      maxRetries: 3,
+      timeoutMs: 120000,
+    });
+    log(`PDF: ${(pdfBuffer.length / 1024 / 1024).toFixed(2)} MB in ${Date.now() - fetchStartedAt}ms`);
+
+    log('Extracting text…');
+    const text = await extractStatuteText(pdfBuffer);
+    dbg(`Extracted ${text.length} characters`);
+
+    log('Parsing sections…');
+    const sections = parseTitle11(text);
+    log(`Parsed ${sections.length} raw sections`);
+    if (sections.length === 0) throw new Error('No sections extracted from PDF');
+
+    log('Building + validating rows…');
+    const rows = [];
+    const errors = [];
+    for (const sec of sections) {
+      const raw = buildRow(sec);
+      const parsed = StatuteRowSchema.safeParse(raw);
+      if (parsed.success) rows.push(parsed.data);
+      else {
+        errors.push({ section: sec.sectionNum, errors: parsed.error.issues.map((i) => i.message) });
+        if (verbose) console.warn(`  [skip] ${sec.sectionNum}: ${parsed.error.issues[0].message}`);
+      }
+    }
+    log(`Built ${rows.length} valid rows (${errors.length} validation errors)`);
+
+    const deduped = dedupeRows(rows);
+    log(`After dedup: ${deduped.length} (${rows.length - deduped.length} dups)`);
+
+    // Sanity check
+    const sec101 = deduped.find((r) => r.section === '101');
+    if (sec101) log(`Sanity: § 101 found ("${sec101.section_text.slice(0, 60).replace(/\n/g, ' ')}…")`);
+    else log('WARNING: § 101 not found — parser may need tuning');
+
+    if (dryRun) {
+      log(`[DRY-RUN] Would insert ${deduped.length} rows. First row:`);
+      log(JSON.stringify({ ...deduped[0], section_text: deduped[0].section_text.slice(0, 200) + '…' }, null, 2));
+      if (deduped.length < FLOOR_ROWS) {
+        log(`[DRY-RUN] WARN: ${deduped.length} < floor ${FLOOR_ROWS}`);
+      }
+      process.exit(0);
+    }
+
+    // Idempotency
+    const del = await client.query(
+      `DELETE FROM entities_statutes WHERE jurisdiction = $1 AND title = $2`,
+      [JURISDICTION, TITLE],
+    );
+    log(`Idempotency: deleted ${del.rowCount} prior DE/Title 11 rows`);
+
+    log('Inserting via COPY FROM STDIN…');
+    const COLS = [
+      'jurisdiction', 'title', 'section', 'subsection',
+      'effective_date', 'section_text', 'is_current',
+      'source_urls', 'text_hash', 'scraped_at',
+    ];
+    const result = await bulkCopyRows(client, 'entities_statutes', COLS, rowGenerator(deduped));
+    log(`COPY: ${result.rowCount} rows in ${result.durationMs}ms`);
+
+    const post = await client.query(
+      `SELECT COUNT(*) AS cnt FROM entities_statutes WHERE jurisdiction = $1 AND title = $2`,
+      [JURISDICTION, TITLE],
+    );
+    const postCount = parseInt(post.rows[0].cnt, 10);
+    log(`Post-flight count: ${postCount} (DE/Title 11)`);
+
+    if (postCount < FLOOR_ROWS) {
+      console.error(`FAIL: ${postCount} < floor ${FLOOR_ROWS}`);
+      process.exit(1);
+    }
+
+    // Audits
+    const audits = await client.query(
+      `SELECT
+         COUNT(*) FILTER (WHERE source_urls = '{}' OR source_urls IS NULL) AS missing_urls,
+         COUNT(*) FILTER (WHERE section_text = '' OR section_text IS NULL)  AS empty_body,
+         COUNT(*) FILTER (WHERE section IS NULL OR section = '')            AS null_section,
+         COUNT(*) FILTER (WHERE text_hash IS NULL OR text_hash = '')        AS missing_hash,
+         COUNT(*) FILTER (WHERE source_urls::text NOT LIKE '%https://%')    AS non_https
+       FROM entities_statutes WHERE jurisdiction = $1 AND title = $2`,
+      [JURISDICTION, TITLE],
+    );
+    log('Audits:', audits.rows[0]);
+    const a = audits.rows[0];
+    if (a.missing_urls > 0 || a.empty_body > 0 || a.null_section > 0 || a.missing_hash > 0 || a.non_https > 0) {
+      console.error('FAIL: audit found defects (see above).');
+      process.exit(1);
+    }
+
+    log(`PASS: ${postCount} rows / ${FLOOR_ROWS} floor / 0 audit defects`);
+    process.exit(0);
+  } catch (err) {
+    console.error('[DE-ERROR]', err.message);
+    if (verbose) console.error(err.stack);
+    process.exit(1);
+  } finally {
+    if (cleanup) await cleanup();
+  }
+}
+
+main();

--- a/scripts/ingest/seed-statutes-ok-title21.mjs
+++ b/scripts/ingest/seed-statutes-ok-title21.mjs
@@ -1,0 +1,269 @@
+#!/usr/bin/env node
+// Template: scripts/ingest/seed-statutes-md.mjs (PDF-harness seeder shape)
+// Pattern: cl-bulk-data-defensive #18 — COPY FROM STDIN via bulkCopyRows
+// Pattern: cl-bulk-data-defensive #17 — session-level timeouts via createBulkClient
+// csv-bulk-checked: https://www.oklegislature.gov/OK_Statutes/CompleteTitles/os21.pdf
+//
+// Oklahoma Title 21 — Crimes and Punishments — Wave 1C ingest.
+//
+// Source PDF: https://www.oklegislature.gov/OK_Statutes/CompleteTitles/os21.pdf
+//   - Official Oklahoma Statutes, published by the Oklahoma Legislature.
+//   - ~3.5 MB, ~884 pages, born-digital text layer.
+//   - Public-domain (state authorship).
+//
+// Schema target: entities_statutes (live shape).
+//
+// Usage:
+//   node scripts/ingest/seed-statutes-ok-title21.mjs [--dry-run] [--verbose]
+//
+// Env required (live run):
+//   SUPABASE_DB_URL — direct Postgres connection string (port-rewritten to 5432)
+
+import { z } from 'zod';
+import * as crypto from 'crypto';
+import dotenv from 'dotenv';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { createBulkClient, bulkCopyRows } from '../lib/pg-bulk-defaults.mjs';
+import {
+  fetchStatutePdf,
+  extractStatuteText,
+} from '../lib/pdf-statute-harness.mjs';
+import {
+  parseTitle21,
+  buildOkSourceUrl,
+  OK_TITLE21_PDF_URL,
+} from './lib/ok-title21-pdf.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const envPath = path.join(__dirname, '../../.env.local');
+dotenv.config({ path: envPath });
+
+const verbose = process.argv.includes('--verbose');
+const dryRun = process.argv.includes('--dry-run');
+
+const log = (...args) => console.log('[OK]', ...args);
+const dbg = (...args) => verbose && console.log('[OK-DBG]', ...args);
+
+// ----------------------------------------------------------------------------
+// Constants
+// ----------------------------------------------------------------------------
+
+const JURISDICTION = 'OK';
+const TITLE = '21';
+const FLOOR_ROWS = 1200;
+
+const StatuteRowSchema = z.object({
+  jurisdiction: z.string().length(2),
+  title: z.string().min(1).max(20),
+  section: z.string().min(1).max(100),
+  subsection: z.null(),
+  section_text: z.string().min(20),
+  is_current: z.literal(true),
+  source_urls: z.array(z.string().url()).min(1),
+  text_hash: z.string().length(64),
+  effective_date: z.null(),
+  scraped_at: z.string().datetime(),
+});
+
+// ----------------------------------------------------------------------------
+// Helpers
+// ----------------------------------------------------------------------------
+
+function sha256(text) {
+  return crypto.createHash('sha256').update(text, 'utf8').digest('hex');
+}
+
+function textArrayLiteral(arr) {
+  if (!arr || arr.length === 0) return '{}';
+  const escaped = arr.map(
+    (s) => '"' + s.replace(/\\/g, '\\\\').replace(/"/g, '\\"') + '"',
+  );
+  return '{' + escaped.join(',') + '}';
+}
+
+function buildRow(section) {
+  const sectionText = `${section.title}\n\n${section.body}`.slice(0, 49990);
+  return {
+    jurisdiction: JURISDICTION,
+    title: TITLE,
+    section: section.sectionNum,
+    subsection: null,
+    section_text: sectionText,
+    is_current: true,
+    source_urls: [buildOkSourceUrl(section.sectionNum)],
+    text_hash: sha256(sectionText),
+    effective_date: null,
+    scraped_at: new Date().toISOString(),
+  };
+}
+
+// OK's PDF lists every section twice — once in the TOC (body = next TOC line
+// with dot leaders, often >20 chars) and once in the real body (longer).
+// Keep the LONGEST body when sectionNum collides so we always end up with
+// the real statute text, not the TOC entry.
+function dedupeRows(rows) {
+  /** @type {Map<string, object>} */
+  const best = new Map();
+  for (const r of rows) {
+    const key = [r.jurisdiction, r.title, r.section].join('::');
+    const prev = best.get(key);
+    if (!prev || r.section_text.length > prev.section_text.length) {
+      best.set(key, r);
+    }
+  }
+  return [...best.values()];
+}
+
+async function* rowGenerator(rows) {
+  for (const r of rows) {
+    yield [
+      r.jurisdiction,
+      r.title,
+      r.section,
+      null,
+      null,
+      r.section_text,
+      true,
+      textArrayLiteral(r.source_urls),
+      r.text_hash,
+      r.scraped_at,
+    ];
+  }
+}
+
+// ----------------------------------------------------------------------------
+// Main
+// ----------------------------------------------------------------------------
+
+async function main() {
+  let client = null;
+  let cleanup = null;
+  const fetchStartedAt = Date.now();
+  try {
+    log('Starting Oklahoma Title 21 ingest (Crimes and Punishments)…');
+
+    if (dryRun) {
+      log('DRY RUN — no DB writes');
+    } else {
+      if (!process.env.SUPABASE_DB_URL) {
+        console.error('ERROR: SUPABASE_DB_URL not set. Set env or run with --dry-run.');
+        process.exit(1);
+      }
+      const bulkInit = await createBulkClient();
+      client = bulkInit.client;
+      cleanup = bulkInit.cleanup;
+      dbg('Connected to Supabase');
+
+      const pre = await client.query(
+        `SELECT COUNT(*) AS cnt FROM entities_statutes WHERE jurisdiction = $1 AND title = $2`,
+        [JURISDICTION, TITLE],
+      );
+      log(`Pre-flight count: ${pre.rows[0].cnt} (OK/Title 21)`);
+    }
+
+    log(`Fetching PDF: ${OK_TITLE21_PDF_URL}`);
+    const pdfBuffer = await fetchStatutePdf(OK_TITLE21_PDF_URL, {
+      maxRetries: 3,
+      timeoutMs: 180000, // 884-page PDF — give it room
+    });
+    log(`PDF: ${(pdfBuffer.length / 1024 / 1024).toFixed(2)} MB in ${Date.now() - fetchStartedAt}ms`);
+
+    log('Extracting text…');
+    const text = await extractStatuteText(pdfBuffer);
+    dbg(`Extracted ${text.length} characters`);
+
+    log('Parsing sections…');
+    const sections = parseTitle21(text);
+    log(`Parsed ${sections.length} raw sections`);
+    if (sections.length === 0) throw new Error('No sections extracted from PDF');
+
+    log('Building + validating rows…');
+    const rows = [];
+    const errors = [];
+    for (const sec of sections) {
+      const raw = buildRow(sec);
+      const parsed = StatuteRowSchema.safeParse(raw);
+      if (parsed.success) rows.push(parsed.data);
+      else {
+        errors.push({ section: sec.sectionNum, errors: parsed.error.issues.map((i) => i.message) });
+        if (verbose) console.warn(`  [skip] ${sec.sectionNum}: ${parsed.error.issues[0].message}`);
+      }
+    }
+    log(`Built ${rows.length} valid rows (${errors.length} validation errors)`);
+
+    const deduped = dedupeRows(rows);
+    log(`After dedup: ${deduped.length} (${rows.length - deduped.length} dups — TOC + body collision is normal)`);
+
+    // Sanity check: § 21-1 (Title of code) is the foundational entry
+    const sec1 = deduped.find((r) => r.section === '21-1');
+    if (sec1) log(`Sanity: § 21-1 found ("${sec1.section_text.slice(0, 60).replace(/\n/g, ' ')}…")`);
+    else log('WARNING: § 21-1 not found — parser may need tuning');
+
+    if (dryRun) {
+      log(`[DRY-RUN] Would insert ${deduped.length} rows. First row:`);
+      log(JSON.stringify({ ...deduped[0], section_text: deduped[0].section_text.slice(0, 200) + '…' }, null, 2));
+      if (deduped.length < FLOOR_ROWS) {
+        log(`[DRY-RUN] WARN: ${deduped.length} < floor ${FLOOR_ROWS}`);
+      }
+      process.exit(0);
+    }
+
+    // Idempotency
+    const del = await client.query(
+      `DELETE FROM entities_statutes WHERE jurisdiction = $1 AND title = $2`,
+      [JURISDICTION, TITLE],
+    );
+    log(`Idempotency: deleted ${del.rowCount} prior OK/Title 21 rows`);
+
+    log('Inserting via COPY FROM STDIN…');
+    const COLS = [
+      'jurisdiction', 'title', 'section', 'subsection',
+      'effective_date', 'section_text', 'is_current',
+      'source_urls', 'text_hash', 'scraped_at',
+    ];
+    const result = await bulkCopyRows(client, 'entities_statutes', COLS, rowGenerator(deduped));
+    log(`COPY: ${result.rowCount} rows in ${result.durationMs}ms`);
+
+    const post = await client.query(
+      `SELECT COUNT(*) AS cnt FROM entities_statutes WHERE jurisdiction = $1 AND title = $2`,
+      [JURISDICTION, TITLE],
+    );
+    const postCount = parseInt(post.rows[0].cnt, 10);
+    log(`Post-flight count: ${postCount} (OK/Title 21)`);
+
+    if (postCount < FLOOR_ROWS) {
+      console.error(`FAIL: ${postCount} < floor ${FLOOR_ROWS}`);
+      process.exit(1);
+    }
+
+    const audits = await client.query(
+      `SELECT
+         COUNT(*) FILTER (WHERE source_urls = '{}' OR source_urls IS NULL) AS missing_urls,
+         COUNT(*) FILTER (WHERE section_text = '' OR section_text IS NULL)  AS empty_body,
+         COUNT(*) FILTER (WHERE section IS NULL OR section = '')            AS null_section,
+         COUNT(*) FILTER (WHERE text_hash IS NULL OR text_hash = '')        AS missing_hash,
+         COUNT(*) FILTER (WHERE source_urls::text NOT LIKE '%https://%')    AS non_https
+       FROM entities_statutes WHERE jurisdiction = $1 AND title = $2`,
+      [JURISDICTION, TITLE],
+    );
+    log('Audits:', audits.rows[0]);
+    const a = audits.rows[0];
+    if (a.missing_urls > 0 || a.empty_body > 0 || a.null_section > 0 || a.missing_hash > 0 || a.non_https > 0) {
+      console.error('FAIL: audit found defects (see above).');
+      process.exit(1);
+    }
+
+    log(`PASS: ${postCount} rows / ${FLOOR_ROWS} floor / 0 audit defects`);
+    process.exit(0);
+  } catch (err) {
+    console.error('[OK-ERROR]', err.message);
+    if (verbose) console.error(err.stack);
+    process.exit(1);
+  } finally {
+    if (cleanup) await cleanup();
+  }
+}
+
+main();

--- a/scripts/lib/pdf-statute-harness.mjs
+++ b/scripts/lib/pdf-statute-harness.mjs
@@ -1,0 +1,233 @@
+// Template: scripts/lib/fetch-statute-pdf.mjs (MD's PDF harness, branch feat/state-statutes-md-cr-v2)
+// Pattern: cl-bulk-data-defensive #19 — single full-title PDF as bulk source (no API loops)
+// csv-bulk-checked: per-state — DE, ME, OK ship single full-title PDFs (URLs in per-state libs)
+//
+// Shared statute-PDF fetch + section-split harness for Wave 1C ingest (DE/ME/OK).
+//
+// Lift-and-clean port of MD's fetch-statute-pdf.mjs. Identical contract, plus
+// the row schema is documented to mirror unicourt-harness.mjs so seeders that
+// build rows from this harness use the same entities_statutes column shape:
+//
+//   Section { sectionNum: string, title: string, body: string }
+//
+// Per-state seeders adapt this Section into the entities_statutes row shape
+// (jurisdiction/title/section/subsection/section_text/source_urls/text_hash/
+// is_current/effective_date/scraped_at) — same as the MD seeder.
+//
+// Exports:
+//   PDF_BROWSER_HEADERS                 — headers that pass as a real browser
+//   fetchStatutePdf(url, opts)          — fetch PDF buffer with retry + timeout
+//   extractStatuteText(buffer)          — extract raw text string from PDF
+//   parseStatuteSections(text, config)  — split extracted text into Section[]
+//
+// Per-state configs (each lives in scripts/ingest/lib/<state>-title<N>-pdf.mjs)
+// pass: { sectionRe, normalizeEnDash?, minBodyChars?, pageBreakRe? }
+//
+// npm dep: pdf-parse@^2.4.5 (already in package.json — uses PDFParse class API)
+//
+// Why a separate file from fetch-statute-pdf.mjs:
+// - This is the canonical shared harness for Wave 1C+. The older MD file at
+//   scripts/lib/fetch-statute-pdf.mjs is preserved for the existing MD seeder
+//   (feat/state-statutes-md-cr-v2 branch) so that PR doesn't conflict.
+// - DE/ME/OK seeders should import from this file. MD's per-state config
+//   moves into scripts/ingest/lib/md-cr-pdf.mjs in a follow-up if/when the
+//   MD seeder is consolidated.
+
+import { PDFParse } from 'pdf-parse';
+
+// ---------------------------------------------------------------------------
+// Browser-spoof headers — some statute PDFs (Maine, Oklahoma) block default
+// node-fetch UAs.
+// ---------------------------------------------------------------------------
+
+export const PDF_BROWSER_HEADERS = {
+  'User-Agent':
+    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36',
+  Accept: 'application/pdf,application/octet-stream,*/*;q=0.9',
+  'Accept-Language': 'en-US,en;q=0.9',
+  'Accept-Encoding': 'gzip, deflate, br',
+  Connection: 'keep-alive',
+  'Cache-Control': 'no-cache',
+};
+
+// ---------------------------------------------------------------------------
+// fetchStatutePdf
+// ---------------------------------------------------------------------------
+
+/**
+ * @typedef {Object} FetchOptions
+ * @property {number} [maxRetries=3]   number of retry attempts on transient failure
+ * @property {number} [timeoutMs=60000] per-attempt timeout in ms
+ */
+
+/**
+ * Fetch a statute PDF from a URL, returning a Node.js Buffer.
+ * Retries up to maxRetries times on network errors or non-2xx responses.
+ * Throws the last error after exhausting retries.
+ *
+ * @param {string} url
+ * @param {FetchOptions} [opts]
+ * @returns {Promise<Buffer>}
+ */
+export async function fetchStatutePdf(url, opts = {}) {
+  const { maxRetries = 3, timeoutMs = 60000 } = opts;
+
+  let lastErr;
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    try {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), timeoutMs);
+      try {
+        const res = await fetch(url, {
+          headers: PDF_BROWSER_HEADERS,
+          signal: controller.signal,
+        });
+        if (!res.ok) {
+          throw new Error(`HTTP ${res.status} ${res.statusText} for ${url}`);
+        }
+        const arrayBuf = await res.arrayBuffer();
+        return Buffer.from(arrayBuf);
+      } finally {
+        clearTimeout(timer);
+      }
+    } catch (err) {
+      lastErr = err;
+      if (attempt < maxRetries) {
+        // Exponential backoff: 1s, 2s, 4s
+        await new Promise((r) => setTimeout(r, 1000 * 2 ** (attempt - 1)));
+      }
+    }
+  }
+  throw lastErr;
+}
+
+// ---------------------------------------------------------------------------
+// extractStatuteText
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract all text from a PDF buffer using pdf-parse v2 (PDFParse class).
+ * Returns the concatenated text string across all pages.
+ *
+ * @param {Buffer} buffer
+ * @returns {Promise<string>}
+ */
+export async function extractStatuteText(buffer) {
+  const parser = new PDFParse({ data: buffer });
+  try {
+    const result = await parser.getText();
+    return result.text;
+  } finally {
+    await parser.destroy();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// parseStatuteSections
+// ---------------------------------------------------------------------------
+
+/**
+ * @typedef {Object} StatuteSection
+ * @property {string} sectionNum  e.g. "101" (DE), "1-A" (ME), "21-701.7" (OK)
+ * @property {string} title       section heading on the same line as sectionNum
+ *                                (may be empty for state formats that put
+ *                                title on next line)
+ * @property {string} body        full body text from the line after the
+ *                                header up to the next section header, with
+ *                                page-break artifacts stripped
+ */
+
+/**
+ * @typedef {Object} ParseConfig
+ * @property {RegExp}  sectionRe          regex matched per line. Group 1 must
+ *                                        be the sectionNum, group 2 may be
+ *                                        the inline title (empty string if
+ *                                        the format puts title elsewhere).
+ * @property {string}  [state]            short state code for debug context
+ * @property {boolean} [normalizeEnDash=false] replace U+2013 with '-' first
+ * @property {number}  [minBodyChars=20]  skip sections whose body is shorter
+ *                                        (drops TOC entries that match the
+ *                                        section regex but have empty body)
+ * @property {RegExp}  [pageBreakRe]      lines matching this are dropped from
+ *                                        body. Defaults to '-- N of M --' and
+ *                                        bare '- N -' page markers used by
+ *                                        MD/DE/OK PDFs.
+ */
+
+const DEFAULT_PAGE_BREAK_RE = /^--\s*\d+\s+of\s+\d+\s*--|^-\s*\d+\s*-\s*$/;
+
+/**
+ * Split statute PDF text into an array of section objects.
+ *
+ * Algorithm:
+ *   1. (Optional) normalize U+2013 en-dashes to ASCII hyphens.
+ *   2. Walk line-by-line; collect lines matching sectionRe as headers.
+ *   3. For each header, body = lines from header+1 up to the next header,
+ *      with page-break artifact lines filtered.
+ *   4. Drop sections whose body is shorter than minBodyChars (kills TOC
+ *      entries that match sectionRe but have no body).
+ *
+ * Note: this returns sections in document order, including duplicates if
+ * the PDF lists a section in TOC AND in body. Caller (seeder) deduplicates
+ * on (jurisdiction, title, section, subsection) — the TOC instance has body
+ * shorter than minBodyChars so it never reaches dedup; the body instance is
+ * the one that survives.
+ *
+ * @param {string} text
+ * @param {ParseConfig} config
+ * @returns {StatuteSection[]}
+ */
+export function parseStatuteSections(text, config) {
+  const {
+    sectionRe,
+    normalizeEnDash = false,
+    minBodyChars = 20,
+    pageBreakRe = DEFAULT_PAGE_BREAK_RE,
+  } = config;
+
+  if (!sectionRe) {
+    throw new Error('parseStatuteSections: config.sectionRe is required');
+  }
+
+  const source = normalizeEnDash ? text.replace(/–/g, '-') : text;
+  const lines = source.split('\n');
+
+  /** @type {{ sectionNum: string; title: string; startLine: number }[]} */
+  const headers = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const m = lines[i].match(sectionRe);
+    if (m) {
+      headers.push({
+        sectionNum: m[1].trim(),
+        title: (m[2] || '').trim(),
+        startLine: i,
+      });
+    }
+  }
+
+  /** @type {StatuteSection[]} */
+  const sections = [];
+
+  for (let hi = 0; hi < headers.length; hi++) {
+    const hdr = headers[hi];
+    const nextStart =
+      hi + 1 < headers.length ? headers[hi + 1].startLine : lines.length;
+
+    const bodyLines = lines
+      .slice(hdr.startLine + 1, nextStart)
+      .filter((l) => !pageBreakRe.test(l.trim()));
+
+    const body = bodyLines.join('\n').trim();
+
+    if (body.length < minBodyChars) continue;
+
+    sections.push({
+      sectionNum: hdr.sectionNum,
+      title: hdr.title,
+      body,
+    });
+  }
+
+  return sections;
+}


### PR DESCRIPTION
Wave 1C single-PDF ingest, OK Title 21 (Crimes & Punishments) via oklegislature.gov. Live: 1418 rows / 1200 floor. Reuses pdf-statute-harness from DE #238. Longest-body-wins dedup applied for TOC collisions.