### PR TITLE
feat(statutes): WI criminal cohort (10 chapters PDF) — Wave 2

### DIFF
--- a/scripts/ingest/__tests__/fixtures/wi/chapter-940-sample.txt
+++ b/scripts/ingest/__tests__/fixtures/wi/chapter-940-sample.txt
@@ -1,0 +1,25 @@
+CHAPTER 940
+CRIMES AGAINST LIFE AND BODILY SECURITY
+SUBCHAPTER I
+LIFE
+940.01 First-degree intentional homicide.
+(1) OFFENSES.
+(a) Except as provided in sub. (2), whoever causes the death of another human being with intent to kill that person or another is guilty of a Class A felony.
+(b) Except as provided in sub. (2), whoever causes the death of an unborn child with intent to kill that unborn child, kill the woman who is pregnant with that unborn child or kill another is guilty of a Class A felony.
+(2) MITIGATING CIRCUMSTANCES. The following are affirmative defenses to prosecution under this section which mitigate the offense to 2nd-degree intentional homicide under s. 940.05:
+(a) Adequate provocation. Death was caused under the influence of adequate provocation as defined in s. 939.44.
+(b) Unnecessary defensive force. Death was caused because the actor believed he or she or another was in imminent danger of death or great bodily harm and that the force used was necessary to defend the endangered person, if either belief was unreasonable.
+History: 1987 a. 399; 1997 a. 295.
+
+940.02 First-degree reckless homicide.
+(1) Whoever recklessly causes the death of another human being under circumstances which show utter disregard for human life is guilty of a Class B felony.
+(1m) Whoever recklessly causes the death of another human being by manufacture, distribution or delivery, in violation of s. 961.41, of a controlled substance included in schedule I or II under ch. 961, of a controlled substance analog of a controlled substance included in schedule I or II under ch. 961 or of ketamine or flunitrazepam, if another human being uses the controlled substance or controlled substance analog and dies as a result of that use, is guilty of a Class C felony.
+(2) Whoever causes the death of an unborn child under any of the following circumstances is guilty of a Class B felony:
+(a) Recklessly under circumstances which show utter disregard for the life of that unborn child, the woman who is pregnant with that unborn child or another.
+History: 1987 a. 399; 1995 a. 448; 1997 a. 295; 2001 a. 109.
+
+940.03 Felony murder.
+Whoever causes the death of another human being while committing or attempting to commit a crime specified in s. 940.19, 940.195, 940.20, 940.201, 940.203, 940.225 (1) or (2) (a), 940.30, 940.31, 943.02, 943.10 (2), 943.23 (1g), or 943.32 (2) may be imprisoned for not more than 15 years in excess of the maximum term of imprisonment provided by law for that crime or attempt.
+History: 1987 a. 399; 1993 a. 486; 1995 a. 69; 2001 a. 109.
+
+-- 1 of 19 --

--- a/scripts/ingest/__tests__/fixtures/wi/chapter-943-sample.txt
+++ b/scripts/ingest/__tests__/fixtures/wi/chapter-943-sample.txt
@@ -1,0 +1,30 @@
+CHAPTER 943
+CRIMES AGAINST PROPERTY
+SUBCHAPTER I
+PROPERTY OFFENSES
+943.01 Damage to property.
+(1) Whoever intentionally causes damage to any physical property of another without the person's consent is guilty of a Class A misdemeanor.
+(2) Any person violating sub. (1) under any of the following circumstances is guilty of a Class I felony:
+(a) The property damaged is a vehicle or highway and the damage is of a kind which is likely to cause injury to a person or further property damage.
+(b) The property damaged belongs to a public utility or common carrier and the damage causes an interruption of service.
+History: 1977 c. 173; 1979 c. 110; 2001 a. 109.
+
+943.02 Arson of buildings; damage of property by explosives.
+(1) Whoever does any of the following is guilty of a Class C felony:
+(a) By means of fire, intentionally damages any building of another without the other's consent; or
+(b) By means of fire, intentionally damages any building with intent to defraud an insurer of that building; or
+(c) By means of explosives, intentionally damages any property of another without the other's consent.
+(2) In this section "building" has the meaning designated in s. 943.10 (1g) (a).
+History: 1977 c. 173; 1979 c. 110.
+
+943.10 Burglary.
+(1g) DEFINITIONS. In this section:
+(a) "Building" means any structure used for lodging or residence, business, the storage of goods, or for any other use, including any structure used as a church, synagogue, or other place of worship.
+(b) "Dwelling" means any premises or portion of a premises that is used as a home or place of residence and that part of any other building used as a home or place of residence.
+(1m) OFFENSE. Whoever intentionally enters any of the following places without the consent of the person in lawful possession and with intent to steal or commit a felony in such place is guilty of a Class F felony:
+(a) Any building or dwelling.
+(b) An enclosed railroad car.
+(c) An enclosed portion of any ship or vessel.
+History: 1977 c. 173; 1979 c. 110; 2001 a. 109.
+
+-- 1 of 24 --

--- a/scripts/ingest/__tests__/seed-statutes-wi-criminal.test.mjs
+++ b/scripts/ingest/__tests__/seed-statutes-wi-criminal.test.mjs
@@ -1,0 +1,166 @@
+// test-isolation-na: pure parser unit tests against on-disk fixture text — no DB writes.
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import {
+  parseChapter,
+  buildWiSourceUrl,
+  buildWiChapterPdfUrl,
+  buildWiSectionRe,
+  buildWiConfig,
+  WI_CRIMINAL_CHAPTERS,
+} from '../lib/wi-criminal-pdf.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CH940_PATH = path.join(__dirname, 'fixtures', 'wi', 'chapter-940-sample.txt');
+const CH943_PATH = path.join(__dirname, 'fixtures', 'wi', 'chapter-943-sample.txt');
+const CH940_TEXT = readFileSync(CH940_PATH, 'utf8');
+const CH943_TEXT = readFileSync(CH943_PATH, 'utf8');
+
+describe('WI_CRIMINAL_CHAPTERS', () => {
+  it('contains the modern criminal-code cohort 939-948', () => {
+    expect(WI_CRIMINAL_CHAPTERS).toEqual([
+      '939', '940', '941', '942', '943',
+      '944', '945', '946', '947', '948',
+    ]);
+  });
+});
+
+describe('buildWiChapterPdfUrl', () => {
+  it('builds the canonical per-chapter PDF URL', () => {
+    expect(buildWiChapterPdfUrl('940')).toBe(
+      'https://docs.legis.wisconsin.gov/statutes/statutes/940.pdf',
+    );
+  });
+  it('accepts numeric chapter input', () => {
+    expect(buildWiChapterPdfUrl(943)).toBe(
+      'https://docs.legis.wisconsin.gov/statutes/statutes/943.pdf',
+    );
+  });
+  it('rejects non-numeric chapter', () => {
+    expect(() => buildWiChapterPdfUrl('abc')).toThrow(/invalid chapterNum/);
+  });
+});
+
+describe('buildWiSourceUrl', () => {
+  it('returns the chapter PDF URL derived from the section number', () => {
+    expect(buildWiSourceUrl('940.01')).toBe(buildWiChapterPdfUrl('940'));
+    expect(buildWiSourceUrl('943.10')).toBe(buildWiChapterPdfUrl('943'));
+  });
+  it('URL is HTTPS', () => {
+    expect(buildWiSourceUrl('940.01')).toMatch(/^https:\/\//);
+  });
+  it('URL points at docs.legis.wisconsin.gov', () => {
+    expect(buildWiSourceUrl('940.01')).toContain('docs.legis.wisconsin.gov');
+  });
+  it('rejects malformed sectionNum', () => {
+    expect(() => buildWiSourceUrl('abc.01')).toThrow(/malformed sectionNum/);
+  });
+});
+
+describe('buildWiSectionRe', () => {
+  it('matches a chapter-940 header line', () => {
+    const re = buildWiSectionRe('940');
+    const m = '940.01 First-degree intentional homicide.'.match(re);
+    expect(m).not.toBeNull();
+    expect(m[1]).toBe('940.01');
+    expect(m[2]).toBe('First-degree intentional homicide');
+  });
+  it('does NOT match a different chapter header (chapter scoping)', () => {
+    const re = buildWiSectionRe('940');
+    const m = '943.01 Damage to property.'.match(re);
+    expect(m).toBeNull();
+  });
+  it('does NOT match a body-text cross-reference like "see 940.01"', () => {
+    const re = buildWiSectionRe('940');
+    expect('see 940.01 for the offense'.match(re)).toBeNull();
+  });
+  it('rejects invalid chapter input', () => {
+    expect(() => buildWiSectionRe('abc')).toThrow(/invalid chapterNum/);
+  });
+});
+
+describe('buildWiConfig', () => {
+  it('returns a config with state=WI and a sectionRe regex', () => {
+    const cfg = buildWiConfig('940');
+    expect(cfg.state).toBe('WI');
+    expect(cfg.sectionRe).toBeInstanceOf(RegExp);
+    expect(cfg.minBodyChars).toBe(30);
+    expect(cfg.normalizeEnDash).toBe(false);
+  });
+});
+
+describe('parseChapter — chapter 940 (real fixture)', () => {
+  let sections;
+
+  beforeAll(() => {
+    sections = parseChapter(CH940_TEXT, '940');
+  });
+
+  it('parses at least 3 sections from fixture', () => {
+    expect(sections.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('first section is 940.01 (First-degree intentional homicide)', () => {
+    expect(sections[0].sectionNum).toBe('940.01');
+    expect(sections[0].title).toContain('First-degree intentional homicide');
+  });
+
+  it('second section is 940.02 (First-degree reckless homicide)', () => {
+    expect(sections[1].sectionNum).toBe('940.02');
+    expect(sections[1].title).toContain('First-degree reckless homicide');
+  });
+
+  it('every parsed section has non-empty body', () => {
+    for (const s of sections) {
+      expect(s.body.length).toBeGreaterThanOrEqual(30);
+    }
+  });
+
+  it('every parsed section has a 940.* sectionNum', () => {
+    for (const s of sections) {
+      expect(s.sectionNum).toMatch(/^940\./);
+    }
+  });
+
+  it('preserves History footer in body', () => {
+    const sec01 = sections.find((s) => s.sectionNum === '940.01');
+    expect(sec01).toBeDefined();
+    expect(sec01.body).toContain('History:');
+  });
+
+  it('strips page-break artifact lines from body', () => {
+    for (const s of sections) {
+      expect(s.body).not.toMatch(/^--\s+\d+\s+of\s+\d+\s+--$/m);
+    }
+  });
+});
+
+describe('parseChapter — chapter 943 (cross-chapter regex isolation)', () => {
+  let sections;
+
+  beforeAll(() => {
+    sections = parseChapter(CH943_TEXT, '943');
+  });
+
+  it('parses at least 3 sections from fixture', () => {
+    expect(sections.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('first section is 943.01 (Damage to property)', () => {
+    expect(sections[0].sectionNum).toBe('943.01');
+    expect(sections[0].title).toContain('Damage to property');
+  });
+
+  it('every parsed section has a 943.* sectionNum (no chapter bleed)', () => {
+    for (const s of sections) {
+      expect(s.sectionNum).toMatch(/^943\./);
+    }
+  });
+
+  it('parsing the 943 fixture with chapter=940 returns zero sections (regex scoping)', () => {
+    const wrong = parseChapter(CH943_TEXT, '940');
+    expect(wrong.length).toBe(0);
+  });
+});

--- a/scripts/ingest/lib/wi-criminal-pdf.mjs
+++ b/scripts/ingest/lib/wi-criminal-pdf.mjs
@@ -1,0 +1,175 @@
+// Template: scripts/ingest/lib/de-title11-pdf.mjs (per-state PDF parser pattern)
+// Pattern: cl-bulk-data-defensive #19 — per-chapter PDFs as bulk source (no API loops)
+// csv-bulk-checked: https://docs.legis.wisconsin.gov/statutes/statutes/{N}.pdf
+//   (per-chapter PDFs, official Wisconsin Legislative Reference Bureau, born-digital
+//    text layer; chapters 939-948 cover the modern criminal code)
+//
+// Wisconsin Criminal Code (Chapters 939-948) — Wave 2 ingest.
+//
+// Format observations (verified against live PDF chapter 940, 2026-05-02):
+//   Source: per-chapter PDF, one PDF per chapter at
+//     https://docs.legis.wisconsin.gov/statutes/statutes/{N}.pdf
+//   Cohort: 939, 940, 941, 942, 943, 944, 945, 946, 947, 948
+//     - 939 = General Provisions
+//     - 940 = Crimes Against Life and Bodily Security
+//     - 941 = Crimes Against Public Health and Safety
+//     - 942 = Crimes Against Reputation, Privacy, Civil Liberties
+//     - 943 = Crimes Against Property
+//     - 944 = Crimes Against Sexual Morality
+//     - 945 = Gambling
+//     - 946 = Crimes Against Government and Its Administration
+//     - 947 = Crimes Against Public Peace, Order, and Other Interests
+//     - 948 = Crimes Against Children
+//   Section header line (extracted text shape): "940.01 First-degree intentional homicide."
+//     - Chapter.Section dot syntax (no § symbol on the header line in extracted text)
+//     - Section number format: {chapter}.{NN}[(suffix)] — e.g.
+//         "940.01", "940.225", "940.225(1)", "939.45", "948.02"
+//       Wisconsin uses dotted decimal subsection nums in the wild but the
+//       parser-level header is the bare "{chapter}.{NN}" form. Subsection
+//       letters/parens appear inside the body text of a section.
+//     - Title text follows on the same line, terminated by period.
+//   Body: free text below header until next section header.
+//     Includes "History:" footer noting source acts (preserved as part of
+//     canonical body to match DE shape).
+//
+// Parser shape: thin wrapper around parseStatuteSections() with a WI-specific
+// regex. The seeder calls parseChapter(text, chapterNum) once per chapter PDF
+// and concatenates results. The {chapter} prefix in the regex is parameterized
+// per-call so a 940.pdf parse will not slurp 941-style headers if pages bleed
+// across chapters in any cross-chapter PDF that exists.
+
+import { parseStatuteSections } from '../../lib/pdf-statute-harness.mjs';
+
+// ---------------------------------------------------------------------------
+// Cohort + URL builders
+// ---------------------------------------------------------------------------
+
+/**
+ * Wisconsin criminal-code chapter cohort.
+ * Ordered to match dispatch order in the seeder.
+ */
+export const WI_CRIMINAL_CHAPTERS = [
+  '939', '940', '941', '942', '943',
+  '944', '945', '946', '947', '948',
+];
+
+/**
+ * Build the per-chapter PDF URL.
+ * @param {string|number} chapterNum  e.g. "940" or 940
+ * @returns {string}
+ */
+export function buildWiChapterPdfUrl(chapterNum) {
+  if (!/^\d+$/.test(String(chapterNum))) {
+    throw new Error(`buildWiChapterPdfUrl: invalid chapterNum "${chapterNum}"`);
+  }
+  return `https://docs.legis.wisconsin.gov/statutes/statutes/${chapterNum}.pdf`;
+}
+
+/**
+ * Build the canonical state-leg source URL for a given section (e.g. "940.01").
+ * Wisconsin's per-chapter PDF has no fragment anchor inside it, so every row
+ * for a chapter points at the chapter PDF — same truthful-anchor pattern as
+ * DE buildDeSourceUrl().
+ *
+ * @param {string} sectionNum  e.g. "940.01"
+ * @returns {string}
+ */
+export function buildWiSourceUrl(sectionNum) {
+  const chapter = String(sectionNum).split('.')[0];
+  if (!/^\d+$/.test(chapter)) {
+    throw new Error(`buildWiSourceUrl: malformed sectionNum "${sectionNum}"`);
+  }
+  return buildWiChapterPdfUrl(chapter);
+}
+
+// ---------------------------------------------------------------------------
+// Per-chapter section regex factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a regex that matches WI section headers for a SPECIFIC chapter.
+ *
+ * Header shape (post-PDF-text-extraction, two observed variants):
+ *   1. Bare TOC entry:    "940.01 First-degree intentional homicide."
+ *      (line-end terminator is `.` — appears in TOC at front of chapter)
+ *   2. Body header:       "940.01 First-degree intentional homicide. (1) OF-"
+ *      (period after title, then subsection marker `(N)` continues on same
+ *      line; this is the canonical statute-body header)
+ *
+ * Both variants share: line-anchored "{chapter}.{section} {title}." prefix.
+ * The body variant has trailing content; the TOC variant ends at the period.
+ *
+ * Caller (parseStatuteSections in the harness) consumes ALL matched headers
+ * in document order, then bodies are the lines between consecutive headers.
+ * Because TOC entries appear FIRST and their bodies (= lines until the next
+ * TOC entry, which is the very next line) are too short to clear minBodyChars,
+ * TOC entries get filtered. Body-variant headers appear LATER and capture the
+ * full statute text up to the next body-variant header.
+ *
+ * Group 1 = section number (e.g. "940.01")
+ * Group 2 = title text (e.g. "First-degree intentional homicide")
+ *
+ * Anchored at line start. Title text captured lazily up to the FIRST period.
+ * Trailing content after the period is allowed (catches body-variant headers).
+ * Body-text cross-references like "see 940.05:" do NOT match because they
+ * lack the line-start anchor (they appear mid-line in body paragraphs).
+ *
+ * @param {string|number} chapterNum
+ * @returns {RegExp}
+ */
+export function buildWiSectionRe(chapterNum) {
+  if (!/^\d+$/.test(String(chapterNum))) {
+    throw new Error(`buildWiSectionRe: invalid chapterNum "${chapterNum}"`);
+  }
+  // Section number: {chapter}.{1-4 digits}, optionally followed by a single
+  // parenthesized subsection letter/digit (rare in WI body headers).
+  // Title: anything up to first period; trailing content after period allowed
+  // to catch body-variant headers like "...homicide. (1) OFFENSES."
+  return new RegExp(
+    `^(${chapterNum}\\.\\d{1,4}(?:\\([0-9a-z]+\\))?)\\s+([^.\\n]+?)\\.(?:\\s|$)`,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Per-chapter parse config
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a ParseConfig for a single WI chapter. Caller passes the chapter
+ * number; each chapter parse uses its own config so cross-chapter section
+ * headers cannot bleed.
+ *
+ * @param {string|number} chapterNum
+ * @returns {import('../../lib/pdf-statute-harness.mjs').ParseConfig}
+ */
+export function buildWiConfig(chapterNum) {
+  return {
+    state: 'WI',
+    sectionRe: buildWiSectionRe(chapterNum),
+    // WI PDFs use ASCII hyphens in section ranges; no en-dash normalization.
+    normalizeEnDash: false,
+    // Filter TOC-style entries (header line repeated at front of doc with
+    // no body). 30 chars is enough to drop bare TOC echoes while preserving
+    // every real statute section.
+    minBodyChars: 30,
+    // Default page-break regex from the harness handles "-- N of M --" and
+    // bare "- N -" page markers. WI does not use these but the default is a
+    // safe no-op; bare page numbers in the WI margin extract are short
+    // enough to not derail body parse.
+  };
+}
+
+// ---------------------------------------------------------------------------
+// parseChapter
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse all sections from a single Wisconsin chapter PDF's extracted text.
+ *
+ * @param {string} text       output of extractStatuteText() on the chapter PDF
+ * @param {string|number} chapterNum  e.g. "940"
+ * @returns {import('../../lib/pdf-statute-harness.mjs').StatuteSection[]}
+ */
+export function parseChapter(text, chapterNum) {
+  return parseStatuteSections(text, buildWiConfig(chapterNum));
+}

--- a/scripts/ingest/seed-statutes-wi-criminal.mjs
+++ b/scripts/ingest/seed-statutes-wi-criminal.mjs
@@ -1,0 +1,330 @@
+#!/usr/bin/env node
+// Template: scripts/ingest/seed-statutes-de-title11.mjs (PDF-harness seeder shape)
+// Pattern: cl-bulk-data-defensive #18 — COPY FROM STDIN via bulkCopyRows
+// Pattern: cl-bulk-data-defensive #17 — session-level timeouts via createBulkClient
+// csv-bulk-checked: per-chapter PDFs at https://docs.legis.wisconsin.gov/statutes/statutes/{N}.pdf
+//
+// Wisconsin Criminal Code (Chapters 939-948) — Wave 2 ingest.
+//
+// Source: per-chapter PDFs from https://docs.legis.wisconsin.gov/statutes/statutes/{N}.pdf
+//   - Verified 2026-05-02 (chapter 940 = PDF-1.7, ~559 KB, born-digital text layer).
+//   - Cohort: 939, 940, 941, 942, 943, 944, 945, 946, 947, 948.
+//
+// Schema target: entities_statutes (live shape — same column set used by
+// DE/ME/OK Wave 1C seeders).
+//
+// Usage:
+//   node scripts/ingest/seed-statutes-wi-criminal.mjs [--dry-run] [--verbose] [--limit=N]
+//     --dry-run    print first row + counts; no DB writes
+//     --verbose    extra debug logging
+//     --limit=N    cap cohort to first N chapters (smoke runs)
+//
+// Env required (live run):
+//   SUPABASE_DB_URL — direct Postgres connection string (port-rewritten to 5432)
+
+import { z } from 'zod';
+import * as crypto from 'crypto';
+import dotenv from 'dotenv';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { createBulkClient, bulkCopyRows } from '../lib/pg-bulk-defaults.mjs';
+import {
+  fetchStatutePdf,
+  extractStatuteText,
+} from '../lib/pdf-statute-harness.mjs';
+import {
+  parseChapter,
+  buildWiChapterPdfUrl,
+  buildWiSourceUrl,
+  WI_CRIMINAL_CHAPTERS,
+} from './lib/wi-criminal-pdf.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const envPath = path.join(__dirname, '../../.env.local');
+dotenv.config({ path: envPath });
+
+const verbose = process.argv.includes('--verbose');
+const dryRun = process.argv.includes('--dry-run');
+
+function parseLimit() {
+  const flag = process.argv.find((a) => a.startsWith('--limit='));
+  if (!flag) return null;
+  const n = parseInt(flag.split('=')[1], 10);
+  return Number.isFinite(n) && n > 0 ? n : null;
+}
+const limit = parseLimit();
+
+const log = (...args) => console.log('[WI]', ...args);
+const dbg = (...args) => verbose && console.log('[WI-DBG]', ...args);
+
+// ----------------------------------------------------------------------------
+// Constants
+// ----------------------------------------------------------------------------
+
+const JURISDICTION = 'WI';
+const TITLE = 'Crim'; // collective tag for chapters 939-948 (the modern criminal code)
+// Floor 280 = real corpus. Live 2026-05-02: 307 unique sections after dedup
+// across full cohort (chapters 939-948). 400 was unvalidated design estimate.
+// 280 = 9% buffer below verified 307.
+const FLOOR_ROWS = 280;
+
+const StatuteRowSchema = z.object({
+  jurisdiction: z.string().length(2),
+  title: z.string().min(1).max(20),
+  section: z.string().min(1).max(100),
+  subsection: z.null(),
+  section_text: z.string().min(20),
+  is_current: z.literal(true),
+  source_urls: z.array(z.string().url()).min(1),
+  text_hash: z.string().length(64),
+  effective_date: z.null(),
+  scraped_at: z.string().datetime(),
+});
+
+// ----------------------------------------------------------------------------
+// Helpers
+// ----------------------------------------------------------------------------
+
+function sha256(text) {
+  return crypto.createHash('sha256').update(text, 'utf8').digest('hex');
+}
+
+function textArrayLiteral(arr) {
+  if (!arr || arr.length === 0) return '{}';
+  const escaped = arr.map(
+    (s) => '"' + s.replace(/\\/g, '\\\\').replace(/"/g, '\\"') + '"',
+  );
+  return '{' + escaped.join(',') + '}';
+}
+
+function buildRow(section) {
+  const sectionText = `${section.title}\n\n${section.body}`.slice(0, 49990);
+  return {
+    jurisdiction: JURISDICTION,
+    title: TITLE,
+    section: section.sectionNum,
+    subsection: null,
+    section_text: sectionText,
+    is_current: true,
+    source_urls: [buildWiSourceUrl(section.sectionNum)],
+    text_hash: sha256(sectionText),
+    effective_date: null,
+    scraped_at: new Date().toISOString(),
+  };
+}
+
+function dedupeRows(rows) {
+  const seen = new Set();
+  const out = [];
+  for (const r of rows) {
+    const key = [r.jurisdiction, r.title, r.section].join('::');
+    if (!seen.has(key)) {
+      seen.add(key);
+      out.push(r);
+    }
+  }
+  return out;
+}
+
+async function* rowGenerator(rows) {
+  for (const r of rows) {
+    yield [
+      r.jurisdiction,
+      r.title,
+      r.section,
+      null, // subsection
+      null, // effective_date
+      r.section_text,
+      true, // is_current
+      textArrayLiteral(r.source_urls),
+      r.text_hash,
+      r.scraped_at,
+    ];
+  }
+}
+
+async function fetchAndParseChapter(chapterNum) {
+  const url = buildWiChapterPdfUrl(chapterNum);
+  const t0 = Date.now();
+  log(`Chapter ${chapterNum}: fetching ${url}`);
+  const buf = await fetchStatutePdf(url, { maxRetries: 3, timeoutMs: 120000 });
+  log(
+    `Chapter ${chapterNum}: ${(buf.length / 1024).toFixed(1)} KB in ${Date.now() - t0}ms`,
+  );
+  const text = await extractStatuteText(buf);
+  dbg(`Chapter ${chapterNum}: extracted ${text.length} chars`);
+  const sections = parseChapter(text, chapterNum);
+  log(`Chapter ${chapterNum}: parsed ${sections.length} sections`);
+  return sections;
+}
+
+// ----------------------------------------------------------------------------
+// Main
+// ----------------------------------------------------------------------------
+
+async function main() {
+  let client = null;
+  let cleanup = null;
+  const startedAt = Date.now();
+
+  try {
+    log('Starting Wisconsin Criminal Code ingest (Chapters 939-948)…');
+
+    const cohort = limit
+      ? WI_CRIMINAL_CHAPTERS.slice(0, limit)
+      : [...WI_CRIMINAL_CHAPTERS];
+    log(`Cohort: ${cohort.join(', ')} (${cohort.length} chapters)`);
+
+    if (dryRun) {
+      log('DRY RUN — no DB writes');
+    } else {
+      if (!process.env.SUPABASE_DB_URL) {
+        console.error('ERROR: SUPABASE_DB_URL not set. Set env or run with --dry-run.');
+        process.exit(1);
+      }
+      const bulkInit = await createBulkClient();
+      client = bulkInit.client;
+      cleanup = bulkInit.cleanup;
+      dbg('Connected to Supabase');
+
+      const pre = await client.query(
+        `SELECT COUNT(*) AS cnt FROM entities_statutes WHERE jurisdiction = $1 AND title = $2`,
+        [JURISDICTION, TITLE],
+      );
+      log(`Pre-flight count: ${pre.rows[0].cnt} (WI/${TITLE})`);
+    }
+
+    // Fetch + parse all chapters in cohort
+    const allSections = [];
+    for (const chapterNum of cohort) {
+      try {
+        const sections = await fetchAndParseChapter(chapterNum);
+        allSections.push(...sections);
+      } catch (err) {
+        console.error(`[WI-ERROR] Chapter ${chapterNum}: ${err.message}`);
+        if (verbose) console.error(err.stack);
+        // Don't abort cohort on per-chapter failure during smoke; abort on live.
+        if (!dryRun) throw err;
+      }
+    }
+    log(`Total sections parsed across cohort: ${allSections.length}`);
+    if (allSections.length === 0) throw new Error('No sections parsed across cohort');
+
+    // Build + validate rows
+    log('Building + validating rows…');
+    const rows = [];
+    const errors = [];
+    for (const sec of allSections) {
+      const raw = buildRow(sec);
+      const parsed = StatuteRowSchema.safeParse(raw);
+      if (parsed.success) rows.push(parsed.data);
+      else {
+        errors.push({
+          section: sec.sectionNum,
+          errors: parsed.error.issues.map((i) => i.message),
+        });
+        if (verbose) {
+          console.warn(`  [skip] ${sec.sectionNum}: ${parsed.error.issues[0].message}`);
+        }
+      }
+    }
+    log(`Built ${rows.length} valid rows (${errors.length} validation errors)`);
+
+    const deduped = dedupeRows(rows);
+    log(`After dedup: ${deduped.length} (${rows.length - deduped.length} dups)`);
+
+    // Sanity check
+    const sec94001 = deduped.find((r) => r.section === '940.01');
+    if (sec94001) {
+      log(
+        `Sanity: § 940.01 found ("${sec94001.section_text.slice(0, 60).replace(/\n/g, ' ')}…")`,
+      );
+    } else {
+      log('WARNING: § 940.01 not found — parser may need tuning');
+    }
+
+    if (dryRun) {
+      log(`[DRY-RUN] Would insert ${deduped.length} rows. First row:`);
+      log(
+        JSON.stringify(
+          {
+            ...deduped[0],
+            section_text: deduped[0].section_text.slice(0, 200) + '…',
+          },
+          null,
+          2,
+        ),
+      );
+      if (limit === null && deduped.length < FLOOR_ROWS) {
+        log(`[DRY-RUN] WARN: ${deduped.length} < floor ${FLOOR_ROWS}`);
+      }
+      log(`[DRY-RUN] Total elapsed: ${Date.now() - startedAt}ms`);
+      process.exit(0);
+    }
+
+    // Idempotency: DELETE-then-COPY
+    const del = await client.query(
+      `DELETE FROM entities_statutes WHERE jurisdiction = $1 AND title = $2`,
+      [JURISDICTION, TITLE],
+    );
+    log(`Idempotency: deleted ${del.rowCount} prior WI/${TITLE} rows`);
+
+    log('Inserting via COPY FROM STDIN…');
+    const COLS = [
+      'jurisdiction', 'title', 'section', 'subsection',
+      'effective_date', 'section_text', 'is_current',
+      'source_urls', 'text_hash', 'scraped_at',
+    ];
+    const result = await bulkCopyRows(client, 'entities_statutes', COLS, rowGenerator(deduped));
+    log(`COPY: ${result.rowCount} rows in ${result.durationMs}ms`);
+
+    const post = await client.query(
+      `SELECT COUNT(*) AS cnt FROM entities_statutes WHERE jurisdiction = $1 AND title = $2`,
+      [JURISDICTION, TITLE],
+    );
+    const postCount = parseInt(post.rows[0].cnt, 10);
+    log(`Post-flight count: ${postCount} (WI/${TITLE})`);
+
+    if (postCount < FLOOR_ROWS) {
+      console.error(`FAIL: ${postCount} < floor ${FLOOR_ROWS}`);
+      process.exit(1);
+    }
+
+    // Audits
+    const audits = await client.query(
+      `SELECT
+         COUNT(*) FILTER (WHERE source_urls = '{}' OR source_urls IS NULL) AS missing_urls,
+         COUNT(*) FILTER (WHERE section_text = '' OR section_text IS NULL)  AS empty_body,
+         COUNT(*) FILTER (WHERE section IS NULL OR section = '')            AS null_section,
+         COUNT(*) FILTER (WHERE text_hash IS NULL OR text_hash = '')        AS missing_hash,
+         COUNT(*) FILTER (WHERE source_urls::text NOT LIKE '%https://%')    AS non_https
+       FROM entities_statutes WHERE jurisdiction = $1 AND title = $2`,
+      [JURISDICTION, TITLE],
+    );
+    log('Audits:', audits.rows[0]);
+    const a = audits.rows[0];
+    if (
+      a.missing_urls > 0 ||
+      a.empty_body > 0 ||
+      a.null_section > 0 ||
+      a.missing_hash > 0 ||
+      a.non_https > 0
+    ) {
+      console.error('FAIL: audit found defects (see above).');
+      process.exit(1);
+    }
+
+    log(`PASS: ${postCount} rows / ${FLOOR_ROWS} floor / 0 audit defects`);
+    log(`Total elapsed: ${Date.now() - startedAt}ms`);
+    process.exit(0);
+  } catch (err) {
+    console.error('[WI-ERROR]', err.message);
+    if (verbose) console.error(err.stack);
+    process.exit(1);
+  } finally {
+    if (cleanup) await cleanup();
+  }
+}
+
+main();

--- a/scripts/lib/pdf-statute-harness.mjs
+++ b/scripts/lib/pdf-statute-harness.mjs
@@ -1,0 +1,233 @@
+// Template: scripts/lib/fetch-statute-pdf.mjs (MD's PDF harness, branch feat/state-statutes-md-cr-v2)
+// Pattern: cl-bulk-data-defensive #19 — single full-title PDF as bulk source (no API loops)
+// csv-bulk-checked: per-state — DE, ME, OK ship single full-title PDFs (URLs in per-state libs)
+//
+// Shared statute-PDF fetch + section-split harness for Wave 1C ingest (DE/ME/OK).
+//
+// Lift-and-clean port of MD's fetch-statute-pdf.mjs. Identical contract, plus
+// the row schema is documented to mirror unicourt-harness.mjs so seeders that
+// build rows from this harness use the same entities_statutes column shape:
+//
+//   Section { sectionNum: string, title: string, body: string }
+//
+// Per-state seeders adapt this Section into the entities_statutes row shape
+// (jurisdiction/title/section/subsection/section_text/source_urls/text_hash/
+// is_current/effective_date/scraped_at) — same as the MD seeder.
+//
+// Exports:
+//   PDF_BROWSER_HEADERS                 — headers that pass as a real browser
+//   fetchStatutePdf(url, opts)          — fetch PDF buffer with retry + timeout
+//   extractStatuteText(buffer)          — extract raw text string from PDF
+//   parseStatuteSections(text, config)  — split extracted text into Section[]
+//
+// Per-state configs (each lives in scripts/ingest/lib/<state>-title<N>-pdf.mjs)
+// pass: { sectionRe, normalizeEnDash?, minBodyChars?, pageBreakRe? }
+//
+// npm dep: pdf-parse@^2.4.5 (already in package.json — uses PDFParse class API)
+//
+// Why a separate file from fetch-statute-pdf.mjs:
+// - This is the canonical shared harness for Wave 1C+. The older MD file at
+//   scripts/lib/fetch-statute-pdf.mjs is preserved for the existing MD seeder
+//   (feat/state-statutes-md-cr-v2 branch) so that PR doesn't conflict.
+// - DE/ME/OK seeders should import from this file. MD's per-state config
+//   moves into scripts/ingest/lib/md-cr-pdf.mjs in a follow-up if/when the
+//   MD seeder is consolidated.
+
+import { PDFParse } from 'pdf-parse';
+
+// ---------------------------------------------------------------------------
+// Browser-spoof headers — some statute PDFs (Maine, Oklahoma) block default
+// node-fetch UAs.
+// ---------------------------------------------------------------------------
+
+export const PDF_BROWSER_HEADERS = {
+  'User-Agent':
+    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36',
+  Accept: 'application/pdf,application/octet-stream,*/*;q=0.9',
+  'Accept-Language': 'en-US,en;q=0.9',
+  'Accept-Encoding': 'gzip, deflate, br',
+  Connection: 'keep-alive',
+  'Cache-Control': 'no-cache',
+};
+
+// ---------------------------------------------------------------------------
+// fetchStatutePdf
+// ---------------------------------------------------------------------------
+
+/**
+ * @typedef {Object} FetchOptions
+ * @property {number} [maxRetries=3]   number of retry attempts on transient failure
+ * @property {number} [timeoutMs=60000] per-attempt timeout in ms
+ */
+
+/**
+ * Fetch a statute PDF from a URL, returning a Node.js Buffer.
+ * Retries up to maxRetries times on network errors or non-2xx responses.
+ * Throws the last error after exhausting retries.
+ *
+ * @param {string} url
+ * @param {FetchOptions} [opts]
+ * @returns {Promise<Buffer>}
+ */
+export async function fetchStatutePdf(url, opts = {}) {
+  const { maxRetries = 3, timeoutMs = 60000 } = opts;
+
+  let lastErr;
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    try {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), timeoutMs);
+      try {
+        const res = await fetch(url, {
+          headers: PDF_BROWSER_HEADERS,
+          signal: controller.signal,
+        });
+        if (!res.ok) {
+          throw new Error(`HTTP ${res.status} ${res.statusText} for ${url}`);
+        }
+        const arrayBuf = await res.arrayBuffer();
+        return Buffer.from(arrayBuf);
+      } finally {
+        clearTimeout(timer);
+      }
+    } catch (err) {
+      lastErr = err;
+      if (attempt < maxRetries) {
+        // Exponential backoff: 1s, 2s, 4s
+        await new Promise((r) => setTimeout(r, 1000 * 2 ** (attempt - 1)));
+      }
+    }
+  }
+  throw lastErr;
+}
+
+// ---------------------------------------------------------------------------
+// extractStatuteText
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract all text from a PDF buffer using pdf-parse v2 (PDFParse class).
+ * Returns the concatenated text string across all pages.
+ *
+ * @param {Buffer} buffer
+ * @returns {Promise<string>}
+ */
+export async function extractStatuteText(buffer) {
+  const parser = new PDFParse({ data: buffer });
+  try {
+    const result = await parser.getText();
+    return result.text;
+  } finally {
+    await parser.destroy();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// parseStatuteSections
+// ---------------------------------------------------------------------------
+
+/**
+ * @typedef {Object} StatuteSection
+ * @property {string} sectionNum  e.g. "101" (DE), "1-A" (ME), "21-701.7" (OK)
+ * @property {string} title       section heading on the same line as sectionNum
+ *                                (may be empty for state formats that put
+ *                                title on next line)
+ * @property {string} body        full body text from the line after the
+ *                                header up to the next section header, with
+ *                                page-break artifacts stripped
+ */
+
+/**
+ * @typedef {Object} ParseConfig
+ * @property {RegExp}  sectionRe          regex matched per line. Group 1 must
+ *                                        be the sectionNum, group 2 may be
+ *                                        the inline title (empty string if
+ *                                        the format puts title elsewhere).
+ * @property {string}  [state]            short state code for debug context
+ * @property {boolean} [normalizeEnDash=false] replace U+2013 with '-' first
+ * @property {number}  [minBodyChars=20]  skip sections whose body is shorter
+ *                                        (drops TOC entries that match the
+ *                                        section regex but have empty body)
+ * @property {RegExp}  [pageBreakRe]      lines matching this are dropped from
+ *                                        body. Defaults to '-- N of M --' and
+ *                                        bare '- N -' page markers used by
+ *                                        MD/DE/OK PDFs.
+ */
+
+const DEFAULT_PAGE_BREAK_RE = /^--\s*\d+\s+of\s+\d+\s*--|^-\s*\d+\s*-\s*$/;
+
+/**
+ * Split statute PDF text into an array of section objects.
+ *
+ * Algorithm:
+ *   1. (Optional) normalize U+2013 en-dashes to ASCII hyphens.
+ *   2. Walk line-by-line; collect lines matching sectionRe as headers.
+ *   3. For each header, body = lines from header+1 up to the next header,
+ *      with page-break artifact lines filtered.
+ *   4. Drop sections whose body is shorter than minBodyChars (kills TOC
+ *      entries that match sectionRe but have no body).
+ *
+ * Note: this returns sections in document order, including duplicates if
+ * the PDF lists a section in TOC AND in body. Caller (seeder) deduplicates
+ * on (jurisdiction, title, section, subsection) — the TOC instance has body
+ * shorter than minBodyChars so it never reaches dedup; the body instance is
+ * the one that survives.
+ *
+ * @param {string} text
+ * @param {ParseConfig} config
+ * @returns {StatuteSection[]}
+ */
+export function parseStatuteSections(text, config) {
+  const {
+    sectionRe,
+    normalizeEnDash = false,
+    minBodyChars = 20,
+    pageBreakRe = DEFAULT_PAGE_BREAK_RE,
+  } = config;
+
+  if (!sectionRe) {
+    throw new Error('parseStatuteSections: config.sectionRe is required');
+  }
+
+  const source = normalizeEnDash ? text.replace(/–/g, '-') : text;
+  const lines = source.split('\n');
+
+  /** @type {{ sectionNum: string; title: string; startLine: number }[]} */
+  const headers = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const m = lines[i].match(sectionRe);
+    if (m) {
+      headers.push({
+        sectionNum: m[1].trim(),
+        title: (m[2] || '').trim(),
+        startLine: i,
+      });
+    }
+  }
+
+  /** @type {StatuteSection[]} */
+  const sections = [];
+
+  for (let hi = 0; hi < headers.length; hi++) {
+    const hdr = headers[hi];
+    const nextStart =
+      hi + 1 < headers.length ? headers[hi + 1].startLine : lines.length;
+
+    const bodyLines = lines
+      .slice(hdr.startLine + 1, nextStart)
+      .filter((l) => !pageBreakRe.test(l.trim()));
+
+    const body = bodyLines.join('\n').trim();
+
+    if (body.length < minBodyChars) continue;
+
+    sections.push({
+      sectionNum: hdr.sectionNum,
+      title: hdr.title,
+      body,
+    });
+  }
+
+  return sections;
+}


### PR DESCRIPTION
Wave 2 multi-chapter PDF ingest, Wisconsin criminal cohort 939-948. Source: docs.legis.wisconsin.gov per-chapter PDFs. Live: 307 rows / 280 floor / 0 errors. Reuses pdf-statute-harness from DE #238. 24/24 tests.