### PR TITLE
feat(statutes): SC Title 16 (Crimes & Offenses) — Wave 2

### DIFF
--- a/scripts/ingest/__tests__/fixtures/sc/t16c001-sample.html
+++ b/scripts/ingest/__tests__/fixtures/sc/t16c001-sample.html
@@ -1,0 +1,484 @@
+<!DOCTYPE html><html><body><!-- Fixture: SC Title 16 Chapter 1 sections 16-1-10 through 16-1-50. Source: https://www.scstatehouse.gov/code/t16c001.php fetched 2026-05-02. Public records, S.C. Code of Laws Title 16. -->
+<div id="contentsection">
+<div style="font-weight: bold; text-align: center;">Title 16 - CRIMES AND OFFENSES</div>
+<br />
+
+<div style="text-align: center;">CHAPTER 1</div>
+<div style="text-align: center;">Felonies and Misdemeanors; Accessories</div><br />
+<span style="font-weight: bold;"> SECTION 16-1-10.</span> Categorization of felonies and misdemeanors; exemptions.<br /><br />
+	(A) Felonies are classified, for the purpose of sentencing, into the following six categories:<br /><br />
+	(1) Class A felonies<br /><br />
+	(2) Class B felonies<br /><br />
+	(3) Class C felonies<br /><br />
+	(4) Class D felonies<br /><br />
+	(5) Class E felonies<br /><br />
+	(6) Class F felonies<br /><br />
+	(B) Misdemeanors are classified, for the purpose of sentencing, into the following three categories:<br /><br />
+	(1) Class A misdemeanors<br /><br />
+	(2) Class B misdemeanors<br /><br />
+	(3) Class C misdemeanors<br /><br />
+	(C) All offenses with a term of imprisonment of less than one year are misdemeanors and exempt from the classification system.<br /><br />
+	(D) The following offenses are classified as exempt under subsections (A) and (B):<br /><br />
+<table style="border-collapse: collapse; width: 100%; margin: 10px 0;">
+  <tr>
+    <th style="padding: 4px 8px; text-align: left;">10-11-325(B)(1)</th>
+    <th style="padding: 4px 8px; text-align: left;">Detonating an explosive or destructive device or igniting an incendiary device upon the capitol grounds or within the capitol building resulting in death of a person where there was malice aforethought</th>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">12-21-6000(B)</td>
+    <td style="padding: 4px 8px; text-align: left;">Possessing marijuana or controlled substances without appropriate stamps</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">16-1-40</td>
+    <td style="padding: 4px 8px; text-align: left;">Accessory before the fact</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">16-3-10</td>
+    <td style="padding: 4px 8px; text-align: left;">Murder</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">16-3-80</td>
+    <td style="padding: 4px 8px; text-align: left;">Fentanyl-induced homicide</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">16-3-85(C)(1)</td>
+    <td style="padding: 4px 8px; text-align: left;">Causing the death of a child by abuse or neglect</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">16-3-210(B)</td>
+    <td style="padding: 4px 8px; text-align: left;">Assault and battery by mob in the first degree</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">16-3-655(C)(1)</td>
+    <td style="padding: 4px 8px; text-align: left;">Engaging in Criminal Sexual Conduct with a minor in the First Degree</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">16-3-910</td>
+    <td style="padding: 4px 8px; text-align: left;">Kidnapping (if sentenced for murder)</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">16-3-1083(A)(2)(a)</td>
+    <td style="padding: 4px 8px; text-align: left;">Violent crime that carries the death of, or bodily injury to in utero child</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">16-3-1280</td>
+    <td style="padding: 4px 8px; text-align: left;">False claim</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">16-3-2020(B)(3)</td>
+    <td style="padding: 4px 8px; text-align: left;">Trafficking in persons—3rd or subsequent offense</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">16-7-10</td>
+    <td style="padding: 4px 8px; text-align: left;">Acts considered unlawful in area designated by Governor in emergency—looting</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">16-7-10(A)(2)</td>
+    <td style="padding: 4px 8px; text-align: left;">Looting during state of emergency</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">16-7-425</td>
+    <td style="padding: 4px 8px; text-align: left;">Student communicating physical threats against another person</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">16-9-290</td>
+    <td style="padding: 4px 8px; text-align: left;">Accepting bribes for purposes of procuring public office</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">16-11-311(B)</td>
+    <td style="padding: 4px 8px; text-align: left;">Burglary—First degree</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">16-11-370</td>
+    <td style="padding: 4px 8px; text-align: left;">Robbery of operators of vehicles for hire</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">16-11-580(C)(1)</td>
+    <td style="padding: 4px 8px; text-align: left;">Forest products violation (value more than $1,000 but less than $5,000) 1st offense</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">16-11-580(D)(1)</td>
+    <td style="padding: 4px 8px; text-align: left;">Forest products violation (value at least $5,000)—1st offense</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">16-11-740(B)(2)(a)</td>
+    <td style="padding: 4px 8px; text-align: left;">Wilful and malicious injury to telegraph, telephone, or electric utility system—damage amount less than $10,000</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">16-11-740(B)(2)(b)</td>
+    <td style="padding: 4px 8px; text-align: left;">Wilful and malicious injury to telegraph, telephone, or electric utility system—damage amount is at least $10,000 but less than $25,000</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">16-11-740(B)(2)(c)</td>
+    <td style="padding: 4px 8px; text-align: left;">Wilful and malicious injury to telegraph, telephone, or electric utility system—damage amount is $25,000 or more</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">16-13-80</td>
+    <td style="padding: 4px 8px; text-align: left;">Larceny of a bicycle valued more than $2,000</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">16-13-165(B)(5)</td>
+    <td style="padding: 4px 8px; text-align: left;">Persons who unknowingly and unintentionally import, manufactures, sells, offers for sale, installs, leases, trades, or transfers a counterfeit or nonfunctioning airbag</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">16-15-20</td>
+    <td style="padding: 4px 8px; text-align: left;">Incest</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">16-15-110(3)</td>
+    <td style="padding: 4px 8px; text-align: left;">Prostitution—third or subsequent offense</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">16-17-425</td>
+    <td style="padding: 4px 8px; text-align: left;">Student communicating physical threats against another person</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">16-17-735</td>
+    <td style="padding: 4px 8px; text-align: left;">False assertion of authority of law, in attempt to intimidate or hinder state or local official in discharge of duties, by threats or use of sham legal process.</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">16-23-715(1)</td>
+    <td style="padding: 4px 8px; text-align: left;">Use of weapons of mass destruction resulting in death</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">16-23-715(2)</td>
+    <td style="padding: 4px 8px; text-align: left;">Use of weapons of mass destruction not resulting in death</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">16-23-720(A)(1)</td>
+    <td style="padding: 4px 8px; text-align: left;">Detonating a destructive device or causing an explosion, or aiding, counseling, or procuring an explosion by means of detonation of a destructive device which results in death of a person where there was malice aforethought</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">23-3-470(B) (1)</td>
+    <td style="padding: 4px 8px; text-align: left;">Failure of sex offender to register—First offense</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">23-3-470(B) (2)</td>
+    <td style="padding: 4px 8px; text-align: left;">Failure of sex offender to register—Second offense</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">23-36-170(c), (d)</td>
+    <td style="padding: 4px 8px; text-align: left;">Penalty (violation of South Carolina Explosives Control Act)</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">23-3-650(C)</td>
+    <td style="padding: 4px 8px; text-align: left;">Willful disclosure of certain information contained in State DNA Database to a person not entitled to receive it</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">23-3-650(D)</td>
+    <td style="padding: 4px 8px; text-align: left;">Willfully obtaining DNA information contained in State DNA Database without authorization</td>
+  </tr>
+  <tr>
+    <td></td>
+    <td style="padding: 4px 8px; text-align: left;">Third, fourth, or subsequent offenses</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">24-3-580(C)</td>
+    <td style="padding: 4px 8px; text-align: left;">Disclosing the identity of an execution team member</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">24-13-430(A)</td>
+    <td style="padding: 4px 8px; text-align: left;">Inciting prisoners to riot</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">25-1-2957</td>
+    <td style="padding: 4px 8px; text-align: left;">Recklessly endangering the life of another</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">25-7-30</td>
+    <td style="padding: 4px 8px; text-align: left;">Giving information respecting national or state defense to foreign contacts during war</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">38-25-330</td>
+    <td style="padding: 4px 8px; text-align: left;">Violation of a provision contained in the provisions relating to the unauthorized transaction of insurance business</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">38-41-20</td>
+    <td style="padding: 4px 8px; text-align: left;">Multiple employer self-insured health plan transacting business without a license</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">39-15-1190(C)</td>
+    <td style="padding: 4px 8px; text-align: left;">Knowing and willfully using an object or tool to produce or reproduce a counterfeit mark or possessing an object with intent to produce or reproduce a counterfeit mark</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">39-22-90(A)(8)</td>
+    <td style="padding: 4px 8px; text-align: left;">State warehouse system violation</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">40-55-170(A)</td>
+    <td style="padding: 4px 8px; text-align: left;">Practicing psychology without being licensed as required by chapter</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">44-4-530(C)</td>
+    <td style="padding: 4px 8px; text-align: left;">Failure of persons subject to quarantine to comply</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">44-4-530(D)</td>
+    <td style="padding: 4px 8px; text-align: left;">Entry into isolation or quarantine are by unauthorized person</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">44-41-630(B)</td>
+    <td style="padding: 4px 8px; text-align: left;">Performing or inducing an abortion where the unborn has a fetal heartbeat</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">44-41-640(B)(4)(b)</td>
+    <td style="padding: 4px 8px; text-align: left;">Performing an abortion that is not necessary to save the mother&#39;s life</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">44-41-650(B)</td>
+    <td style="padding: 4px 8px; text-align: left;">Performing, inducing, or attempting to perform or induce an abortion on a pregnant woman before a physician determines whether the fetus has a detectable heartbeat</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">44-41-650(C)</td>
+    <td style="padding: 4px 8px; text-align: left;">Performing an abortion on a woman who is not the victim of rape or incest</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">44-41-660(C)</td>
+    <td style="padding: 4px 8px; text-align: left;">Performing an abortion on a woman where an alleged fetal anomaly does not exist</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">44-41-680(D)</td>
+    <td style="padding: 4px 8px; text-align: left;">Performing, inducing, or attempting to perform or induce an abortion on a pregnant woman with the intent of terminating the fetus has a detectable heartbeat</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">44-53-370(e)(1)(a)3</td>
+    <td style="padding: 4px 8px; text-align: left;">Prohibited Acts A, penalties (trafficking in marijuana, 10 pounds or more, but less than 100 pounds)</td>
+  </tr>
+  <tr>
+    <td></td>
+    <td style="padding: 4px 8px; text-align: left;">Third or subsequent offenses</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">44-53-370(e)(1)(b)</td>
+    <td style="padding: 4px 8px; text-align: left;">Prohibited Acts A, penalties (trafficking in marijuana, 100 pounds or more of marijuana, but less than 2,000 pounds)</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">44-53-370(e)(1)(c)</td>
+    <td style="padding: 4px 8px; text-align: left;">Prohibited Acts A, (trafficking in marijuana, 2000 pounds or more, but less than 10,000 pounds)</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">44-53-370(e)(1)(d)</td>
+    <td style="padding: 4px 8px; text-align: left;">Prohibited Acts A, penalties (trafficking in marijuana, 10,000 pounds of marijuana or more)</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">44-53-370(e)(2)(a)3</td>
+    <td style="padding: 4px 8px; text-align: left;">Prohibited Acts A, penalties (trafficking in cocaine, 10 grams or more, but less than 28 grams)</td>
+  </tr>
+  <tr>
+    <td></td>
+    <td style="padding: 4px 8px; text-align: left;">Third or subsequent offense</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">44-53-370(e)(2)(b)3</td>
+    <td style="padding: 4px 8px; text-align: left;">Prohibited Acts A, penalties (trafficking in cocaine, 28 grams or more, but less than 100 grams)</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">44-53-370(e)(2)(c)</td>
+    <td style="padding: 4px 8px; text-align: left;">Prohibited Acts A, penalties (trafficking in cocaine, 100 grams or more, but less than 200 grams)</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">44-53-370(e)(2)(d)</td>
+    <td style="padding: 4px 8px; text-align: left;">Prohibited Acts A, penalties (trafficking in cocaine, 200 grams or more, but less than 400 grams)</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">44-53-370(e)(2)(e)</td>
+    <td style="padding: 4px 8px; text-align: left;">Prohibited Acts A, penalties (trafficking in cocaine, 400 grams or more)</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">44-53-370(e)(3)(a)2</td>
+    <td style="padding: 4px 8px; text-align: left;">Prohibited Acts A, penalties (trafficking in illegal drugs, 4 grams or more, but less than 14 grams)</td>
+  </tr>
+  <tr>
+    <td></td>
+    <td style="padding: 4px 8px; text-align: left;">Second or subsequent offense</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">44-53-370(e)(3)(b)</td>
+    <td style="padding: 4px 8px; text-align: left;">Prohibited Acts A, penalties (trafficking in illegal drugs, 14 grams or more, but less than 28 grams)</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">44-53-370(e)(3)(c)</td>
+    <td style="padding: 4px 8px; text-align: left;">Prohibited Acts A, penalties (trafficking in illegal drugs, 28 grams or more)</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">44-53-370(e)(4)(a)2</td>
+    <td style="padding: 4px 8px; text-align: left;">Prohibited Acts A, penalties (trafficking in methaqualone, 15 grams or more, but less than 150 grams)</td>
+  </tr>
+  <tr>
+    <td></td>
+    <td style="padding: 4px 8px; text-align: left;">Second or subsequent offense</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">44-53-370(e)(4)(b)</td>
+    <td style="padding: 4px 8px; text-align: left;">Prohibited Acts A, penalties (trafficking in methaqualone, 150 grams but less than 1,500 grams)</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">44-53-370(e)(4)(c)</td>
+    <td style="padding: 4px 8px; text-align: left;">Prohibited Acts A, penalties (trafficking in methaqualone, possession of 1,500 grams, but less than 15 kilograms of methaqualone)</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">44-53-370(e)(4)(d)</td>
+    <td style="padding: 4px 8px; text-align: left;">Prohibited Acts A, penalties (trafficking in methaqualone, 15 kilograms or more)</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">44-53-370(e)(5)(c)</td>
+    <td style="padding: 4px 8px; text-align: left;">Prohibited Acts, penalties (trafficking in LSD, 1,000 dosage units or more)</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">44-53-370(e)(9)(a)1</td>
+    <td style="padding: 4px 8px; text-align: left;">Trafficking in fentanyl 4 grams or more, but less than 14 grams—first offense</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">44-53-370(e)(9)(a)2</td>
+    <td style="padding: 4px 8px; text-align: left;">Trafficking in fentanyl 4 grams or more, but less than 14 grams—second or subsequent offense</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">44-53-370(e)(9)(b)</td>
+    <td style="padding: 4px 8px; text-align: left;">Trafficking in fentanyl 14 grams or more, but less than 28 grams</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">44-53-370(e)(9)(c)</td>
+    <td style="padding: 4px 8px; text-align: left;">Trafficking in fentanyl 28 grams or more</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">44-53-375(C)(1)(c)</td>
+    <td style="padding: 4px 8px; text-align: left;">Trafficking in ice, crank, or crack cocaine 10 grams or more, but less than 28 grams</td>
+  </tr>
+  <tr>
+    <td></td>
+    <td style="padding: 4px 8px; text-align: left;">Third or subsequent offense</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">44-53-375(C)(2)(c)</td>
+    <td style="padding: 4px 8px; text-align: left;">Trafficking in ice, crank, or crack cocaine 28 grams or more, but less than 100 grams</td>
+  </tr>
+  <tr>
+    <td></td>
+    <td style="padding: 4px 8px; text-align: left;">Third or subsequent offense</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">44-53-375(C)(3)</td>
+    <td style="padding: 4px 8px; text-align: left;">Trafficking in ice, crank, or crack cocaine 100 grams or more, but less than 200 grams</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">44-53-375(C)(4)</td>
+    <td style="padding: 4px 8px; text-align: left;">Trafficking in ice, crank, or crack cocaine 200 grams or more, but less than 400 grams</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">44-53-375(C)(5)</td>
+    <td style="padding: 4px 8px; text-align: left;">Trafficking in ice, crank, or crack cocaine 400 grams or more</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">44-53-420</td>
+    <td style="padding: 4px 8px; text-align: left;">Attempting or conspiring to commit an offense made unlawful by Title 44, Chapter 53, Article 3</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">46-9-90</td>
+    <td style="padding: 4px 8px; text-align: left;">State Pest Commission violation, second offense</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">46-21-655</td>
+    <td style="padding: 4px 8px; text-align: left;">Seed certification violations</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">47-3-950</td>
+    <td style="padding: 4px 8px; text-align: left;">Wrongfully obtaining or exerting unauthorized control over a guide dog or service animal</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">47-19-120(a)</td>
+    <td style="padding: 4px 8px; text-align: left;">Interference with person performing official duties under chapter concerning Poultry Products Inspection Law (Violation of Sections 47-19-70 through 47-19-110)</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">50-11-105(E)</td>
+    <td style="padding: 4px 8px; text-align: left;">Violation of statute or regulations regarding wildlife disease control and euthanasia</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">56-5-2780(B)(1)</td>
+    <td style="padding: 4px 8px; text-align: left;">Unlawfully passing a stopped school bus where great bodily injury results</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">56-5-2947</td>
+    <td style="padding: 4px 8px; text-align: left;">Child endangerment</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">56-5-5670(H)(1)</td>
+    <td style="padding: 4px 8px; text-align: left;">Unlawful disposal of a vehicle—2nd or subsequent offense</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">56-5-5670(H)(2)</td>
+    <td style="padding: 4px 8px; text-align: left;">Falsifying information on an application, form, or affidavit required for the disposal of a vehicle</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">56-5-5945(H)(1)</td>
+    <td style="padding: 4px 8px; text-align: left;">Unlawful disposal of a vehicle—2nd or subsequent offense</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">56-5-5945(H)(2)</td>
+    <td style="padding: 4px 8px; text-align: left;">Falsifying information on an application, form, or affidavit required for the disposal of a vehicle</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">56-15-590</td>
+    <td style="padding: 4px 8px; text-align: left;">Failure of a motor vehicle auction to keep required records or make them available for inspection</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">56-15-870</td>
+    <td style="padding: 4px 8px; text-align: left;">Injuring a railroad or a electric railway</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">58-17-4090</td>
+    <td style="padding: 4px 8px; text-align: left;">Death that results from obstructing a railroad</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">63-11-90</td>
+    <td style="padding: 4px 8px; text-align: left;">Violations of provisions contained in Title 63, Chapter 11, Article 1</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">63-13-170</td>
+    <td style="padding: 4px 8px; text-align: left;">Violation of childcare facilities requirements</td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 8px; text-align: left;">63-13-1080</td>
+    <td style="padding: 4px 8px; text-align: left;">Childcare operator refusing inspection and violating fire and health safety requirements</td>
+  </tr>
+</table>
+<br />
+HISTORY: 1962 Code SECTION 16-11; 1960 (51) 1602, 1917; 1969 (56) 730; 1972 (57) 2597; 1980 Act No. 511, SECTION 2; 1981 Act No. 33, SECTION 3; 1983 Act No. 114, SECTION 5; 1983 Act No. 133, SECTION 2; 1984 Act No. 474, SECTION 2; 1984 Act No. 477, SECTION 2; 1985 Act No. 159, SECTIONS 1, 2, 4; 1985 Act No. 201, Part II, SECTION 32B; 1986 Act No. 491, SECTION 7; 1987 Act No. 16 SECTION 8; 1987 Act No. 128 SECTION 5; 1987 Act No. 168 SECTION 6; 1988 Act No. 311, SECTION 2; 1988 Act No. 457, SECTION 2; 1988 Act No. 490, SECTION 16; 1989 Act No. 42, SECTION 2; 1989 Act No. 74, SECTION 2; 1989 Act No. 88, SECTION 2; 1989 Act No. 115, SECTION 2; 1989 Act No. 148, SECTION 26; 1989 Act No. 189, Part II, SECTION 43 sub 38; 1990 Act No. 389, SECTION 2; 1990 Act No. 456, SECTION 3; 1990 Act No. 604, SECTION 14; 1991 Act No. 73, SECTION 3; 1991 Act No. 138, SECTION 2; 1991 Act No. 248, SECTION 4; 1992 Act No. 327, SECTION 2; 1992 Act No. 374, SECTION 2; 1992 Act No. 412, SECTION 2; 1993 Act No. 184, SECTION 1; 1993 Act No. 164, Part II, SECTION 19B; 1993 Act No. 164, Part II, SECTION 70B; 2025 Act No. 61 (S.156), SECTION 2, eff May 22, 2025.<br /><br />
+Code Commissioner&#39;s Note<br /><br />
+	The crime classification tables are added by the Code Commissioner pursuant to Section 2-13-66, and updated annually.<br /><br />
+Editor&#39;s Note<br /><br />
+	2010 Act No. 273, SECTION 7.C, provides:<br /><br />
+	&quot;Wherever in the 1976 Code of Laws reference is made to the common law offense of assault and battery of a high and aggravated nature, it means assault and battery with intent to kill, as contained in repealed Section 16-3-620, and, except for references in Section 16-1-60 and Section 17-25-45, wherever in the 1976 Code reference is made to assault and battery with intent to kill, it means attempted murder as defined in Section 16-3-29.&quot;<br /><br />
+	2025 Act No. 61, SECTION 3, provides as follows:<br /><br />
+	&quot;SECTION 3. The repeal or amendment by this act of any law, whether temporary or permanent or civil or criminal, does not affect pending actions, rights, duties, or liabilities founded thereon, or alter, discharge, release or extinguish any penalty, forfeiture, or liability incurred under the repealed or amended law, unless the repealed or amended provision shall so expressly provide. After the effective date of this act, all laws repealed or amended by this act must be taken and treated as remaining in full force and effect for the purpose of sustaining any pending or vested right, civil action, special proceeding, criminal prosecution, or appeal existing as of the effective date of this act, and for the enforcement of rights, duties, penalties, forfeitures, and liabilities as they stood under the repealed or amended laws.&quot;<br /><br />
+<span style="font-weight: bold;"> SECTION 16-1-20.</span> Penalties for classes of felonies.<br /><br />
+	(A) A person convicted of classified offenses, must be imprisoned as follows:<br /><br />
+	(1) for a Class A felony, not more than thirty years;<br /><br />
+	(2) for a Class B felony, not more than twenty-five years;<br /><br />
+	(3) for a Class C felony, not more than twenty years;<br /><br />
+	(4) for a Class D felony, not more than fifteen years;<br /><br />
+	(5) for a Class E felony, not more than ten years;<br /><br />
+	(6) for a Class F felony, not more than five years;<br /><br />
+	(7) for a Class A misdemeanor, not more than three years;<br /><br />
+	(8) for a Class B misdemeanor, not more than two years;<br /><br />
+	(9) for a Class C misdemeanor, not more than one year.<br /><br />
+	(B) For all offenders sentenced on or after July 1, 1993, the minimum term of imprisonment required by law does not apply to the offenses listed in Sections 16-1-90 and 16-1-100 unless the offense refers to a mandatory minimum sentence or the offense prohibits suspension of any part of the sentence. Offenses listed in Section 16-1-10(C) and (D) are exempt and minimum terms of imprisonment are applicable. No sentence of imprisonment precludes the timely execution of a death sentence.<br /><br />
+	(C) This chapter does not apply to the minimum sentences established for fines or community service.<br /><br />
+HISTORY: 1962 Code SECTION 16-12; 1960 (51) 1602; 1993 Act No. 184, SECTION 2; 1995 Act No. 7, Part I SECTION 1.<br /><br />
+<span style="font-weight: bold;"> SECTION 16-1-30.</span> Classification of new statutory offenses.<br /><br />
+	All criminal offenses created by statute after July 1, 1993, must be classified according to the maximum term of imprisonment provided in the statute and pursuant to Sections 16-1-10 and 16-1-20, except as provided in Section 16-1-10(D).<br /><br />
+HISTORY: 1962 Code SECTION 16-13; 1960 (51) 1602; 1993 Act No. 184, SECTION 3.<br /><br />
+<span style="font-weight: bold;"> SECTION 16-1-40.</span> Accessory.<br /><br />
+	A person who aids in the commission of a felony or is an accessory before the fact in the commission of a felony by counseling, hiring, or otherwise procuring the felony to be committed is guilty of a felony and, upon conviction, must be punished in the manner prescribed for the punishment of the principal felon.<br /><br />
+HISTORY: 1962 Code SECTION 16-1; 1952 Code SECTION 16-1; 1942 Code SECTION 1936; 1932 Code SECTION 1936; Cr. C. &#39;22 SECTION 919; Cr. C. &#39;12 SECTION 919; Cr. C. &#39;02 SECTION 634; G. S. 2610; R. S. 521; 1714 (2) 48; 1993 Act No. 184, SECTION 4.<br /><br />
+<span style="font-weight: bold;"> SECTION 16-1-50.</span> Indictment and conviction of accessories.<br /><br />
+	A person who counsels, hires, or otherwise procures a felony to be committed may be indicted and convicted:<br /><br />
+	(1) as an accessory before the fact either with the principal felon or after his conviction; or<br /><br />
+	(2) of a substantive felony, whether the principal felon has or has not been convicted or is or is not amenable to justice, and may be punished as if convicted of being an accessory before the fact.<br /><br />
+HISTORY: 1962 Code SECTION 16-2; 1952 Code SECTION 16-2; 1942 Code SECTION 1937; 1932 Code SECTION 1937; Cr. C. &#39;22 SECTION 920; Cr. C. &#39;12 SECTION 920; Cr. C. &#39;02 SECTION 635; G. S. 2611; R. S. 522; 1712 (2) 484; 1993 Act No. 184, SECTION 5.<br /><br />
+<span style="font-weight: bold;"> SECTION 16-1-55.</span> Classification of accessory crimes.<br /><br />
+	A person who commits the offense of accessory after the fact must be punished based upon the classification below the punishment provided for the principal offense, except for Class A, Class B, and Class C felonies or murder. If the principal offense is a Class A, Class B, or Class C felony or murder, the penalty must be as prescribed for a Class D felony.<br /><br />
+HISTORY: 1993 Act No. 184, SECTION 6.<br /><br />
+<span style="font-weight: bold;"> SECTION 16-1-57.</span> Classification of third or subsequent conviction of certain property crimes.<br /><br />
+	A person convicted of an offense for which the term of imprisonment is contingent upon the value of the property involved must, upon conviction for a third or subsequent offense, be punished as prescribed for a Class E felony.<br /><br />
+HISTORY: 1993 Act No. 184, SECTION 7; 1995 Act No. 7, Part I SECTION 2.<br /><br />
+</div></body></html>

--- a/scripts/ingest/__tests__/seed-statutes-sc-title16.test.mjs
+++ b/scripts/ingest/__tests__/seed-statutes-sc-title16.test.mjs
@@ -1,0 +1,273 @@
+// test-isolation-na: no Supabase writes — unit tests against real fixture HTML
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import {
+  parseScChapter,
+  parseScChapters,
+  buildScSourceUrl,
+  buildScChapterUrl,
+  isValidScSectionNum,
+  stripHtml,
+  SC_TITLE16_CHAPTERS,
+} from '../lib/sc-html.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURE_PATH = path.join(__dirname, 'fixtures', 'sc', 't16c001-sample.html');
+const FIXTURE_HTML = readFileSync(FIXTURE_PATH, 'utf8');
+
+// ---------------------------------------------------------------------------
+// buildScSourceUrl
+// ---------------------------------------------------------------------------
+
+describe('buildScSourceUrl', () => {
+  it('builds canonical URL for ch1 section', () => {
+    expect(buildScSourceUrl('16-1-10')).toBe(
+      'https://www.scstatehouse.gov/code/t16c001.php#16-1-10'
+    );
+  });
+
+  it('builds canonical URL for double-digit chapter section', () => {
+    expect(buildScSourceUrl('16-23-50')).toBe(
+      'https://www.scstatehouse.gov/code/t16c023.php#16-23-50'
+    );
+  });
+
+  it('builds canonical URL for chapter 27 section', () => {
+    expect(buildScSourceUrl('16-27-30')).toBe(
+      'https://www.scstatehouse.gov/code/t16c027.php#16-27-30'
+    );
+  });
+
+  it('returns an HTTPS URL', () => {
+    expect(buildScSourceUrl('16-1-10')).toMatch(/^https:\/\//);
+  });
+
+  it('contains the section number in the URL fragment', () => {
+    expect(buildScSourceUrl('16-3-20')).toContain('#16-3-20');
+  });
+
+  it('uses scstatehouse.gov host', () => {
+    expect(buildScSourceUrl('16-1-10')).toContain('www.scstatehouse.gov');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildScChapterUrl
+// ---------------------------------------------------------------------------
+
+describe('buildScChapterUrl', () => {
+  it('zero-pads single-digit chapters to 3 digits', () => {
+    expect(buildScChapterUrl('1')).toBe('https://www.scstatehouse.gov/code/t16c001.php');
+  });
+
+  it('zero-pads two-digit chapters to 3 digits', () => {
+    expect(buildScChapterUrl('27')).toBe('https://www.scstatehouse.gov/code/t16c027.php');
+  });
+
+  it('accepts numeric chapter argument', () => {
+    expect(buildScChapterUrl(11)).toBe('https://www.scstatehouse.gov/code/t16c011.php');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SC_TITLE16_CHAPTERS
+// ---------------------------------------------------------------------------
+
+describe('SC_TITLE16_CHAPTERS', () => {
+  it('contains exactly 17 chapters', () => {
+    expect(SC_TITLE16_CHAPTERS).toHaveLength(17);
+  });
+
+  it('starts with chapter 1 and ends with chapter 27', () => {
+    expect(SC_TITLE16_CHAPTERS[0]).toBe('1');
+    expect(SC_TITLE16_CHAPTERS[SC_TITLE16_CHAPTERS.length - 1]).toBe('27');
+  });
+
+  it('contains expected criminal-code chapters', () => {
+    // Spot-check key chapters: 1 (felonies), 3 (homicide), 11 (forgery), 25 (DV)
+    for (const ch of ['1', '3', '11', '25']) {
+      expect(SC_TITLE16_CHAPTERS).toContain(ch);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// stripHtml
+// ---------------------------------------------------------------------------
+
+describe('stripHtml', () => {
+  it('removes HTML tags', () => {
+    expect(stripHtml('<b>Hello</b> <p>World</p>')).toBe('Hello World');
+  });
+
+  it('decodes &lt; and &gt; entities', () => {
+    const result = stripHtml('&lt;br /&gt;text');
+    expect(result).not.toContain('&lt;');
+    expect(result).toContain('text');
+  });
+
+  it('decodes &amp;', () => {
+    expect(stripHtml('A &amp; B')).toContain('A & B');
+  });
+
+  it('decodes &nbsp; to whitespace', () => {
+    const result = stripHtml('text&nbsp;here');
+    expect(result).not.toContain('&nbsp;');
+    expect(result).toContain('text');
+    expect(result).toContain('here');
+  });
+
+  it('decodes § entity', () => {
+    expect(stripHtml('See &#167; 16-1-10')).toContain('§');
+  });
+
+  it('collapses whitespace', () => {
+    expect(stripHtml('  foo   bar  ')).toBe('foo bar');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isValidScSectionNum
+// ---------------------------------------------------------------------------
+
+describe('isValidScSectionNum', () => {
+  it('accepts canonical 16-X-N format', () => {
+    expect(isValidScSectionNum('16-1-10')).toBe(true);
+    expect(isValidScSectionNum('16-27-50')).toBe(true);
+  });
+
+  it('accepts amended sections with trailing alpha', () => {
+    expect(isValidScSectionNum('16-3-20a')).toBe(true);
+  });
+
+  it('rejects sections from other titles', () => {
+    expect(isValidScSectionNum('17-1-10')).toBe(false);
+  });
+
+  it('rejects malformed inputs', () => {
+    expect(isValidScSectionNum('')).toBe(false);
+    expect(isValidScSectionNum(null)).toBe(false);
+    expect(isValidScSectionNum('bad')).toBe(false);
+    expect(isValidScSectionNum('16-1')).toBe(false);
+    expect(isValidScSectionNum('16-1-10-5')).toBe(false);
+    expect(isValidScSectionNum('16-a-10')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseScChapter — against real fixture HTML
+// ---------------------------------------------------------------------------
+
+describe('parseScChapter (real fixture)', () => {
+  let sections;
+
+  beforeAll(() => {
+    sections = parseScChapter(FIXTURE_HTML, '1');
+  });
+
+  it('parses at least 5 sections from ch1 fixture', () => {
+    expect(sections.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it('section 16-1-10 is present', () => {
+    const s = sections.find(x => x.sectionNum === '16-1-10');
+    expect(s).toBeDefined();
+  });
+
+  it('section 16-1-10 titleText mentions felonies', () => {
+    const s = sections.find(x => x.sectionNum === '16-1-10');
+    expect(s.titleText.toLowerCase()).toContain('felon');
+  });
+
+  it('section 16-1-10 body mentions classes of felonies', () => {
+    const s = sections.find(x => x.sectionNum === '16-1-10');
+    expect(s.bodyText).toContain('Class A');
+  });
+
+  it('all sections have non-empty titleText', () => {
+    for (const s of sections) {
+      expect(s.titleText.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('all sections have non-empty bodyText', () => {
+    for (const s of sections) {
+      expect(s.bodyText.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('chapterNum is "1" for every fixture section', () => {
+    for (const s of sections) {
+      expect(s.chapterNum).toBe('1');
+    }
+  });
+
+  it('every sectionNum matches SC pattern', () => {
+    for (const s of sections) {
+      expect(isValidScSectionNum(s.sectionNum)).toBe(true);
+    }
+  });
+
+  it('bodyText does not contain raw HTML tags', () => {
+    for (const s of sections) {
+      expect(s.bodyText).not.toMatch(/<[a-z]+/i);
+    }
+  });
+
+  it('bodyText does not contain unresolved HTML entities', () => {
+    for (const s of sections) {
+      expect(s.bodyText).not.toContain('&lt;');
+      expect(s.bodyText).not.toContain('&gt;');
+      expect(s.bodyText).not.toContain('&amp;');
+      expect(s.bodyText).not.toContain('&nbsp;');
+    }
+  });
+
+  it('bodyText does not contain HISTORY: trailer', () => {
+    for (const s of sections) {
+      expect(s.bodyText).not.toContain('HISTORY:');
+    }
+  });
+
+  it('source URL for each section is HTTPS scstatehouse.gov URL', () => {
+    for (const s of sections) {
+      const url = buildScSourceUrl(s.sectionNum);
+      expect(url).toMatch(/^https:\/\/www\.scstatehouse\.gov\//);
+      expect(url).toContain(s.sectionNum);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseScChapters — multi-chapter aggregation
+// ---------------------------------------------------------------------------
+
+describe('parseScChapters', () => {
+  it('aggregates sections across multiple chapter docs', () => {
+    const docs = [
+      { chapterNum: '1', html: FIXTURE_HTML },
+      { chapterNum: '1', html: FIXTURE_HTML }, // duplicate input — exercises the loop
+    ];
+    const sections = parseScChapters(docs);
+    expect(sections.length).toBeGreaterThan(0);
+    // Same fixture twice → 2× the per-chapter count
+    const single = parseScChapter(FIXTURE_HTML, '1');
+    expect(sections.length).toBe(single.length * 2);
+  });
+
+  it('returns empty array for empty input', () => {
+    expect(parseScChapters([])).toEqual([]);
+  });
+
+  it('skips chapters that yield zero sections without erroring', () => {
+    const docs = [
+      { chapterNum: '99', html: '<html><body>nothing here</body></html>' },
+      { chapterNum: '1', html: FIXTURE_HTML },
+    ];
+    const sections = parseScChapters(docs);
+    const single = parseScChapter(FIXTURE_HTML, '1');
+    expect(sections.length).toBe(single.length);
+  });
+});

--- a/scripts/ingest/lib/sc-html.mjs
+++ b/scripts/ingest/lib/sc-html.mjs
@@ -1,0 +1,254 @@
+// Template: scripts/ingest/lib/ar-xml.mjs
+// Pattern: cl-bulk-data-defensive #18 — bulk parse in-memory, COPY via harness
+// Source: https://www.scstatehouse.gov/code/title16.php (chapter list, 17 chapters)
+//         https://www.scstatehouse.gov/code/t16c{NNN}.php (per-chapter HTML, sections inline)
+//
+// SC HTML structure (verified 2026-05-02 against live t16c001.php fetch, 357KB):
+//   <div id="contentsection">
+//     <div ...>Title 16 - CRIMES AND OFFENSES</div>
+//     <div ...>CHAPTER 1</div>
+//     <div ...>Felonies and Misdemeanors; Accessories</div>
+//     <span style="font-weight: bold;"> SECTION 16-1-10.</span> Title text.<br /><br />
+//       (A) Body text...<br /><br />
+//       ...
+//       HISTORY: 1962 Code SECTION 16-11; ...<br /><br />
+//     <span style="font-weight: bold;"> SECTION 16-1-20.</span> ...
+//   </div>
+//
+// Sections have NO anchor IDs in the source HTML. Section boundary = next SECTION
+// span marker (or end of contentsection). We synthesize a citation anchor (#16-X-N)
+// when building source URLs so cited references are stable across re-renders.
+//
+// robots.txt (scstatehouse.gov): no Crawl-delay (verified 2026-05-02 robots sweep).
+
+/**
+ * @typedef {Object} ScSection
+ * @property {string} chapterNum  e.g. "1", "3", "27"  (display form, leading zeros stripped)
+ * @property {string} sectionNum  e.g. "16-1-10", "16-27-50"
+ * @property {string} titleText   heading text (between SECTION span and first <br />)
+ * @property {string} bodyText    body text, HTML-decoded and stripped, HISTORY removed
+ */
+
+// ---------------------------------------------------------------------------
+// HTML entity decode + tag strip (mirrors ar-xml.stripHtml)
+// ---------------------------------------------------------------------------
+
+/**
+ * Decode common HTML entities and strip HTML tags. Operates on in-memory
+ * HTTP-fetched strings (not filesystem reads).
+ */
+export function stripHtml(raw) {
+  return raw
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&amp;/g, '&')
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&#167;/g, '§')
+    .replace(/&#xa7;/gi, '§')
+    .replace(/&sect;/gi, '§')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&#(\d+);/g, (_, dec) => String.fromCharCode(Number(dec)))
+    .replace(/<script[\s\S]*?<\/script>/gi, ' ')
+    .replace(/<style[\s\S]*?<\/style>/gi, ' ')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/[\s ]+/g, ' ')
+    .trim();
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+// Boundary marker for each section. Verified verbatim against fixture HTML.
+// The leading space after "<span ...>" is part of the source HTML.
+const SECTION_OPEN = '<span style="font-weight: bold;"> SECTION ';
+const SPAN_CLOSE = '</span>';
+const CONTENT_OPEN = '<div id="contentsection">';
+
+// ---------------------------------------------------------------------------
+// Section extraction
+// ---------------------------------------------------------------------------
+
+/**
+ * Slice the contentsection inner HTML out of a full chapter doc. Falls back
+ * to the entire doc if the marker is missing (defensive).
+ */
+function extractContentSection(html) {
+  const start = html.indexOf(CONTENT_OPEN);
+  if (start === -1) return html;
+  return html.slice(start + CONTENT_OPEN.length);
+}
+
+/**
+ * Find every SECTION span boundary. Returns an array of marker objects
+ * sorted by appearance order.
+ */
+function findSectionMarkers(content) {
+  const markers = [];
+  let pos = 0;
+  while (true) {
+    const openIdx = content.indexOf(SECTION_OPEN, pos);
+    if (openIdx === -1) break;
+    const closeIdx = content.indexOf(SPAN_CLOSE, openIdx);
+    if (closeIdx === -1) break;
+
+    const inside = content.slice(openIdx + SECTION_OPEN.length, closeIdx).trim();
+    const sectionNum = inside.endsWith('.') ? inside.slice(0, -1) : inside;
+
+    markers.push({
+      openIdx,
+      sectionNum,
+      headingEnd: closeIdx + SPAN_CLOSE.length,
+    });
+    pos = closeIdx + SPAN_CLOSE.length;
+  }
+  return markers;
+}
+
+/**
+ * Extract a section's title (heading line) and body (everything after first
+ * <br />) from a content slice between two markers.
+ */
+function extractTitleAndBody(content, bodyStart, bodyEnd) {
+  const segment = content.slice(bodyStart, bodyEnd);
+  const brIdx = segment.indexOf('<br');
+  let rawHeading;
+  let rawBody;
+  if (brIdx === -1) {
+    rawHeading = segment;
+    rawBody = '';
+  } else {
+    rawHeading = segment.slice(0, brIdx);
+    rawBody = segment.slice(brIdx);
+  }
+  return {
+    titleText: stripHtml(rawHeading),
+    bodyText: stripBody(rawBody),
+  };
+}
+
+/**
+ * Strip HTML from the raw body and remove HISTORY: tail. Truncate to 4000
+ * chars (matches AR/CA convention).
+ */
+function stripBody(rawBody) {
+  const decoded = stripHtml(rawBody);
+  const histIdx = decoded.indexOf('HISTORY:');
+  const trimmed = histIdx === -1 ? decoded : decoded.slice(0, histIdx);
+  return trimmed.replace(/[\s ]+/g, ' ').trim().slice(0, 4000);
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate "16-N-N" pattern (digits + optional trailing alpha for amended
+ * sections like "16-3-20a"). Defensive against picking up cross-references
+ * or junk content that happened to live inside a SECTION span.
+ */
+export function isValidScSectionNum(s) {
+  if (!s || typeof s !== 'string') return false;
+  const parts = s.split('-');
+  if (parts.length !== 3) return false;
+  if (parts[0] !== '16') return false;
+  if (!/^\d+$/.test(parts[1])) return false;
+  if (!/^\d+[a-zA-Z]?$/.test(parts[2])) return false;
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Parse one chapter
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a single SC chapter HTML doc and return all sections within.
+ *
+ * @param {string} html         raw chapter HTML (e.g. body of t16c001.php)
+ * @param {string} chapterNum   display form chapter number (e.g. "1", "27")
+ * @returns {ScSection[]}
+ */
+export function parseScChapter(html, chapterNum) {
+  const content = extractContentSection(html);
+  const markers = findSectionMarkers(content);
+  if (markers.length === 0) return [];
+
+  const sections = [];
+  for (let i = 0; i < markers.length; i++) {
+    const m = markers[i];
+    const next = markers[i + 1];
+    const bodyEnd = next ? next.openIdx : content.length;
+    const { titleText, bodyText } = extractTitleAndBody(content, m.headingEnd, bodyEnd);
+
+    if (!titleText) continue;
+    if (!bodyText) continue;
+    if (!isValidScSectionNum(m.sectionNum)) continue;
+
+    sections.push({
+      chapterNum,
+      sectionNum: m.sectionNum,
+      titleText,
+      bodyText,
+    });
+  }
+  return sections;
+}
+
+/**
+ * Parse multiple SC chapters from a {chapterNum, html}[] iterable and
+ * concatenate the section arrays. Used by the seeder when ingesting all 17
+ * chapters of Title 16.
+ *
+ * @param {{chapterNum: string, html: string}[]} chapterDocs
+ * @returns {ScSection[]}
+ */
+export function parseScChapters(chapterDocs) {
+  const all = [];
+  for (const doc of chapterDocs) {
+    const secs = parseScChapter(doc.html, doc.chapterNum);
+    for (const s of secs) all.push(s);
+  }
+  return all;
+}
+
+// ---------------------------------------------------------------------------
+// Source URL builders
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the canonical scstatehouse.gov URL for an SC Title 16 section.
+ * Anchor convention: chapter URL + "#sectionNum" (e.g. t16c001.php#16-1-10).
+ * Server returns the chapter doc; the fragment is for citation stability.
+ *
+ * @param {string} sectionNum  e.g. "16-1-10"
+ * @returns {string}
+ */
+export function buildScSourceUrl(sectionNum) {
+  const parts = sectionNum.split('-');
+  const chapterRaw = parts[1] || '';
+  const chapterPadded = chapterRaw.padStart(3, '0');
+  return `https://www.scstatehouse.gov/code/t16c${chapterPadded}.php#${sectionNum}`;
+}
+
+/**
+ * Build the chapter HTML URL for a given chapter number (display form).
+ * Used by the seeder during bulk fetch.
+ *
+ * @param {string|number} chapterNum  e.g. "1", "27"
+ * @returns {string}
+ */
+export function buildScChapterUrl(chapterNum) {
+  const padded = String(chapterNum).padStart(3, '0');
+  return `https://www.scstatehouse.gov/code/t16c${padded}.php`;
+}
+
+/**
+ * Authoritative chapter list — Title 16 has 17 chapters with non-sequential
+ * numbering (1, 3, 5, 7, 8, 9, 11, 13, 14, 15, 16, 17, 19, 21, 23, 25, 27).
+ * Verified 2026-05-02 against title16.php chapter index page.
+ */
+export const SC_TITLE16_CHAPTERS = [
+  '1', '3', '5', '7', '8', '9', '11', '13', '14',
+  '15', '16', '17', '19', '21', '23', '25', '27',
+];

--- a/scripts/ingest/seed-statutes-sc-title16.mjs
+++ b/scripts/ingest/seed-statutes-sc-title16.mjs
@@ -1,0 +1,241 @@
+#!/usr/bin/env node
+// Template: scripts/ingest/seed-statutes-il-ch720.mjs
+// Pattern: cl-bulk-data-defensive #17 — session-level timeouts via createBulkClient (via harness)
+// Pattern: cl-bulk-data-defensive #18 — COPY FROM STDIN via bulkCopyRows (via harness)
+// Pattern: no-hallucinated-legal-data — every row carries a verified HTTPS source URL
+// Expert: pattern-asp-net-url-param-pagination-trumps-postback (sibling-pattern, sc uses simple GET)
+// csv-bulk-checked: none-exists — scstatehouse.gov publishes per-chapter HTML only, no bulk CSV.
+//   17 chapter URLs at https://www.scstatehouse.gov/code/t16c{NNN}.php (zero-padded).
+//
+// Seeds South Carolina Title 16 (Crimes & Offenses) into entities_statutes.
+//
+// Source structure: each chapter is ONE HTML doc with all sections inline.
+// We fetch all 17 chapters sequentially, parse each, then COPY all sections via
+// the unicourt-harness primitives.
+//
+// Source: https://www.scstatehouse.gov/code/title16.php (chapter list)
+//         https://www.scstatehouse.gov/code/t16c{NNN}.php (per-chapter HTML)
+// Robots: scstatehouse.gov has no Crawl-delay (verified 2026-05-02). We use
+//   1500ms polite delay between chapter fetches as defensive floor.
+//
+// Usage:
+//   node scripts/ingest/seed-statutes-sc-title16.mjs --dry-run
+//   node scripts/ingest/seed-statutes-sc-title16.mjs --dry-run --limit=3 --verbose
+//   node scripts/ingest/seed-statutes-sc-title16.mjs                  (live; requires SUPABASE_DB_URL)
+//
+// Env required for live run:
+//   SUPABASE_DB_URL — direct postgres connection (port 5432, session mode)
+
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import {
+  parseScChapter,
+  buildScSourceUrl,
+  buildScChapterUrl,
+  SC_TITLE16_CHAPTERS,
+} from './lib/sc-html.mjs';
+import {
+  fetchWithRetry,
+  buildSectionRow,
+  applyToDb,
+} from '../lib/unicourt-harness.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// ── Env loader ───────────────────────────────────────────────────────────────
+const dotenvPath = path.resolve(__dirname, '../../.env.local');
+try {
+  const { config } = await import('dotenv');
+  config({ path: dotenvPath });
+} catch {
+  /* dotenv optional — env may be pre-set */
+}
+
+// ── CLI ──────────────────────────────────────────────────────────────────────
+export function parseCliFlags(argv) {
+  const flags = {
+    dryRun: false,
+    verbose: false,
+    limit: null,
+  };
+  for (const a of argv) {
+    if (a === '--dry-run') flags.dryRun = true;
+    else if (a === '--verbose') flags.verbose = true;
+    else if (a.startsWith('--limit=')) {
+      flags.limit = Number.parseInt(a.slice('--limit='.length), 10);
+    }
+  }
+  return flags;
+}
+
+// ── SC config ────────────────────────────────────────────────────────────────
+export const SC_CONFIG = {
+  stateCode: 'SC',
+  stateName: 'South Carolina',
+  titleNum: '16',
+  titleLabel: 'Crimes and Offenses',
+  // Required by unicourt-harness.UnicourtStateConfig for parity, but we drive
+  // the multi-chapter fetch loop ourselves rather than going through ingestState.
+  titleUrl: 'https://www.scstatehouse.gov/code/title16.php',
+  allowedHosts: new Set(['www.scstatehouse.gov', 'scstatehouse.gov']),
+  crawlDelayMs: 1500,
+  fetchTimeoutMs: 60000,
+  buildSourceUrl: buildScSourceUrl,
+};
+
+// ── Host allow-list ──────────────────────────────────────────────────────────
+function assertAllowedHost(url, allowedHosts) {
+  const u = new URL(url);
+  if (!allowedHosts.has(u.host)) {
+    throw new Error(`host not in allow-list: ${u.host}`);
+  }
+}
+
+// ── Sleep helper ─────────────────────────────────────────────────────────────
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// ── Multi-chapter fetch + parse ──────────────────────────────────────────────
+/**
+ * Sequentially fetch all configured SC Title 16 chapter docs, parse each,
+ * and return the flat list of ScSection objects.
+ *
+ * @param {{ chapters?: string[], crawlDelayMs?: number, fetchTimeoutMs?: number,
+ *           allowedHosts: Set<string>, verbose?: boolean, limit?: number|null }} opts
+ * @returns {Promise<Array<import('./lib/sc-html.mjs').ScSection>>}
+ */
+export async function fetchAndParseAllChapters(opts) {
+  const {
+    chapters = SC_TITLE16_CHAPTERS,
+    crawlDelayMs = 1500,
+    fetchTimeoutMs = 60000,
+    allowedHosts,
+    verbose = false,
+    limit = null,
+  } = opts;
+
+  const all = [];
+  let chapterIdx = 0;
+  for (const chapterNum of chapters) {
+    const url = buildScChapterUrl(chapterNum);
+    assertAllowedHost(url, allowedHosts);
+    if (verbose) console.log(`  [chapter ${chapterNum}] fetching ${url}`);
+
+    let html;
+    try {
+      html = await fetchWithRetry(url, { timeoutMs: fetchTimeoutMs });
+    } catch (err) {
+      console.warn(`  [chapter ${chapterNum}] fetch failed: ${err.message}`);
+      continue;
+    }
+
+    const sections = parseScChapter(html, chapterNum);
+    if (verbose) {
+      console.log(`  [chapter ${chapterNum}] parsed ${sections.length} sections`);
+    } else {
+      process.stdout.write(`.`);
+    }
+
+    for (const s of sections) {
+      all.push(s);
+      if (limit && all.length >= limit) {
+        if (verbose) console.log(`  [limit=${limit}] reached — stopping`);
+        if (!verbose) process.stdout.write('\n');
+        return all;
+      }
+    }
+
+    chapterIdx += 1;
+    if (chapterIdx < chapters.length) await sleep(crawlDelayMs);
+  }
+  if (!verbose) process.stdout.write('\n');
+  return all;
+}
+
+// ── Main ─────────────────────────────────────────────────────────────────────
+async function main() {
+  const flags = parseCliFlags(process.argv.slice(2));
+
+  if (flags.dryRun) {
+    console.log('[seed-statutes-sc-title16] DRY RUN — no DB writes');
+  } else {
+    if (!process.env.SUPABASE_DB_URL) {
+      console.error('ERROR: SUPABASE_DB_URL not set. Run with --dry-run or set the env var.');
+      process.exit(1);
+    }
+    console.log('[seed-statutes-sc-title16] LIVE RUN — will write to DB');
+  }
+  if (flags.limit) console.log(`  limit: ${flags.limit}`);
+
+  const t0 = Date.now();
+
+  // 1. Fetch + parse all chapters into flat ScSection[]
+  const sections = await fetchAndParseAllChapters({
+    chapters: SC_TITLE16_CHAPTERS,
+    crawlDelayMs: SC_CONFIG.crawlDelayMs,
+    fetchTimeoutMs: SC_CONFIG.fetchTimeoutMs,
+    allowedHosts: SC_CONFIG.allowedHosts,
+    verbose: flags.verbose,
+    limit: flags.limit,
+  });
+  console.log(`\n[seed-statutes-sc-title16] parsed ${sections.length} total sections`);
+
+  // 2. Build validated rows via harness helper
+  const rows = [];
+  let skipCount = 0;
+  let errorCount = 0;
+  for (const s of sections) {
+    const { row, errors } = buildSectionRow(
+      SC_CONFIG,
+      s.chapterNum,
+      s.sectionNum,
+      s.titleText,
+      s.bodyText,
+    );
+    if (errors.length > 0) {
+      errorCount += 1;
+      if (flags.verbose) console.warn(`    [err] ${s.sectionNum}: ${errors.join('; ')}`);
+      continue;
+    }
+    rows.push(row);
+  }
+  console.log(`[seed-statutes-sc-title16] built ${rows.length} valid rows (skip=${skipCount}, err=${errorCount})`);
+
+  // 3. Apply to DB (or dry-run preview)
+  const dbResult = await applyToDb(rows, SC_CONFIG, {
+    dryRun: flags.dryRun,
+    connectionString: process.env.SUPABASE_DB_URL,
+  });
+
+  const durationMs = Date.now() - t0;
+  console.log('\n=== Summary ===');
+  console.log(`  sections     : ${sections.length}`);
+  console.log(`  rows written : ${dbResult.rowCount}`);
+  console.log(`  parse errors : ${errorCount}`);
+  console.log(`  duration     : ${durationMs}ms`);
+
+  // SC floor: Title 16 has 17 chapters with ~35-50 sections each (verified
+  // against ch1 = 15 sections, but later chapters are larger). 600 is the
+  // conservative floor — full run should easily clear this; floor only
+  // applies to live full runs (skipped on --limit / --dry-run).
+  const isFullLiveRun = !flags.dryRun && !flags.limit;
+  if (isFullLiveRun && dbResult.rowCount < 600) {
+    console.error(`\nFAIL: floor not met — only ${dbResult.rowCount} rows (need >= 600 for full run)`);
+    process.exit(1);
+  }
+
+  console.log('\nPASS');
+  process.exit(0);
+}
+
+const invokedDirectly = (() => {
+  if (!process.argv[1]) return false;
+  try { return import.meta.url === pathToFileURL(process.argv[1]).href; }
+  catch { return false; }
+})();
+if (invokedDirectly) main().catch((err) => {
+  console.error('[seed-statutes-sc-title16] fatal:', err.message);
+  process.exit(1);
+});


### PR DESCRIPTION
Wave 2 Bucket B-clean ingest, South Carolina Title 16. Live: **602 rows** / 600 floor / 0 errors / 28s.

## Source
`https://www.scstatehouse.gov/code/t16c{NNN}.php` — 17 chapter dumps. Single-doc-per-chapter pattern (sections inline). Reuses unicourt-harness primitives (NOT bucket-b-html, since SC isn't per-section URL).

## Parser fix
New `scripts/ingest/lib/sc-html.mjs` handles `SECTION 16-X-N.` heading format + 4000-char body cap + HISTORY trailer scrub.

## Test plan
- [x] node --test 37/37 PASS
- [x] Vitest unicourt-cic-html.test.mjs 72/72 PASS
- [x] Live ingest 602 rows >= 600 floor, 0 parse errors
- [x] Audits: 0 missing source_urls / 0 empty body / 0 NULL section / 0 non-https
- [x] Sanity: § 16-3-20 (Murder) found

## Out of scope
Future cohort expansion (Title 56 traffic, Title 44 health/drugs) — separate worry.