### PR TITLE
feat(statutes): MI Chapter 750 — Wave 3 PDF (790 rows)

### DIFF
--- a/scripts/ingest/__tests__/fixtures/mi/chapter750-sample.txt
+++ b/scripts/ingest/__tests__/fixtures/mi/chapter750-sample.txt
@@ -1,0 +1,139 @@
+750.1 Michigan penal code; short title.
+Sec. 1.
+Short title—This act shall be known and may be cited as "The Michigan Penal Code".
+History: 1931, Act 328, Eff. Sept. 18, 1931 ;-- CL 1948, 750.1
+Compiler's Notes: The catchlines following the act section numbers were incorporated as part of the act
+as enacted.
+750.2 Rule of construction.
+Sec. 2.
+Rule of construction—The rule that a penal statute is to be strictly construed shall not apply
+to this act or any of the provisions thereof. All provisions of this act shall be construed
+according to the fair import of their terms, to promote justice and to effect the objects of the
+law.
+History: 1931, Act 328, Eff. Sept. 18, 1931 ;-- CL 1948, 750.2
+750.7 Felony; definition.
+Sec. 7.
+Felony—The term "felony" when used in this act, shall be construed to mean an offense for
+which the offender, on conviction may be punished by death, or by imprisonment in state
+prison.
+History: 1931, Act 328, Eff. Sept. 18, 1931 ;-- CL 1948, 750.7
+750.8 Misdemeanor; definition.
+Sec. 8.
+Misdemeanor—When any act or omission, not a felony, is punishable according to law, by
+a fine, penalty or forfeiture, and imprisonment, or by such fine, penalty or forfeiture, or
+Rendered Saturday, May 2, 2026 	Page 2 of 459 	Michigan Compiled Laws Complete Through PA 9 of 2026
+Courtesy of legislature.mi.gov
+
+-- 2 of 459 --
+
+imprisonment, in the discretion of the court, such act or omission shall be deemed a
+misdemeanor.
+History: 1931, Act 328, Eff. Sept. 18, 1931 ;-- CL 1948, 750.8
+Former Law: See section 11 of Ch. XXXV of Act 314 of 1915, being CL 1915, § 13403; CL 1929, §
+15150.
+750.10a Sexually delinquent persons; definition.
+Sec. 10a.
+The term "sexually delinquent person" when used in this act shall mean any person whose
+sexual behavior is characterized by repetitive or compulsive acts which indicate a disregard of
+consequences or the recognized rights of others, or by the use of force upon another person in
+attempting sex relations of either a heterosexual or homosexual nature, or by the commission
+of sexual aggressions against children under the age of 16.
+History: Add. 1952, Act 73, Eff. Sept. 18, 1952
+Rendered Saturday, May 2, 2026 	Page 3 of 459 	Michigan Compiled Laws Complete Through PA 9 of 2026
+Courtesy of legislature.mi.gov
+
+-- 3 of 459 --
+
+Chapter II
+ABDUCTION
+750.11, 750.12 Repealed. 2010, Act 102, Imd. Eff. June 25, 2010.
+Compiler's Notes: The repealed sections pertained to unlawful taking of a woman and compelling her to
+marry.
+750.14 Repealed. 2023, Act 11, Eff. Feb. 13, 2024
+Compiler's Notes: The repealed section pertained to penalties for the administration of drugs with the
+intent to procure a miscarriage.
+Constitutionality: Section held unconstitutional as relating to abortions in the first trimester of a
+pregnancy as authorized by the pregnant woman's attending physician in the exercise of the physician's
+medical judgment. People v Bricker, 389 Mich 524; 208 NW2d 172 (1973).
+Former Law: See section 34 of Ch. 153 of R.S. 1846, being CL 1857, § 5744; CL 1871, § 7543; How., §
+9108; CL 1897, § 11503; CL 1915, § 15225; CL 1929, § 16741; sec. 35 of Ch. 153 of R.S. 1846; Act 61 of
+1867; CL 1871, § 7544; How., § 9109; CL 1897, § 11504; CL 1915, § 15226; and CL 1929, § 16742.
+750.316 First degree murder; incarceration order upon conviction; penalty; definitions.
+Sec. 316.
+Rendered Saturday, May 2, 2026 	Page 265 of 459 	Michigan Compiled Laws Complete Through PA 9 of 2026
+Courtesy of legislature.mi.gov
+
+-- 265 of 459 --
+
+(1) Except as provided in sections 25 and 25a of chapter IX of the code of criminal
+procedure, 1927 PA 175, MCL 769.25 and 769.25a, a person who commits any of the
+following is guilty of first degree murder and shall be punished by imprisonment for life
+without eligibility for parole:
+(a) Murder perpetrated by means of poison, lying in wait, or any other willful, deliberate,
+and premeditated killing.
+(b) Murder committed in the perpetration of, or attempt to perpetrate, arson, criminal sexual
+conduct in the first, second, or third degree, child abuse in the first degree, a major controlled
+substance offense, robbery, carjacking, breaking and entering of a dwelling, home invasion in
+the first or second degree, larceny of any kind, extortion, kidnapping, vulnerable adult abuse in
+the first or second degree under section 145n, torture under section 85, aggravated stalking
+under section 411i, or unlawful imprisonment under section 349b.
+(c) A murder of a peace officer or a corrections officer committed while the peace officer or
+corrections officer is lawfully engaged in the performance of any of his or her duties as a
+peace officer or corrections officer, knowing that the peace officer or corrections officer is a
+peace officer or corrections officer engaged in the performance of his or her duty as a peace
+officer or corrections officer.
+(2) Immediately following a conviction under this section, a court shall enter an order
+committing the convicted person to the jurisdiction of the department of corrections for
+incarceration in a state correctional facility pending sentencing using a form created by the
+state court administrative office for this purpose. This order becomes effective if both of the
+following apply:
+(a) The sheriff agrees to transport for final sentencing the person from the state correctional
+facility to the county and from the county back to the state correctional facility.
+(b) The convicted person was not less than 18 years of age at the time he or she committed
+the offense for which he or she was convicted under this section.
+(3) A court shall hold the sentencing hearing not more than 45 days after a person is
+committed to the department of corrections under subsection (2).
+(4) As used in this section:
+(a) "Arson" means a felony violation under chapter X.
+(b) "Corrections officer" means any of the following:
+(i) A prison or jail guard or other prison or jail personnel.
+(ii) Any of the personnel of a boot camp, special alternative incarceration unit, or other
+minimum security correctional facility.
+(iii) A parole or probation officer.
+(c) "Major controlled substance offense" means any of the following:
+(i) A violation of section 7401(2)(a)(i) to (iii) of the public health code, 1978 PA 368, MCL
+333.7401.
+(ii) A violation of section 7403(2)(a)(i) to (iii) of the public health code, 1978 PA 368, MCL
+333.7403.
+(iii) A conspiracy to commit an offense listed in subparagraph (i) or (ii).
+(d) "Peace officer" means any of the following:
+(i) A police or conservation officer of this state or a political subdivision of this state.
+(ii) A police or conservation officer of the United States.
+(iii) A police or conservation officer of another state or a political subdivision of another
+state.
+Rendered Saturday, May 2, 2026 	Page 266 of 459 	Michigan Compiled Laws Complete Through PA 9 of 2026
+Courtesy of legislature.mi.gov
+
+-- 266 of 459 --
+
+History: 1931, Act 328, Eff. Sept. 18, 1931 ;-- CL 1948, 750.316 ;-- Am. 1969, Act 331, Eff. Mar. 20,
+1970 ;-- Am. 1980, Act 28, Imd. Eff. Mar. 7, 1980 ;-- Am. 1994, Act 267, Eff. Oct. 1, 1994 ;-- Am. 1996,
+Act 20, Eff. Apr. 1, 1996 ;-- Am. 1996, Act 21, Eff. Apr. 1, 1996 ;-- Am. 1999, Act 189, Eff. Apr. 1,
+2000 ;-- Am. 2004, Act 58, Eff. June 11, 2004 ;-- Am. 2006, Act 415, Eff. Dec. 1, 2006 ;-- Am. 2013, Act
+39, Imd. Eff. June 4, 2013 ;-- Am. 2014, Act 23, Imd. Eff. Mar. 4, 2014 ;-- Am. 2014, Act 158, Eff. July 1,
+2014 ;-- Am. 2022, Act 149, Imd. Eff. July 19, 2022
+Constitutionality: This section, which provides a mandatory life sentence for first degree murder, does
+not violate constitutional guarantees of due process and equal protection or the guarantee against cruel and
+unusual punishment. People v Hall, 396 Mich 650; 242 NW2d 377 (1976).The use of common-law
+definition of rape in this section, until it was amended by 1980 PA 28, does not violate the equal protection
+clause. People v McDonald, 409 Mich 110; 293 NW2d 588 (1980).In People v Gay, 407 Mich 681; 289
+NW2d 651 (1980), the Michigan supreme court held that the prosecution of defendants under this section
+subsequent to their convictions in federal court for the same acts is limited by the double jeopardy clause
+of the Michigan constitution.In People v Wilder, 411 Mich 328; 308 NW2d 112 (1981), the Michigan
+supreme court held that conviction and sentence for both first-degree felony murder and the underlying
+felony of armed robbery violates the state constitutional prohibition against double jeopardy.A mandatory
+life sentence imposed for conspiracy to commit first-degree, even if nonparolable, is not so excessive as to
+constitute cruel and unusual punishment; nor does it violate the Equal Protection Clauses of the Michigan
+and United States Constitutions. People v Fernandez, 427 Mich 321; 398 NW2d 311 (1986).
+Former Law: See section 1 of Ch. 153 of R.S. 1846, being CL 1857, § 5711; CL 1871, § 7510; How., §
+9075; CL 1897, § 11470; CL 1915, § 15192; and CL 1929, § 16708.

--- a/scripts/ingest/__tests__/seed-statutes-mi-chapter750.test.mjs
+++ b/scripts/ingest/__tests__/seed-statutes-mi-chapter750.test.mjs
@@ -1,0 +1,192 @@
+// test-isolation-na: pure parser unit tests against on-disk fixture text — no DB writes.
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import {
+  parseChapter750,
+  buildMiSourceUrl,
+  isRepealedTitle,
+  MI_CHAPTER750_PDF_URL,
+  MI_CONFIG,
+} from '../lib/mi-pdf.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURE_PATH = path.join(__dirname, 'fixtures', 'mi', 'chapter750-sample.txt');
+const FIXTURE_TEXT = readFileSync(FIXTURE_PATH, 'utf8');
+
+describe('MI_CONFIG', () => {
+  it('has MI state code', () => {
+    expect(MI_CONFIG.state).toBe('MI');
+  });
+  it('has a sectionRe regex', () => {
+    expect(MI_CONFIG.sectionRe).toBeInstanceOf(RegExp);
+  });
+  it('has a custom pageBreakRe (overrides harness default)', () => {
+    expect(MI_CONFIG.pageBreakRe).toBeInstanceOf(RegExp);
+  });
+  it('does NOT normalize en-dashes (MI uses ASCII hyphens)', () => {
+    expect(MI_CONFIG.normalizeEnDash).toBe(false);
+  });
+});
+
+describe('buildMiSourceUrl', () => {
+  it('returns the chapter-level PDF URL for any section', () => {
+    expect(buildMiSourceUrl('1')).toBe(MI_CHAPTER750_PDF_URL);
+    expect(buildMiSourceUrl('316')).toBe(MI_CHAPTER750_PDF_URL);
+    expect(buildMiSourceUrl('10a')).toBe(MI_CHAPTER750_PDF_URL);
+  });
+
+  it('URL is HTTPS', () => {
+    expect(buildMiSourceUrl('1')).toMatch(/^https:\/\//);
+  });
+
+  it('URL points at legislature.mi.gov', () => {
+    expect(buildMiSourceUrl('1')).toContain('legislature.mi.gov');
+  });
+
+  it('URL ends in .pdf', () => {
+    expect(buildMiSourceUrl('1')).toMatch(/\.pdf$/);
+  });
+});
+
+describe('isRepealedTitle', () => {
+  it('flags titles starting with "Repealed."', () => {
+    expect(isRepealedTitle('Repealed. 2023, Act 11, Eff. Feb. 13, 2024')).toBe(true);
+  });
+  it('flags titles starting with "Transferred."', () => {
+    expect(isRepealedTitle('Transferred. 1968, Act 39')).toBe(true);
+  });
+  it('does NOT flag normal titles', () => {
+    expect(isRepealedTitle('Michigan penal code; short title.')).toBe(false);
+    expect(isRepealedTitle('First degree murder; punishment.')).toBe(false);
+  });
+  it('does NOT flag titles that merely mention the word repealed mid-string', () => {
+    expect(isRepealedTitle('Provisions affecting the repealed sections of …')).toBe(false);
+  });
+  it('handles empty / null defensively', () => {
+    expect(isRepealedTitle('')).toBe(false);
+    expect(isRepealedTitle(null)).toBe(false);
+    expect(isRepealedTitle(undefined)).toBe(false);
+  });
+  it('is case-insensitive on the leading verb', () => {
+    expect(isRepealedTitle('REPEALED. 1990, Act 1')).toBe(true);
+    expect(isRepealedTitle('repealed. 1990, Act 1')).toBe(true);
+  });
+});
+
+describe('parseChapter750 (real fixture)', () => {
+  let sections;
+
+  beforeAll(() => {
+    sections = parseChapter750(FIXTURE_TEXT);
+  });
+
+  it('parses at least 5 sections from fixture', () => {
+    expect(sections.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it('first section is § 1', () => {
+    expect(sections[0].sectionNum).toBe('1');
+  });
+
+  it('§ 1 title contains "short title"', () => {
+    expect(sections[0].title.toLowerCase()).toContain('short title');
+  });
+
+  it('§ 1 body mentions "Michigan Penal Code"', () => {
+    expect(sections[0].body).toContain('Michigan Penal Code');
+  });
+
+  it('parses an alpha-suffix section (§ 10a)', () => {
+    const sec10a = sections.find((s) => s.sectionNum === '10a');
+    expect(sec10a).toBeDefined();
+    expect(sec10a.title.toLowerCase()).toContain('sexually delinquent');
+  });
+
+  it('parses § 316 (First degree murder)', () => {
+    const sec316 = sections.find((s) => s.sectionNum === '316');
+    expect(sec316).toBeDefined();
+    expect(sec316.title.toLowerCase()).toContain('first degree murder');
+  });
+
+  it('preserves a repealed section header (filtering happens at seeder level)', () => {
+    const sec14 = sections.find((s) => s.sectionNum === '14');
+    expect(sec14).toBeDefined();
+    expect(isRepealedTitle(sec14.title)).toBe(true);
+  });
+
+  it('every parsed section has non-empty body above floor', () => {
+    for (const s of sections) {
+      expect(s.body.length).toBeGreaterThanOrEqual(20);
+    }
+  });
+
+  it('every parsed section has a sectionNum starting with a digit', () => {
+    for (const s of sections) {
+      expect(s.sectionNum).toMatch(/^\d/);
+    }
+  });
+
+  it('section numbers match the documented MI shape (digits + optional single lowercase letter)', () => {
+    for (const s of sections) {
+      expect(s.sectionNum).toMatch(/^\d{1,4}[a-z]?$/);
+    }
+  });
+
+  it('body is stripped of "-- N of M --" page-break marker lines', () => {
+    for (const s of sections) {
+      expect(s.body).not.toMatch(/^--\s+\d+\s+of\s+\d+\s+--$/m);
+    }
+  });
+
+  it('body is stripped of MI per-page footer ("Rendered ... Page N of M ... Michigan Compiled Laws ...")', () => {
+    for (const s of sections) {
+      expect(s.body).not.toMatch(/^Rendered\b.*Page\s+\d+\s+of\s+\d+.*Michigan Compiled Laws/m);
+    }
+  });
+
+  it('body is stripped of "Courtesy of legislature.mi.gov" footer', () => {
+    for (const s of sections) {
+      expect(s.body).not.toMatch(/^Courtesy of legislature\.mi\.gov$/m);
+    }
+  });
+
+  it('preserves "History:" line in section bodies', () => {
+    const sec1 = sections.find((s) => s.sectionNum === '1');
+    expect(sec1.body).toContain('History:');
+  });
+
+  it('preserves "Sec. N" in-body line (not double-matched as a header)', () => {
+    const sec1 = sections.find((s) => s.sectionNum === '1');
+    expect(sec1.body).toContain('Sec. 1.');
+  });
+
+  it('section regex does NOT match range-repealed lines like "750.19-750.24 Repealed."', () => {
+    // Construct a synthetic range-repealed input and confirm 0 matches
+    const rangeText = '750.19-750.24 Repealed. 1968, Act 39, Eff. Jan. 1, 1969.\nSome notes here long enough to pass floor xx';
+    const out = parseChapter750(rangeText);
+    expect(out.length).toBe(0);
+  });
+
+  it('section regex does NOT match range-repealed lines like "750.11, 750.12 Repealed."', () => {
+    const rangeText = '750.11, 750.12 Repealed. 2010, Act 102, Imd. Eff. June 25, 2010.\nSome notes here long enough to pass floor xx';
+    const out = parseChapter750(rangeText);
+    expect(out.length).toBe(0);
+  });
+
+  it('returns sections in document order', () => {
+    // First few should be § 1, § 2, then later (post-jump) § 7, § 8, § 10a, § 14, § 316
+    const nums = sections.map((s) => s.sectionNum);
+    expect(nums.indexOf('1')).toBeLessThan(nums.indexOf('2'));
+    expect(nums.indexOf('2')).toBeLessThan(nums.indexOf('316'));
+  });
+
+  it('does not produce duplicate (sectionNum) entries within fixture', () => {
+    const seen = new Set();
+    for (const s of sections) {
+      expect(seen.has(s.sectionNum)).toBe(false);
+      seen.add(s.sectionNum);
+    }
+  });
+});

--- a/scripts/ingest/lib/mi-pdf.mjs
+++ b/scripts/ingest/lib/mi-pdf.mjs
@@ -1,0 +1,139 @@
+// Template: scripts/ingest/lib/de-title11-pdf.mjs (per-state PDF parser pattern)
+// Pattern: cl-bulk-data-defensive #19 — single full-Chapter PDF as bulk source
+// csv-bulk-checked: https://legislature.mi.gov/documents/mcl/pdf/mcl-chap750.pdf
+//   (~2.06 MB, 459 pages, official Michigan Penal Code, born-digital text layer,
+//   complete through PA 9 of 2026, actively maintained.)
+//
+// Michigan Compiled Laws — Chapter 750 — Penal Code.
+//
+// Format observations (verified against live PDF, 2026-05-02):
+//   Title page: "Chapter 750 / MICHIGAN PENAL CODE / THE MICHIGAN PENAL CODE /
+//     Act 328 of 1931" + multi-paragraph statement of purpose.
+//
+//   Section header line:  "750.1 Michigan penal code; short title."
+//                         "750.10a Sexually delinquent persons; definition."
+//     - MCL prefix `750.` is implicit on every section in this chapter.
+//     - Section number: 1-3 digits with optional single lowercase letter suffix
+//       (e.g. "1", "10a", "316b"). NO decimal-subsection (`.M`) and NO
+//       alpha+digit (`a1`) observed in 903 raw header matches across the PDF.
+//     - Single ASCII space between section number and title text on same line.
+//     - Title may wrap onto the next line (caller treats the wrap as part of
+//       body — acceptable noise that preserves information).
+//     - Every section also has a "Sec. N" line a few lines down inside the body
+//       (NOT on the header line; we don't double-match it).
+//
+//   Body: free text below header until next section header.
+//     - Includes "History:", "Compiler's Notes:", "Constitutionality:",
+//       "Former Law:" sub-blocks. KEEP these; they are part of the canonical
+//       statute as published.
+//
+//   Page-break artifacts to strip:
+//     - "-- N of 459 --" markers (handled by harness DEFAULT_PAGE_BREAK_RE).
+//     - Per-page header/footer pair the MI PDF emits between every page:
+//         "Rendered <Day>, <Month> <Day>, <Year> \tPage N of 459 \tMichigan
+//          Compiled Laws Complete Through PA 9 of 2026"
+//         "Courtesy of legislature.mi.gov"
+//       These would otherwise leak into body and pollute every section.
+//
+//   Range-repealed lines like "750.19-750.24 Repealed. ..." or
+//     "750.11, 750.12 Repealed. ..." are intentionally NOT matched by the
+//     section regex (the comma/dash breaks the strict header shape). 18 such
+//     lines exist; their content is purely historical and redundant with the
+//     individual repealed-section entries that the parser DOES match.
+//
+//   Individually-repealed sections (e.g. "750.14 Repealed. 2023, Act 11, Eff.
+//     Feb. 13, 2024") DO match the regex; the seeder filters them at row-build
+//     time by detecting `title.startsWith('Repealed.')` or `'Transferred.'`.
+//     This keeps the parser format-agnostic and re-usable.
+
+import { parseStatuteSections } from '../../lib/pdf-statute-harness.mjs';
+
+// Stable PDF URL — the only authoritative bulk source.
+export const MI_CHAPTER750_PDF_URL =
+  'https://legislature.mi.gov/documents/mcl/pdf/mcl-chap750.pdf';
+
+// Section header regex.
+//   Group 1: section number — `<digits>` or `<digits><single-lowercase-letter>`
+//     e.g. "1", "10a", "33a", "316b"
+//   Group 2: title text — everything after the single space on the header line
+//
+// Anchored at line start. The MCL `750.` prefix is required and is part of the
+// match (but not part of the captured section number — we store just the
+// section portion to match the canonical "Sec. N" reference style attorneys
+// use). Trailing period in title is preserved by group 2.
+//
+// IMPORTANT — `(?!;--)` negative lookahead: the MI PDF wraps multi-amendment
+// History citation lines such that wrapped continuations like
+//   "750.25 ;-- Am. 2002, Act 672, Eff. Mar. 31, 2003"
+// land at line start with the same shape as a real header. Without the
+// negative lookahead, those wrapped continuations matched as phantom-§-25
+// duplicate sections (parser-bug confirmed against 22 dups in 900 raw matches
+// during 2026-05-02 live ingest probe). The lookahead drops 31 such false
+// positives without losing any real section, including curly-quoted titles
+// like `750.5 "Crime" defined.` which a naive `^[A-Za-z]` tightening would
+// have wrongly excluded (verified against 9 curly-quote sections in the PDF).
+const MI_SECTION_RE = /^750\.(\d{1,4}[a-z]?)\s+(?!;--)(.+)$/;
+
+// Strip MI's per-page header/footer in addition to the harness default.
+const MI_PAGE_BREAK_RE =
+  /^--\s*\d+\s+of\s+\d+\s*--$|^-\s*\d+\s*-\s*$|^Rendered\s+\S+,\s+.+Page\s+\d+\s+of\s+\d+.+Michigan Compiled Laws.*$|^Courtesy of legislature\.mi\.gov\s*$/;
+
+/** @type {import('../../lib/pdf-statute-harness.mjs').ParseConfig} */
+export const MI_CONFIG = {
+  state: 'MI',
+  sectionRe: MI_SECTION_RE,
+  // No en-dashes observed in MI section numbers.
+  normalizeEnDash: false,
+  // 20-char floor drops nothing meaningful for MI (every real section has a
+  // History: line at minimum). Even individually-repealed sections have ~80
+  // chars of compiler notes — they pass the floor but are filtered later by
+  // the seeder via the title prefix.
+  minBodyChars: 20,
+  pageBreakRe: MI_PAGE_BREAK_RE,
+};
+
+/**
+ * Parse all sections from the MI Chapter 750 PDF text.
+ * @param {string} text  output of extractStatuteText() on the mcl-chap750.pdf
+ *                       buffer
+ * @returns {import('../../lib/pdf-statute-harness.mjs').StatuteSection[]}
+ */
+export function parseChapter750(text) {
+  return parseStatuteSections(text, MI_CONFIG);
+}
+
+/**
+ * Build the authoritative state-leg URL for a given section number.
+ *
+ * The Michigan single-PDF source has no per-section anchor inside it. The
+ * legislature.mi.gov SPA provides per-section deep-links of the form
+ *   https://legislature.mi.gov/Laws/MCL?objectName=mcl-750-<section>
+ * but those resolve client-side via JavaScript, so they are unreliable as
+ * verification anchors for downstream consumers (curl + cheerio see an empty
+ * shell). Pointing every row at the authoritative chapter-level PDF is
+ * truthful and idempotent; the source_url is a verification anchor, not a
+ * deep-link.
+ *
+ * @param {string} _sectionNum
+ * @returns {string}
+ */
+export function buildMiSourceUrl(_sectionNum) {
+  return MI_CHAPTER750_PDF_URL;
+}
+
+/**
+ * Helper — does the section header title indicate a repealed/transferred
+ * statute? The seeder uses this to skip historical entries from row build.
+ *
+ * Why filter at the seeder, not the parser: parseStatuteSections is shared
+ * across DE/ME/OK/MI and stays format-agnostic. The repealed-detection rule
+ * is MI-specific (DE/OK do not emit individual-repealed sections in the same
+ * shape).
+ *
+ * @param {string} title  the parsed section title (group 2 of MI_SECTION_RE)
+ * @returns {boolean}
+ */
+export function isRepealedTitle(title) {
+  if (!title) return false;
+  return /^(Repealed|Transferred)\b/i.test(title.trim());
+}

--- a/scripts/ingest/seed-statutes-mi-chapter750.mjs
+++ b/scripts/ingest/seed-statutes-mi-chapter750.mjs
@@ -1,0 +1,290 @@
+#!/usr/bin/env node
+// Template: scripts/ingest/seed-statutes-de-title11.mjs (PDF-harness seeder shape)
+// Pattern: cl-bulk-data-defensive #18 — COPY FROM STDIN via bulkCopyRows
+// Pattern: cl-bulk-data-defensive #17 — session-level timeouts via createBulkClient
+// csv-bulk-checked: https://legislature.mi.gov/documents/mcl/pdf/mcl-chap750.pdf
+//
+// Michigan Compiled Laws — Chapter 750 — Penal Code — Wave 3 ingest.
+//
+// Source PDF: https://legislature.mi.gov/documents/mcl/pdf/mcl-chap750.pdf
+//   - Official Michigan Compiled Laws, prepared by the Michigan Legislature.
+//   - Complete through PA 9 of 2026 (per page footer).
+//   - ~2.06 MB, 459 pages, born-digital text layer.
+//   - Pivots from SPA-walled per-section deep-links (legislature.mi.gov/Laws/MCL?objectName=…)
+//     which only resolve client-side, to the chapter-level bulk PDF that is
+//     authoritative AND machine-readable.
+//
+// Schema target: entities_statutes (live shape, see scripts/lib/unicourt-harness.mjs
+// header for column documentation; same row shape as DE/ME/OK seeders).
+//
+// Usage:
+//   node scripts/ingest/seed-statutes-mi-chapter750.mjs [--dry-run] [--verbose]
+//
+// Env required (live run):
+//   SUPABASE_DB_URL — direct Postgres connection string (port-rewritten to 5432)
+//
+// Idempotency: pre-INSERT DELETE WHERE jurisdiction='MI' AND title='750' wipes
+// any prior MI/Chapter-750 rows so re-runs are stable.
+
+import { z } from 'zod';
+import * as crypto from 'crypto';
+import dotenv from 'dotenv';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { createBulkClient, bulkCopyRows } from '../lib/pg-bulk-defaults.mjs';
+import {
+  fetchStatutePdf,
+  extractStatuteText,
+} from '../lib/pdf-statute-harness.mjs';
+import {
+  parseChapter750,
+  buildMiSourceUrl,
+  isRepealedTitle,
+  MI_CHAPTER750_PDF_URL,
+} from './lib/mi-pdf.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const envPath = path.join(__dirname, '../../.env.local');
+dotenv.config({ path: envPath });
+
+const verbose = process.argv.includes('--verbose');
+const dryRun = process.argv.includes('--dry-run');
+
+const log = (...args) => console.log('[MI]', ...args);
+const dbg = (...args) => verbose && console.log('[MI-DBG]', ...args);
+
+// ----------------------------------------------------------------------------
+// Constants
+// ----------------------------------------------------------------------------
+
+const JURISDICTION = 'MI';
+const TITLE = '750';
+// 500 floor — current corpus measures 812 active sections; 500 is the worry-
+// path-2 conservative floor that survives upstream re-codifications.
+const FLOOR_ROWS = 500;
+
+const StatuteRowSchema = z.object({
+  jurisdiction: z.string().length(2),
+  title: z.string().min(1).max(20),
+  section: z.string().min(1).max(100),
+  subsection: z.null(),
+  section_text: z.string().min(20),
+  is_current: z.literal(true),
+  source_urls: z.array(z.string().url()).min(1),
+  text_hash: z.string().length(64),
+  effective_date: z.null(),
+  scraped_at: z.string().datetime(),
+});
+
+// ----------------------------------------------------------------------------
+// Helpers
+// ----------------------------------------------------------------------------
+
+function sha256(text) {
+  return crypto.createHash('sha256').update(text, 'utf8').digest('hex');
+}
+
+function textArrayLiteral(arr) {
+  if (!arr || arr.length === 0) return '{}';
+  const escaped = arr.map(
+    (s) => '"' + s.replace(/\\/g, '\\\\').replace(/"/g, '\\"') + '"',
+  );
+  return '{' + escaped.join(',') + '}';
+}
+
+function buildRow(section) {
+  // Compose section_text as "<title>\n\n<body>" — same shape as DE seeder so
+  // entities_statutes is uniform across states. Cap at 49,990 chars to stay
+  // safely under any text-column ceilings; MI's longest body is well under
+  // this in practice.
+  const sectionText = `${section.title}\n\n${section.body}`.slice(0, 49990);
+  return {
+    jurisdiction: JURISDICTION,
+    title: TITLE,
+    section: section.sectionNum,
+    subsection: null,
+    section_text: sectionText,
+    is_current: true,
+    source_urls: [buildMiSourceUrl(section.sectionNum)],
+    text_hash: sha256(sectionText),
+    effective_date: null,
+    scraped_at: new Date().toISOString(),
+  };
+}
+
+function dedupeRows(rows) {
+  const seen = new Set();
+  const out = [];
+  for (const r of rows) {
+    const key = [r.jurisdiction, r.title, r.section].join('::');
+    if (!seen.has(key)) {
+      seen.add(key);
+      out.push(r);
+    }
+  }
+  return out;
+}
+
+async function* rowGenerator(rows) {
+  for (const r of rows) {
+    yield [
+      r.jurisdiction,
+      r.title,
+      r.section,
+      null, // subsection
+      null, // effective_date
+      r.section_text,
+      true, // is_current
+      textArrayLiteral(r.source_urls),
+      r.text_hash,
+      r.scraped_at,
+    ];
+  }
+}
+
+// ----------------------------------------------------------------------------
+// Main
+// ----------------------------------------------------------------------------
+
+async function main() {
+  let client = null;
+  let cleanup = null;
+  const fetchStartedAt = Date.now();
+  try {
+    log('Starting Michigan Chapter 750 ingest (Penal Code)…');
+
+    if (dryRun) {
+      log('DRY RUN — no DB writes');
+    } else {
+      if (!process.env.SUPABASE_DB_URL) {
+        console.error('ERROR: SUPABASE_DB_URL not set. Set env or run with --dry-run.');
+        process.exit(1);
+      }
+      const bulkInit = await createBulkClient();
+      client = bulkInit.client;
+      cleanup = bulkInit.cleanup;
+      dbg('Connected to Supabase');
+
+      const pre = await client.query(
+        `SELECT COUNT(*) AS cnt FROM entities_statutes WHERE jurisdiction = $1 AND title = $2`,
+        [JURISDICTION, TITLE],
+      );
+      log(`Pre-flight count: ${pre.rows[0].cnt} (MI/Chapter 750)`);
+    }
+
+    log(`Fetching PDF: ${MI_CHAPTER750_PDF_URL}`);
+    const pdfBuffer = await fetchStatutePdf(MI_CHAPTER750_PDF_URL, {
+      maxRetries: 3,
+      timeoutMs: 180000,
+    });
+    log(`PDF: ${(pdfBuffer.length / 1024 / 1024).toFixed(2)} MB in ${Date.now() - fetchStartedAt}ms`);
+
+    log('Extracting text…');
+    const text = await extractStatuteText(pdfBuffer);
+    dbg(`Extracted ${text.length} characters`);
+
+    log('Parsing sections…');
+    const allSections = parseChapter750(text);
+    log(`Parsed ${allSections.length} raw sections`);
+    if (allSections.length === 0) throw new Error('No sections extracted from PDF');
+
+    // MI-specific filter: drop individually-repealed/transferred sections.
+    // These match the section regex but their bodies are purely historical
+    // notes about a now-defunct statute; they would clutter customer-facing
+    // search. Range-repealed lines (e.g. "750.19-750.24 Repealed.") are
+    // already excluded at the regex level and don't need this filter.
+    const sections = allSections.filter((s) => !isRepealedTitle(s.title));
+    const dropped = allSections.length - sections.length;
+    log(`Active sections: ${sections.length} (dropped ${dropped} repealed/transferred)`);
+
+    log('Building + validating rows…');
+    const rows = [];
+    const errors = [];
+    for (const sec of sections) {
+      const raw = buildRow(sec);
+      const parsed = StatuteRowSchema.safeParse(raw);
+      if (parsed.success) rows.push(parsed.data);
+      else {
+        errors.push({ section: sec.sectionNum, errors: parsed.error.issues.map((i) => i.message) });
+        if (verbose) console.warn(`  [skip] ${sec.sectionNum}: ${parsed.error.issues[0].message}`);
+      }
+    }
+    log(`Built ${rows.length} valid rows (${errors.length} validation errors)`);
+
+    const deduped = dedupeRows(rows);
+    log(`After dedup: ${deduped.length} (${rows.length - deduped.length} dups)`);
+
+    // Sanity check — § 316 is First-Degree Murder, the most-cited section in
+    // the chapter. Its absence would mean the parser regressed.
+    const sec316 = deduped.find((r) => r.section === '316');
+    if (sec316) log(`Sanity: § 316 found ("${sec316.section_text.slice(0, 60).replace(/\n/g, ' ')}…")`);
+    else log('WARNING: § 316 not found — parser may need tuning');
+
+    if (dryRun) {
+      log(`[DRY-RUN] Would insert ${deduped.length} rows. First row:`);
+      log(JSON.stringify({ ...deduped[0], section_text: deduped[0].section_text.slice(0, 200) + '…' }, null, 2));
+      if (deduped.length < FLOOR_ROWS) {
+        log(`[DRY-RUN] WARN: ${deduped.length} < floor ${FLOOR_ROWS}`);
+      }
+      process.exit(0);
+    }
+
+    // Idempotency
+    const del = await client.query(
+      `DELETE FROM entities_statutes WHERE jurisdiction = $1 AND title = $2`,
+      [JURISDICTION, TITLE],
+    );
+    log(`Idempotency: deleted ${del.rowCount} prior MI/Chapter 750 rows`);
+
+    log('Inserting via COPY FROM STDIN…');
+    const COLS = [
+      'jurisdiction', 'title', 'section', 'subsection',
+      'effective_date', 'section_text', 'is_current',
+      'source_urls', 'text_hash', 'scraped_at',
+    ];
+    const result = await bulkCopyRows(client, 'entities_statutes', COLS, rowGenerator(deduped));
+    log(`COPY: ${result.rowCount} rows in ${result.durationMs}ms`);
+
+    const post = await client.query(
+      `SELECT COUNT(*) AS cnt FROM entities_statutes WHERE jurisdiction = $1 AND title = $2`,
+      [JURISDICTION, TITLE],
+    );
+    const postCount = parseInt(post.rows[0].cnt, 10);
+    log(`Post-flight count: ${postCount} (MI/Chapter 750)`);
+
+    if (postCount < FLOOR_ROWS) {
+      console.error(`FAIL: ${postCount} < floor ${FLOOR_ROWS}`);
+      process.exit(1);
+    }
+
+    // Audits
+    const audits = await client.query(
+      `SELECT
+         COUNT(*) FILTER (WHERE source_urls = '{}' OR source_urls IS NULL) AS missing_urls,
+         COUNT(*) FILTER (WHERE section_text = '' OR section_text IS NULL)  AS empty_body,
+         COUNT(*) FILTER (WHERE section IS NULL OR section = '')            AS null_section,
+         COUNT(*) FILTER (WHERE text_hash IS NULL OR text_hash = '')        AS missing_hash,
+         COUNT(*) FILTER (WHERE source_urls::text NOT LIKE '%https://%')    AS non_https
+       FROM entities_statutes WHERE jurisdiction = $1 AND title = $2`,
+      [JURISDICTION, TITLE],
+    );
+    log('Audits:', audits.rows[0]);
+    const a = audits.rows[0];
+    if (a.missing_urls > 0 || a.empty_body > 0 || a.null_section > 0 || a.missing_hash > 0 || a.non_https > 0) {
+      console.error('FAIL: audit found defects (see above).');
+      process.exit(1);
+    }
+
+    log(`PASS: ${postCount} rows / ${FLOOR_ROWS} floor / 0 audit defects`);
+    process.exit(0);
+  } catch (err) {
+    console.error('[MI-ERROR]', err.message);
+    if (verbose) console.error(err.stack);
+    process.exit(1);
+  } finally {
+    if (cleanup) await cleanup();
+  }
+}
+
+main();

--- a/scripts/lib/pdf-statute-harness.mjs
+++ b/scripts/lib/pdf-statute-harness.mjs
@@ -1,0 +1,233 @@
+// Template: scripts/lib/fetch-statute-pdf.mjs (MD's PDF harness, branch feat/state-statutes-md-cr-v2)
+// Pattern: cl-bulk-data-defensive #19 — single full-title PDF as bulk source (no API loops)
+// csv-bulk-checked: per-state — DE, ME, OK ship single full-title PDFs (URLs in per-state libs)
+//
+// Shared statute-PDF fetch + section-split harness for Wave 1C ingest (DE/ME/OK).
+//
+// Lift-and-clean port of MD's fetch-statute-pdf.mjs. Identical contract, plus
+// the row schema is documented to mirror unicourt-harness.mjs so seeders that
+// build rows from this harness use the same entities_statutes column shape:
+//
+//   Section { sectionNum: string, title: string, body: string }
+//
+// Per-state seeders adapt this Section into the entities_statutes row shape
+// (jurisdiction/title/section/subsection/section_text/source_urls/text_hash/
+// is_current/effective_date/scraped_at) — same as the MD seeder.
+//
+// Exports:
+//   PDF_BROWSER_HEADERS                 — headers that pass as a real browser
+//   fetchStatutePdf(url, opts)          — fetch PDF buffer with retry + timeout
+//   extractStatuteText(buffer)          — extract raw text string from PDF
+//   parseStatuteSections(text, config)  — split extracted text into Section[]
+//
+// Per-state configs (each lives in scripts/ingest/lib/<state>-title<N>-pdf.mjs)
+// pass: { sectionRe, normalizeEnDash?, minBodyChars?, pageBreakRe? }
+//
+// npm dep: pdf-parse@^2.4.5 (already in package.json — uses PDFParse class API)
+//
+// Why a separate file from fetch-statute-pdf.mjs:
+// - This is the canonical shared harness for Wave 1C+. The older MD file at
+//   scripts/lib/fetch-statute-pdf.mjs is preserved for the existing MD seeder
+//   (feat/state-statutes-md-cr-v2 branch) so that PR doesn't conflict.
+// - DE/ME/OK seeders should import from this file. MD's per-state config
+//   moves into scripts/ingest/lib/md-cr-pdf.mjs in a follow-up if/when the
+//   MD seeder is consolidated.
+
+import { PDFParse } from 'pdf-parse';
+
+// ---------------------------------------------------------------------------
+// Browser-spoof headers — some statute PDFs (Maine, Oklahoma) block default
+// node-fetch UAs.
+// ---------------------------------------------------------------------------
+
+export const PDF_BROWSER_HEADERS = {
+  'User-Agent':
+    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36',
+  Accept: 'application/pdf,application/octet-stream,*/*;q=0.9',
+  'Accept-Language': 'en-US,en;q=0.9',
+  'Accept-Encoding': 'gzip, deflate, br',
+  Connection: 'keep-alive',
+  'Cache-Control': 'no-cache',
+};
+
+// ---------------------------------------------------------------------------
+// fetchStatutePdf
+// ---------------------------------------------------------------------------
+
+/**
+ * @typedef {Object} FetchOptions
+ * @property {number} [maxRetries=3]   number of retry attempts on transient failure
+ * @property {number} [timeoutMs=60000] per-attempt timeout in ms
+ */
+
+/**
+ * Fetch a statute PDF from a URL, returning a Node.js Buffer.
+ * Retries up to maxRetries times on network errors or non-2xx responses.
+ * Throws the last error after exhausting retries.
+ *
+ * @param {string} url
+ * @param {FetchOptions} [opts]
+ * @returns {Promise<Buffer>}
+ */
+export async function fetchStatutePdf(url, opts = {}) {
+  const { maxRetries = 3, timeoutMs = 60000 } = opts;
+
+  let lastErr;
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    try {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), timeoutMs);
+      try {
+        const res = await fetch(url, {
+          headers: PDF_BROWSER_HEADERS,
+          signal: controller.signal,
+        });
+        if (!res.ok) {
+          throw new Error(`HTTP ${res.status} ${res.statusText} for ${url}`);
+        }
+        const arrayBuf = await res.arrayBuffer();
+        return Buffer.from(arrayBuf);
+      } finally {
+        clearTimeout(timer);
+      }
+    } catch (err) {
+      lastErr = err;
+      if (attempt < maxRetries) {
+        // Exponential backoff: 1s, 2s, 4s
+        await new Promise((r) => setTimeout(r, 1000 * 2 ** (attempt - 1)));
+      }
+    }
+  }
+  throw lastErr;
+}
+
+// ---------------------------------------------------------------------------
+// extractStatuteText
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract all text from a PDF buffer using pdf-parse v2 (PDFParse class).
+ * Returns the concatenated text string across all pages.
+ *
+ * @param {Buffer} buffer
+ * @returns {Promise<string>}
+ */
+export async function extractStatuteText(buffer) {
+  const parser = new PDFParse({ data: buffer });
+  try {
+    const result = await parser.getText();
+    return result.text;
+  } finally {
+    await parser.destroy();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// parseStatuteSections
+// ---------------------------------------------------------------------------
+
+/**
+ * @typedef {Object} StatuteSection
+ * @property {string} sectionNum  e.g. "101" (DE), "1-A" (ME), "21-701.7" (OK)
+ * @property {string} title       section heading on the same line as sectionNum
+ *                                (may be empty for state formats that put
+ *                                title on next line)
+ * @property {string} body        full body text from the line after the
+ *                                header up to the next section header, with
+ *                                page-break artifacts stripped
+ */
+
+/**
+ * @typedef {Object} ParseConfig
+ * @property {RegExp}  sectionRe          regex matched per line. Group 1 must
+ *                                        be the sectionNum, group 2 may be
+ *                                        the inline title (empty string if
+ *                                        the format puts title elsewhere).
+ * @property {string}  [state]            short state code for debug context
+ * @property {boolean} [normalizeEnDash=false] replace U+2013 with '-' first
+ * @property {number}  [minBodyChars=20]  skip sections whose body is shorter
+ *                                        (drops TOC entries that match the
+ *                                        section regex but have empty body)
+ * @property {RegExp}  [pageBreakRe]      lines matching this are dropped from
+ *                                        body. Defaults to '-- N of M --' and
+ *                                        bare '- N -' page markers used by
+ *                                        MD/DE/OK PDFs.
+ */
+
+const DEFAULT_PAGE_BREAK_RE = /^--\s*\d+\s+of\s+\d+\s*--|^-\s*\d+\s*-\s*$/;
+
+/**
+ * Split statute PDF text into an array of section objects.
+ *
+ * Algorithm:
+ *   1. (Optional) normalize U+2013 en-dashes to ASCII hyphens.
+ *   2. Walk line-by-line; collect lines matching sectionRe as headers.
+ *   3. For each header, body = lines from header+1 up to the next header,
+ *      with page-break artifact lines filtered.
+ *   4. Drop sections whose body is shorter than minBodyChars (kills TOC
+ *      entries that match sectionRe but have no body).
+ *
+ * Note: this returns sections in document order, including duplicates if
+ * the PDF lists a section in TOC AND in body. Caller (seeder) deduplicates
+ * on (jurisdiction, title, section, subsection) — the TOC instance has body
+ * shorter than minBodyChars so it never reaches dedup; the body instance is
+ * the one that survives.
+ *
+ * @param {string} text
+ * @param {ParseConfig} config
+ * @returns {StatuteSection[]}
+ */
+export function parseStatuteSections(text, config) {
+  const {
+    sectionRe,
+    normalizeEnDash = false,
+    minBodyChars = 20,
+    pageBreakRe = DEFAULT_PAGE_BREAK_RE,
+  } = config;
+
+  if (!sectionRe) {
+    throw new Error('parseStatuteSections: config.sectionRe is required');
+  }
+
+  const source = normalizeEnDash ? text.replace(/–/g, '-') : text;
+  const lines = source.split('\n');
+
+  /** @type {{ sectionNum: string; title: string; startLine: number }[]} */
+  const headers = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const m = lines[i].match(sectionRe);
+    if (m) {
+      headers.push({
+        sectionNum: m[1].trim(),
+        title: (m[2] || '').trim(),
+        startLine: i,
+      });
+    }
+  }
+
+  /** @type {StatuteSection[]} */
+  const sections = [];
+
+  for (let hi = 0; hi < headers.length; hi++) {
+    const hdr = headers[hi];
+    const nextStart =
+      hi + 1 < headers.length ? headers[hi + 1].startLine : lines.length;
+
+    const bodyLines = lines
+      .slice(hdr.startLine + 1, nextStart)
+      .filter((l) => !pageBreakRe.test(l.trim()));
+
+    const body = bodyLines.join('\n').trim();
+
+    if (body.length < minBodyChars) continue;
+
+    sections.push({
+      sectionNum: hdr.sectionNum,
+      title: hdr.title,
+      body,
+    });
+  }
+
+  return sections;
+}


### PR DESCRIPTION
## Summary
Wave 3 statute ingest: Michigan Penal Code (MCL Chapter 750) from the legislature.mi.gov bulk PDF. Pivots from SPA-walled per-section deep-links to the chapter-level PDF (the only authoritative AND machine-readable source).

- Source: https://legislature.mi.gov/documents/mcl/pdf/mcl-chap750.pdf (2.06 MB, 459 pages, complete through PA 9 of 2026)
- Live ingest: **790 active rows** in `entities_statutes` (jurisdiction='MI', title='750')
- 339 alpha-suffix sections (e.g. § 10a, § 316b)
- 88 individually-repealed sections filtered at seeder level (kept the parser format-agnostic)
- 18 range-repealed lines like `750.19-750.24 Repealed.` excluded at regex level
- Floor 500 cleared; 5/5 audits clean (missing_urls=0, empty_body=0, null_section=0, missing_hash=0, non_https=0)

Reuses `scripts/lib/pdf-statute-harness.mjs` from DE PR #238 (port-in-place since the harness is not yet on master).

## Parser quality fix
Section regex includes negative lookahead `(?!;--)` to drop wrapped History citation continuations like `750.25 ;-- Am. 2002, Act 672, ...` that otherwise match as phantom-§-25 duplicate sections. Caught against 22 dups in 900 raw matches during a live probe; the lookahead preserves all 9 curly-quote titles like `750.5 "Crime" defined.` that a naive `^[A-Za-z]` tightening would have wrongly excluded.

## Test plan
- [x] Unit: `npm test -- --run scripts/ingest/__tests__/seed-statutes-mi-chapter750.test.mjs` — **33/33 pass**
- [x] Live: `node scripts/ingest/seed-statutes-mi-chapter750.mjs --verbose` — 790 rows, 0 dups, 0 validation errors, 0 audit defects
- [x] Idempotency: re-running deletes prior MI/750 rows and re-inserts cleanly
- [x] Sanity: § 316 (First Degree Murder) found and verified
- [x] Page-footer / page-break artifact stripping verified against real fixture spanning a page boundary

🤖 Generated with [Claude Code](https://claude.com/claude-code)