### PR TITLE
feat(statutes): NV criminal cohort (9 chapters) — Wave 2

### DIFF
--- a/scripts/ingest/__tests__/fixtures/nv/NRS-200-sample.html
+++ b/scripts/ingest/__tests__/fixtures/nv/NRS-200-sample.html
@@ -1,0 +1,1706 @@
+<!doctype html>
+<html>
+
+<head>
+<meta http-equiv=Content-Type content="text/html; charset=windows-1252">
+<meta name=Generator content="Microsoft Word 15 (filtered)">
+<meta name="format-detection" content="telephone=no">
+<title>NRS: CHAPTER 200 - CRIMES AGAINST THE PERSON</title>
+<style>
+	<!--
+	/* Font Definitions */
+
+	@font-face
+		{font-family: "Wingdings 3";
+		panose-1: 5 4 1 2 1 8 7 7 7 7;}
+		
+	/* Style Definitions */
+
+	 /* ==================================================================
+	   NRS & NRS RELATED STYLE DEFINITIONS
+	   ================================================================== */
+
+	a:link, span.MsoHyperlink
+		{font-family:"Times New Roman",serif;
+		color:blue;
+		text-decoration:underline;}
+		
+	a:visited, span.MsoHyperlinkFollowed
+		{color:#954F72;
+		text-decoration:underline;}
+		
+	p.MsoNormal, li.MsoNormal, div.MsoNormal
+		{margin:0;
+		margin-bottom:0;
+		line-height:100%;
+		font-size:1rem;
+		font-family:"Times New Roman",serif;}
+			
+	p.MsoTitle, li.MsoTitle, div.MsoTitle
+		{margin-top:1.25rem;
+		margin-right:0;
+		margin-bottom:1.25rem;
+		margin-left:0;
+		text-align:center;
+		line-height:100%;
+		punctuation-wrap:simple;
+		text-autospace:none;
+		font-size:1.25rem;
+		font-family:"Times New Roman",serif;
+		font-weight:bold;}	
+
+	p.Chapter, li.Chapter, div.Chapter
+		{margin-top:3rem;
+		margin-right:0;
+		margin-bottom:2rem;
+		margin-left:0;
+		text-align:center;
+		line-height:100%;
+		punctuation-wrap:simple;
+		text-autospace:none;
+		font-size:1.25rem;
+		font-family:"Times New Roman",serif;}
+
+	p.Chaptertext, li.Chaptertext, div.Chaptertext
+		{margin-top:0;
+		margin-right:0;
+		margin-bottom:1rem;
+		margin-left:0;
+		text-align:center;
+		line-height:100%;
+		punctuation-wrap:simple;
+		text-autospace:none;
+		font-size:1rem;
+		font-family:"Times New Roman",serif;
+		font-weight:bold;}
+
+	p.ChapterTitle, li.ChapterTitle, div.ChapterTitle
+		{margin-top:0;
+		margin-right:0;
+		margin-bottom:1rem;
+		margin-left:0;
+		text-align:center;
+		line-height:100%;
+		font-size:1rem;
+		font-family:"Times New Roman",serif;
+		font-weight:bold;}
+
+	p.COHead1, li.COHead1, div.COHead1
+		{margin-top:1.6669rem;
+		margin-right:0;
+		margin-bottom:1rem;
+		margin-left:0;
+		text-align:center;
+		line-height:100%;
+		font-size:0.875rem;
+		font-family:"Times New Roman",serif;
+		font-weight:bold;}
+		
+	p.COHead2, li.COHead2, div.COHead2
+		{margin-top:1rem;
+		margin-right:0;
+		margin-bottom:1rem;
+		margin-left:0;
+		text-align:center;
+		line-height:100%;
+		font-size:0.875rem;
+		font-family:"Times New Roman",serif;
+		font-weight:bold;}
+		
+	p.COHead3, li.COHead3, div.COHead3
+		{margin-top:1rem;
+		margin-right:0;
+		margin-bottom:1rem;
+		margin-left:0;
+		text-align:center;
+		line-height:100%;
+		font-size:0.875rem;
+		font-family:"Times New Roman",serif;}
+		
+	p.COHead4, li.COHead4, div.COHead4
+		{margin-top:1rem;
+		margin-right:0;
+		margin-bottom:1rem;
+		margin-left:0;
+		text-align:center;
+		line-height:100%;
+		font-size:0.875rem;
+		font-family:"Times New Roman",serif;
+		font-variant:small-caps;
+		font-weight:550;}
+		
+	p.COLeadline, li.COLeadline, div.COLeadline
+		{margin-top:0;
+		margin-right:0;
+		margin-bottom:0;
+		margin-left:1.5in;
+		margin-bottom:0.30rem;
+		text-align:justify;
+		text-indent:-1.5in;
+		line-height:100%;
+		font-size:0.875rem;
+		font-weight:550;
+		font-family:"Times New Roman",serif;}
+
+	p.ConstConLeadline, li.ConstConLeadline, div.ConstConLeadline
+		{margin-top:0;
+		margin-right:0;
+		margin-bottom:0;
+		margin-left:.4in;
+		margin-bottom:.0;
+		text-align:justify;
+		text-indent:-.4in;
+		line-height:100%;
+		font-size:1rem;
+		font-family:"Times New Roman",serif;
+		font-weight:bold;
+		text-decoration:underline;}
+		
+	p.ConstConList, li.ConstConList, div.ConstConList
+		{margin-top:0;
+		margin-right:0;
+		margin-bottom:0;
+		margin-left:.4in;
+		margin-bottom:0;
+		text-align:justify;
+		text-indent:-.4in;
+		line-height:100%;
+		font-size:1rem;
+		font-family:"Times New Roman",serif;}
+		
+	p.ConstConParaIndent, li.ConstConParaIndent, div.ConstConParaIndent
+		{margin-top:0;
+		margin-right:0;
+		margin-bottom:0;
+		margin-left:.4in;
+		margin-bottom:0;
+		text-align:justify;
+		text-indent:-.4in;
+		line-height:100%;
+		font-size:1rem;
+		font-family:"Times New Roman",serif;}
+		
+	p.ConstConSigLine, li.ConstConSigLine, div.ConstConSigLine
+		{margin-top:0;
+		margin-right:0;
+		margin-bottom:0;
+		margin-left:.4in;
+		margin-bottom:0;
+		text-align:justify;
+		text-indent:-.4in;
+		line-height:100%;
+		font-size:1rem;
+		font-family:"Times New Roman",serif;}
+
+	p.ConstConH2, li.ConstConH2, div.ConstConH2
+		{margin-top:0;
+		margin-right:0;
+		margin-bottom:0.875rem;
+		margin-left:0;
+		text-align:center;
+		line-height:100%;
+		page-break-after:avoid;
+		font-size:0.875rem;
+		font-family:"Times New Roman",serif;}
+
+	p.ConstH1, li.ConstH1, div.ConstH1
+		{margin-top:1.6669rem;
+		margin-right:0;
+		margin-bottom:0.875rem;
+		margin-left:0;
+		text-align:center;
+		line-height:100%;
+		page-break-after:avoid;
+		font-size:0.875rem;
+		font-family:"Times New Roman",serif;
+		font-weight:bold;}
+
+	p.ConstH2csc, li.ConstH2csc, div.ConstH2csc
+		{margin-top:0;
+		margin-right:0;
+		margin-bottom:0.875rem;
+		margin-left:0;
+		text-align:center;
+		line-height:100%;
+		page-break-after:avoid;
+		font-size:0.875rem;
+		font-family:"Times New Roman",serif;
+		font-variant:small-caps;}	
+		
+	p.ConstH2CSC0, li.ConstH2CSC0, div.ConstH2CSC0
+		{margin-top:0;
+		margin-right:0;
+		margin-bottom:0.875rem;
+		margin-left:0;
+		text-align:center;
+		line-height:100%;
+		page-break-after:avoid;
+		font-size:0.875rem;
+		font-family:"Times New Roman",serif;
+		font-variant:small-caps;}
+		
+	p.ConstPrefComment, li.ConstPrefComment, div.ConstPrefComment
+		{margin-top:0;
+		margin-right:0;
+		margin-bottom:0.1669rem;
+		margin-left:0;
+		text-align:justify;
+		line-height:100;
+		font-size:0.875rem;
+		font-family:"Times New Roman",serif;}
+
+	p.ConstPrefList, li.ConstPrefList, div.ConstPrefList
+		{margin:0;
+		margin-bottom:0;
+		text-align:justify;
+		line-height:100%;
+		font-size:1rem;
+		font-family:"Times New Roman",serif;}
+
+	p.ConstPrefPara, li.ConstPrefPara, div.ConstPrefPara
+		{margin-top:0;
+		margin-right:0;
+		margin-bottom:0.1669rem;
+		margin-left:0;
+		text-align:justify;
+		line-height:100%;
+		font-size:0.875rem;
+		font-family:"Times New Roman",serif;}	
+
+	p.ConstPrefTOC, li.ConstPrefTOC, div.ConstPrefTOC
+		{margin:0;
+		margin-bottom:.0
+		text-align:justify;
+		line-height:100%;
+		font-size:1rem;
+		font-family:"Times New Roman",serif;}
+		
+	p.ConstPrelimPara, li.ConstPrelimPara, div.ConstPrelimPara
+		{margin:0;
+		margin-bottom:0;
+		text-align:justify;
+		line-height:100%;
+		font-size:0.875rem;
+		font-family:"Times New Roman",serif;}
+		
+	p.ConstSecTOC, li.ConstSecTOC, div.ConstSecTOC
+		{margin-top:0;
+		margin-right:0;
+		margin-bottom:0;
+		margin-left:1.5in;
+		margin-bottom:0;
+		/* text-align:justify; Justifying causes misaligned tabbing.*/
+		text-indent:-1.5in;
+		line-height:100%;
+		font-size:1rem;
+		font-family:"Times New Roman",serif;}
+		
+	p.ConstSourceNote, li.ConstSourceNote, div.ConstSourceNote
+		{margin-top:0;
+		margin-right:0;
+		margin-bottom:0.875rem;
+		margin-left:0;
+		text-align:justify;
+		line-height:100%;
+		font-size:0.875rem;
+		font-family:"Times New Roman",serif;}
+		
+	p.ConstTOC, li.ConstTOC, div.ConstTOC
+		{margin-top:0;
+		margin-right:0;
+		margin-bottom:0;
+		margin-left:1.5in;
+		margin-bottom:0;
+		text-align:justify;
+		text-indent:-1.5in;
+		line-height:100%;
+		font-size:1rem;
+		font-family:"Times New Roman",serif;}
+
+	p.DocHeading, li.DocHeading, div.DocHeading
+		{margin-top:1rem;
+		margin-right:0;
+		margin-bottom:1rem;
+		margin-left:0;
+		text-align:center;
+		line-height:100%;
+		page-break-after:avoid;
+		punctuation-wrap:simple;
+		text-autospace:none;
+		font-size:1rem;
+		font-family:"Times New Roman",serif;
+		font-weight:bold;}
+		
+	p.DocHeading2, li.DocHeading2, div.DocHeading2
+		{margin-top:1rem;
+		margin-right:0;
+		margin-bottom:1rem;
+		margin-left:0;
+		text-align:center;
+		line-height:100%;
+		page-break-after:avoid;
+		punctuation-wrap:simple;
+		text-autospace:none;
+		font-size:1rem;/
+		font-family:"Times New Roman",serif;
+		font-weight:bold;}	
+
+	p.J-Dash, li.J-Dash, div.J-Dash
+		{margin-top:1rem;
+		margin-right:0;
+		margin-left:0;
+		margin-bottom:4rem;
+		text-align:center;
+		line-height:100%;
+		font-size:1rem;
+		font-family:"Times New Roman",serif;}
+
+	p.Letter, li.Letter, div.Letter
+		{margin-top:1.6669;
+		margin-right:0;
+		margin-bottom:0.8831rem;
+		margin-left:0;
+		text-align:center;
+		line-height:100%;
+		font-size:0.875rem;
+		font-family:"Times New Roman",serif;
+		font-weight:bold;}	
+		
+	p.Level0, li.Level0, div.Level0
+		{margin-top:0.3331rem;
+		margin-right:0;
+		margin-bottom:0.1669rem;
+		margin-left:99.35pt;
+		text-indent:-99.35pt;
+		line-height:100%;
+		page-break-after:avoid;
+		font-size:0.875rem;
+		font-family:"Times New Roman",serif;
+		font-weight:bold;}
+		
+	 p.Level1, li.Level1, div.Level1
+		{margin-top:0;
+		margin-right:0;
+		margin-bottom:0;
+		margin-left:99.0pt;
+		margin-bottom:0.25rem;
+		text-indent:-99.0pt;
+		line-height:100%;
+		font-size:0.875rem;
+		font-family:"Times New Roman",serif;}
+		
+	p.Level2, li.Level2, div.Level2
+		{margin-top:0;
+		margin-right:0;
+		margin-bottom:0;
+		margin-left:99.0pt;
+		margin-bottom:0.25rem;
+		text-indent:-99.0pt;
+		line-height:100%;
+		font-size:0.875rem;
+		font-family:"Times New Roman",serif;}
+		
+	p.Level3, li.Level3, div.Level3
+		{margin-top:0;
+		margin-right:0;
+		margin-bottom:0;
+		margin-left:99.0pt;
+		margin-bottom:0.25rem;
+		text-indent:-99.0pt;
+		line-height:100%;
+		font-size:0.875rem;
+		font-family:"Times New Roman",serif;}
+		
+	p.Level4, li.Level4, div.Level4
+		{margin-top:0;
+		margin-right:0;
+		margin-bottom:0;
+		margin-left:99.0pt;
+		margin-bottom:0.25rem;
+		text-indent:-99.0pt;
+		line-height:100%;
+		font-size:0.875rem;
+		font-family:"Times New Roman",serif;}
+		
+	p.Level5, li.Level5, div.Level5
+		{margin-top:0;
+		margin-right:0;
+		margin-bottom:0;
+		margin-left:99.0pt;
+		margin-bottom:0.25rem;
+		text-indent:-99.0pt;
+		line-height:100%;
+		font-size:0.875rem;
+		font-family:"Times New Roman",serif;}	
+
+	p.NRStable, li.NRStable, div.NRStable
+		{margin:0;
+		margin-bottom:0;
+		line-height:100%;
+		font-size:0.875rem;/
+		font-family:"Times New Roman",serif;}
+
+	p.NRStable1, li.NRStable1, div.NRStable1
+		{margin:0;
+		margin-bottom:0;
+		text-align:justify;
+		line-height:100%;
+		font-size:0.875rem;
+		font-family:"Times New Roman",serif;}
+
+	p.NRStablehead, li.NRStablehead, div.NRStablehead
+		{margin:0;
+		margin-bottom:0;
+		text-align:justify;
+		line-height:100%;
+		font-size:0.875rem;
+		font-family:"Times New Roman",serif;}
+
+	p.RedistrictingText, li.RedistrictingText, div.RedistrictingText
+		{margin-top:0;
+		margin-right:0;
+		margin-bottom:0.875rem;
+		margin-left:0;
+		text-align:justify;
+		line-height:100%;
+		font-size:0.875rem;
+		font-family:"Times New Roman",serif;}
+
+	p.RuleHead1, li.RuleHead1, div.RuleHead1
+		{margin-top:0;
+		margin-right:0;
+		margin-bottom:0.875rem
+		margin-left:0;
+		text-align:center;
+		line-height:100%;
+		font-size:0.875rem;
+		font-family:"Times New Roman",serif;}	
+
+	p.RuleHead2, li.RuleHead2, div.RuleHead2
+		{margin-top:0.875rem;
+		margin-right:0;
+		margin-bottom:10.0pt;
+		margin-left:0;
+		text-align:center;
+		line-height:100%;
+		font-size:0.875rem;
+		font-family:"Times New Roman",serif;
+		font-weight:bold;}	
+		
+	p.RuleIntro, li.RuleIntro, div.RuleIntro
+		{margin-top:0;
+		margin-right:0;
+		margin-bottom:0.875rem;
+		margin-left:0;
+		text-align:center;
+		line-height:100%;
+		page-break-after:avoid;
+		font-size:0.875rem;
+		font-family:"Times New Roman",serif;
+		font-weight:bold;}
+
+	p.RuleTitle, li.RuleTitle, div.RuleTitle
+		{margin-top:1.1669rem;
+		margin-right:0;
+		margin-bottom:1.1669rem;
+		margin-left:0;
+		text-align:center;
+		line-height:100%;
+		font-size:1.1669rem;
+		font-family:"Times New Roman",serif;
+		font-weight:bold;}	
+
+	p.SectBody, li.SectBody, div.SectBody
+		{margin:0;
+		margin-bottom:0.2rem;
+		text-align:justify;
+		line-height:100%;
+		font-size:1rem;
+		font-family:"Times New Roman",serif;}
+
+	p.Section, li.Section, div.Section
+		{font-weight:bold;}
+
+	p.SourceNote, li.SourceNote, div.SourceNote
+		{margin-top:0;
+		margin-right:0;
+		margin-bottom:0.875rem;
+		margin-left:0;
+		text-align:justify;
+		line-height:100%;
+		font-size:0.875rem;
+		font-family:"Times New Roman",serif;}	
+
+	 p.TocNote, li.TocNote, div.TocNote
+		{margin-top:1.6669rem;
+		margin-right:0;
+		margin-bottom:0;
+		margin-left:76.3pt;
+		margin-bottom:0.25rem;
+		text-align:justify;
+		text-indent:-76.3pt;
+		line-height:100%;
+		font-size:0.875rem;
+		font-family:"Times New Roman",serif;
+		font-weight:bold;}
+
+	span.Extension
+		{font-family:"Tahoma",sans-serif;
+		color:white;
+		font-weight:bold;
+		font-style:italic;}
+
+	span.Leadline
+		{font-family:"Times New Roman",serif;
+		font-weight:bold;}
+		
+	span.Section
+		{font-weight:bold;}	
+		
+	span.Empty
+		{font-weight:bold;}
+		
+	 /* ==================================================================
+	   NAC-SPECIFIC STYLE DEFINITIONS
+	   ================================================================== */
+	
+	p.NACBody, li.NACBody, div.NACBody
+		{margin:0;
+		margin-bottom:0.2rem;
+		text-align:justify;
+		line-height:100%;
+		font-size:1rem;
+		font-family:"Times New Roman",serif;}
+
+	p.NACHead, li.NACHead, div.NACHead
+		{margin-top:0;
+		margin-right:0;
+		margin-bottom:2rem;
+		margin-left:0;
+		text-align:center;
+		line-height:100%;
+		font-size:1rem;
+		font-family:"Times New Roman",serif;
+		font-weight:bold;}
+
+	p.NACReview, li.NACReview, div.NACReview
+		{margin-top:0;
+		margin-right:0;
+		margin-bottom:0;
+		margin-left:0;
+		text-align:justify;
+		line-height:100%;
+		font-size:1rem;
+		font-family:"Times New Roman",serif;}			
+
+	p.NACSource, li.NACSource, div.NACSource
+		{margin-top:0;
+		margin-right:0;
+		margin-bottom:0.875rem;
+		margin-left:0;
+		text-align:justify;
+		line-height:100%;
+		font-size:0.875rem;
+		font-family:"Times New Roman",serif;}
+
+	p.NACTable, li.NACTable, div.NACTable
+		{margin:0;
+		margin-bottom:0;
+		line-height:100%;
+		font-size:0.875rem;
+		font-family:"Times New Roman",serif;}		
+
+	span.NRSAuthority
+		{font-family:"Times New Roman",serif;
+		font-weight:normal;}
+	
+	span.NACLead
+		{font-family:"Times New Roman",serif;
+		font-weight:bold;}
+
+	span.NACSection
+		{font-family:"Times New Roman",serif;
+		font-weight:bold;}		
+
+	/* NAC TOC STYLES */
+
+	p.MsoToc1, li.MsoToc1, div.MsoToc1
+		{margin-top:1.6669rem;
+		margin-right:0;
+		margin-bottom:1rem;
+		margin-left:0;
+		text-align:center;
+		line-height:100%;
+		font-size:0.875rem;
+		font-family:"Times New Roman",serif;
+		font-weight:bold;}
+
+	p.MsoToc2, li.MsoToc2, div.MsoToc2
+		{margin-top:1rem;
+		margin-right:0;
+		margin-bottom:1rem;
+		margin-left:0;
+		text-indent:0;
+		text-align:center;
+		line-height:100%;
+		font-size:0.875rem;
+		font-family:"Times New Roman",serif;
+		font-weight:bold;}
+
+	p.MsoToc3, li.MsoToc3, div.MsoToc3
+		{margin-top:0;
+		margin-right:0;
+		margin-bottom:0.30rem;
+		margin-left:1.0in;
+		text-indent:-1.0in;
+		text-align:justify;
+		line-height:100%;
+		font-size:0.875rem;
+		font-family:"Times New Roman",serif;
+		font-weight:550;}
+		
+	 /* ==================================================================
+	   Page Definitions
+	   ================================================================== */
+	 @page WordSection1
+		{size:8.5in 11.0in;
+		margin:1.0in 1.0in 1.0in 1.0in;}
+
+	div.WordSection1
+		{page:WordSection1;}
+	-->
+	</style>
+
+</head>
+
+<body lang=EN-US link=blue vlink="#954F72">
+
+<div class="WordSection1">
+
+<p class="MsoNormal"><b><span style='color:white'>[Rev. 4/15/2026 11:32:24
+AM--2025]</span></b></p>
+
+<p class="Chapter"><a name=NRS200></a>CHAPTER 200 - CRIMES AGAINST THE PERSON</p>
+
+<p class="COHead2">HOMICIDE</p>
+
+<p class="COLeadline"><a href="#NRS200Sec010">NRS&#8194;200.010</a>���������� �Murder�
+defined. </p>
+
+<p class="COLeadline"><a href="#NRS200Sec020">NRS&#8194;200.020</a>���������� Malice:
+Express and implied defined.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec030">NRS&#8194;200.030</a>���������� Degrees
+of murder; penalties.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec033">NRS&#8194;200.033</a>���������� Circumstances
+aggravating first degree murder.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec035">NRS&#8194;200.035</a>���������� Circumstances
+mitigating first degree murder.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec040">NRS&#8194;200.040</a>���������� �Manslaughter�
+defined.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec050">NRS&#8194;200.050</a>���������� �Voluntary
+manslaughter� defined.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec060">NRS&#8194;200.060</a>���������� When
+killing punished as murder.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec070">NRS&#8194;200.070</a>���������� �Involuntary
+manslaughter� defined.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec080">NRS&#8194;200.080</a>���������� Punishment
+for voluntary manslaughter.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec090">NRS&#8194;200.090</a>���������� Punishment
+for involuntary manslaughter.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec110">NRS&#8194;200.110</a>���������� Place
+of trial for homicide.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec120">NRS&#8194;200.120</a>���������� �Justifiable
+homicide� defined; no duty to retreat under certain circumstances.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec130">NRS&#8194;200.130</a>���������� Bare
+fear insufficient to justify killing; reasonable fear required; rebuttable
+presumption under certain circumstances.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec140">NRS&#8194;200.140</a>���������� Justifiable
+homicide by peace officer.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec150">NRS&#8194;200.150</a>���������� Justifiable
+or excusable homicide.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec160">NRS&#8194;200.160</a>���������� Additional
+cases of justifiable homicide.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec170">NRS&#8194;200.170</a>���������� Burden
+of proving circumstances of mitigation or justifiable or excusable homicide.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec180">NRS&#8194;200.180</a>���������� Excusable
+homicide by misadventure.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec190">NRS&#8194;200.190</a>���������� Justifiable
+or excusable homicide not punishable.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec200">NRS&#8194;200.200</a>���������� Killing
+in self-defense.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec210">NRS&#8194;200.210</a>���������� Killing
+of unborn quick child; penalty.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec220">NRS&#8194;200.220</a>���������� Taking
+drugs to terminate pregnancy; penalty.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec230">NRS&#8194;200.230</a>���������� Death
+resulting from overloading of passenger vessel; penalties.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec240">NRS&#8194;200.240</a>���������� Owner
+of animal that kills human being guilty of manslaughter under certain
+circumstances; penalty.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec260">NRS&#8194;200.260</a>���������� Death
+resulting from unlawful manufacture or storage of explosives; penalty.</p>
+
+<p class="COHead2">BODILY INJURY</p>
+
+<p class="COLeadline"><a href="#NRS200Sec275">NRS&#8194;200.275</a>���������� Justifiable
+infliction or threat of bodily injury not punishable.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec278">NRS&#8194;200.278</a>���������� Information
+required to be provided to school district of person in secondary school who
+causes serious bodily injury.</p>
+
+<p class="COHead2">MAYHEM</p>
+
+<p class="COLeadline"><a href="#NRS200Sec280">NRS&#8194;200.280</a>���������� Definition;
+penalty.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec290">NRS&#8194;200.290</a>���������� Instrument
+or manner of inflicting injury immaterial.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec300">NRS&#8194;200.300</a>���������� Injury
+not resulting in permanent injury; defendant may be convicted of assault.</p>
+
+<p class="COHead2">KIDNAPPING</p>
+
+<p class="COLeadline"><a href="#NRS200Sec310">NRS&#8194;200.310</a>���������� Degrees.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec320">NRS&#8194;200.320</a>���������� Kidnapping
+in first degree: Penalties.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec330">NRS&#8194;200.330</a>���������� Kidnapping
+in second degree: Penalties.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec340">NRS&#8194;200.340</a>���������� Penalty
+for aiding or abetting.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec350">NRS&#8194;200.350</a>���������� Where
+proceedings may be instituted; consent is not defense.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec357">NRS&#8194;200.357</a>���������� Law
+enforcement officer required to take child into protective custody if child in
+danger of being removed from jurisdiction.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec359">NRS&#8194;200.359</a>���������� Detention,
+concealment or removal of child from person having lawful custody or from
+jurisdiction of court and relocation of child by parent without written consent
+of other parent or court permission: Penalties; limitation on issuance of
+arrest warrant; restitution; exceptions.</p>
+
+<p class="COHead2">SEXUAL ASSAULT AND SEDUCTION</p>
+
+<p class="COLeadline"><a href="#NRS200Sec364">NRS&#8194;200.364</a>���������� Definitions.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec366">NRS&#8194;200.366</a>���������� Sexual
+assault: Definition; penalties; exclusions.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec368">NRS&#8194;200.368</a>���������� Statutory
+sexual seduction: Penalties.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec373">NRS&#8194;200.373</a>���������� Sexual
+assault of spouse by spouse.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec377">NRS&#8194;200.377</a>���������� Victims
+of certain sexual offenses: Legislative findings and declarations.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec3771">NRS&#8194;200.3771</a>�������� Victims
+of certain sexual offenses: Confidentiality of records and reports that reveal
+identity; when disclosure permitted; penalty.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec3772">NRS&#8194;200.3772</a>�������� Victims
+of certain sexual offenses: Procedure for substituting pseudonym for name on
+files, records and reports; actual identity confidential; when disclosure
+required; immunity for unintentional disclosure.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec3773">NRS&#8194;200.3773</a>�������� Victims
+of certain sexual offenses: Public officer or employee prohibited from
+disclosing identity; exceptions; penalty.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec3774">NRS&#8194;200.3774</a>�������� Victims
+of certain sexual offenses: Effect of waiver of confidentiality.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec378">NRS&#8194;200.378</a>���������� Court
+may impose temporary or extended order to restrict conduct of alleged
+perpetrator, defendant or convicted person; penalty for violation of order;
+dissemination of order; notice provided in order.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec3781">NRS&#8194;200.3781</a>�������� Petitioner
+for order: Deferment of costs and fees; free information concerning order; no
+fee for serving order.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec3782">NRS&#8194;200.3782</a>�������� Duration
+of orders; dissolution or modification of orders.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec3783">NRS&#8194;200.3783</a>�������� Order
+to be transmitted to law enforcement agencies; enforcement.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec37835">NRS&#8194;200.37835</a>������ Duty
+to transmit information concerning temporary or extended order to Central
+Repository.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec3784">NRS&#8194;200.3784</a>�������� Victim
+to be given certain information and documents concerning case; clerk to keep
+record of order or condition restricting conduct of defendant.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec3786">NRS&#8194;200.3786</a>�������� Sexual
+assault forensic evidence kits: Duties of medical provider, law enforcement
+agency and forensic laboratory.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec3788">NRS&#8194;200.3788</a>�������� Statewide
+program to track sexual assault forensic evidence kits: Requirements; annual
+report; participation; immunity from civil liability.</p>
+
+<p class="COHead2">ROBBERY</p>
+
+<p class="COLeadline"><a href="#NRS200Sec380">NRS&#8194;200.380</a>���������� Definition;
+penalty.</p>
+
+<p class="COHead2">ATTEMPTS TO KILL</p>
+
+<p class="COLeadline"><a href="#NRS200Sec390">NRS&#8194;200.390</a>���������� Administration
+of poison: Penalty.</p>
+
+<p class="COHead2">BATTERY WITH INTENT TO COMMIT A CRIME</p>
+
+<p class="COLeadline"><a href="#NRS200Sec400">NRS&#8194;200.400</a>���������� Definition;
+penalties.</p>
+
+<p class="COHead2">ADMINISTRATION OF DRUG TO AID COMMISSION OF CRIME</p>
+
+<p class="COLeadline"><a href="#NRS200Sec405">NRS&#8194;200.405</a>���������� Administration
+of drug to aid commission of felony: Penalty.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec408">NRS&#8194;200.408</a>���������� Administration
+of controlled substance to aid commission of crime of violence: Penalty;
+definitions.</p>
+
+<p class="COHead2">DUELS AND CHALLENGES</p>
+
+<p class="COLeadline"><a href="#NRS200Sec410">NRS&#8194;200.410</a>���������� Death
+resulting from duel; penalty.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec430">NRS&#8194;200.430</a>���������� Incriminating
+testimony; witness�s privilege.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec440">NRS&#8194;200.440</a>���������� Posting
+for not fighting; use of contemptuous language.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec450">NRS&#8194;200.450</a>���������� Challenges
+to fight; penalties.</p>
+
+<p class="COHead2">FALSE IMPRISONMENT</p>
+
+<p class="COLeadline"><a href="#NRS200Sec460">NRS&#8194;200.460</a>���������� Definition;
+penalties.</p>
+
+<p class="COHead2">INVOLUNTARY SERVITUDE; PURCHASE OR SALE OF PERSON</p>
+
+<p class="COLeadline"><a href="#NRS200Sec463">NRS&#8194;200.463</a>���������� Involuntary
+servitude; penalties.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec4631">NRS&#8194;200.4631</a>�������� Involuntary
+servitude of minors; penalties.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec464">NRS&#8194;200.464</a>���������� Recruiting,
+enticing, harboring, transporting, providing or obtaining another person to be
+held in involuntary servitude; benefiting from another person being held in
+involuntary servitude; penalty.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec465">NRS&#8194;200.465</a>���������� Assuming
+rights of ownership over another person; purchase or sale of person; penalty.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec466">NRS&#8194;200.466</a>���������� Power
+of court to order restitution for violation of <a
+href="#NRS200Sec463">NRS 200.463</a>, <a
+href="#NRS200Sec464">200.464</a> or <a
+href="#NRS200Sec465">200.465</a>.</p>
+
+<p class="COHead2">TRAFFICKING IN PERSONS</p>
+
+<p class="COLeadline"><a href="#NRS200Sec467">NRS&#8194;200.467</a>���������� Trafficking
+in persons for financial gain; penalties.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec468">NRS&#8194;200.468</a>���������� Trafficking
+in persons for illegal purposes; penalty.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec4685">NRS&#8194;200.4685</a>�������� Trafficking
+in children; penalty. [Effective until the date on which the 35th state
+ratifies and enters into the version of the Interstate Compact on the Placement
+of Children set forth in <a href="NRS-127F.html#NRS127FSec020">NRS 127F.020</a>.]</p>
+
+<p class="COLeadline"><a href="#NRS200Sec4685">NRS&#8194;200.4685</a>�������� Trafficking
+in children; penalty. [Effective on the date on which the 35th state ratifies
+and enters into the version of the Interstate Compact on the Placement of
+Children set forth in <a href="NRS-127F.html#NRS127FSec020">NRS 127F.020</a>.]</p>
+
+<p class="COLeadline"><a href="#NRS200Sec469">NRS&#8194;200.469</a>���������� Power
+of court to order restitution for violation of <a
+href="#NRS200Sec467">NRS 200.467</a>, <a
+href="#NRS200Sec468">200.468</a> or <a
+href="#NRS200Sec4685">200.4685</a>.</p>
+
+<p class="COHead2">ASSAULT AND BATTERY</p>
+
+<p class="COLeadline"><a href="#NRS200Sec471">NRS&#8194;200.471</a>���������� Assault:
+Definitions; penalties. [Effective through June 30, 2026.]</p>
+
+<p class="COLeadline"><a href="#NRS200Sec471">NRS&#8194;200.471</a>���������� Assault:
+Definitions; penalties. [Effective July 1, 2026.]</p>
+
+<p class="COLeadline"><a href="#NRS200Sec481">NRS&#8194;200.481</a>���������� Battery:
+Definitions; penalties. [Effective through June 30, 2026.]</p>
+
+<p class="COLeadline"><a href="#NRS200Sec481">NRS&#8194;200.481</a>���������� Battery:
+Definitions; penalties. [Effective July 1, 2026.]</p>
+
+<p class="COLeadline"><a href="#NRS200Sec485">NRS&#8194;200.485</a>���������� Battery
+which constitutes domestic violence: Penalties; referring child for counseling;
+right to trial by jury; restriction against probation and suspension; notice of
+prohibition against owning or possessing firearm; order to surrender, sell or
+transfer firearm; penalty for violation concerning firearm; definitions.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec490">NRS&#8194;200.490</a>���������� Provoking
+assault: Penalty.</p>
+
+<p class="COHead2">CRIMINAL NEGLECT OF PATIENTS</p>
+
+<p class="COLeadline"><a href="#NRS200Sec495">NRS&#8194;200.495</a>���������� Definitions;
+penalties.</p>
+
+<p class="COHead2">ABUSE AND NEGLECT OF CHILDREN</p>
+
+<p class="COLeadline"><a href="#NRS200Sec508">NRS&#8194;200.508</a>���������� Abuse,
+neglect or endangerment of child: Penalties; definitions.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec5081">NRS&#8194;200.5081</a>�������� District
+attorney may refer person suspected of violating <a
+href="#NRS200Sec508">NRS 200.508</a> for treatment or counseling.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec5083">NRS&#8194;200.5083</a>�������� Mutilation
+of genitalia of female child: Penalties; definitions.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec5085">NRS&#8194;200.5085</a>�������� Use
+of nonmedical remedial treatment.</p>
+
+<p class="COHead2">ABUSE, NEGLECT, EXPLOITATION, ISOLATION OR ABANDONMENT OF
+OLDER PERSONS AND VULNERABLE PERSONS</p>
+
+<p class="COLeadline"><a href="#NRS200Sec5091">NRS&#8194;200.5091</a>�������� Policy
+of State.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec5092">NRS&#8194;200.5092</a>�������� Definitions.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec50925">NRS&#8194;200.50925</a>������ �Reasonable
+cause to believe� and �as soon as reasonably practicable� defined.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec5093">NRS&#8194;200.5093</a>�������� Report
+of abuse, neglect, exploitation, isolation or abandonment of older person or
+vulnerable person; voluntary and mandatory reports; investigation; penalty.
+[Effective through June 30, 2026.]</p>
+
+<p class="COLeadline"><a href="#NRS200Sec5093">NRS&#8194;200.5093</a>�������� Report
+of abuse, neglect, exploitation, isolation or abandonment of older person or
+vulnerable person; voluntary and mandatory reports; investigation; penalty.
+[Effective July 1, 2026.]</p>
+
+<p class="COLeadline"><a href="#NRS200Sec5094">NRS&#8194;200.5094</a>�������� Reports:
+Manner of making; contents.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec5095">NRS&#8194;200.5095</a>�������� Reports
+and records confidential; permissible or required disclosure; penalty.
+[Effective until the date on which the Nevada Certification Board, or its
+successor organization, ceases certifying peer recovery support specialists or
+peer recovery support specialist supervisors.]</p>
+
+<p class="COLeadline"><a href="#NRS200Sec5095">NRS&#8194;200.5095</a>�������� Reports
+and records confidential; permissible or required disclosure; penalty.
+[Effective on the date on which the Nevada Certification Board, or its
+successor organization, ceases certifying peer recovery support specialists or
+peer recovery support specialist supervisors.]</p>
+
+<p class="COLeadline"><a href="#NRS200Sec50955">NRS&#8194;200.50955</a>������ Law
+enforcement agency: Required to act promptly in obtaining certain warrants.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec50957">NRS&#8194;200.50957</a>������ Person
+named on account held in joint tenancy may be prosecuted for exploitation.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec5096">NRS&#8194;200.5096</a>�������� Immunity
+from civil or criminal liability for reporting, investigating or submitting
+information; exception.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec5097">NRS&#8194;200.5097</a>�������� Admissibility
+of evidence.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec5098">NRS&#8194;200.5098</a>�������� Duties
+of Aging and Disability Services Division of Department of Human Services
+regarding older persons or vulnerable persons; organization and operation of
+teams for provision of assistance.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec50981">NRS&#8194;200.50981</a>������ Sheriff
+to designate point of contact for Aging and Disability Services Division of
+Department of Human Services.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec50982">NRS&#8194;200.50982</a>������ Disclosure
+of information concerning reports and investigations to other agencies or legal
+representative of older person or vulnerable person; disclosure of information
+concerning suspect in investigation of abuse, neglect, exploitation, isolation
+or abandonment of older person or vulnerable person.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec50984">NRS&#8194;200.50984</a>������ Inspection
+of records pertaining to older person or vulnerable person on whose behalf
+investigation is conducted.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec50986">NRS&#8194;200.50986</a>������ Petition
+for removal of guardian of older person or vulnerable person.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec5099">NRS&#8194;200.5099</a>�������� Penalties.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec50995">NRS&#8194;200.50995</a>������ Penalties
+for conspiracy.</p>
+
+<p class="COHead2">LIBEL</p>
+
+<p class="COLeadline"><a href="#NRS200Sec510">NRS&#8194;200.510</a>���������� Definition;
+penalties; truth may be given in evidence; jury to determine law and fact.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec520">NRS&#8194;200.520</a>���������� Publication
+defined.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec530">NRS&#8194;200.530</a>���������� Liability
+of editor or publisher.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec540">NRS&#8194;200.540</a>���������� Criminal
+proceedings: Venue.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec550">NRS&#8194;200.550</a>���������� Furnishing
+libelous information: Penalty.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec560">NRS&#8194;200.560</a>���������� Threatening
+to publish libel: Penalty.</p>
+
+<p class="COHead2">HARASSMENT AND STALKING</p>
+
+<p class="COLeadline"><a href="#NRS200Sec571">NRS&#8194;200.571</a>���������� Harassment:
+Definition; penalties.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec575">NRS&#8194;200.575</a>���������� Stalking:
+Definitions; penalties; entry of finding in judgment of conviction or
+admonishment of rights.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec581">NRS&#8194;200.581</a>���������� Where
+offense committed.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec591">NRS&#8194;200.591</a>���������� Court
+may impose temporary or extended order to restrict conduct of alleged
+perpetrator, defendant or convicted person; penalty for violation of order;
+dissemination of order; notice provided in order.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec592">NRS&#8194;200.592</a>���������� Petitioner
+for order: Deferment of costs and fees; free information concerning order; no
+fee for serving order.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec594">NRS&#8194;200.594</a>���������� Duration
+of orders; dissolution or modification of orders.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec597">NRS&#8194;200.597</a>���������� Order
+to be transmitted to law enforcement agencies; enforcement.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec599">NRS&#8194;200.599</a>���������� Duty
+to transmit information concerning temporary or extended order to Central
+Repository.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec601">NRS&#8194;200.601</a>���������� Victim
+to be given certain information and documents concerning case; clerk to keep
+record of order or condition restricting conduct of defendant.</p>
+
+<p class="COHead2">PEEPING</p>
+
+<p class="COLeadline"><a href="#NRS200Sec603">NRS&#8194;200.603</a>���������� Peering,
+peeping or spying through window, door or other opening of dwelling of another;
+penalties.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec604">NRS&#8194;200.604</a>���������� Capturing
+image of private area of another person; distributing, disclosing, displaying,
+transmitting or publishing image of private area of another person; penalties;
+exceptions; confidentiality of image.</p>
+
+<p class="COHead2">HAZING</p>
+
+<p class="COLeadline"><a href="#NRS200Sec605">NRS&#8194;200.605</a>���������� Penalties;
+definition.</p>
+
+<p class="COHead2">INTERCEPTION AND DISCLOSURE OF WIRE AND RADIO COMMUNICATIONS
+OR PRIVATE CONVERSATIONS</p>
+
+<p class="COLeadline"><a href="#NRS200Sec610">NRS&#8194;200.610</a>���������� Definitions.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec620">NRS&#8194;200.620</a>���������� Interception
+and attempted interception of wire communication prohibited; exceptions.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec630">NRS&#8194;200.630</a>���������� Disclosure
+of existence, content or substance of wire or radio communication prohibited;
+exceptions.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec640">NRS&#8194;200.640</a>���������� Unauthorized
+connection with facilities prohibited.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec650">NRS&#8194;200.650</a>���������� Unauthorized,
+surreptitious intrusion of privacy by listening device prohibited.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec690">NRS&#8194;200.690</a>���������� Penalties.</p>
+
+<p class="COHead2">CHILD SEXUAL ABUSE MATERIAL</p>
+
+<p class="COLeadline"><a href="#NRS200Sec700">NRS&#8194;200.700</a>���������� Definitions.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec710">NRS&#8194;200.710</a>���������� Unlawful
+to use minor in producing child sexual abuse material or as subject of sexual
+portrayal in performance.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec720">NRS&#8194;200.720</a>���������� Promotion
+of sexual performance of minor unlawful.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec725">NRS&#8194;200.725</a>���������� Preparing,
+advertising or distributing child sexual abuse material or computer-generated
+child sexual abuse material unlawful; penalty.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec727">NRS&#8194;200.727</a>���������� Use
+of Internet to control visual presentation depicting sexual conduct of person
+under 16 years of age; penalties.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec730">NRS&#8194;200.730</a>���������� Possession
+of visual presentation depicting sexual conduct of person under 16 years of age
+or computer-generated child sexual abuse material unlawful; penalties; unit of
+prosecution.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec735">NRS&#8194;200.735</a>���������� Exemption
+for purposes of law enforcement.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec737">NRS&#8194;200.737</a>���������� Use
+of electronic communication device by minor to possess, transmit or distribute
+sexual images of minor; penalties.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec740">NRS&#8194;200.740</a>���������� Determination
+by court or jury of whether person was minor.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec750">NRS&#8194;200.750</a>���������� Penalties.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec760">NRS&#8194;200.760</a>���������� Forfeiture.</p>
+
+<p class="COHead2">DISSEMINATION OF INTIMATE IMAGE</p>
+
+<p class="COLeadline"><a href="#NRS200Sec765">NRS&#8194;200.765</a>���������� Definitions.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec770">NRS&#8194;200.770</a>���������� �Intimate
+image� defined.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec775">NRS&#8194;200.775</a>���������� �Sexual
+conduct� defined.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec780">NRS&#8194;200.780</a>���������� Unlawful
+dissemination of intimate image; exceptions; penalty.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec785">NRS&#8194;200.785</a>���������� Demands
+in exchange for removal of intimate image; penalty.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec790">NRS&#8194;200.790</a>���������� Liability
+of interactive computer service.</p>
+
+<p class="COHead2">PERFORMANCE OF HEALTH CARE OR SURGICAL PROCEDURE WITHOUT A
+LICENSE</p>
+
+<p class="COLeadline"><a href="#NRS200Sec800">NRS&#8194;200.800</a>���������� Definitions.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec810">NRS&#8194;200.810</a>���������� �Health
+care procedure� defined.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec820">NRS&#8194;200.820</a>���������� �Surgical
+procedure� defined.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec830">NRS&#8194;200.830</a>���������� Performance
+of health care procedure without license; penalties.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec840">NRS&#8194;200.840</a>���������� Performance
+of surgical procedure without license; penalties.</p>
+
+<p class="COHead2">INVOLUNTARY IMPLANTATION OF MICROCHIP OR PERMANENT
+IDENTIFICATION MARKER</p>
+
+<p class="COLeadline"><a href="#NRS200Sec870">NRS&#8194;200.870</a>���������� Penalty;
+definitions.</p>
+
+<p class="COHead2">BULLYING BY USE OF ELECTRONIC COMMUNICATION DEVICE</p>
+
+<p class="COLeadline"><a href="#NRS200Sec900">NRS&#8194;200.900</a>���������� Penalties;
+definitions.</p>
+
+<p class="COHead2">UNLAWFUL INSTALLATION OF MOBILE TRACKING DEVICE</p>
+
+<p class="COLeadline"><a href="#NRS200Sec930">NRS&#8194;200.930</a>���������� Penalty;
+definitions.</p>
+
+<p class="COHead2">CRIMES RELATING TO ASSISTED REPRODUCTION</p>
+
+<p class="COLeadline"><a href="#NRS200Sec960">NRS&#8194;200.960</a>���������� Definitions.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec965">NRS&#8194;200.965</a>���������� �Assisted
+reproduction� defined.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec970">NRS&#8194;200.970</a>���������� �Human
+reproductive material� defined.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec975">NRS&#8194;200.975</a>���������� Fertility
+fraud; penalties; notice of conviction to professional licensing board.</p>
+
+<p class="COLeadline"><a href="#NRS200Sec980">NRS&#8194;200.980</a>���������� Conveying
+false information relating to assisted reproduction; penalty; notice of
+conviction to professional licensing board.</p>
+
+<p class="J-Dash">_________</p>
+
+<p class="DocHeading">HOMICIDE</p>
+
+<p class="SectBody"><span class="Empty">����� <a name=NRS200Sec010></a>NRS&#8194;</span><span
+class="Section">200.010</span><span class="Empty">&#8194;&#8194;</span><span
+class="Leadline">�Murder� defined.</span><span class="Empty">&#8194;&#8194;</span>Murder
+is the unlawful killing of a human being:</p>
+
+<p class="SectBody">����� 1.&#8194;&#8194;With malice aforethought, either
+express or implied;</p>
+
+<p class="SectBody">����� 2.&#8194;&#8194;Caused by a controlled substance which
+was sold, given, traded or otherwise made available to a person in violation of
+<a href="NRS-453.html#NRS453">chapter 453</a> of NRS; or</p>
+
+<p class="SectBody">����� 3.&#8194;&#8194;Caused by a violation of <a
+href="NRS-453.html#NRS453Sec3325">NRS 453.3325</a>.</p>
+
+<p class="SectBody"><span style='font-family:"Wingdings 3"'>�</span> The unlawful
+killing may be effected by any of the various means by which death may be
+occasioned.</p>
+
+<p class="SourceNote">����� [1911 C&amp;P � 119; RL � 6384; NCL � 10066]&#8212;(NRS A <a
+href="../Statutes/62nd/Stats198303.html#Stats198303page512">1983,
+512</a>; <a
+href="../Statutes/63rd/Stats198507.html#Stats198507page1598">1985,
+1598</a>; <a
+href="../Statutes/65th/Stats198903.html#Stats198903page589">1989,
+589</a>; <a
+href="../Statutes/73rd/Stats200511.html#Stats200511page1059">2005,
+1059</a>)</p>
+
+<p class="SectBody"><span class="Empty">����� <a name=NRS200Sec020></a>NRS&#8194;</span><span
+class="Section">200.020</span><span class="Empty">&#8194;&#8194;</span><span
+class="Leadline">Malice: Express and implied defined.</span></p>
+
+<p class="SectBody">����� 1.&#8194;&#8194;Express malice is that deliberate
+intention unlawfully to take away the life of a fellow creature, which is
+manifested by external circumstances capable of proof.</p>
+
+<p class="SectBody">����� 2.&#8194;&#8194;Malice shall be implied when no considerable
+provocation appears, or when all the circumstances of the killing show an
+abandoned and malignant heart.</p>
+
+<p class="SourceNote">����� [1911 C&amp;P � 120; A <a
+href="../Statutes/27th1915/Stats191501.html#Stats191501page67">1915,
+67</a>; 1919 RL � 6385; NCL � 10067]</p>
+
+<p class="SectBody"><span class="Empty">����� <a name=NRS200Sec030></a>NRS&#8194;</span><span
+class="Section">200.030</span><span class="Empty">&#8194;&#8194;</span><span
+class="Leadline">Degrees of murder; penalties.</span></p>
+
+<p class="SectBody">����� 1.&#8194;&#8194;Murder of the first degree is murder
+which is:</p>
+
+<p class="SectBody">����� (a)&#8194;Perpetrated by means of poison, lying in wait
+or torture, or by any other kind of willful, deliberate and premeditated
+killing;</p>
+
+<p class="SectBody">����� (b)&#8194;Committed in the perpetration or attempted
+perpetration of sexual assault, kidnapping, arson, robbery, burglary, invasion
+of the home, sexual abuse of a child, sexual molestation of a child under the
+age of 14 years, child abuse or abuse of an older person or vulnerable person
+pursuant to <a href="#NRS200Sec5099">NRS 200.5099</a>;</p>
+
+<p class="SectBody">����� (c)&#8194;Committed to avoid or prevent the lawful
+arrest of any person by a peace officer or to effect the escape of any person
+from legal custody;</p>
+
+<p class="SectBody">����� (d)&#8194;Committed on the property of a public or
+private school, at an activity sponsored by a public or private school or on a
+school bus while the bus was engaged in its official duties by a person who
+intended to create a great risk of death or substantial bodily harm to more
+than one person by means of a weapon, device or course of action that would
+normally be hazardous to the lives of more than one person; or</p>
+
+<p class="SectBody">����� (e)&#8194;Committed in the perpetration or attempted
+perpetration of an act of terrorism.</p>
+
+<p class="SectBody">����� 2.&#8194;&#8194;Murder of the second degree is all
+other kinds of murder.</p>
+
+<p class="SectBody">����� 3.&#8194;&#8194;The jury before whom any person
+indicted for murder is tried shall, if they find the person guilty thereof,
+designate by their verdict whether the person is guilty of murder of the first
+or second degree.</p>
+
+<p class="SectBody">����� 4.&#8194;&#8194;A person convicted of murder of the
+first degree is guilty of a category A felony and shall be punished:</p>
+
+<p class="SectBody">����� (a)&#8194;By death, only if one or more aggravating circumstances
+are found and any mitigating circumstance or circumstances which are found do
+not outweigh the aggravating circumstance or circumstances, unless a court has
+made a finding pursuant to <a href="NRS-174.html#NRS174Sec098">NRS 174.098</a>
+that the defendant is a person with an intellectual disability and has stricken
+the notice of intent to seek the death penalty; or</p>
+
+<p class="SectBody">����� (b)&#8194;By imprisonment in the state prison:</p>
+
+<p class="SectBody">������������ (1)&#8194;For life without the possibility of
+parole;</p>
+
+<p class="SectBody">������������ (2)&#8194;For life with the possibility of
+parole, with eligibility for parole beginning when a minimum of 20 years has
+been served; or</p>
+
+<p class="SectBody">������������ (3)&#8194;For a definite term of 50 years, with
+eligibility for parole beginning when a minimum of 20 years has been served.</p>
+
+<p class="SectBody"><span style='font-family:"Wingdings 3"'>�</span> A
+determination of whether aggravating circumstances exist is not necessary to
+fix the penalty at imprisonment for life with or without the possibility of
+parole.</p>
+
+<p class="SectBody">����� 5.&#8194;&#8194;A person convicted of murder of the
+second degree is guilty of a category A felony and shall be punished by
+imprisonment in the state prison:</p>
+
+<p class="SectBody">����� (a)&#8194;For life with the possibility of parole, with
+eligibility for parole beginning when a minimum of 10 years has been served; or</p>
+
+<p class="SectBody">����� (b)&#8194;For a definite term of 25 years, with
+eligibility for parole beginning when a minimum of 10 years has been served.</p>
+
+<p class="SectBody">����� 6.&#8194;&#8194;As used in this section:</p>
+
+<p class="SectBody">����� (a)&#8194;�Act of terrorism� has the meaning ascribed
+to it in <a href="NRS-202.html#NRS202Sec4415">NRS 202.4415</a>;</p>
+
+<p class="SectBody">����� (b)&#8194;�Child abuse� means physical injury of a
+nonaccidental nature to a child under the age of 18 years;</p>
+
+<p class="SectBody">����� (c)&#8194;�School bus� has the meaning ascribed to it
+in <a href="NRS-483.html#NRS483Sec160">NRS 483.160</a>;</p>
+
+<p class="SectBody">����� (d)&#8194;�Sexual abuse of a child� means any of the
+acts described in <a href="NRS-432B.html#NRS432BSec100">NRS 432B.100</a>; and</p>
+
+<p class="SectBody">����� (e)&#8194;�Sexual molestation� means any willful and
+lewd or lascivious act, other than acts constituting the crime of sexual
+assault, upon or with the body, or any part or member thereof, of a child under
+the age of 14 years, with the intent of arousing, appealing to, or gratifying
+the lust, passions or sexual desires of the perpetrator or of the child.</p>
+
+<p class="SourceNote">����� [1911 C&amp;P � 121; A <a
+href="../Statutes/27th1915/Stats191501.html#Stats191501page67">1915,
+67</a>; <a
+href="../Statutes/29th1919/Stats191903.html#Stats191903page468">1919,
+468</a>; <a
+href="../Statutes/43rd1947/Stats194702.html#Stats194702page302">1947,
+302</a>; 1943 NCL � 10068]&#8212;(NRS A <a
+href="../Statutes/48th1957/Stats195702.html#Stats195702page330">1957,
+330</a>; <a
+href="../Statutes/49th1959/Stats195904.html#Stats195904page781">1959,
+781</a>; <a
+href="../Statutes/50th1960/Stats196003.html#Stats196003page399">1960,
+399</a>; <a
+href="../Statutes/51st1961/Stats196102.html#Stats196102page235">1961,
+235</a>, <a
+href="../Statutes/51st1961/Stats196103.html#Stats196103page486">486</a>;
+<a
+href="../Statutes/54th/Stats196703.html#Stats196703page467">1967,
+467</a>, <a
+href="../Statutes/54th/Stats196708.html#Stats196708page1470">1470</a>;
+<a
+href="../Statutes/57th/Stats197308.html#Stats197308page1803">1973,
+1803</a>; <a
+href="../Statutes/58th/Stats197507.html#Stats197507page1580">1975,
+1580</a>; <a
+href="../Statutes/59th/Stats197704.html#Stats197704page864">1977,
+864</a>, <a
+href="../Statutes/59th/Stats197707.html#Stats197707page1541">1541</a>,
+<a
+href="../Statutes/59th/Stats197707.html#Stats197707page1627">1627</a>;
+<a
+href="../Statutes/65th/Stats198905.html#Stats198905page865">1989,
+865</a>, <a
+href="../Statutes/65th/Stats198908.html#Stats198908page1451">1451</a>;
+<a
+href="../Statutes/68th/Stats199502.html#Stats199502page257">1995,
+257</a>, <a
+href="../Statutes/68th/Stats199506.html#Stats199506page1181">1181</a>;
+<a
+href="../Statutes/70th/Stats199909.html#Stats199909page1335">1999,
+1335</a>; <a
+href="../Statutes/72nd/Stats200306.html#Stats200306page770">2003,
+770</a>, <a
+href="../Statutes/72nd/Stats200324.html#Stats200324page2944">2944</a>;
+<a
+href="../Statutes/74th/Stats200701.html#Stats200701page74">2007,
+74</a>; <a
+href="../Statutes/77th2013/Stats201304.html#Stats201304page689">2013,
+689</a>)</p>
+
+<p class="SectBody"><span class="Empty">����� <a name=NRS200Sec033></a>NRS&#8194;</span><span
+class="Section">200.033</span><span class="Empty">&#8194;&#8194;</span><span
+class="Leadline">Circumstances aggravating first degree murder.</span><span
+class="Empty">&#8194;&#8194;</span>The only circumstances by which murder of the
+first degree may be aggravated are:</p>
+
+<p class="SectBody">����� 1.&#8194;&#8194;The murder was committed by a person
+under sentence of imprisonment.</p>
+
+<p class="SectBody">����� 2.&#8194;&#8194;The murder was committed by a person
+who, at any time before a penalty hearing is conducted for the murder pursuant
+to <a href="NRS-175.html#NRS175Sec552">NRS 175.552</a>, is or has been convicted
+of:</p>
+
+<p class="SectBody">����� (a)&#8194;Another murder and the provisions of
+subsection 12 do not otherwise apply to that other murder; or</p>
+
+<p class="SectBody">����� (b)&#8194;A felony involving the use or threat of
+violence to the person of another and the provisions of subsection 4 do not
+otherwise apply to that felony.</p>
+
+<p class="SectBody"><span style='font-family:"Wingdings 3"'>�</span> For the
+purposes of this subsection, a person shall be deemed to have been convicted at
+the time the jury verdict of guilt is rendered or upon pronouncement of guilt
+by a judge or judges sitting without a jury.</p>
+
+<p class="SectBody">����� 3.&#8194;&#8194;The murder was committed by a person
+who knowingly created a great risk of death to more than one person by means of
+a weapon, device or course of action which would normally be hazardous to the
+lives of more than one person.</p>
+
+<p class="SectBody">����� 4.&#8194;&#8194;The murder was committed while the
+person was engaged, alone or with others, in the commission of, or an attempt
+to commit or flight after committing or attempting to commit, any robbery,
+arson in the first degree, burglary, invasion of the home or kidnapping in the
+first degree, and the person charged:</p>
+
+<p class="SectBody">����� (a)&#8194;Killed or attempted to kill the person
+murdered; or</p>
+
+<p class="SectBody">����� (b)&#8194;Knew or had reason to know that life would be
+taken or lethal force used.</p>
+
+<p class="SectBody">����� 5.&#8194;&#8194;The murder was committed to avoid or
+prevent a lawful arrest or to effect an escape from custody.</p>
+
+<p class="SectBody">����� 6.&#8194;&#8194;The murder was committed by a person,
+for himself or herself or another, to receive money or any other thing of
+monetary value.</p>
+
+<p class="SectBody">����� 7.&#8194;&#8194;The murder was committed upon a peace
+officer or firefighter who was killed while engaged in the performance of his
+or her official duty or because of an act performed in his or her official
+capacity, and the defendant knew or reasonably should have known that the
+victim was a peace officer or firefighter. For the purposes of this subsection,
+�peace officer� means:</p>
+
+<p class="SectBody">����� (a)&#8194;An employee of the Department of Corrections
+who does not exercise general control over offenders imprisoned within the
+institutions and facilities of the Department, but whose normal duties require
+the employee to come into contact with those offenders when carrying out the duties
+prescribed by the Director of the Department.</p>
+
+<p class="SectBody">����� (b)&#8194;Any person upon whom some or all of the
+powers of a peace officer are conferred pursuant to <a
+href="NRS-289.html#NRS289Sec150">NRS 289.150</a> to <a
+href="NRS-289.html#NRS289Sec360">289.360</a>, inclusive, when carrying out those
+powers.</p>
+
+<p class="SectBody">����� 8.&#8194;&#8194;The murder involved torture or the
+mutilation of the victim.</p>
+
+<p class="SectBody">����� 9.&#8194;&#8194;The murder was committed upon one or
+more persons at random and without apparent motive.</p>
+
+<p class="SectBody">����� 10.&#8194;&#8194;The murder was committed upon a person
+less than 14 years of age.</p>
+
+<p class="SectBody">����� 11.&#8194;&#8194;The murder was committed upon a person
+because of the actual or perceived race, color, religion, national origin,
+physical or mental disability, sexual orientation or gender identity or
+expression of that person.</p>
+
+<p class="SectBody">����� 12.&#8194;&#8194;The defendant has, in the immediate
+proceeding, been convicted of more than one offense of murder in the first or
+second degree. For the purposes of this subsection, a person shall be deemed to
+have been convicted of a murder at the time the jury verdict of guilt is rendered
+or upon pronouncement of guilt by a judge or judges sitting without a jury.</p>
+
+<p class="SectBody">����� 13.&#8194;&#8194;The person, alone or with others,
+subjected or attempted to subject the victim of the murder to nonconsensual
+sexual penetration immediately before, during or immediately after the
+commission of the murder. For the purposes of this subsection:</p>
+
+<p class="SectBody">����� (a)&#8194;�Nonconsensual� means against the victim�s
+will or under conditions in which the person knows or reasonably should know
+that the victim is mentally or physically incapable of resisting, consenting or
+understanding the nature of his or her conduct, including, but not limited to,
+conditions in which the person knows or reasonably should know that the victim
+is dead.</p>
+
+<p class="SectBody">����� (b)&#8194;�Sexual penetration� means cunnilingus,
+fellatio or any intrusion, however slight, of any part of the victim�s body or
+any object manipulated or inserted by a person, alone or with others, into the
+genital or anal openings of the body of the victim, whether or not the victim
+is alive. The term includes, but is not limited to, anal intercourse and sexual
+intercourse in what would be its ordinary meaning.</p>
+
+<p class="SectBody">����� 14.&#8194;&#8194;The murder was committed on the
+property of a public or private school, at an activity sponsored by a public or
+private school or on a school bus while the bus was engaged in its official
+duties by a person who intended to create a great risk of death or substantial
+bodily harm to more than one person by means of a weapon, device or course of
+action that would normally be hazardous to the lives of more than one person.
+For the purposes of this subsection, �school bus� has the meaning ascribed to
+it in <a href="NRS-483.html#NRS483Sec160">NRS 483.160</a>.</p>
+
+<p class="SectBody">����� 15.&#8194;&#8194;The murder was committed with the
+intent to commit, cause, aid, further or conceal an act of terrorism. For the
+purposes of this subsection, �act of terrorism� has the meaning ascribed to it
+in <a href="NRS-202.html#NRS202Sec4415">NRS 202.4415</a>.</p>
+
+<p class="SourceNote">����� (Added to NRS by <a
+href="../Statutes/59th/Stats197707.html#Stats197707page1542">1977,
+1542</a>; A <a
+href="../Statutes/61st/Stats198103.html#Stats198103page521">1981,
+521</a>, <a
+href="../Statutes/61st/Stats198111.html#Stats198111page2011">2011</a>;
+<a
+href="../Statutes/62nd/Stats198302.html#Stats198302page286">1983,
+286</a>; <a
+href="../Statutes/63rd/Stats198509.html#Stats198509page1979">1985,
+1979</a>; <a
+href="../Statutes/65th/Stats198908.html#Stats198908page1451">1989,
+1451</a>; <a
+href="../Statutes/67th/Stats199301.html#Stats199301page76">1993,
+76</a>; <a
+href="../Statutes/68th/Stats199501.html#Stats199501page2">1995,
+2</a>, <a
+href="../Statutes/68th/Stats199501.html#Stats199501page138">138</a>,
+<a
+href="../Statutes/68th/Stats199508.html#Stats199508page1490">1490</a>,
+<a
+href="../Statutes/68th/Stats199514.html#Stats199514page2705">2705</a>;
+<a
+href="../Statutes/69th/Stats199709.html#Stats199709page1293">1997,
+1293</a>; <a
+href="../Statutes/70th/Stats199909.html#Stats199909page1336">1999,
+1336</a>; <a
+href="../Statutes/17thSS/Stats2001SS1702.html#Stats2001SS1702page229">2001
+Special Session, 229</a>; <a
+href="../Statutes/72nd/Stats200324.html#Stats200324page2945">2003,
+2945</a>; <a
+href="../Statutes/73rd/Stats200504.html#Stats200504page317">2005,
+317</a>; <a
+href="../Statutes/79th2017/Stats201707.html#Stats201707page1065">2017,
+1065</a>)</p>
+
+<p class="SectBody"><span class="Empty">����� <a name=NRS200Sec035></a>NRS&#8194;</span><span
+class="Section">200.035</span><span class="Empty">&#8194;&#8194;</span><span
+class="Leadline">Circumstances mitigating first degree murder.</span><span
+class="Empty">&#8194;&#8194;</span>Murder of the first degree may be mitigated by
+any of the following circumstances, even though the mitigating circumstance is
+not sufficient to constitute a defense or reduce the degree of the crime:</p>
+
+<p class="SectBody">����� 1.&#8194;&#8194;The defendant has no significant
+history of prior criminal activity.</p>
+
+<p class="SectBody">����� 2.&#8194;&#8194;The murder was committed while the
+defendant was under the influence of extreme mental or emotional disturbance.</p>
+
+<p class="SectBody">����� 3.&#8194;&#8194;The victim was a participant in the
+defendant�s criminal conduct or consented to the act.</p>
+
+<p class="SectBody">����� 4.&#8194;&#8194;The defendant was an accomplice in a
+murder committed by another person and the defendant�s participation in the
+murder was relatively minor.</p>
+
+<p class="SectBody">����� 5.&#8194;&#8194;The defendant acted under duress or
+under the domination of another person.</p>
+
+<p class="SectBody">����� 6.&#8194;&#8194;The youth of the defendant at the time
+of the crime.</p>
+
+<p class="SectBody">����� 7.&#8194;&#8194;Any other mitigating circumstance.</p>
+
+<p class="SourceNote">����� (Added to NRS by <a
+href="../Statutes/59th/Stats197707.html#Stats197707page1543">1977,
+1543</a>)</p>
+
+<p class="SectBody"><span class="Empty">����� <a name=NRS200Sec040></a>NRS&#8194;</span><span
+class="Section">200.040</span><span class="Empty">&#8194;&#8194;</span><span
+class="Leadline">�Manslaughter� defined.</span></p>
+
+<p class="SectBody">����� 1.&#8194;&#8194;Manslaughter is the unlawful killing of
+a human being, without malice express or implied, and without any mixture of
+deliberation.</p>
+
+<p class="SectBody">����� 2.&#8194;&#8194;Manslaughter must be voluntary, upon a
+sudden heat of passion, caused by a provocation apparently sufficient to make
+the passion irresistible, or involuntary, in the commission of an unlawful act,
+or a lawful act without due caution or circumspection.</p>
+
+<p class="SectBody">����� 3.&#8194;&#8194;Manslaughter does not include vehicular
+manslaughter as described in <a href="NRS-484B.html#NRS484BSec657">NRS 484B.657</a>.</p>
+
+<p class="SourceNote">����� [1911 C&amp;P � 122; RL � 6387; NCL � 10069]&#8212;(NRS A <a
+href="../Statutes/62nd/Stats198305.html#Stats198305page1014">1983,
+1014</a>; <a
+href="../Statutes/68th/Stats199509.html#Stats199509page1725">1995,
+1725</a>; <a
+href="../Statutes/73rd/Stats200501.html#Stats200501page79">2005,
+79</a>)</p>
+
+<p class="SectBody"><span class="Empty">����� <a name=NRS200Sec050></a>NRS&#8194;</span><span
+class="Section">200.050</span><span class="Empty">&#8194;&#8194;</span><span
+class="Leadline">�Voluntary manslaughter� defined.</span></p>
+
+<p class="SectBody">����� 1.&#8194;&#8194;In cases of voluntary manslaughter,
+there must be a serious and highly provoking injury inflicted upon the person
+killing, sufficient to excite an irresistible passion in a reasonable person,
+or an attempt by the person killed to commit a serious personal injury on the
+person killing.</p>
+
+<p class="SectBody">����� 2.&#8194;&#8194;Voluntary manslaughter does not include
+vehicular manslaughter as described in <a href="NRS-484B.html#NRS484BSec657">NRS
+484B.657</a>.</p>
+
+<p class="SourceN
+</body></html>

--- a/scripts/ingest/__tests__/seed-statutes-nv-criminal.test.mjs
+++ b/scripts/ingest/__tests__/seed-statutes-nv-criminal.test.mjs
@@ -1,0 +1,314 @@
+// test-isolation-na: no Supabase writes — unit tests against real fixture HTML
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import {
+  parseNVChapter,
+  parseNVChapters,
+  buildNVSourceUrl,
+  buildNVChapterUrl,
+  isValidNvSectionNum,
+  stripHtml,
+  NV_CHAPTERS,
+} from '../lib/nv-html.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURE_PATH = path.join(__dirname, 'fixtures', 'nv', 'NRS-200-sample.html');
+const FIXTURE_HTML = readFileSync(FIXTURE_PATH, 'utf8');
+
+// ---------------------------------------------------------------------------
+// buildNVSourceUrl
+// ---------------------------------------------------------------------------
+
+describe('buildNVSourceUrl', () => {
+  it('builds canonical URL for ch200 section', () => {
+    expect(buildNVSourceUrl('200.010')).toBe(
+      'https://www.leg.state.nv.us/NRS/NRS-200.html#NRS200Sec010'
+    );
+  });
+
+  it('builds canonical URL for ch484C (numeric+letter chapter)', () => {
+    expect(buildNVSourceUrl('484C.030')).toBe(
+      'https://www.leg.state.nv.us/NRS/NRS-484C.html#NRS484CSec030'
+    );
+  });
+
+  it('builds canonical URL for 4-digit section number', () => {
+    expect(buildNVSourceUrl('200.5099')).toBe(
+      'https://www.leg.state.nv.us/NRS/NRS-200.html#NRS200Sec5099'
+    );
+  });
+
+  it('returns an HTTPS URL', () => {
+    expect(buildNVSourceUrl('200.010')).toMatch(/^https:\/\//);
+  });
+
+  it('contains the section anchor in the URL fragment', () => {
+    expect(buildNVSourceUrl('205.060')).toContain('#NRS205Sec060');
+  });
+
+  it('uses leg.state.nv.us host', () => {
+    expect(buildNVSourceUrl('200.010')).toContain('www.leg.state.nv.us');
+  });
+
+  it('falls back to index.html for malformed sectionNum without dot', () => {
+    expect(buildNVSourceUrl('badformat')).toContain('index.html');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildNVChapterUrl
+// ---------------------------------------------------------------------------
+
+describe('buildNVChapterUrl', () => {
+  it('builds URL for numeric chapter', () => {
+    expect(buildNVChapterUrl('200')).toBe('https://www.leg.state.nv.us/NRS/NRS-200.html');
+  });
+
+  it('builds URL for numeric+letter chapter', () => {
+    expect(buildNVChapterUrl('484C')).toBe('https://www.leg.state.nv.us/NRS/NRS-484C.html');
+  });
+
+  it('accepts numeric chapter argument', () => {
+    expect(buildNVChapterUrl(207)).toBe('https://www.leg.state.nv.us/NRS/NRS-207.html');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// NV_CHAPTERS
+// ---------------------------------------------------------------------------
+
+describe('NV_CHAPTERS', () => {
+  it('contains exactly 9 chapters', () => {
+    expect(NV_CHAPTERS).toHaveLength(9);
+  });
+
+  it('starts with chapter 200', () => {
+    expect(NV_CHAPTERS[0]).toBe('200');
+  });
+
+  it('contains expected criminal-code chapters', () => {
+    // 200 (homicide/assault), 205 (property), 207 (misc), 453 (drugs), 484C (DUI)
+    for (const ch of ['200', '205', '207', '453', '484C']) {
+      expect(NV_CHAPTERS).toContain(ch);
+    }
+  });
+
+  it('includes the 484A-E DUI/traffic cohort', () => {
+    expect(NV_CHAPTERS).toContain('484A');
+    expect(NV_CHAPTERS).toContain('484B');
+    expect(NV_CHAPTERS).toContain('484C');
+    expect(NV_CHAPTERS).toContain('484D');
+    expect(NV_CHAPTERS).toContain('484E');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// stripHtml
+// ---------------------------------------------------------------------------
+
+describe('stripHtml', () => {
+  it('removes HTML tags', () => {
+    expect(stripHtml('<b>Hello</b> <p>World</p>')).toBe('Hello World');
+  });
+
+  it('decodes &lt; and &gt; entities', () => {
+    const result = stripHtml('&lt;br /&gt;text');
+    expect(result).not.toContain('&lt;');
+    expect(result).toContain('text');
+  });
+
+  it('decodes &amp;', () => {
+    expect(stripHtml('A &amp; B')).toContain('A & B');
+  });
+
+  it('decodes &nbsp; to whitespace', () => {
+    const result = stripHtml('text&nbsp;here');
+    expect(result).not.toContain('&nbsp;');
+    expect(result).toContain('text');
+    expect(result).toContain('here');
+  });
+
+  it('decodes &#8194; en-space (NV MS-Word artifact) to whitespace', () => {
+    const result = stripHtml('NRS&#8194;200.010');
+    expect(result).not.toContain('&#8194;');
+    expect(result).toContain('NRS');
+    expect(result).toContain('200.010');
+  });
+
+  it('decodes &#8212; em-dash to ASCII dash', () => {
+    expect(stripHtml('text&#8212;more')).toContain('-');
+  });
+
+  it('decodes § entity', () => {
+    expect(stripHtml('See &#167; 200.010')).toContain('§');
+  });
+
+  it('drops unicode replacement chars from charset mismatch', () => {
+    expect(stripHtml('Murder�defined')).not.toContain('�');
+  });
+
+  it('collapses whitespace', () => {
+    expect(stripHtml('  foo   bar  ')).toBe('foo bar');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isValidNvSectionNum
+// ---------------------------------------------------------------------------
+
+describe('isValidNvSectionNum', () => {
+  it('accepts canonical chapter.section format', () => {
+    expect(isValidNvSectionNum('200.010')).toBe(true);
+    expect(isValidNvSectionNum('200.5099')).toBe(true);
+  });
+
+  it('accepts numeric+letter chapter (484A.005)', () => {
+    expect(isValidNvSectionNum('484A.005')).toBe(true);
+    expect(isValidNvSectionNum('484C.030')).toBe(true);
+  });
+
+  it('accepts trailing alpha on section digits', () => {
+    expect(isValidNvSectionNum('200.030a')).toBe(true);
+  });
+
+  it('rejects malformed inputs', () => {
+    expect(isValidNvSectionNum('')).toBe(false);
+    expect(isValidNvSectionNum(null)).toBe(false);
+    expect(isValidNvSectionNum('bad')).toBe(false);
+    expect(isValidNvSectionNum('200')).toBe(false);
+    expect(isValidNvSectionNum('200..010')).toBe(false);
+    expect(isValidNvSectionNum('200.010.5')).toBe(false);
+    expect(isValidNvSectionNum('abc.def')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseNVChapter — against real fixture HTML
+// ---------------------------------------------------------------------------
+
+describe('parseNVChapter (real fixture)', () => {
+  let sections;
+
+  beforeAll(() => {
+    sections = parseNVChapter(FIXTURE_HTML, '200');
+  });
+
+  it('parses at least 5 sections from ch200 fixture', () => {
+    expect(sections.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it('section 200.010 is present', () => {
+    const s = sections.find(x => x.sectionNum === '200.010');
+    expect(s).toBeDefined();
+  });
+
+  it('section 200.010 titleText mentions Murder', () => {
+    const s = sections.find(x => x.sectionNum === '200.010');
+    expect(s.titleText).toMatch(/Murder/i);
+  });
+
+  it('section 200.010 body mentions unlawful killing', () => {
+    const s = sections.find(x => x.sectionNum === '200.010');
+    expect(s.bodyText.toLowerCase()).toContain('unlawful killing');
+  });
+
+  it('section 200.020 is present (Malice)', () => {
+    const s = sections.find(x => x.sectionNum === '200.020');
+    expect(s).toBeDefined();
+    expect(s.titleText.toLowerCase()).toContain('malice');
+  });
+
+  it('all sections have non-empty titleText', () => {
+    for (const s of sections) {
+      expect(s.titleText.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('all sections have non-empty bodyText', () => {
+    for (const s of sections) {
+      expect(s.bodyText.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('chapterNum is "200" for every fixture section', () => {
+    for (const s of sections) {
+      expect(s.chapterNum).toBe('200');
+    }
+  });
+
+  it('every sectionNum matches NV pattern', () => {
+    for (const s of sections) {
+      expect(isValidNvSectionNum(s.sectionNum)).toBe(true);
+    }
+  });
+
+  it('bodyText does not contain raw HTML tags', () => {
+    for (const s of sections) {
+      expect(s.bodyText).not.toMatch(/<[a-z]+/i);
+    }
+  });
+
+  it('bodyText does not contain unresolved HTML entities', () => {
+    for (const s of sections) {
+      expect(s.bodyText).not.toContain('&lt;');
+      expect(s.bodyText).not.toContain('&gt;');
+      expect(s.bodyText).not.toContain('&amp;');
+      expect(s.bodyText).not.toContain('&nbsp;');
+      expect(s.bodyText).not.toContain('&#8194;');
+    }
+  });
+
+  it('bodyText does not contain SourceNote/history bracket markers', () => {
+    // Source notes start with `[1911 C&P` or similar bracketed legislative history.
+    // Stripping is bracket-aware: we drop the entire <p class="SourceNote"> paragraph
+    // before tag-stripping, so the bracket itself should never reach bodyText.
+    for (const s of sections) {
+      expect(s.bodyText).not.toMatch(/^\s*\[\d{4}/);
+    }
+  });
+
+  it('source URL for each section is HTTPS leg.state.nv.us URL', () => {
+    for (const s of sections) {
+      const url = buildNVSourceUrl(s.sectionNum);
+      expect(url).toMatch(/^https:\/\/www\.leg\.state\.nv\.us\//);
+      expect(url).toContain(`NRS-${s.chapterNum}.html`);
+    }
+  });
+
+  it('returns empty array for non-NV HTML', () => {
+    expect(parseNVChapter('<html><body>not NV</body></html>', '200')).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseNVChapters — multi-chapter aggregation
+// ---------------------------------------------------------------------------
+
+describe('parseNVChapters', () => {
+  it('aggregates sections across multiple chapter docs', () => {
+    const docs = [
+      { chapterNum: '200', html: FIXTURE_HTML },
+      { chapterNum: '200', html: FIXTURE_HTML }, // duplicate input — exercises the loop
+    ];
+    const sections = parseNVChapters(docs);
+    expect(sections.length).toBeGreaterThan(0);
+    const single = parseNVChapter(FIXTURE_HTML, '200');
+    expect(sections.length).toBe(single.length * 2);
+  });
+
+  it('returns empty array for empty input', () => {
+    expect(parseNVChapters([])).toEqual([]);
+  });
+
+  it('skips chapters that yield zero sections without erroring', () => {
+    const docs = [
+      { chapterNum: '999', html: '<html><body>nothing here</body></html>' },
+      { chapterNum: '200', html: FIXTURE_HTML },
+    ];
+    const sections = parseNVChapters(docs);
+    const single = parseNVChapter(FIXTURE_HTML, '200');
+    expect(sections.length).toBe(single.length);
+  });
+});

--- a/scripts/ingest/lib/nv-html.mjs
+++ b/scripts/ingest/lib/nv-html.mjs
@@ -1,0 +1,393 @@
+// Template: scripts/ingest/lib/sc-html.mjs (sibling-shipped, single-doc-per-chapter pattern)
+// Pattern: cl-bulk-data-defensive #18 — bulk parse in-memory, COPY via harness
+// Source: https://www.leg.state.nv.us/NRS/index.html (chapter list)
+//         https://www.leg.state.nv.us/NRS/NRS-{N}.html (per-chapter HTML, sections inline)
+//
+// NV HTML structure (verified 2026-05-02 against live NRS-200.html ~512KB; NRS-484A.html;
+// NRS-484C.html; NRS-205.html; NRS-207.html). MS-Word generated; Times New Roman styling.
+//
+// Each chapter doc has TWO halves:
+//   1. Top half: Table of Contents using `<a href="#NRS200Sec010">NRS 200.010</a>` style
+//      links. We ignore these — they are not section markers, they're cross-refs.
+//   2. Bottom half: actual statute text starting at `<p class="DocHeading">...</p>`.
+//      Per-section paragraphs anchor like:
+//
+//      <p class="SectBody"><span class="Empty">… <a name=NRS200Sec010></a>NRS </span>
+//      <span class="Section">200.010</span><span class="Empty">  </span>
+//      <span class="Leadline">"Murder" defined.</span> Murder is the unlawful killing…</p>
+//
+//      <p class="SectBody">… 1.  With malice aforethought, either…</p>
+//      <p class="SectBody">… 2.  Caused by…</p>
+//      …
+//      <p class="SourceNote">… [1911 C&P …]—(NRS A <a href="…">1983, 512</a>; …)</p>
+//
+//      Next section starts at the next `<a name=NRS{ChapterNum}Sec...>` anchor.
+//
+// Anchor convention: `NRS{ChapterNum}Sec{SectionDigits}` — chapter may be numeric
+// (`200`, `205`) OR numeric+letter (`484A`, `484B`, `484C`). Citation form combines
+// chapter + 3-digit section: `200.010`, `484C.030`.
+//
+// robots.txt (leg.state.nv.us): no Crawl-delay (verified 2026-05-02). 1500ms polite
+// delay between chapter fetches as defensive floor.
+
+/**
+ * @typedef {Object} NVSection
+ * @property {string} chapterNum  e.g. "200", "484A", "484C"   (matches URL chapter slug)
+ * @property {string} sectionNum  e.g. "200.010", "484C.030"   (canonical NRS citation)
+ * @property {string} titleText   Leadline text — heading
+ * @property {string} bodyText    full body, HTML-decoded and stripped, history removed
+ */
+
+// ---------------------------------------------------------------------------
+// HTML entity decode + tag strip
+// ---------------------------------------------------------------------------
+
+/**
+ * Decode common HTML entities and strip HTML tags. NV's HTML uses Microsoft Word
+ * artifacts heavily — en-spaces (`&#8194;`), em-dashes (`&#8212;`), and curly
+ * quotes that may come through as raw bytes after a windows-1252 → UTF-8 round
+ * trip. Replace with ASCII near-equivalents for clean DB storage.
+ */
+export function stripHtml(raw) {
+  return raw
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&amp;/g, '&')
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&#167;/g, '§')
+    .replace(/&#xa7;/gi, '§')
+    .replace(/&sect;/gi, '§')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&#8194;/g, ' ')   // en-space (MS-Word artifact)
+    .replace(/&#8212;/g, '-')   // em-dash
+    .replace(/&#8211;/g, '-')   // en-dash
+    .replace(/&#(\d+);/g, (_, dec) => String.fromCharCode(Number(dec)))
+    .replace(/<script[\s\S]*?<\/script>/gi, ' ')
+    .replace(/<style[\s\S]*?<\/style>/gi, ' ')
+    .replace(/<[^>]+>/g, ' ')
+    // Replace common windows-1252 curly quotes / dashes that came through as raw
+    // unicode from the fetch layer:
+    .replace(/[‘’]/g, "'")
+    .replace(/[“”]/g, '"')
+    .replace(/[–—]/g, '-')
+    .replace(/�/g, '')     // unicode replacement char (encoding mismatch)
+    .replace(/[\s ]+/g, ' ')
+    .trim();
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+// NV emits the anchor without quotes around the value: `<a name=NRS200Sec010>`.
+const ANCHOR_PREFIX = '<a name=NRS';
+// Document-body marker — only sections AFTER this point are real statutes; anything
+// before is the TOC (which uses `<a href="#NRS...Sec...">` not `<a name=...>`).
+const DOC_BODY_MARKERS = [
+  '<p class="DocHeading">',
+  '<p class=DocHeading>',
+];
+
+// ---------------------------------------------------------------------------
+// Doc body extraction
+// ---------------------------------------------------------------------------
+
+/**
+ * Slice the document body (post-TOC) out of a full chapter doc. Returns the
+ * substring starting at the first DocHeading marker. Falls back to scanning the
+ * second half of the document if no DocHeading marker present (defensive).
+ */
+function extractDocBody(html) {
+  for (const marker of DOC_BODY_MARKERS) {
+    const idx = html.indexOf(marker);
+    if (idx !== -1) return html.slice(idx);
+  }
+  // Defensive fallback: chapter likely small and TOC-less. Skip first 25% of doc
+  // to avoid TOC link false positives.
+  return html.slice(Math.floor(html.length / 4));
+}
+
+// ---------------------------------------------------------------------------
+// Source-note removal (history block)
+// ---------------------------------------------------------------------------
+
+/**
+ * Strip every `<p class="SourceNote">…</p>` (and `class=SourceNote` no-quotes
+ * variant) out of an HTML slice. Uses indexOf-based scanning — no regex on the
+ * file contents.
+ */
+function stripSourceNotes(slice) {
+  const variants = ['<p class="SourceNote">', '<p class=SourceNote>'];
+  let out = slice;
+  for (const open of variants) {
+    while (true) {
+      const start = out.indexOf(open);
+      if (start === -1) break;
+      const end = out.indexOf('</p>', start);
+      if (end === -1) {
+        // unterminated — drop everything from start (defensive, never observed)
+        out = out.slice(0, start);
+        break;
+      }
+      out = out.slice(0, start) + ' ' + out.slice(end + '</p>'.length);
+    }
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Section anchor scan
+// ---------------------------------------------------------------------------
+
+/**
+ * Find every `<a name=NRS{ChapterNum}Sec{NNN}>` anchor in the body. Returns an
+ * array of marker objects sorted by appearance order.
+ *
+ * Anchor pattern: `<a name=NRS200Sec010>` (no quotes around the attribute value).
+ * The chapterNum portion can include a single trailing letter (e.g. `484A`).
+ *
+ * We require an exact chapter-prefix match so cross-references like
+ * `<a href="NRS-453.html#NRS453Sec3325">` (an `href`, not a `name`, but defensive
+ * just in case markup ever drifts) cannot pollute another chapter's section list.
+ */
+function findSectionAnchors(body, chapterNum) {
+  const chapterAnchorStart = `${ANCHOR_PREFIX}${chapterNum}Sec`;
+  const markers = [];
+  let pos = 0;
+  while (true) {
+    const startIdx = body.indexOf(chapterAnchorStart, pos);
+    if (startIdx === -1) break;
+    const closeIdx = body.indexOf('>', startIdx);
+    if (closeIdx === -1) break;
+    const inside = body.slice(startIdx + ANCHOR_PREFIX.length, closeIdx);
+    const sepIdx = inside.indexOf('Sec');
+    if (sepIdx === -1) {
+      pos = closeIdx + 1;
+      continue;
+    }
+    const anchorChapter = inside.slice(0, sepIdx);
+    const sectionDigits = inside.slice(sepIdx + 'Sec'.length);
+    if (anchorChapter !== chapterNum) {
+      pos = closeIdx + 1;
+      continue;
+    }
+    if (!sectionDigits || !/^[\dA-Za-z]+$/.test(sectionDigits)) {
+      pos = closeIdx + 1;
+      continue;
+    }
+    markers.push({
+      anchorIdx: startIdx,
+      bodyEndOfAnchor: closeIdx + 1,
+      chapterNum,
+      sectionDigits,
+    });
+    pos = closeIdx + 1;
+  }
+  return markers;
+}
+
+// ---------------------------------------------------------------------------
+// Title + body extraction
+// ---------------------------------------------------------------------------
+
+/**
+ * Pull the Leadline text (heading) from the section's first paragraph.
+ *
+ * MS-Word emits `<span\nclass="Leadline">` (newline between the tag name and
+ * the class attribute) when a paragraph wraps in the source document. We scan
+ * for a `class="Leadline"` (or `class=Leadline`) attribute appearance and walk
+ * BACKWARD to the enclosing `<span` opener, then forward to the next `>` that
+ * closes the open tag, and finally to the matching `</span>` for the body.
+ *
+ * Returns the empty string if not found — caller will skip empty-title sections.
+ */
+function extractLeadline(slice) {
+  const attrVariants = ['class="Leadline"', 'class=Leadline'];
+  for (const attr of attrVariants) {
+    const attrIdx = slice.indexOf(attr);
+    if (attrIdx === -1) continue;
+    // Walk back to the nearest `<span` opener.
+    const spanOpen = slice.lastIndexOf('<span', attrIdx);
+    if (spanOpen === -1 || spanOpen > attrIdx) continue;
+    // Find the `>` that closes the opening tag (must come AFTER the attr).
+    const tagClose = slice.indexOf('>', attrIdx);
+    if (tagClose === -1) continue;
+    // Find the matching `</span>` for the leadline body.
+    const spanClose = slice.indexOf('</span>', tagClose);
+    if (spanClose === -1) continue;
+    return stripHtml(slice.slice(tagClose + 1, spanClose));
+  }
+  return '';
+}
+
+/**
+ * Strip HTML from the raw body and remove SourceNote tail. Truncate to 4000
+ * chars (matches AR/CA/SC convention).
+ *
+ * Two-stage: first strip the SourceNote paragraphs (history block), then
+ * tag-strip the remainder.
+ */
+function stripBody(rawBody) {
+  const noHistory = stripSourceNotes(rawBody);
+  const decoded = stripHtml(noHistory);
+  return decoded.replace(/[\s ]+/g, ' ').trim().slice(0, 4000);
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate canonical NRS citation pattern: chapter + dot + section digits.
+ *   chapter: digits, optionally followed by a single letter (484A, 484B, …)
+ *   section: digits, optionally followed by a single letter
+ * Examples accepted: "200.010", "484C.030", "200.5099"
+ * Examples rejected: "", "200", "200..010", "abc.def"
+ */
+export function isValidNvSectionNum(s) {
+  if (!s || typeof s !== 'string') return false;
+  const parts = s.split('.');
+  if (parts.length !== 2) return false;
+  if (!/^\d+[A-Za-z]?$/.test(parts[0])) return false;
+  if (!/^\d+[A-Za-z]?$/.test(parts[1])) return false;
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Citation builder
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert raw section digits (as they appear in the URL anchor) into the canonical
+ * NRS citation form. The anchor `NRS200Sec010` → citation `200.010`. Anchor digits
+ * preserve leading zeros — NRS 200.010 is the official form, not "NRS 200.10".
+ */
+function buildCitation(chapterNum, sectionDigits) {
+  return `${chapterNum}.${sectionDigits}`;
+}
+
+// ---------------------------------------------------------------------------
+// Parse one chapter
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a single NV chapter HTML doc and return all sections within.
+ *
+ * @param {string} html         raw chapter HTML (e.g. body of NRS-200.html)
+ * @param {string} chapterNum   display form chapter number (e.g. "200", "484A")
+ * @returns {NVSection[]}
+ */
+export function parseNVChapter(html, chapterNum) {
+  const body = extractDocBody(html);
+  const markers = findSectionAnchors(body, chapterNum);
+  if (markers.length === 0) return [];
+
+  const sections = [];
+  for (let i = 0; i < markers.length; i++) {
+    const m = markers[i];
+    const next = markers[i + 1];
+    const sliceEnd = next ? next.anchorIdx : body.length;
+    const sectionSlice = body.slice(m.anchorIdx, sliceEnd);
+
+    const titleText = extractLeadline(sectionSlice);
+    const bodyText = stripBody(sectionSlice);
+    const sectionNum = buildCitation(m.chapterNum, m.sectionDigits);
+
+    if (!titleText) continue;
+    if (!bodyText) continue;
+    if (!isValidNvSectionNum(sectionNum)) continue;
+
+    sections.push({
+      chapterNum,
+      sectionNum,
+      titleText,
+      bodyText,
+    });
+  }
+  return sections;
+}
+
+/**
+ * Parse multiple NV chapters from a {chapterNum, html}[] iterable and concatenate
+ * the section arrays. Mirrors parseScChapters.
+ *
+ * @param {{chapterNum: string, html: string}[]} chapterDocs
+ * @returns {NVSection[]}
+ */
+export function parseNVChapters(chapterDocs) {
+  const all = [];
+  for (const doc of chapterDocs) {
+    const secs = parseNVChapter(doc.html, doc.chapterNum);
+    for (const s of secs) all.push(s);
+  }
+  return all;
+}
+
+// ---------------------------------------------------------------------------
+// Source URL builders
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the canonical leg.state.nv.us URL for an NV NRS section.
+ * Section URL = chapter doc URL + #NRS{chapter}Sec{sectionDigits}.
+ *
+ *   buildNVSourceUrl("200.010") → https://www.leg.state.nv.us/NRS/NRS-200.html#NRS200Sec010
+ *   buildNVSourceUrl("484C.030") → https://www.leg.state.nv.us/NRS/NRS-484C.html#NRS484CSec030
+ *
+ * @param {string} sectionNum  e.g. "200.010"
+ * @returns {string}
+ */
+export function buildNVSourceUrl(sectionNum) {
+  const dotIdx = sectionNum.indexOf('.');
+  if (dotIdx === -1) {
+    // Defensive: caller validated already, but never produce a malformed URL.
+    return 'https://www.leg.state.nv.us/NRS/index.html';
+  }
+  const chapter = sectionNum.slice(0, dotIdx);
+  const sectionDigits = sectionNum.slice(dotIdx + 1);
+  return `https://www.leg.state.nv.us/NRS/NRS-${chapter}.html#NRS${chapter}Sec${sectionDigits}`;
+}
+
+/**
+ * Build the chapter HTML URL for a given chapter number (display form).
+ * Used by the seeder during bulk fetch.
+ *
+ *   buildNVChapterUrl("200") → https://www.leg.state.nv.us/NRS/NRS-200.html
+ *   buildNVChapterUrl("484A") → https://www.leg.state.nv.us/NRS/NRS-484A.html
+ *
+ * @param {string|number} chapterNum
+ * @returns {string}
+ */
+export function buildNVChapterUrl(chapterNum) {
+  return `https://www.leg.state.nv.us/NRS/NRS-${String(chapterNum)}.html`;
+}
+
+/**
+ * Authoritative chapter cohort for the NV criminal-statute seeder.
+ *
+ *   200   — Crimes Against the Person (homicide, assault, sexual offenses, kidnapping)
+ *   205   — Crimes Against Property (theft, burglary, fraud)
+ *   207   — Miscellaneous Crimes
+ *   453   — Controlled Substances
+ *   484A  — Traffic Laws Generally (DUI definitional + procedural)
+ *   484B  — Rules of the Road
+ *   484C  — Driving Under the Influence
+ *   484D  — Equipment / vehicle
+ *   484E  — Accidents and Accident Reports (hit-and-run)
+ *
+ * These nine chapters cover the criminal-defense surface area we need for INAA's
+ * NV intake / playbook generation. Verified live (2026-05-02) — all nine return
+ * 200 OK with `<a name=NRS{N}Sec*>` anchors present.
+ */
+export const NV_CHAPTERS = [
+  '200',
+  '205',
+  '207',
+  '453',
+  '484A',
+  '484B',
+  '484C',
+  '484D',
+  '484E',
+];

--- a/scripts/ingest/seed-statutes-nv-criminal.mjs
+++ b/scripts/ingest/seed-statutes-nv-criminal.mjs
@@ -1,0 +1,249 @@
+#!/usr/bin/env node
+// Template: scripts/ingest/seed-statutes-sc-title16.mjs (sibling, single-doc-per-chapter)
+// Pattern: cl-bulk-data-defensive #17 — session-level timeouts via createBulkClient (via harness)
+// Pattern: cl-bulk-data-defensive #18 — COPY FROM STDIN via bulkCopyRows (via harness)
+// Pattern: no-hallucinated-legal-data — every row carries a verified HTTPS source URL
+// csv-bulk-checked: none-exists — leg.state.nv.us publishes per-chapter HTML only, no bulk CSV.
+//   9 chapter URLs at https://www.leg.state.nv.us/NRS/NRS-{N}.html (numeric or numeric+letter slug).
+//
+// Seeds Nevada Revised Statutes (NRS) criminal-defense cohort into entities_statutes.
+//
+// Source structure: each NRS chapter is ONE HTML doc with all sections inline.
+// We fetch all 9 cohort chapters sequentially, parse each into NVSection[], then COPY
+// all sections via the unicourt-harness primitives.
+//
+// Source: https://www.leg.state.nv.us/NRS/index.html (chapter list)
+//         https://www.leg.state.nv.us/NRS/NRS-{N}.html (per-chapter HTML)
+// Robots: leg.state.nv.us has no Crawl-delay (verified 2026-05-02). We use
+//   1500ms polite delay between chapter fetches as defensive floor.
+//
+// Usage:
+//   node scripts/ingest/seed-statutes-nv-criminal.mjs --dry-run
+//   node scripts/ingest/seed-statutes-nv-criminal.mjs --dry-run --limit=3 --verbose
+//   node scripts/ingest/seed-statutes-nv-criminal.mjs                  (live; requires SUPABASE_DB_URL)
+//
+// Env required for live run:
+//   SUPABASE_DB_URL — direct postgres connection (port 5432, session mode)
+
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import {
+  parseNVChapter,
+  buildNVSourceUrl,
+  buildNVChapterUrl,
+  NV_CHAPTERS,
+} from './lib/nv-html.mjs';
+import {
+  fetchWithRetry,
+  buildSectionRow,
+  applyToDb,
+} from '../lib/unicourt-harness.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// ── Env loader ───────────────────────────────────────────────────────────────
+const dotenvPath = path.resolve(__dirname, '../../.env.local');
+try {
+  const { config } = await import('dotenv');
+  config({ path: dotenvPath });
+} catch {
+  /* dotenv optional — env may be pre-set */
+}
+
+// ── CLI ──────────────────────────────────────────────────────────────────────
+export function parseCliFlags(argv) {
+  const flags = {
+    dryRun: false,
+    verbose: false,
+    limit: null,
+  };
+  for (const a of argv) {
+    if (a === '--dry-run') flags.dryRun = true;
+    else if (a === '--verbose') flags.verbose = true;
+    else if (a.startsWith('--limit=')) {
+      flags.limit = Number.parseInt(a.slice('--limit='.length), 10);
+    }
+  }
+  return flags;
+}
+
+// ── NV config ────────────────────────────────────────────────────────────────
+//
+// Note: our seeder drives the multi-chapter fetch loop directly (not through
+// `unicourt-harness.ingestState`, which assumes single-doc-per-title). The
+// config object only needs the fields used by `buildSectionRow` + `applyToDb`:
+//   stateCode, stateName, titleNum, buildSourceUrl
+// `titleNum` is logical here — NV groups criminal statutes across chapters
+// 200/205/207/453/484A-E rather than a single title number. We use "criminal"
+// as the title slug so DELETE-then-COPY idempotency keys cleanly per cohort.
+// ─────────────────────────────────────────────────────────────────────────────
+export const NV_CONFIG = {
+  stateCode: 'NV',
+  stateName: 'Nevada',
+  titleNum: 'criminal',
+  titleLabel: 'Criminal Code (chapters 200/205/207/453/484A-E)',
+  // Required by unicourt-harness.UnicourtStateConfig for parity, but unused here
+  // because we drive the multi-chapter fetch loop ourselves rather than going
+  // through ingestState.
+  titleUrl: 'https://www.leg.state.nv.us/NRS/index.html',
+  allowedHosts: new Set(['www.leg.state.nv.us', 'leg.state.nv.us']),
+  crawlDelayMs: 1500,
+  fetchTimeoutMs: 60000,
+  buildSourceUrl: buildNVSourceUrl,
+};
+
+// ── Host allow-list ──────────────────────────────────────────────────────────
+function assertAllowedHost(url, allowedHosts) {
+  const u = new URL(url);
+  if (!allowedHosts.has(u.host)) {
+    throw new Error(`host not in allow-list: ${u.host}`);
+  }
+}
+
+// ── Sleep helper ─────────────────────────────────────────────────────────────
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// ── Multi-chapter fetch + parse ──────────────────────────────────────────────
+/**
+ * Sequentially fetch all configured NV cohort chapter docs, parse each, and
+ * return the flat list of NVSection objects.
+ *
+ * @param {{ chapters?: string[], crawlDelayMs?: number, fetchTimeoutMs?: number,
+ *           allowedHosts: Set<string>, verbose?: boolean, limit?: number|null }} opts
+ * @returns {Promise<Array<import('./lib/nv-html.mjs').NVSection>>}
+ */
+export async function fetchAndParseAllChapters(opts) {
+  const {
+    chapters = NV_CHAPTERS,
+    crawlDelayMs = 1500,
+    fetchTimeoutMs = 60000,
+    allowedHosts,
+    verbose = false,
+    limit = null,
+  } = opts;
+
+  const all = [];
+  let chapterIdx = 0;
+  for (const chapterNum of chapters) {
+    const url = buildNVChapterUrl(chapterNum);
+    assertAllowedHost(url, allowedHosts);
+    if (verbose) console.log(`  [chapter ${chapterNum}] fetching ${url}`);
+
+    let html;
+    try {
+      html = await fetchWithRetry(url, { timeoutMs: fetchTimeoutMs });
+    } catch (err) {
+      console.warn(`  [chapter ${chapterNum}] fetch failed: ${err.message}`);
+      continue;
+    }
+
+    const sections = parseNVChapter(html, chapterNum);
+    if (verbose) {
+      console.log(`  [chapter ${chapterNum}] parsed ${sections.length} sections`);
+    } else {
+      process.stdout.write(`.`);
+    }
+
+    for (const s of sections) {
+      all.push(s);
+      if (limit && all.length >= limit) {
+        if (verbose) console.log(`  [limit=${limit}] reached — stopping`);
+        if (!verbose) process.stdout.write('\n');
+        return all;
+      }
+    }
+
+    chapterIdx += 1;
+    if (chapterIdx < chapters.length) await sleep(crawlDelayMs);
+  }
+  if (!verbose) process.stdout.write('\n');
+  return all;
+}
+
+// ── Main ─────────────────────────────────────────────────────────────────────
+async function main() {
+  const flags = parseCliFlags(process.argv.slice(2));
+
+  if (flags.dryRun) {
+    console.log('[seed-statutes-nv-criminal] DRY RUN — no DB writes');
+  } else {
+    if (!process.env.SUPABASE_DB_URL) {
+      console.error('ERROR: SUPABASE_DB_URL not set. Run with --dry-run or set the env var.');
+      process.exit(1);
+    }
+    console.log('[seed-statutes-nv-criminal] LIVE RUN — will write to DB');
+  }
+  if (flags.limit) console.log(`  limit: ${flags.limit}`);
+
+  const t0 = Date.now();
+
+  // 1. Fetch + parse all chapters into flat NVSection[]
+  const sections = await fetchAndParseAllChapters({
+    chapters: NV_CHAPTERS,
+    crawlDelayMs: NV_CONFIG.crawlDelayMs,
+    fetchTimeoutMs: NV_CONFIG.fetchTimeoutMs,
+    allowedHosts: NV_CONFIG.allowedHosts,
+    verbose: flags.verbose,
+    limit: flags.limit,
+  });
+  console.log(`\n[seed-statutes-nv-criminal] parsed ${sections.length} total sections`);
+
+  // 2. Build validated rows via harness helper
+  const rows = [];
+  let skipCount = 0;
+  let errorCount = 0;
+  for (const s of sections) {
+    const { row, errors } = buildSectionRow(
+      NV_CONFIG,
+      s.chapterNum,
+      s.sectionNum,
+      s.titleText,
+      s.bodyText,
+    );
+    if (errors.length > 0) {
+      errorCount += 1;
+      if (flags.verbose) console.warn(`    [err] ${s.sectionNum}: ${errors.join('; ')}`);
+      continue;
+    }
+    rows.push(row);
+  }
+  console.log(`[seed-statutes-nv-criminal] built ${rows.length} valid rows (skip=${skipCount}, err=${errorCount})`);
+
+  // 3. Apply to DB (or dry-run preview)
+  const dbResult = await applyToDb(rows, NV_CONFIG, {
+    dryRun: flags.dryRun,
+    connectionString: process.env.SUPABASE_DB_URL,
+  });
+
+  const durationMs = Date.now() - t0;
+  console.log('\n=== Summary ===');
+  console.log(`  sections     : ${sections.length}`);
+  console.log(`  rows written : ${dbResult.rowCount}`);
+  console.log(`  parse errors : ${errorCount}`);
+  console.log(`  duration     : ${durationMs}ms`);
+
+  // NV floor: parent plan estimates ~500-700 across the 9-chapter cohort. 500 is
+  // the conservative floor — full run should easily clear this; floor only
+  // applies to live full runs (skipped on --limit / --dry-run).
+  const isFullLiveRun = !flags.dryRun && !flags.limit;
+  if (isFullLiveRun && dbResult.rowCount < 500) {
+    console.error(`\nFAIL: floor not met — only ${dbResult.rowCount} rows (need >= 500 for full run)`);
+    process.exit(1);
+  }
+
+  console.log('\nPASS');
+  process.exit(0);
+}
+
+const invokedDirectly = (() => {
+  if (!process.argv[1]) return false;
+  try { return import.meta.url === pathToFileURL(process.argv[1]).href; }
+  catch { return false; }
+})();
+if (invokedDirectly) main().catch((err) => {
+  console.error('[seed-statutes-nv-criminal] fatal:', err.message);
+  process.exit(1);
+});


### PR DESCRIPTION
Wave 2 multi-chapter ingest, Nevada criminal cohort via leg.state.nv.us.

## Source
`https://www.leg.state.nv.us/NRS/NRS-{N}.html` — 9 chapters: 200, 205, 207, 453, 484A-E (homicide/property/misc/drugs/DUI).

## Live result
- 1,189 rows / 500 floor / 0 errors / 17s
- Per-chapter section counts: 200=154, 205=238, 207=70, 453=191, 484A=128, 484B=198, 484C=73, 484D=124, 484E=13

## Test plan
- [x] node --test 44/44 PASS
- [x] Live ingest 1,189 rows >= 500 floor
- [x] Audits: 0 missing source_urls / 0 empty body / 0 NULL section / 0 non-https
- [x] MS-Word HTML newline-span quirk handled
- [x] Alphanumeric chapter IDs (484A-E) parsed

## Notes
title slug = `criminal` (not numeric) — distinguishes from future cohorts (e.g. NV traffic-civil).