### PR TITLE
feat(statutes): MT Title 45 via mca.legmt.gov 3-level traversal (328 rows)

### DIFF
--- a/scripts/ingest/__tests__/fixtures/mt/chapter5-part1-sections-index.html
+++ b/scripts/ingest/__tests__/fixtures/mt/chapter5-part1-sections-index.html
@@ -1,0 +1,174 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<APM_DO_NOT_TOUCH>
+
+<script type="text/javascript">
+(function(){
+window.GVRp=!!window.GVRp;try{(function(){(function(){var I={decrypt:function(I){try{return JSON.parse(function(I){I=I.split("l");var l="";for(var O=0;O<I.length;++O)l+=String.fromCharCode(I[O]);return l}(I))}catch(O){}}};return I={configuration:I.decrypt("123l34l97l99l116l105l118l101l34l58l34l110l111l34l44l34l100l101l98l117l103l103l105l110l103l34l58l34l110l111l34l44l34l109l111l100l117l108l101l49l34l58l34l101l110l97l98l108l101l100l34l44l34l109l111l100l117l108l101l50l34l58l34l101l110l97l98l108l101l100l34l44l34l109l111l100l117l108l101l51l34l58l34l101l110l97l98l108l101l100l34l44l34l109l111l100l117l108l101l52l34l58l34l101l110l97l98l108l101l100l34l125")}})();
+var JI=78;try{var LI,OI,ZI=J(594)?1:0,_I=J(709)?1:0,Ij=J(721)?1:0,lj=J(338)?1:0,Lj=J(586)?1:0,sj=J(235)?1:0,Sj=J(309)?1:0,_j=J(52)?1:0;for(var IJ=(J(889),0);IJ<OI;++IJ)ZI+=J(866)?2:1,_I+=J(628)?2:1,Ij+=J(324)?2:1,lj+=(J(842),2),Lj+=J(851)?2:1,sj+=J(752)?2:1,Sj+=(J(919),2),_j+=J(224)?3:2;LI=ZI+_I+Ij+lj+Lj+sj+Sj+_j;window.Ss===LI&&(window.Ss=++LI)}catch(jJ){window.Ss=LI}var lJ=!0;function L(I,l){I+=l;return I.toString(36)}
+function LJ(I){var l=66;!I||document[z(l,184,171,181,171,164,171,174,171,182,187,149,182,163,182,167)]&&document[Z(l,184,171,181,171,164,171,174,171,182,187,149,182,163,182,167)]!==z(l,184,171,181,171,164,174,167)||(lJ=!1);return lJ}function OJ(){}LJ(window[OJ[L(1086776,JI)]]===OJ);LJ(typeof ie9rgb4!==L(1242178186121,JI));LJ(RegExp("\x3c")[L(1372127,JI)](function(){return"\x3c"})&!RegExp(z(JI,198,129,178))[Z(JI,194,179,193,194)](function(){return"'x3'+'d';"}));
+var ZJ=window[z(JI,175,194,194,175,177,182,147,196,179,188,194)]||RegExp(Z(JI,187,189,176,183,202,175,188,178,192,189,183,178),L(-60,JI))[L(1372127,JI)](window["\x6e\x61vi\x67a\x74\x6f\x72"]["\x75\x73e\x72A\x67\x65\x6et"]),sJ=+new Date+(J(268)?6E5:489017),iJ,Il,jl,Ll=window[z(JI,193,179,194,162,183,187,179,189,195,194)],ol=ZJ?J(182)?3E4:26197:J(755)?6E3:5261;
+document[Z(JI,175,178,178,147,196,179,188,194,154,183,193,194,179,188,179,192)]&&document[z(JI,175,178,178,147,196,179,188,194,154,183,193,194,179,188,179,192)](Z(JI,196,183,193,183,176,183,186,183,194,199,177,182,175,188,181,179),function(I){var l=26;document[z(l,144,131,141,131,124,131,134,131,142,147,109,142,123,142,127)]&&(document[z(l,144,131,141,131,124,131,134,131,142,147,109,142,123,142,127)]===L(1058781957,l)&&I[Z(l,131,141,110,140,143,141,142,127,126)]?jl=!0:document[Z(l,144,131,141,131,
+124,131,134,131,142,147,109,142,123,142,127)]===L(68616527640,l)&&(iJ=+new Date,jl=!1,Ol()))});function Z(I){var l=arguments.length,O=[],s=1;while(s<l)O[s-1]=arguments[s++]-I;return String.fromCharCode.apply(String,O)}function Ol(){if(!document[z(14,127,131,115,128,135,97,115,122,115,113,130,125,128)])return!0;var I=+new Date;if(I>sJ&&(J(882)?664796:6E5)>I-iJ)return LJ(!1);var l=LJ(Il&&!jl&&iJ+ol<I);iJ=I;Il||(Il=!0,Ll(function(){Il=!1},J(416)?1:0));return l}Ol();
+var zl=[J(842)?17795081:24175262,J(256)?27611931586:2147483647,J(270)?1558153217:1841826341];function Zl(I){var l=2;I=typeof I===L(1743045674,l)?I:I[Z(l,118,113,85,118,116,107,112,105)](J(691)?36:25);var O=window[I];if(!O||!O[Z(l,118,113,85,118,116,107,112,105)])return;var s=""+O;window[I]=function(I,l){Il=!1;return O(I,l)};window[I][Z(l,118,113,85,118,116,107,112,105)]=function(){return s}}for(var sl=(J(752),0);sl<zl[L(1294399127,JI)];++sl)Zl(zl[sl]);LJ(!1!==window[z(JI,149,164,160,190)]);
+window.IZ=window.IZ||{};window.IZ.Oj="085ff0748a1940008572eb876c207ddb328758d18daef3fb3822c01a4a76c61b9bdb4d4471e1148558389348fcc7f8f75969a56264716fd97e284eebcaf91d579a31bd94b4a0e979";function z(I){var l=arguments.length,O=[];for(var s=1;s<l;++s)O.push(arguments[s]-I);return String.fromCharCode.apply(String,O)}function Sl(I){var l=+new Date,O;!document[Z(94,207,211,195,208,215,177,195,202,195,193,210,205,208,159,202,202)]||l>sJ&&(J(358)?6E5:460975)>l-iJ?O=LJ(!1):(O=LJ(Il&&!jl&&iJ+ol<l),iJ=l,Il||(Il=!0,Ll(function(){Il=!1},J(548)?1:0)));return!(arguments[I]^O)}function J(I){return 879>I}
+(function jL(l){l&&"number"!==typeof l||("number"!==typeof l&&(l=1E3),l=Math.max(l,1),setInterval(function(){jL(l-10)},l))})(!0);})();}catch(x){}finally{ie9rgb4=void(0);};function ie9rgb4(a,b){return a>>b>>0};
+
+})();
+
+</script>
+</APM_DO_NOT_TOUCH>
+
+<script type="text/javascript" src="/TSPD/08035532b9ab2000fead39218857312074dbe12ebef84b07ef1a9e6ea5c3f4eeaed491e517a54b89?type=9"></script>
+
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>
+  
+    Part 1. Homicide - Table of Contents, Title 45, Chapter 5, MCA
+  
+</title>
+    <link rel='shortcut icon' type='../../../image/x-icon' href='../../../images/favicon-16x16.png'>
+    <link rel="stylesheet" type="text/css" href="../../../bootstrap/css/bootstrap.min.css">
+    <link href='http://fonts.googleapis.com/css?family=Lato&subset=latin,latin-ext' rel='stylesheet' type='text/css'>
+    <link rel="stylesheet" href="../../../font-awesome/css/font-awesome.min.css">
+    <link rel="stylesheet" type="text/css" href="../../../css/mca-navigation.css">
+    <link rel="stylesheet" type="text/css" href="../../../css/mt.css">
+</head>
+<body class="section-doc">
+
+<nav class="navbar navbar-inverse mca-navbar">
+    <div class="container-fluid">
+        <!-- Brand and toggle get grouped for better mobile display -->
+        <div class="navbar-header">
+            <button type="button" class="navbar-toggle collapsed" data-toggle="collapse"
+                    data-target="#bs-example-navbar-collapse-1" aria-expanded="false">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+            </button>
+            <a class="navbar-brand" href="https://www.legmt.gov">
+                <img class="nav-img" src="../../../images/branch-logo-web.png" alt="Montana Legislature">
+            </a>
+        </div>
+
+        <!-- Collect the nav links, forms, and other content for toggling -->
+        <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
+            <ul class="nav navbar-nav">
+                <li><a href="../../../index.html">MCA Contents</a></li>
+                <li><a href="https://archive.legmt.gov/search/index.html#start=0&query=mca&collection=MCA">Search</a></li>
+                <li><a href="../../../help.html">Help</a></li>
+            </ul>
+            
+        </div><!-- /.navbar-collapse -->
+    </div><!-- /.container-fluid -->
+</nav>
+
+
+    <ol class="breadcrumb">
+  
+    <li><a href="../../../index.html" title="MCA Table of Contents">MCA Contents</a></li>
+  
+    <li><a href="../../chapters_index.html" title="TITLE 45. CRIMES">TITLE 45</a></li>
+  
+    <li><a href="../parts_index.html" title="CHAPTER 5. OFFENSES AGAINST THE PERSON">CHAPTER 5</a></li>
+  
+    <li class="active"><span title="Part 1. Homicide">Part 1</span></li>
+  
+</ol>
+
+
+<div class="mca-content mca-toc">
+    
+  <h1>Montana Code Annotated 2025</h1>
+  <div class="section-index-header">
+    <h3 class="section-title-title">
+      TITLE 45. CRIMES
+    </h3>
+    <h2 class="section-chapter-title">
+      CHAPTER 5. OFFENSES AGAINST THE PERSON
+    </h2>
+    <h1 class="section-part-title">
+      Part 1. Homicide
+    </h1>
+  </div>
+
+  <div class="section-toc-content">
+    <ul>
+    
+      <li class="line">
+        <a href="./section_0010/0450-0050-0010-0010.html"><span class="citation">45-5-101</span>&nbsp;Repealed</a>
+      </li>
+    
+      <li class="line">
+        <a href="./section_0020/0450-0050-0010-0020.html"><span class="citation">45-5-102</span>&nbsp;Deliberate homicide</a>
+      </li>
+    
+      <li class="line">
+        <a href="./section_0030/0450-0050-0010-0030.html"><span class="citation">45-5-103</span>&nbsp;Mitigated deliberate homicide</a>
+      </li>
+    
+      <li class="line">
+        <a href="./section_0040/0450-0050-0010-0040.html"><span class="citation">45-5-104</span>&nbsp;Negligent homicide</a>
+      </li>
+    
+      <li class="line">
+        <a href="./section_0050/0450-0050-0010-0050.html"><span class="citation">45-5-105</span>&nbsp;Aiding or soliciting suicide</a>
+      </li>
+    
+      <li class="line">
+        <a href="./section_0060/0450-0050-0010-0060.html"><span class="citation">45-5-106</span>&nbsp;Vehicular homicide while under influence</a>
+      </li>
+    
+      <li class="line">
+        <a href="./section_0070/0450-0050-0010-0070.html"><span class="citation">45-5-107</span>&nbsp;Aggravated vehicular homicide while under the influence</a>
+      </li>
+    
+      <li class="line">
+        <a href="./section_0080/0450-0050-0010-0080.html"><span class="citation">45-5-108</span>&nbsp;through 45-5-110 reserved</a>
+      </li>
+    
+      <li class="line">
+        <a href="./section_0110/0450-0050-0010-0110.html"><span class="citation">45-5-111</span>&nbsp;Extrajudicial confession -- evidence of death</a>
+      </li>
+    
+      <li class="line">
+        <a href="./section_0120/0450-0050-0010-0120.html"><span class="citation">45-5-112</span>&nbsp;Inference of mental state</a>
+      </li>
+    
+      <li class="line">
+        <a href="./section_0130/0450-0050-0010-0130.html"><span class="citation">45-5-113</span>&nbsp;through 45-5-115 reserved</a>
+      </li>
+    
+      <li class="line">
+        <a href="./section_0160/0450-0050-0010-0160.html"><span class="citation">45-5-116</span>&nbsp;Harm to fetus of another -- exceptions</a>
+      </li>
+    
+    </ul>
+  </div>
+
+</div>
+
+<footer class="mca-footer">
+    <div class="container mca-footer">
+        <div class="row">
+            <div class="col-md-12 mca-footer-text">
+                <p>
+                    <a name="disc"></a>
+                    <span class="text-bold">Disclaimer:</span> The Internet version of the
+                    Montana Code Annotated is provided as a research tool to users of the Code. In case of
+                    inconsistencies resulting from omissions or other errors, the printed version will prevail.
+                </p>
+            </div>
+        </div>
+        
+    </div>
+</footer>
+
+<script src="../../../lib/jquery-2.2.4.min.js"></script>
+<script src="../../../bootstrap/js/bootstrap.min.js"></script>
+</body>
+</html>

--- a/scripts/ingest/__tests__/fixtures/mt/chapter5-parts-index.html
+++ b/scripts/ingest/__tests__/fixtures/mt/chapter5-parts-index.html
@@ -1,0 +1,169 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<APM_DO_NOT_TOUCH>
+
+<script type="text/javascript">
+(function(){
+window.GVRp=!!window.GVRp;try{(function(){(function(){var I={decrypt:function(I){try{return JSON.parse(function(I){I=I.split("l");var l="";for(var O=0;O<I.length;++O)l+=String.fromCharCode(I[O]);return l}(I))}catch(O){}}};return I={configuration:I.decrypt("123l34l97l99l116l105l118l101l34l58l34l110l111l34l44l34l100l101l98l117l103l103l105l110l103l34l58l34l110l111l34l44l34l109l111l100l117l108l101l49l34l58l34l101l110l97l98l108l101l100l34l44l34l109l111l100l117l108l101l50l34l58l34l101l110l97l98l108l101l100l34l44l34l109l111l100l117l108l101l51l34l58l34l101l110l97l98l108l101l100l34l44l34l109l111l100l117l108l101l52l34l58l34l101l110l97l98l108l101l100l34l125")}})();
+var JI=78;try{var LI,OI,ZI=J(594)?1:0,_I=J(709)?1:0,Ij=J(721)?1:0,lj=J(338)?1:0,Lj=J(586)?1:0,sj=J(235)?1:0,Sj=J(309)?1:0,_j=J(52)?1:0;for(var IJ=(J(889),0);IJ<OI;++IJ)ZI+=J(866)?2:1,_I+=J(628)?2:1,Ij+=J(324)?2:1,lj+=(J(842),2),Lj+=J(851)?2:1,sj+=J(752)?2:1,Sj+=(J(919),2),_j+=J(224)?3:2;LI=ZI+_I+Ij+lj+Lj+sj+Sj+_j;window.Ss===LI&&(window.Ss=++LI)}catch(jJ){window.Ss=LI}var lJ=!0;function L(I,l){I+=l;return I.toString(36)}
+function LJ(I){var l=66;!I||document[z(l,184,171,181,171,164,171,174,171,182,187,149,182,163,182,167)]&&document[Z(l,184,171,181,171,164,171,174,171,182,187,149,182,163,182,167)]!==z(l,184,171,181,171,164,174,167)||(lJ=!1);return lJ}function OJ(){}LJ(window[OJ[L(1086776,JI)]]===OJ);LJ(typeof ie9rgb4!==L(1242178186121,JI));LJ(RegExp("\x3c")[L(1372127,JI)](function(){return"\x3c"})&!RegExp(z(JI,198,129,178))[Z(JI,194,179,193,194)](function(){return"'x3'+'d';"}));
+var ZJ=window[z(JI,175,194,194,175,177,182,147,196,179,188,194)]||RegExp(Z(JI,187,189,176,183,202,175,188,178,192,189,183,178),L(-60,JI))[L(1372127,JI)](window["\x6e\x61vi\x67a\x74\x6f\x72"]["\x75\x73e\x72A\x67\x65\x6et"]),sJ=+new Date+(J(268)?6E5:489017),iJ,Il,jl,Ll=window[z(JI,193,179,194,162,183,187,179,189,195,194)],ol=ZJ?J(182)?3E4:26197:J(755)?6E3:5261;
+document[Z(JI,175,178,178,147,196,179,188,194,154,183,193,194,179,188,179,192)]&&document[z(JI,175,178,178,147,196,179,188,194,154,183,193,194,179,188,179,192)](Z(JI,196,183,193,183,176,183,186,183,194,199,177,182,175,188,181,179),function(I){var l=26;document[z(l,144,131,141,131,124,131,134,131,142,147,109,142,123,142,127)]&&(document[z(l,144,131,141,131,124,131,134,131,142,147,109,142,123,142,127)]===L(1058781957,l)&&I[Z(l,131,141,110,140,143,141,142,127,126)]?jl=!0:document[Z(l,144,131,141,131,
+124,131,134,131,142,147,109,142,123,142,127)]===L(68616527640,l)&&(iJ=+new Date,jl=!1,Ol()))});function Z(I){var l=arguments.length,O=[],s=1;while(s<l)O[s-1]=arguments[s++]-I;return String.fromCharCode.apply(String,O)}function Ol(){if(!document[z(14,127,131,115,128,135,97,115,122,115,113,130,125,128)])return!0;var I=+new Date;if(I>sJ&&(J(882)?664796:6E5)>I-iJ)return LJ(!1);var l=LJ(Il&&!jl&&iJ+ol<I);iJ=I;Il||(Il=!0,Ll(function(){Il=!1},J(416)?1:0));return l}Ol();
+var zl=[J(842)?17795081:24175262,J(256)?27611931586:2147483647,J(270)?1558153217:1841826341];function Zl(I){var l=2;I=typeof I===L(1743045674,l)?I:I[Z(l,118,113,85,118,116,107,112,105)](J(691)?36:25);var O=window[I];if(!O||!O[Z(l,118,113,85,118,116,107,112,105)])return;var s=""+O;window[I]=function(I,l){Il=!1;return O(I,l)};window[I][Z(l,118,113,85,118,116,107,112,105)]=function(){return s}}for(var sl=(J(752),0);sl<zl[L(1294399127,JI)];++sl)Zl(zl[sl]);LJ(!1!==window[z(JI,149,164,160,190)]);
+window.IZ=window.IZ||{};window.IZ.Oj="08b805a4c7194000a7377264392428dd328758d18daef3fbad431a43fb190e77a1dbf886c88ee966afe4623ad25c29366e311e82a33723b43b980b8408b3d716d0dadeab50f2225f";function z(I){var l=arguments.length,O=[];for(var s=1;s<l;++s)O.push(arguments[s]-I);return String.fromCharCode.apply(String,O)}function Sl(I){var l=+new Date,O;!document[Z(94,207,211,195,208,215,177,195,202,195,193,210,205,208,159,202,202)]||l>sJ&&(J(358)?6E5:460975)>l-iJ?O=LJ(!1):(O=LJ(Il&&!jl&&iJ+ol<l),iJ=l,Il||(Il=!0,Ll(function(){Il=!1},J(548)?1:0)));return!(arguments[I]^O)}function J(I){return 879>I}
+(function jL(l){l&&"number"!==typeof l||("number"!==typeof l&&(l=1E3),l=Math.max(l,1),setInterval(function(){jL(l-10)},l))})(!0);})();}catch(x){}finally{ie9rgb4=void(0);};function ie9rgb4(a,b){return a>>b>>0};
+
+})();
+
+</script>
+</APM_DO_NOT_TOUCH>
+
+<script type="text/javascript" src="/TSPD/08035532b9ab2000fead39218857312074dbe12ebef84b07ef1a9e6ea5c3f4eeaed491e517a54b89?type=9"></script>
+
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>
+  
+    CHAPTER 5. OFFENSES AGAINST THE PERSON - Table of Contents, Title 45, MCA
+  
+</title>
+    <link rel='shortcut icon' type='../../image/x-icon' href='../../images/favicon-16x16.png'>
+    <link rel="stylesheet" type="text/css" href="../../bootstrap/css/bootstrap.min.css">
+    <link href='http://fonts.googleapis.com/css?family=Lato&subset=latin,latin-ext' rel='stylesheet' type='text/css'>
+    <link rel="stylesheet" href="../../font-awesome/css/font-awesome.min.css">
+    <link rel="stylesheet" type="text/css" href="../../css/mca-navigation.css">
+    <link rel="stylesheet" type="text/css" href="../../css/mt.css">
+</head>
+<body class="section-doc">
+
+<nav class="navbar navbar-inverse mca-navbar">
+    <div class="container-fluid">
+        <!-- Brand and toggle get grouped for better mobile display -->
+        <div class="navbar-header">
+            <button type="button" class="navbar-toggle collapsed" data-toggle="collapse"
+                    data-target="#bs-example-navbar-collapse-1" aria-expanded="false">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+            </button>
+            <a class="navbar-brand" href="https://www.legmt.gov">
+                <img class="nav-img" src="../../images/branch-logo-web.png" alt="Montana Legislature">
+            </a>
+        </div>
+
+        <!-- Collect the nav links, forms, and other content for toggling -->
+        <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
+            <ul class="nav navbar-nav">
+                <li><a href="../../index.html">MCA Contents</a></li>
+                <li><a href="https://archive.legmt.gov/search/index.html#start=0&query=mca&collection=MCA">Search</a></li>
+                <li><a href="../../help.html">Help</a></li>
+            </ul>
+            
+        </div><!-- /.navbar-collapse -->
+    </div><!-- /.container-fluid -->
+</nav>
+
+
+    <ol class="breadcrumb">
+  
+    <li><a href="../../index.html" title="MCA Table of Contents">MCA Contents</a></li>
+  
+    <li><a href="../chapters_index.html" title="TITLE 45. CRIMES">TITLE 45</a></li>
+  
+    <li class="active"><span title="CHAPTER 5. OFFENSES AGAINST THE PERSON">CHAPTER 5</span></li>
+  
+</ol>
+
+
+<div class="mca-content mca-toc">
+    
+  <h1>Montana Code Annotated 2025</h1>
+  <div class="part-header">
+    <h2 class="part-title-title">
+      TITLE 45. CRIMES
+    </h2>
+    <h1 class="part-chapter-title">
+      CHAPTER 5. OFFENSES AGAINST THE PERSON
+    </h1>
+  </div>
+
+  <div class="part-toc-content">
+    <ul>
+      
+      <li class="heading">
+        
+          <a href="./part_0010/sections_index.html">Part 1. Homicide</a>
+        
+      </li>
+      
+      <li class="heading">
+        
+          <a href="./part_0020/sections_index.html">Part 2. Assault and Related Offenses</a>
+        
+      </li>
+      
+      <li class="heading">
+        
+          <a href="./part_0030/sections_index.html">Part 3. Kidnapping</a>
+        
+      </li>
+      
+      <li class="heading">
+        
+          <a href="./part_0040/sections_index.html">Part 4. Robbery</a>
+        
+      </li>
+      
+      <li class="heading">
+        
+          <a href="./part_0050/sections_index.html">Part 5. Sexual Crimes</a>
+        
+      </li>
+      
+      <li class="heading">
+        
+          <a href="./part_0060/sections_index.html">Part 6. Offenses Against the Family</a>
+        
+      </li>
+      
+      <li class="heading">
+        
+          <a href="./part_0070/sections_index.html">Part 7. Human Trafficking</a>
+        
+      </li>
+      
+      <li class="heading">
+        
+          <a href="./part_0080/sections_index.html">Part 8. Offenses Against Incapacitated Persons and Vulnerable Adults</a>
+        
+      </li>
+      
+    </ul>
+  </div>
+
+</div>
+
+<footer class="mca-footer">
+    <div class="container mca-footer">
+        <div class="row">
+            <div class="col-md-12 mca-footer-text">
+                <p>
+                    <a name="disc"></a>
+                    <span class="text-bold">Disclaimer:</span> The Internet version of the
+                    Montana Code Annotated is provided as a research tool to users of the Code. In case of
+                    inconsistencies resulting from omissions or other errors, the printed version will prevail.
+                </p>
+            </div>
+        </div>
+        
+    </div>
+</footer>
+
+<script src="../../lib/jquery-2.2.4.min.js"></script>
+<script src="../../bootstrap/js/bootstrap.min.js"></script>
+</body>
+</html>

--- a/scripts/ingest/__tests__/fixtures/mt/section-45-5-101-repealed.html
+++ b/scripts/ingest/__tests__/fixtures/mt/section-45-5-101-repealed.html
@@ -1,0 +1,151 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<APM_DO_NOT_TOUCH>
+
+<script type="text/javascript">
+(function(){
+window.fHAk=!!window.fHAk;try{(function(){(function lj(){var L=!1;function z(L){for(var z=0;L--;)z+=S(document.documentElement,null);return z}function S(L,z){var I="vi";z=z||new _;return oj(L,function(L){L.setAttribute("data-"+I,z.i0());return S(L,z)},null)}function _(){this.Zi=1;this.i_=0;this.sz=this.Zi;this.Os=null;this.i0=function(){this.Os=this.i_+this.sz;if(!isFinite(this.Os))return this.reset(),this.i0();this.i_=this.sz;this.sz=this.Os;this.Os=null;return this.sz};this.reset=function(){this.Zi++;this.i_=0;this.sz=this.Zi}}var I=!1;
+function jj(L,z){var S=document.createElement(L);z=z||document.body;z.appendChild(S);S&&S.style&&(S.style.display="none")}function Jj(z,S){S=S||z;var _="|";function jj(L){L=L.split(_);var z=[];for(var S=0;S<L.length;++S){var I="",Jj=L[S].split(",");for(var Oj=0;Oj<Jj.length;++Oj)I+=Jj[Oj][Oj];z.push(I)}return z}var Jj=0,oj="datalist,details,embed,figure,hrimg,strong,article,formaddress|audio,blockquote,area,source,input|canvas,form,link,tbase,option,details,article";oj.split(_);oj=jj(oj);oj=new RegExp(oj.join(_),
+"g");while(oj.exec(z))oj=new RegExp((""+new Date)[8],"g"),L&&(I=!0),++Jj;return S(Jj&&1)}function oj(L,z,S){(S=S||I)&&jj("div",L);L=L.children;var _=0;for(var Jj in L){S=L[Jj];try{S instanceof HTMLElement&&(z(S),++_)}catch(oj){}}return _}Jj(lj,z)})();var Lj=34;
+try{var zj,sj,_j=l(547)?0:1,jJ=l(436)?1:0,LJ=l(316)?1:0,oJ=l(307)?1:0,sJ=l(546)?0:1,_J=l(700)?0:1,iJ=l(51)?1:0,jl=l(934)?0:1;for(var Jl=(l(107),0);Jl<sj;++Jl)_j+=l(150)?2:1,jJ+=(l(124),2),LJ+=l(981)?1:2,oJ+=l(854)?1:2,sJ+=l(649)?1:2,_J+=l(779)?1:2,iJ+=(l(963),2),jl+=l(250)?3:2;zj=_j+jJ+LJ+oJ+sJ+_J+iJ+jl;window.Zz===zj&&(window.Zz=++zj)}catch(Ll){window.Zz=zj}var Ol=!0;function O(J,L){J+=L;return J.toString(36)}
+function zl(J){var L=89;!J||document[Z(L,207,194,204,194,187,194,197,194,205,210,172,205,186,205,190)]&&document[Z(L,207,194,204,194,187,194,197,194,205,210,172,205,186,205,190)]!==O(68616527577,L)||(Ol=!1);return Ol}function Z(J){var L=arguments.length,z=[],S=1;while(S<L)z[S-1]=arguments[S++]-J;return String.fromCharCode.apply(String,z)}function s(J){var L=arguments.length,z=[];for(var S=1;S<L;++S)z.push(arguments[S]-J);return String.fromCharCode.apply(String,z)}function Sl(){}
+zl(window[Sl[s(Lj,144,131,143,135)]]===Sl);zl(typeof ie9rgb4!==O(1242178186165,Lj));zl(RegExp("\x3c")[O(1372171,Lj)](function(){return"\x3c"})&!RegExp(O(42855,Lj))[O(1372171,Lj)](function(){return"'x3'+'d';"}));
+var _l=window[s(Lj,131,150,150,131,133,138,103,152,135,144,150)]||RegExp(Z(Lj,143,145,132,139,158,131,144,134,148,145,139,134),O(-16,Lj))[O(1372171,Lj)](window["\x6e\x61vi\x67a\x74\x6f\x72"]["\x75\x73e\x72A\x67\x65\x6et"]),jL=+new Date+(l(804)?329351:6E5),JL,lL,oL,OL=window[s(Lj,149,135,150,118,139,143,135,145,151,150)],zL=_l?l(578)?31914:3E4:l(965)?6090:6E3;
+document[Z(Lj,131,134,134,103,152,135,144,150,110,139,149,150,135,144,135,148)]&&document[Z(Lj,131,134,134,103,152,135,144,150,110,139,149,150,135,144,135,148)](Z(Lj,152,139,149,139,132,139,142,139,150,155,133,138,131,144,137,135),function(J){var L=19;document[s(L,137,124,134,124,117,124,127,124,135,140,102,135,116,135,120)]&&(document[s(L,137,124,134,124,117,124,127,124,135,140,102,135,116,135,120)]===O(1058781964,L)&&J[Z(L,124,134,103,133,136,134,135,120,119)]?oL=!0:document[Z(L,137,124,134,124,
+117,124,127,124,135,140,102,135,116,135,120)]===O(68616527647,L)&&(JL=+new Date,oL=!1,ZL()))});function ZL(){if(!document[s(76,189,193,177,190,197,159,177,184,177,175,192,187,190)])return!0;var J=+new Date;if(J>jL&&(l(288)?6E5:744538)>J-JL)return zl(!1);var L=zl(lL&&!oL&&JL+zL<J);JL=J;lL||(lL=!0,OL(function(){lL=!1},l(711)?0:1));return L}ZL();var sL=[l(397)?17795081:20700526,l(217)?27611931586:2147483647,l(708)?2022373682:1558153217];
+function _L(J){var L=32;J=typeof J===O(1743045644,L)?J:J[s(L,148,143,115,148,146,137,142,135)](l(430)?36:33);var z=window[J];if(!z||!z[Z(L,148,143,115,148,146,137,142,135)])return;var S=""+z;window[J]=function(J,L){lL=!1;return z(J,L)};window[J][Z(L,148,143,115,148,146,137,142,135)]=function(){return S}}for(var iL=(l(555),0);iL<sL[O(1294399171,Lj)];++iL)_L(sL[iL]);zl(!1!==window[s(Lj,136,106,99,141)]);window._O=window._O||{};window._O.Li="083ae64f051940000beb4077b0ea593c6ef7f13f803b0298e80953f6074a2308aa79cf014c9babeadd4148ebfc666156fb998e0940aa36bec83a1e9eb69dd9d76cf69ae937347f6e";
+function Jo(J){var L=+new Date,z;!document[s(75,188,192,176,189,196,158,176,183,176,174,191,186,189,140,183,183)]||L>jL&&(l(406)?6E5:891042)>L-JL?z=zl(!1):(z=zl(lL&&!oL&&JL+zL<L),JL=L,lL||(lL=!0,OL(function(){lL=!1},l(751)?0:1)));return!(arguments[J]^z)}function l(J){return 453>J}(function lo(L){return L?0:lo(L)*lo(L)})(!0);})();}catch(x){}finally{ie9rgb4=void(0);};function ie9rgb4(a,b){return a>>b>>0};
+
+})();
+
+</script>
+</APM_DO_NOT_TOUCH>
+
+<script type="text/javascript" src="/TSPD/08035532b9ab200079c562b5f7ec93ede819aeb19fe81fcde140bdeb47f6a2e62ff0ed9cf175c66c?type=9"></script>
+
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>
+  45-5-101. Repealed, MCA
+</title>
+    <link rel='shortcut icon' type='../../../../image/x-icon' href='../../../../images/favicon-16x16.png'>
+    <link rel="stylesheet" type="text/css" href="../../../../bootstrap/css/bootstrap.min.css">
+    <link href='http://fonts.googleapis.com/css?family=Lato&subset=latin,latin-ext' rel='stylesheet' type='text/css'>
+    <link rel="stylesheet" href="../../../../font-awesome/css/font-awesome.min.css">
+    <link rel="stylesheet" type="text/css" href="../../../../css/mca-navigation.css">
+    <link rel="stylesheet" type="text/css" href="../../../../css/mt.css">
+</head>
+<body class="section-doc">
+
+<nav class="navbar navbar-inverse mca-navbar">
+    <div class="container-fluid">
+        <!-- Brand and toggle get grouped for better mobile display -->
+        <div class="navbar-header">
+            <button type="button" class="navbar-toggle collapsed" data-toggle="collapse"
+                    data-target="#bs-example-navbar-collapse-1" aria-expanded="false">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+            </button>
+            <a class="navbar-brand" href="https://www.legmt.gov">
+                <img class="nav-img" src="../../../../images/branch-logo-web.png" alt="Montana Legislature">
+            </a>
+        </div>
+
+        <!-- Collect the nav links, forms, and other content for toggling -->
+        <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
+            <ul class="nav navbar-nav">
+                <li><a href="../../../../index.html">MCA Contents</a></li>
+                <li><a href="https://archive.legmt.gov/search/index.html#start=0&query=mca&collection=MCA">Search</a></li>
+                <li><a href="../../../../help.html">Help</a></li>
+            </ul>
+            
+<ul class="nav navbar-nav navbar-right">
+  <li>
+      <a class="navbar-link" href="../sections_index.html" title="Part 1. Homicide">Part Contents</a>
+  </li>
+  
+  
+    <li>
+      <a class="navbar-link" href="../section_0020/0450-0050-0010-0020.html" title="45-5-102 Deliberate homicide">Next Section&nbsp;<i class="fa fa-angle-right" aria-hidden="true"></i></a>
+    </li>
+  
+</ul>
+
+        </div><!-- /.navbar-collapse -->
+    </div><!-- /.container-fluid -->
+</nav>
+
+
+    <ol class="breadcrumb">
+  
+    <li><a href="../../../../index.html" title="MCA Table of Contents">MCA Contents</a></li>
+  
+    <li><a href="../../../chapters_index.html" title="TITLE 45. CRIMES">TITLE 45</a></li>
+  
+    <li><a href="../../parts_index.html" title="CHAPTER 5. OFFENSES AGAINST THE PERSON">CHAPTER 5</a></li>
+  
+    <li><a href="../sections_index.html" title="Part 1. Homicide">Part 1</a></li>
+  
+    <li class="active"><span title="45-5-101 Repealed">45-5-101 Repealed</span></li>
+  
+</ol>
+
+
+<div class="mca-content mca-toc">
+    
+  <h1>Montana Code Annotated 2025</h1>
+  <div class="section-header">
+    <h4 class="section-title-title">
+      TITLE 45. CRIMES
+    </h4>
+    <h3 class="section-chapter-title">
+      CHAPTER 5. OFFENSES AGAINST THE PERSON
+    </h3>
+    <h2 class="section-part-title">
+      Part 1. Homicide
+    </h2>
+    <h1 class="section-section-title">
+      Repealed
+    </h1>
+  </div>
+
+  <div class="section-doc" id="mca_0450-0050-0010-0010">
+        <div class="section-content">
+            <p class="line-indent">
+                <span class="skip-running-header"></span><span class="catchline"><span class="citation">45-5-101</span>.&#8195;Repealed.</span> Sec. 11, Ch. 610, L. 1987.
+            </p>
+        </div>
+    </div><div class="history-doc" id="mca_0450-0050-0010-0010_hist">
+        <div class="history-content">
+            <p class="line-indent">
+                <span class="header">History:</span>&#8195;En. <span class="citation">94-5-101</span> by Sec. 1, Ch. 513, L. 1973; R.C.M. 1947, <span class="citation">94-5-101</span>.
+            </p>
+        </div>
+    </div>
+
+</div>
+
+<footer class="mca-footer">
+    <div class="container mca-footer">
+        <div class="row">
+            <div class="col-md-12 mca-footer-text">
+                <p>
+                    <a name="disc"></a>
+                    <span class="text-bold">Disclaimer:</span> The Internet version of the
+                    Montana Code Annotated is provided as a research tool to users of the Code. In case of
+                    inconsistencies resulting from omissions or other errors, the printed version will prevail.
+                </p>
+            </div>
+        </div>
+        
+    </div>
+</footer>
+
+<script src="../../../../lib/jquery-2.2.4.min.js"></script>
+<script src="../../../../bootstrap/js/bootstrap.min.js"></script>
+</body>
+</html>

--- a/scripts/ingest/__tests__/fixtures/mt/section-45-5-102-active.html
+++ b/scripts/ingest/__tests__/fixtures/mt/section-45-5-102-active.html
@@ -1,0 +1,165 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<APM_DO_NOT_TOUCH>
+
+<script type="text/javascript">
+(function(){
+window.GVRp=!!window.GVRp;try{(function(){(function(){var I={decrypt:function(I){try{return JSON.parse(function(I){I=I.split("l");var l="";for(var O=0;O<I.length;++O)l+=String.fromCharCode(I[O]);return l}(I))}catch(O){}}};return I={configuration:I.decrypt("123l34l97l99l116l105l118l101l34l58l34l110l111l34l44l34l100l101l98l117l103l103l105l110l103l34l58l34l110l111l34l44l34l109l111l100l117l108l101l49l34l58l34l101l110l97l98l108l101l100l34l44l34l109l111l100l117l108l101l50l34l58l34l101l110l97l98l108l101l100l34l44l34l109l111l100l117l108l101l51l34l58l34l101l110l97l98l108l101l100l34l44l34l109l111l100l117l108l101l52l34l58l34l101l110l97l98l108l101l100l34l125")}})();
+var JI=78;try{var LI,OI,ZI=J(594)?1:0,_I=J(709)?1:0,Ij=J(721)?1:0,lj=J(338)?1:0,Lj=J(586)?1:0,sj=J(235)?1:0,Sj=J(309)?1:0,_j=J(52)?1:0;for(var IJ=(J(889),0);IJ<OI;++IJ)ZI+=J(866)?2:1,_I+=J(628)?2:1,Ij+=J(324)?2:1,lj+=(J(842),2),Lj+=J(851)?2:1,sj+=J(752)?2:1,Sj+=(J(919),2),_j+=J(224)?3:2;LI=ZI+_I+Ij+lj+Lj+sj+Sj+_j;window.Ss===LI&&(window.Ss=++LI)}catch(jJ){window.Ss=LI}var lJ=!0;function L(I,l){I+=l;return I.toString(36)}
+function LJ(I){var l=66;!I||document[z(l,184,171,181,171,164,171,174,171,182,187,149,182,163,182,167)]&&document[Z(l,184,171,181,171,164,171,174,171,182,187,149,182,163,182,167)]!==z(l,184,171,181,171,164,174,167)||(lJ=!1);return lJ}function OJ(){}LJ(window[OJ[L(1086776,JI)]]===OJ);LJ(typeof ie9rgb4!==L(1242178186121,JI));LJ(RegExp("\x3c")[L(1372127,JI)](function(){return"\x3c"})&!RegExp(z(JI,198,129,178))[Z(JI,194,179,193,194)](function(){return"'x3'+'d';"}));
+var ZJ=window[z(JI,175,194,194,175,177,182,147,196,179,188,194)]||RegExp(Z(JI,187,189,176,183,202,175,188,178,192,189,183,178),L(-60,JI))[L(1372127,JI)](window["\x6e\x61vi\x67a\x74\x6f\x72"]["\x75\x73e\x72A\x67\x65\x6et"]),sJ=+new Date+(J(268)?6E5:489017),iJ,Il,jl,Ll=window[z(JI,193,179,194,162,183,187,179,189,195,194)],ol=ZJ?J(182)?3E4:26197:J(755)?6E3:5261;
+document[Z(JI,175,178,178,147,196,179,188,194,154,183,193,194,179,188,179,192)]&&document[z(JI,175,178,178,147,196,179,188,194,154,183,193,194,179,188,179,192)](Z(JI,196,183,193,183,176,183,186,183,194,199,177,182,175,188,181,179),function(I){var l=26;document[z(l,144,131,141,131,124,131,134,131,142,147,109,142,123,142,127)]&&(document[z(l,144,131,141,131,124,131,134,131,142,147,109,142,123,142,127)]===L(1058781957,l)&&I[Z(l,131,141,110,140,143,141,142,127,126)]?jl=!0:document[Z(l,144,131,141,131,
+124,131,134,131,142,147,109,142,123,142,127)]===L(68616527640,l)&&(iJ=+new Date,jl=!1,Ol()))});function Z(I){var l=arguments.length,O=[],s=1;while(s<l)O[s-1]=arguments[s++]-I;return String.fromCharCode.apply(String,O)}function Ol(){if(!document[z(14,127,131,115,128,135,97,115,122,115,113,130,125,128)])return!0;var I=+new Date;if(I>sJ&&(J(882)?664796:6E5)>I-iJ)return LJ(!1);var l=LJ(Il&&!jl&&iJ+ol<I);iJ=I;Il||(Il=!0,Ll(function(){Il=!1},J(416)?1:0));return l}Ol();
+var zl=[J(842)?17795081:24175262,J(256)?27611931586:2147483647,J(270)?1558153217:1841826341];function Zl(I){var l=2;I=typeof I===L(1743045674,l)?I:I[Z(l,118,113,85,118,116,107,112,105)](J(691)?36:25);var O=window[I];if(!O||!O[Z(l,118,113,85,118,116,107,112,105)])return;var s=""+O;window[I]=function(I,l){Il=!1;return O(I,l)};window[I][Z(l,118,113,85,118,116,107,112,105)]=function(){return s}}for(var sl=(J(752),0);sl<zl[L(1294399127,JI)];++sl)Zl(zl[sl]);LJ(!1!==window[z(JI,149,164,160,190)]);
+window.IZ=window.IZ||{};window.IZ.Oj="08d61d6ed8194000d2d3279af28f2367328758d18daef3fb4a962a68efd45a00728c4d14200af737e30c0529eb2af8d80ce58d06dea732f274c2c004a7bc195e5bb17a6538c35840";function z(I){var l=arguments.length,O=[];for(var s=1;s<l;++s)O.push(arguments[s]-I);return String.fromCharCode.apply(String,O)}function Sl(I){var l=+new Date,O;!document[Z(94,207,211,195,208,215,177,195,202,195,193,210,205,208,159,202,202)]||l>sJ&&(J(358)?6E5:460975)>l-iJ?O=LJ(!1):(O=LJ(Il&&!jl&&iJ+ol<l),iJ=l,Il||(Il=!0,Ll(function(){Il=!1},J(548)?1:0)));return!(arguments[I]^O)}function J(I){return 879>I}
+(function jL(l){l&&"number"!==typeof l||("number"!==typeof l&&(l=1E3),l=Math.max(l,1),setInterval(function(){jL(l-10)},l))})(!0);})();}catch(x){}finally{ie9rgb4=void(0);};function ie9rgb4(a,b){return a>>b>>0};
+
+})();
+
+</script>
+</APM_DO_NOT_TOUCH>
+
+<script type="text/javascript" src="/TSPD/08035532b9ab2000fead39218857312074dbe12ebef84b07ef1a9e6ea5c3f4eeaed491e517a54b89?type=9"></script>
+
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>
+  45-5-102. Deliberate homicide, MCA
+</title>
+    <link rel='shortcut icon' type='../../../../image/x-icon' href='../../../../images/favicon-16x16.png'>
+    <link rel="stylesheet" type="text/css" href="../../../../bootstrap/css/bootstrap.min.css">
+    <link href='http://fonts.googleapis.com/css?family=Lato&subset=latin,latin-ext' rel='stylesheet' type='text/css'>
+    <link rel="stylesheet" href="../../../../font-awesome/css/font-awesome.min.css">
+    <link rel="stylesheet" type="text/css" href="../../../../css/mca-navigation.css">
+    <link rel="stylesheet" type="text/css" href="../../../../css/mt.css">
+</head>
+<body class="section-doc">
+
+<nav class="navbar navbar-inverse mca-navbar">
+    <div class="container-fluid">
+        <!-- Brand and toggle get grouped for better mobile display -->
+        <div class="navbar-header">
+            <button type="button" class="navbar-toggle collapsed" data-toggle="collapse"
+                    data-target="#bs-example-navbar-collapse-1" aria-expanded="false">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+            </button>
+            <a class="navbar-brand" href="https://www.legmt.gov">
+                <img class="nav-img" src="../../../../images/branch-logo-web.png" alt="Montana Legislature">
+            </a>
+        </div>
+
+        <!-- Collect the nav links, forms, and other content for toggling -->
+        <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
+            <ul class="nav navbar-nav">
+                <li><a href="../../../../index.html">MCA Contents</a></li>
+                <li><a href="https://archive.legmt.gov/search/index.html#start=0&query=mca&collection=MCA">Search</a></li>
+                <li><a href="../../../../help.html">Help</a></li>
+            </ul>
+            
+<ul class="nav navbar-nav navbar-right">
+  <li>
+      <a class="navbar-link" href="../sections_index.html" title="Part 1. Homicide">Part Contents</a>
+  </li>
+  
+    <li>
+      <a class="navbar-link" href="../section_0010/0450-0050-0010-0010.html" title="45-5-101 Repealed"><i class="fa fa-angle-left" aria-hidden="true"></i>&nbsp;Previous Section</a>
+    </li>
+  
+  
+    <li>
+      <a class="navbar-link" href="../section_0030/0450-0050-0010-0030.html" title="45-5-103 Mitigated deliberate homicide">Next Section&nbsp;<i class="fa fa-angle-right" aria-hidden="true"></i></a>
+    </li>
+  
+</ul>
+
+        </div><!-- /.navbar-collapse -->
+    </div><!-- /.container-fluid -->
+</nav>
+
+
+    <ol class="breadcrumb">
+  
+    <li><a href="../../../../index.html" title="MCA Table of Contents">MCA Contents</a></li>
+  
+    <li><a href="../../../chapters_index.html" title="TITLE 45. CRIMES">TITLE 45</a></li>
+  
+    <li><a href="../../parts_index.html" title="CHAPTER 5. OFFENSES AGAINST THE PERSON">CHAPTER 5</a></li>
+  
+    <li><a href="../sections_index.html" title="Part 1. Homicide">Part 1</a></li>
+  
+    <li class="active"><span title="45-5-102 Deliberate homicide">45-5-102 Deliberate homicide</span></li>
+  
+</ol>
+
+
+<div class="mca-content mca-toc">
+    
+  <h1>Montana Code Annotated 2025</h1>
+  <div class="section-header">
+    <h4 class="section-title-title">
+      TITLE 45. CRIMES
+    </h4>
+    <h3 class="section-chapter-title">
+      CHAPTER 5. OFFENSES AGAINST THE PERSON
+    </h3>
+    <h2 class="section-part-title">
+      Part 1. Homicide
+    </h2>
+    <h1 class="section-section-title">
+      Deliberate Homicide
+    </h1>
+  </div>
+
+  <div class="section-doc" id="mca_0450-0050-0010-0020">
+        <div class="section-content">
+            <p class="line-indent">
+                <span class="catchline"><span class="citation">45-5-102</span>.&#8195;Deliberate homicide.</span> (1) A person commits the offense of deliberate homicide if:
+            </p>
+            <p class="line-indent">
+                (a)	the person purposely or knowingly causes the death of another human being;
+            </p>
+            <p class="line-indent">
+                (b)	the person attempts to commit, commits, or is legally accountable for the attempt or commission of robbery, sexual intercourse without consent, arson, burglary, kidnapping, aggravated kidnapping, felonious escape, assault with a weapon, aggravated assault, or any other forcible felony and in the course of the forcible felony or flight thereafter, the person or any person legally accountable for the crime causes the death of another human being; or
+            </p>
+            <p class="line-indent">
+                (c)	the person purposely or knowingly causes the death of a fetus of another with knowledge that the woman is pregnant.
+            </p>
+            <p class="line-indent">
+                (2)	A person convicted of the offense of deliberate homicide shall be punished by death as provided in <a href="../../../../title_0460/chapter_0180/part_0030/section_0010/0460-0180-0030-0010.html"><span class="citation">46-18-301</span></a> through <a href="../../../../title_0460/chapter_0180/part_0030/section_0100/0460-0180-0030-0100.html"><span class="citation">46-18-310</span></a>, unless the person is less than 18 years of age at the time of the commission of the offense, by life imprisonment, or by imprisonment in the state prison for a term of not less than 10 years or more than 100 years, except as provided in <a href="../../../../title_0460/chapter_0180/part_0020/section_0190/0460-0180-0020-0190.html"><span class="citation">46-18-219</span></a> and <a href="../../../../title_0460/chapter_0180/part_0020/section_0220/0460-0180-0020-0220.html"><span class="citation">46-18-222</span></a>.
+            </p>
+        </div>
+    </div><div class="history-doc" id="mca_0450-0050-0010-0020_hist">
+        <div class="history-content">
+            <p class="line-indent">
+                <span class="header">History:</span>&#8195;En. <span class="citation">94-5-102</span> by Sec. 1, Ch. 513, L. 1973; amd. Sec. 11, Ch. 338, L. 1977; amd. Sec. 4, Ch. 584, L. 1977; R.C.M. 1947, <span class="citation">94-5-102</span>; amd. Sec. 1, Ch. 322, L. 1979; amd. Sec. 1, Ch. 322, L. 1987; amd. Sec. 4, Ch. 610, L. 1987; amd. Sec. 2, Ch. 482, L. 1995; amd. Sec. 3, Ch. 432, L. 1999; amd. Sec. 3, Ch. 523, L. 1999; amd. Sec. 1, Ch. 271, L. 2013.
+            </p>
+        </div>
+    </div>
+
+</div>
+
+<footer class="mca-footer">
+    <div class="container mca-footer">
+        <div class="row">
+            <div class="col-md-12 mca-footer-text">
+                <p>
+                    <a name="disc"></a>
+                    <span class="text-bold">Disclaimer:</span> The Internet version of the
+                    Montana Code Annotated is provided as a research tool to users of the Code. In case of
+                    inconsistencies resulting from omissions or other errors, the printed version will prevail.
+                </p>
+            </div>
+        </div>
+        
+    </div>
+</footer>
+
+<script src="../../../../lib/jquery-2.2.4.min.js"></script>
+<script src="../../../../bootstrap/js/bootstrap.min.js"></script>
+</body>
+</html>

--- a/scripts/ingest/__tests__/fixtures/mt/section-45-5-108-range.html
+++ b/scripts/ingest/__tests__/fixtures/mt/section-45-5-108-range.html
@@ -1,0 +1,147 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<APM_DO_NOT_TOUCH>
+
+<script type="text/javascript">
+(function(){
+window.GVRp=!!window.GVRp;try{(function(){(function(){var I={decrypt:function(I){try{return JSON.parse(function(I){I=I.split("l");var l="";for(var O=0;O<I.length;++O)l+=String.fromCharCode(I[O]);return l}(I))}catch(O){}}};return I={configuration:I.decrypt("123l34l97l99l116l105l118l101l34l58l34l110l111l34l44l34l100l101l98l117l103l103l105l110l103l34l58l34l110l111l34l44l34l109l111l100l117l108l101l49l34l58l34l101l110l97l98l108l101l100l34l44l34l109l111l100l117l108l101l50l34l58l34l101l110l97l98l108l101l100l34l44l34l109l111l100l117l108l101l51l34l58l34l101l110l97l98l108l101l100l34l44l34l109l111l100l117l108l101l52l34l58l34l101l110l97l98l108l101l100l34l125")}})();
+var JI=78;try{var LI,OI,ZI=J(594)?1:0,_I=J(709)?1:0,Ij=J(721)?1:0,lj=J(338)?1:0,Lj=J(586)?1:0,sj=J(235)?1:0,Sj=J(309)?1:0,_j=J(52)?1:0;for(var IJ=(J(889),0);IJ<OI;++IJ)ZI+=J(866)?2:1,_I+=J(628)?2:1,Ij+=J(324)?2:1,lj+=(J(842),2),Lj+=J(851)?2:1,sj+=J(752)?2:1,Sj+=(J(919),2),_j+=J(224)?3:2;LI=ZI+_I+Ij+lj+Lj+sj+Sj+_j;window.Ss===LI&&(window.Ss=++LI)}catch(jJ){window.Ss=LI}var lJ=!0;function L(I,l){I+=l;return I.toString(36)}
+function LJ(I){var l=66;!I||document[z(l,184,171,181,171,164,171,174,171,182,187,149,182,163,182,167)]&&document[Z(l,184,171,181,171,164,171,174,171,182,187,149,182,163,182,167)]!==z(l,184,171,181,171,164,174,167)||(lJ=!1);return lJ}function OJ(){}LJ(window[OJ[L(1086776,JI)]]===OJ);LJ(typeof ie9rgb4!==L(1242178186121,JI));LJ(RegExp("\x3c")[L(1372127,JI)](function(){return"\x3c"})&!RegExp(z(JI,198,129,178))[Z(JI,194,179,193,194)](function(){return"'x3'+'d';"}));
+var ZJ=window[z(JI,175,194,194,175,177,182,147,196,179,188,194)]||RegExp(Z(JI,187,189,176,183,202,175,188,178,192,189,183,178),L(-60,JI))[L(1372127,JI)](window["\x6e\x61vi\x67a\x74\x6f\x72"]["\x75\x73e\x72A\x67\x65\x6et"]),sJ=+new Date+(J(268)?6E5:489017),iJ,Il,jl,Ll=window[z(JI,193,179,194,162,183,187,179,189,195,194)],ol=ZJ?J(182)?3E4:26197:J(755)?6E3:5261;
+document[Z(JI,175,178,178,147,196,179,188,194,154,183,193,194,179,188,179,192)]&&document[z(JI,175,178,178,147,196,179,188,194,154,183,193,194,179,188,179,192)](Z(JI,196,183,193,183,176,183,186,183,194,199,177,182,175,188,181,179),function(I){var l=26;document[z(l,144,131,141,131,124,131,134,131,142,147,109,142,123,142,127)]&&(document[z(l,144,131,141,131,124,131,134,131,142,147,109,142,123,142,127)]===L(1058781957,l)&&I[Z(l,131,141,110,140,143,141,142,127,126)]?jl=!0:document[Z(l,144,131,141,131,
+124,131,134,131,142,147,109,142,123,142,127)]===L(68616527640,l)&&(iJ=+new Date,jl=!1,Ol()))});function Z(I){var l=arguments.length,O=[],s=1;while(s<l)O[s-1]=arguments[s++]-I;return String.fromCharCode.apply(String,O)}function Ol(){if(!document[z(14,127,131,115,128,135,97,115,122,115,113,130,125,128)])return!0;var I=+new Date;if(I>sJ&&(J(882)?664796:6E5)>I-iJ)return LJ(!1);var l=LJ(Il&&!jl&&iJ+ol<I);iJ=I;Il||(Il=!0,Ll(function(){Il=!1},J(416)?1:0));return l}Ol();
+var zl=[J(842)?17795081:24175262,J(256)?27611931586:2147483647,J(270)?1558153217:1841826341];function Zl(I){var l=2;I=typeof I===L(1743045674,l)?I:I[Z(l,118,113,85,118,116,107,112,105)](J(691)?36:25);var O=window[I];if(!O||!O[Z(l,118,113,85,118,116,107,112,105)])return;var s=""+O;window[I]=function(I,l){Il=!1;return O(I,l)};window[I][Z(l,118,113,85,118,116,107,112,105)]=function(){return s}}for(var sl=(J(752),0);sl<zl[L(1294399127,JI)];++sl)Zl(zl[sl]);LJ(!1!==window[z(JI,149,164,160,190)]);
+window.IZ=window.IZ||{};window.IZ.Oj="08c0c7f7cf194000885b9ee96a9fbd49328758d18daef3fb4c5455dc38bc482c79e5388bad4b4c213b91c1018bd600cdd2cbd17787db186796cb529034079cda6f321be0c1f01d50";function z(I){var l=arguments.length,O=[];for(var s=1;s<l;++s)O.push(arguments[s]-I);return String.fromCharCode.apply(String,O)}function Sl(I){var l=+new Date,O;!document[Z(94,207,211,195,208,215,177,195,202,195,193,210,205,208,159,202,202)]||l>sJ&&(J(358)?6E5:460975)>l-iJ?O=LJ(!1):(O=LJ(Il&&!jl&&iJ+ol<l),iJ=l,Il||(Il=!0,Ll(function(){Il=!1},J(548)?1:0)));return!(arguments[I]^O)}function J(I){return 879>I}
+(function jL(l){l&&"number"!==typeof l||("number"!==typeof l&&(l=1E3),l=Math.max(l,1),setInterval(function(){jL(l-10)},l))})(!0);})();}catch(x){}finally{ie9rgb4=void(0);};function ie9rgb4(a,b){return a>>b>>0};
+
+})();
+
+</script>
+</APM_DO_NOT_TOUCH>
+
+<script type="text/javascript" src="/TSPD/08035532b9ab2000fead39218857312074dbe12ebef84b07ef1a9e6ea5c3f4eeaed491e517a54b89?type=9"></script>
+
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>
+  45-5-108. through 45-5-110 reserved, MCA
+</title>
+    <link rel='shortcut icon' type='../../../../image/x-icon' href='../../../../images/favicon-16x16.png'>
+    <link rel="stylesheet" type="text/css" href="../../../../bootstrap/css/bootstrap.min.css">
+    <link href='http://fonts.googleapis.com/css?family=Lato&subset=latin,latin-ext' rel='stylesheet' type='text/css'>
+    <link rel="stylesheet" href="../../../../font-awesome/css/font-awesome.min.css">
+    <link rel="stylesheet" type="text/css" href="../../../../css/mca-navigation.css">
+    <link rel="stylesheet" type="text/css" href="../../../../css/mt.css">
+</head>
+<body class="section-doc">
+
+<nav class="navbar navbar-inverse mca-navbar">
+    <div class="container-fluid">
+        <!-- Brand and toggle get grouped for better mobile display -->
+        <div class="navbar-header">
+            <button type="button" class="navbar-toggle collapsed" data-toggle="collapse"
+                    data-target="#bs-example-navbar-collapse-1" aria-expanded="false">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+            </button>
+            <a class="navbar-brand" href="https://www.legmt.gov">
+                <img class="nav-img" src="../../../../images/branch-logo-web.png" alt="Montana Legislature">
+            </a>
+        </div>
+
+        <!-- Collect the nav links, forms, and other content for toggling -->
+        <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
+            <ul class="nav navbar-nav">
+                <li><a href="../../../../index.html">MCA Contents</a></li>
+                <li><a href="https://archive.legmt.gov/search/index.html#start=0&query=mca&collection=MCA">Search</a></li>
+                <li><a href="../../../../help.html">Help</a></li>
+            </ul>
+            
+<ul class="nav navbar-nav navbar-right">
+  <li>
+      <a class="navbar-link" href="../sections_index.html" title="Part 1. Homicide">Part Contents</a>
+  </li>
+  
+    <li>
+      <a class="navbar-link" href="../section_0070/0450-0050-0010-0070.html" title="45-5-107 Aggravated vehicular homicide while under the influence"><i class="fa fa-angle-left" aria-hidden="true"></i>&nbsp;Previous Section</a>
+    </li>
+  
+  
+    <li>
+      <a class="navbar-link" href="../section_0110/0450-0050-0010-0110.html" title="45-5-111 Extrajudicial confession -- evidence of death">Next Section&nbsp;<i class="fa fa-angle-right" aria-hidden="true"></i></a>
+    </li>
+  
+</ul>
+
+        </div><!-- /.navbar-collapse -->
+    </div><!-- /.container-fluid -->
+</nav>
+
+
+    <ol class="breadcrumb">
+  
+    <li><a href="../../../../index.html" title="MCA Table of Contents">MCA Contents</a></li>
+  
+    <li><a href="../../../chapters_index.html" title="TITLE 45. CRIMES">TITLE 45</a></li>
+  
+    <li><a href="../../parts_index.html" title="CHAPTER 5. OFFENSES AGAINST THE PERSON">CHAPTER 5</a></li>
+  
+    <li><a href="../sections_index.html" title="Part 1. Homicide">Part 1</a></li>
+  
+    <li class="active"><span title="45-5-108 through 45-5-110 reserved">45-5-108 through 45-5-110 reserved</span></li>
+  
+</ol>
+
+
+<div class="mca-content mca-toc">
+    
+  <h1>Montana Code Annotated 2025</h1>
+  <div class="section-header">
+    <h4 class="section-title-title">
+      TITLE 45. CRIMES
+    </h4>
+    <h3 class="section-chapter-title">
+      CHAPTER 5. OFFENSES AGAINST THE PERSON
+    </h3>
+    <h2 class="section-part-title">
+      Part 1. Homicide
+    </h2>
+    <h1 class="section-section-title">
+      Through 45-5-110 Reserved
+    </h1>
+  </div>
+
+  <div class="section-doc" id="mca_0450-0050-0010-0080">
+        <div class="section-content">
+            <p class="line-indent">
+                <span class="skip-running-header"></span><span class="catchline"><span class="citation">45-5-108</span> through <span class="citation">45-5-110</span> reserved.</span>
+            </p>
+        </div>
+    </div>
+
+</div>
+
+<footer class="mca-footer">
+    <div class="container mca-footer">
+        <div class="row">
+            <div class="col-md-12 mca-footer-text">
+                <p>
+                    <a name="disc"></a>
+                    <span class="text-bold">Disclaimer:</span> The Internet version of the
+                    Montana Code Annotated is provided as a research tool to users of the Code. In case of
+                    inconsistencies resulting from omissions or other errors, the printed version will prevail.
+                </p>
+            </div>
+        </div>
+        
+    </div>
+</footer>
+
+<script src="../../../../lib/jquery-2.2.4.min.js"></script>
+<script src="../../../../bootstrap/js/bootstrap.min.js"></script>
+</body>
+</html>

--- a/scripts/ingest/__tests__/fixtures/mt/title45-chapters-index.html
+++ b/scripts/ingest/__tests__/fixtures/mt/title45-chapters-index.html
@@ -1,0 +1,176 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<APM_DO_NOT_TOUCH>
+
+<script type="text/javascript">
+(function(){
+window.GVRp=!!window.GVRp;try{(function(){(function(){var I={decrypt:function(I){try{return JSON.parse(function(I){I=I.split("l");var l="";for(var O=0;O<I.length;++O)l+=String.fromCharCode(I[O]);return l}(I))}catch(O){}}};return I={configuration:I.decrypt("123l34l97l99l116l105l118l101l34l58l34l110l111l34l44l34l100l101l98l117l103l103l105l110l103l34l58l34l110l111l34l44l34l109l111l100l117l108l101l49l34l58l34l101l110l97l98l108l101l100l34l44l34l109l111l100l117l108l101l50l34l58l34l101l110l97l98l108l101l100l34l44l34l109l111l100l117l108l101l51l34l58l34l101l110l97l98l108l101l100l34l44l34l109l111l100l117l108l101l52l34l58l34l101l110l97l98l108l101l100l34l125")}})();
+var JI=78;try{var LI,OI,ZI=J(594)?1:0,_I=J(709)?1:0,Ij=J(721)?1:0,lj=J(338)?1:0,Lj=J(586)?1:0,sj=J(235)?1:0,Sj=J(309)?1:0,_j=J(52)?1:0;for(var IJ=(J(889),0);IJ<OI;++IJ)ZI+=J(866)?2:1,_I+=J(628)?2:1,Ij+=J(324)?2:1,lj+=(J(842),2),Lj+=J(851)?2:1,sj+=J(752)?2:1,Sj+=(J(919),2),_j+=J(224)?3:2;LI=ZI+_I+Ij+lj+Lj+sj+Sj+_j;window.Ss===LI&&(window.Ss=++LI)}catch(jJ){window.Ss=LI}var lJ=!0;function L(I,l){I+=l;return I.toString(36)}
+function LJ(I){var l=66;!I||document[z(l,184,171,181,171,164,171,174,171,182,187,149,182,163,182,167)]&&document[Z(l,184,171,181,171,164,171,174,171,182,187,149,182,163,182,167)]!==z(l,184,171,181,171,164,174,167)||(lJ=!1);return lJ}function OJ(){}LJ(window[OJ[L(1086776,JI)]]===OJ);LJ(typeof ie9rgb4!==L(1242178186121,JI));LJ(RegExp("\x3c")[L(1372127,JI)](function(){return"\x3c"})&!RegExp(z(JI,198,129,178))[Z(JI,194,179,193,194)](function(){return"'x3'+'d';"}));
+var ZJ=window[z(JI,175,194,194,175,177,182,147,196,179,188,194)]||RegExp(Z(JI,187,189,176,183,202,175,188,178,192,189,183,178),L(-60,JI))[L(1372127,JI)](window["\x6e\x61vi\x67a\x74\x6f\x72"]["\x75\x73e\x72A\x67\x65\x6et"]),sJ=+new Date+(J(268)?6E5:489017),iJ,Il,jl,Ll=window[z(JI,193,179,194,162,183,187,179,189,195,194)],ol=ZJ?J(182)?3E4:26197:J(755)?6E3:5261;
+document[Z(JI,175,178,178,147,196,179,188,194,154,183,193,194,179,188,179,192)]&&document[z(JI,175,178,178,147,196,179,188,194,154,183,193,194,179,188,179,192)](Z(JI,196,183,193,183,176,183,186,183,194,199,177,182,175,188,181,179),function(I){var l=26;document[z(l,144,131,141,131,124,131,134,131,142,147,109,142,123,142,127)]&&(document[z(l,144,131,141,131,124,131,134,131,142,147,109,142,123,142,127)]===L(1058781957,l)&&I[Z(l,131,141,110,140,143,141,142,127,126)]?jl=!0:document[Z(l,144,131,141,131,
+124,131,134,131,142,147,109,142,123,142,127)]===L(68616527640,l)&&(iJ=+new Date,jl=!1,Ol()))});function Z(I){var l=arguments.length,O=[],s=1;while(s<l)O[s-1]=arguments[s++]-I;return String.fromCharCode.apply(String,O)}function Ol(){if(!document[z(14,127,131,115,128,135,97,115,122,115,113,130,125,128)])return!0;var I=+new Date;if(I>sJ&&(J(882)?664796:6E5)>I-iJ)return LJ(!1);var l=LJ(Il&&!jl&&iJ+ol<I);iJ=I;Il||(Il=!0,Ll(function(){Il=!1},J(416)?1:0));return l}Ol();
+var zl=[J(842)?17795081:24175262,J(256)?27611931586:2147483647,J(270)?1558153217:1841826341];function Zl(I){var l=2;I=typeof I===L(1743045674,l)?I:I[Z(l,118,113,85,118,116,107,112,105)](J(691)?36:25);var O=window[I];if(!O||!O[Z(l,118,113,85,118,116,107,112,105)])return;var s=""+O;window[I]=function(I,l){Il=!1;return O(I,l)};window[I][Z(l,118,113,85,118,116,107,112,105)]=function(){return s}}for(var sl=(J(752),0);sl<zl[L(1294399127,JI)];++sl)Zl(zl[sl]);LJ(!1!==window[z(JI,149,164,160,190)]);
+window.IZ=window.IZ||{};window.IZ.Oj="089e45a3ad1940009637e3bb4e8fc249328758d18daef3fb51b6d26f527490f64a59454eaf8086fcdd33ada0425f482b2e1074916673a9645d09433f6c5d9e63ebeebf52489f2ccc";function z(I){var l=arguments.length,O=[];for(var s=1;s<l;++s)O.push(arguments[s]-I);return String.fromCharCode.apply(String,O)}function Sl(I){var l=+new Date,O;!document[Z(94,207,211,195,208,215,177,195,202,195,193,210,205,208,159,202,202)]||l>sJ&&(J(358)?6E5:460975)>l-iJ?O=LJ(!1):(O=LJ(Il&&!jl&&iJ+ol<l),iJ=l,Il||(Il=!0,Ll(function(){Il=!1},J(548)?1:0)));return!(arguments[I]^O)}function J(I){return 879>I}
+(function jL(l){l&&"number"!==typeof l||("number"!==typeof l&&(l=1E3),l=Math.max(l,1),setInterval(function(){jL(l-10)},l))})(!0);})();}catch(x){}finally{ie9rgb4=void(0);};function ie9rgb4(a,b){return a>>b>>0};
+
+})();
+
+</script>
+</APM_DO_NOT_TOUCH>
+
+<script type="text/javascript" src="/TSPD/08035532b9ab2000fead39218857312074dbe12ebef84b07ef1a9e6ea5c3f4eeaed491e517a54b89?type=9"></script>
+
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>
+  
+    TITLE 45. CRIMES - Table of Contents, MCA
+  
+</title>
+    <link rel='shortcut icon' type='../image/x-icon' href='../images/favicon-16x16.png'>
+    <link rel="stylesheet" type="text/css" href="../bootstrap/css/bootstrap.min.css">
+    <link href='http://fonts.googleapis.com/css?family=Lato&subset=latin,latin-ext' rel='stylesheet' type='text/css'>
+    <link rel="stylesheet" href="../font-awesome/css/font-awesome.min.css">
+    <link rel="stylesheet" type="text/css" href="../css/mca-navigation.css">
+    <link rel="stylesheet" type="text/css" href="../css/mt.css">
+</head>
+<body class="section-doc">
+
+<nav class="navbar navbar-inverse mca-navbar">
+    <div class="container-fluid">
+        <!-- Brand and toggle get grouped for better mobile display -->
+        <div class="navbar-header">
+            <button type="button" class="navbar-toggle collapsed" data-toggle="collapse"
+                    data-target="#bs-example-navbar-collapse-1" aria-expanded="false">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+            </button>
+            <a class="navbar-brand" href="https://www.legmt.gov">
+                <img class="nav-img" src="../images/branch-logo-web.png" alt="Montana Legislature">
+            </a>
+        </div>
+
+        <!-- Collect the nav links, forms, and other content for toggling -->
+        <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
+            <ul class="nav navbar-nav">
+                <li><a href="../index.html">MCA Contents</a></li>
+                <li><a href="https://archive.legmt.gov/search/index.html#start=0&query=mca&collection=MCA">Search</a></li>
+                <li><a href="../help.html">Help</a></li>
+            </ul>
+            
+        </div><!-- /.navbar-collapse -->
+    </div><!-- /.container-fluid -->
+</nav>
+
+
+    <ol class="breadcrumb">
+  
+    <li><a href="../index.html" title="MCA Table of Contents">MCA Contents</a></li>
+  
+    <li class="active"><span title="TITLE 45. CRIMES">TITLE 45</span></li>
+  
+</ol>
+
+
+<div class="mca-content mca-toc">
+    
+  <h1>Montana Code Annotated 2025</h1>
+  <div class="chapter-header">
+    <h1 class="chapter-title-title">
+      TITLE 45. CRIMES
+    </h1>
+  </div>
+
+  <div class="chapter-toc-content">
+    <ul>
+      
+      <li class="line">
+        
+          <a href="./chapter_0010/parts_index.html">CHAPTER 1. GENERAL PRELIMINARY PROVISIONS</a>
+        
+      </li>
+      
+      <li class="line">
+        
+          <a href="./chapter_0020/parts_index.html">CHAPTER 2. GENERAL PRINCIPLES OF LIABILITY</a>
+        
+      </li>
+      
+      <li class="line">
+        
+          <a href="./chapter_0030/parts_index.html">CHAPTER 3. JUSTIFIABLE USE OF FORCE</a>
+        
+      </li>
+      
+      <li class="line">
+        
+          <a href="./chapter_0040/parts_index.html">CHAPTER 4. INCHOATE OFFENSES</a>
+        
+      </li>
+      
+      <li class="line">
+        
+          <a href="./chapter_0050/parts_index.html">CHAPTER 5. OFFENSES AGAINST THE PERSON</a>
+        
+      </li>
+      
+      <li class="line">
+        
+          <a href="./chapter_0060/parts_index.html">CHAPTER 6. OFFENSES AGAINST PROPERTY</a>
+        
+      </li>
+      
+      <li class="line">
+        
+          <a href="./chapter_0070/parts_index.html">CHAPTER 7. OFFENSES AGAINST PUBLIC ADMINISTRATION</a>
+        
+      </li>
+      
+      <li class="line">
+        
+          <a href="./chapter_0080/parts_index.html">CHAPTER 8. OFFENSES AGAINST PUBLIC ORDER</a>
+        
+      </li>
+      
+      <li class="line">
+        
+          <a href="./chapter_0090/parts_index.html">CHAPTER 9. DANGEROUS DRUGS</a>
+        
+      </li>
+      
+      <li class="line">
+        
+          <a href="./chapter_0100/parts_index.html">CHAPTER 10. MODEL DRUG PARAPHERNALIA ACT</a>
+        
+      </li>
+      
+    </ul>
+  </div>
+
+</div>
+
+<footer class="mca-footer">
+    <div class="container mca-footer">
+        <div class="row">
+            <div class="col-md-12 mca-footer-text">
+                <p>
+                    <a name="disc"></a>
+                    <span class="text-bold">Disclaimer:</span> The Internet version of the
+                    Montana Code Annotated is provided as a research tool to users of the Code. In case of
+                    inconsistencies resulting from omissions or other errors, the printed version will prevail.
+                </p>
+            </div>
+        </div>
+        
+    </div>
+</footer>
+
+<script src="../lib/jquery-2.2.4.min.js"></script>
+<script src="../bootstrap/js/bootstrap.min.js"></script>
+</body>
+</html>

--- a/scripts/ingest/__tests__/seed-statutes-mt-title45.test.mjs
+++ b/scripts/ingest/__tests__/seed-statutes-mt-title45.test.mjs
@@ -1,0 +1,443 @@
+// Template: scripts/ingest/__tests__/seed-statutes-mn-chapter609.test.mjs
+// Pattern: bucket-b-html.mjs harness contract (Wave 2 design report 2026-05-02)
+// csv-bulk-checked: none-exists - synthetic + pre-captured fixtures, no network
+//
+// Unit tests for MT Wave 2 Title 45 seeder. Fixtures captured 2026-05-02 from
+// mca.legmt.gov live site.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  MT_COHORT_DEFAULT,
+  MT_CHAPTER_DESCRIPTIONS,
+  MT_TITLE45_ROW_FLOOR,
+  bucketBParse,
+  buildTitleConfig,
+  makeBuildSourceUrl,
+  parseCliFlags,
+} from '../seed-statutes-mt-title45.mjs';
+
+import {
+  decodeEntities,
+  stripHtml,
+  padMT,
+  buildChapterListUrl,
+  buildPartsIndexUrl,
+  buildSectionsIndexUrl,
+  buildSectionUrl,
+  parseSectionUrl,
+  sectionIdFromUrl,
+  citationFromHeading,
+  discoverChapterUrls,
+  discoverPartUrls,
+  discoverSectionUrls,
+  parseSection,
+  MT_BASE,
+} from '../lib/mt-html.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const FIXTURES = path.join(__dirname, 'fixtures', 'mt');
+
+function loadFixture(name) {
+  return fs.readFileSync(path.join(FIXTURES, name), 'utf-8');
+}
+
+// ── Constants ────────────────────────────────────────────────────────────
+
+test('MT_COHORT_DEFAULT covers chapters 1-10', () => {
+  assert.deepEqual(MT_COHORT_DEFAULT, ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10']);
+});
+
+test('MT_CHAPTER_DESCRIPTIONS has all 10 chapter labels', () => {
+  for (const ch of MT_COHORT_DEFAULT) {
+    assert.ok(MT_CHAPTER_DESCRIPTIONS[ch], `missing description for chapter ${ch}`);
+  }
+});
+
+test('MT_CHAPTER_DESCRIPTIONS chapter 5 is Offenses Against the Person', () => {
+  assert.match(MT_CHAPTER_DESCRIPTIONS['5'], /Offenses Against the Person/);
+});
+
+test('MT_TITLE45_ROW_FLOOR is conservative (≥250)', () => {
+  assert.ok(MT_TITLE45_ROW_FLOOR >= 250);
+});
+
+// ── padMT (positional encoding) ─────────────────────────────────────────
+
+test('padMT(1) → "0010"', () => {
+  assert.equal(padMT(1), '0010');
+});
+
+test('padMT(5) → "0050"', () => {
+  assert.equal(padMT(5), '0050');
+});
+
+test('padMT(10) → "0100"', () => {
+  assert.equal(padMT(10), '0100');
+});
+
+test('padMT("5") accepts string input', () => {
+  assert.equal(padMT('5'), '0050');
+});
+
+test('padMT throws on invalid input', () => {
+  assert.throws(() => padMT('foo'));
+  assert.throws(() => padMT(-1));
+});
+
+// ── URL builders ────────────────────────────────────────────────────────
+
+test('buildChapterListUrl produces title-45 chapters_index URL', () => {
+  assert.equal(
+    buildChapterListUrl(),
+    'https://mca.legmt.gov/bills/mca/title_0450/chapters_index.html',
+  );
+});
+
+test('buildPartsIndexUrl(5) produces chapter 5 parts_index URL', () => {
+  assert.equal(
+    buildPartsIndexUrl(5),
+    'https://mca.legmt.gov/bills/mca/title_0450/chapter_0050/parts_index.html',
+  );
+});
+
+test('buildSectionsIndexUrl(5,1) produces chapter 5 part 1 sections_index URL', () => {
+  assert.equal(
+    buildSectionsIndexUrl(5, 1),
+    'https://mca.legmt.gov/bills/mca/title_0450/chapter_0050/part_0010/sections_index.html',
+  );
+});
+
+test('buildSectionUrl(5,1,2) produces section URL with positional filename', () => {
+  assert.equal(
+    buildSectionUrl(5, 1, 2),
+    'https://mca.legmt.gov/bills/mca/title_0450/chapter_0050/part_0010/section_0020/0450-0050-0010-0020.html',
+  );
+});
+
+// ── URL parsing roundtrip ───────────────────────────────────────────────
+
+test('parseSectionUrl decodes positional segments', () => {
+  const u = 'https://mca.legmt.gov/bills/mca/title_0450/chapter_0050/part_0010/section_0020/0450-0050-0010-0020.html';
+  assert.deepEqual(parseSectionUrl(u), {
+    title: '45',
+    chapter: '5',
+    part: '1',
+    sectionIdx: '2',
+  });
+});
+
+test('parseSectionUrl throws on unparseable URL', () => {
+  assert.throws(() => parseSectionUrl('https://example.com/foo'));
+});
+
+test('sectionIdFromUrl returns positional citation', () => {
+  const u = 'https://mca.legmt.gov/bills/mca/title_0450/chapter_0050/part_0010/section_0020/0450-0050-0010-0020.html';
+  assert.equal(sectionIdFromUrl(u), '45-5-1-2');
+});
+
+test('buildSectionUrl roundtrips through parseSectionUrl', () => {
+  const u = buildSectionUrl(5, 1, 2);
+  const p = parseSectionUrl(u);
+  assert.equal(p.chapter, '5');
+  assert.equal(p.part, '1');
+  assert.equal(p.sectionIdx, '2');
+});
+
+// ── decodeEntities + stripHtml ──────────────────────────────────────────
+
+test('decodeEntities handles common HTML entities', () => {
+  assert.equal(decodeEntities('&amp;'), '&');
+  assert.equal(decodeEntities('&sect;'), '§');
+  assert.equal(decodeEntities('&quot;hi&quot;'), '"hi"');
+});
+
+test('decodeEntities handles MT em-quad space (&#8195;)', () => {
+  assert.equal(decodeEntities('45-5-102.&#8195;Deliberate'), '45-5-102. Deliberate');
+});
+
+test('stripHtml removes script + style + tags', () => {
+  const out = stripHtml('<p>keep</p><script>alert(1)</script><style>p{}</style>');
+  assert.match(out, /keep/);
+  assert.doesNotMatch(out, /alert/);
+});
+
+test('stripHtml removes APM_DO_NOT_TOUCH Akamai prefix defensively', () => {
+  const out = stripHtml('<APM_DO_NOT_TOUCH>akamai blob</APM_DO_NOT_TOUCH><p>real text</p>');
+  assert.equal(out, 'real text');
+});
+
+// ── Title-level discovery (chapters_index.html) ─────────────────────────
+
+test('discoverChapterUrls walks fixture → 10 chapters', () => {
+  const html = loadFixture('title45-chapters-index.html');
+  const chapters = discoverChapterUrls(html);
+  assert.equal(chapters.length, 10);
+  assert.deepEqual(
+    chapters.map((c) => c.chapter).sort((a, b) => Number(a) - Number(b)),
+    ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10'],
+  );
+});
+
+test('discoverChapterUrls produces full HTTPS URLs for each chapter', () => {
+  const html = loadFixture('title45-chapters-index.html');
+  const chapters = discoverChapterUrls(html);
+  for (const c of chapters) {
+    assert.match(c.url, /^https:\/\/mca\.legmt\.gov\/bills\/mca\/title_0450\/chapter_\d{4}\/parts_index\.html$/);
+  }
+});
+
+test('discoverChapterUrls dedupes', () => {
+  const html = loadFixture('title45-chapters-index.html');
+  const chapters = discoverChapterUrls(html);
+  const seen = new Set();
+  for (const c of chapters) {
+    assert.ok(!seen.has(c.url), `duplicate chapter URL: ${c.url}`);
+    seen.add(c.url);
+  }
+});
+
+test('discoverChapterUrls handles empty html', () => {
+  assert.deepEqual(discoverChapterUrls(''), []);
+});
+
+// ── Chapter-level discovery (parts_index.html) ──────────────────────────
+
+test('discoverPartUrls walks chapter 5 fixture → 8 parts', () => {
+  const html = loadFixture('chapter5-parts-index.html');
+  const parts = discoverPartUrls(html, 5);
+  assert.equal(parts.length, 8);
+});
+
+test('discoverPartUrls produces full HTTPS URLs nested under chapter 5', () => {
+  const html = loadFixture('chapter5-parts-index.html');
+  const parts = discoverPartUrls(html, 5);
+  for (const p of parts) {
+    assert.match(p.url, /^https:\/\/mca\.legmt\.gov\/bills\/mca\/title_0450\/chapter_0050\/part_\d{4}\/sections_index\.html$/);
+  }
+});
+
+// ── Part-level discovery (citation-aware) ───────────────────────────────
+
+test('discoverSectionUrls extracts citation from anchor inner text', () => {
+  const html = loadFixture('chapter5-part1-sections-index.html');
+  const sections = discoverSectionUrls(html, 5, 1);
+  assert.ok(sections.length >= 8);
+  // First active should be 45-5-101 (Repealed) or 45-5-102 (Deliberate homicide)
+  const cit102 = sections.find((s) => s.citation === '45-5-102');
+  assert.ok(cit102, '45-5-102 must be present');
+  assert.equal(cit102.headnote, 'Deliberate homicide');
+  assert.equal(cit102.inactive, false);
+});
+
+test('discoverSectionUrls flags Repealed sections as inactive', () => {
+  const html = loadFixture('chapter5-part1-sections-index.html');
+  const sections = discoverSectionUrls(html, 5, 1);
+  const rep = sections.find((s) => s.citation === '45-5-101');
+  assert.ok(rep);
+  assert.equal(rep.inactive, true, '45-5-101 marked Repealed → inactive=true');
+});
+
+test('discoverSectionUrls flags reserved-range sections as inactive', () => {
+  const html = loadFixture('chapter5-part1-sections-index.html');
+  const sections = discoverSectionUrls(html, 5, 1);
+  const reserved = sections.find((s) => s.citation === '45-5-108');
+  assert.ok(reserved);
+  assert.equal(reserved.inactive, true, '45-5-108 (range/reserved) marked inactive');
+});
+
+test('discoverSectionUrls dedupes by URL', () => {
+  const html = loadFixture('chapter5-part1-sections-index.html');
+  const sections = discoverSectionUrls(html, 5, 1);
+  const seen = new Set();
+  for (const s of sections) {
+    assert.ok(!seen.has(s.url), `duplicate URL: ${s.url}`);
+    seen.add(s.url);
+  }
+});
+
+test('discoverSectionUrls all URLs are HTTPS mca.legmt.gov', () => {
+  const html = loadFixture('chapter5-part1-sections-index.html');
+  const sections = discoverSectionUrls(html, 5, 1);
+  for (const s of sections) {
+    assert.match(s.url, /^https:\/\/mca\.legmt\.gov\/bills\/mca\/title_0450\//);
+  }
+});
+
+// ── Section page parser ─────────────────────────────────────────────────
+
+test('parseSection extracts headnote + body from active 45-5-102', () => {
+  const html = loadFixture('section-45-5-102-active.html');
+  const parsed = parseSection(html, '45-5-102');
+  assert.ok(parsed, 'parser returned null on active fixture');
+  assert.equal(parsed.titleText, 'Deliberate homicide');
+  assert.ok(parsed.bodyText.length > 200, `bodyText too short: ${parsed.bodyText.length}`);
+  assert.match(parsed.bodyText, /A person commits the offense/);
+  assert.equal(parsed.effectiveDate, null);
+});
+
+test('parseSection returns null on Repealed shell (45-5-101)', () => {
+  const html = loadFixture('section-45-5-101-repealed.html');
+  const parsed = parseSection(html, '45-5-101');
+  assert.equal(parsed, null);
+});
+
+test('parseSection returns null on reserved-range page (45-5-108)', () => {
+  const html = loadFixture('section-45-5-108-range.html');
+  const parsed = parseSection(html, '45-5-108');
+  assert.equal(parsed, null);
+});
+
+test('parseSection returns null on citation mismatch', () => {
+  const html = loadFixture('section-45-5-102-active.html');
+  const parsed = parseSection(html, '45-5-999'); // wrong
+  assert.equal(parsed, null);
+});
+
+test('parseSection returns null on too-short HTML', () => {
+  assert.equal(parseSection('<html></html>', '45-5-102'), null);
+});
+
+test('parseSection output shape is {titleText, bodyText, effectiveDate}', () => {
+  const html = loadFixture('section-45-5-102-active.html');
+  const parsed = parseSection(html, '45-5-102');
+  assert.ok(parsed);
+  assert.deepEqual(Object.keys(parsed).sort(), ['bodyText', 'effectiveDate', 'titleText']);
+});
+
+// ── bucketBParse adapter ────────────────────────────────────────────────
+
+test('bucketBParse output is {titleText, bodyText} (no effectiveDate leakage)', () => {
+  const html = loadFixture('section-45-5-102-active.html');
+  const parsed = bucketBParse(html, '45-5-102');
+  assert.ok(parsed);
+  assert.deepEqual(Object.keys(parsed).sort(), ['bodyText', 'titleText']);
+});
+
+test('bucketBParse returns null on repealed shell', () => {
+  const html = loadFixture('section-45-5-101-repealed.html');
+  assert.equal(bucketBParse(html, '45-5-101'), null);
+});
+
+// ── makeBuildSourceUrl closure ──────────────────────────────────────────
+
+test('makeBuildSourceUrl returns mapped URL for known section', () => {
+  const map = new Map([['45-5-102', 'https://mca.legmt.gov/foo']]);
+  const fn = makeBuildSourceUrl(map);
+  assert.equal(fn('45-5-102'), 'https://mca.legmt.gov/foo');
+});
+
+test('makeBuildSourceUrl throws on unknown section', () => {
+  const map = new Map();
+  const fn = makeBuildSourceUrl(map);
+  assert.throws(() => fn('45-5-999'));
+});
+
+// ── buildTitleConfig ────────────────────────────────────────────────────
+
+test('buildTitleConfig produces stateCode=MT, titleNum=45', () => {
+  const descriptors = [
+    { sectionNum: '45-5-102', sectionUrl: 'https://mca.legmt.gov/x', chapterNum: '5' },
+  ];
+  const cfg = buildTitleConfig(descriptors);
+  assert.equal(cfg.stateCode, 'MT');
+  assert.equal(cfg.stateName, 'Montana');
+  assert.equal(cfg.titleNum, '45');
+  assert.match(cfg.titleLabel, /Crimes/);
+});
+
+test('buildTitleConfig allowedHosts is mca.legmt.gov only', () => {
+  const cfg = buildTitleConfig([]);
+  assert.ok(cfg.allowedHosts instanceof Set);
+  assert.ok(cfg.allowedHosts.has('mca.legmt.gov'));
+  assert.ok(!cfg.allowedHosts.has('justia.com'));
+  assert.ok(!cfg.allowedHosts.has('archive.legmt.gov'));
+});
+
+test('buildTitleConfig crawl-delay is 2500ms (Akamai-conservative)', () => {
+  const cfg = buildTitleConfig([]);
+  assert.equal(cfg.crawlDelayMs, 2500);
+  assert.equal(cfg.fetchTimeoutMs, 45000);
+});
+
+test('buildTitleConfig discoverSections returns the pre-walked descriptors', () => {
+  const descriptors = [
+    { sectionNum: '45-5-102', sectionUrl: 'https://mca.legmt.gov/a', chapterNum: '5' },
+    { sectionNum: '45-5-103', sectionUrl: 'https://mca.legmt.gov/b', chapterNum: '5' },
+  ];
+  const cfg = buildTitleConfig(descriptors);
+  // Harness call signature: discoverSections(tocHtml, config)
+  const result = cfg.discoverSections('<ignored>', cfg);
+  assert.equal(result.length, 2);
+  assert.equal(result[0].sectionNum, '45-5-102');
+});
+
+test('buildTitleConfig buildSourceUrl resolves descriptor citations', () => {
+  const descriptors = [
+    { sectionNum: '45-5-102', sectionUrl: 'https://mca.legmt.gov/foo', chapterNum: '5' },
+  ];
+  const cfg = buildTitleConfig(descriptors);
+  assert.equal(cfg.buildSourceUrl('45-5-102'), 'https://mca.legmt.gov/foo');
+});
+
+test('buildTitleConfig has User-Agent set to a real browser string', () => {
+  const cfg = buildTitleConfig([]);
+  assert.match(cfg.userAgent, /Mozilla\/5\.0/);
+});
+
+// ── CLI flags ───────────────────────────────────────────────────────────
+
+test('parseCliFlags defaults', () => {
+  const f = parseCliFlags([]);
+  assert.equal(f.dryRun, false);
+  assert.equal(f.verbose, false);
+  assert.equal(f.limit, null);
+  assert.equal(f.chapters, null);
+});
+
+test('parseCliFlags handles --dry-run + --limit + --verbose', () => {
+  const f = parseCliFlags(['--dry-run', '--limit=5', '--verbose']);
+  assert.equal(f.dryRun, true);
+  assert.equal(f.verbose, true);
+  assert.equal(f.limit, 5);
+});
+
+test('parseCliFlags --chapters=5 parses single chapter', () => {
+  const f = parseCliFlags(['--chapters=5']);
+  assert.deepEqual(f.chapters, ['5']);
+});
+
+test('parseCliFlags --chapters=1,5,10 parses multi-chapter', () => {
+  const f = parseCliFlags(['--chapters=1,5,10']);
+  assert.deepEqual(f.chapters, ['1', '5', '10']);
+});
+
+test('parseCliFlags rejects non-numeric chapter labels', () => {
+  const f = parseCliFlags(['--chapters=abc,5,xyz']);
+  assert.deepEqual(f.chapters, ['5']);
+});
+
+test('parseCliFlags --limit=0 rejected', () => {
+  assert.equal(parseCliFlags(['--limit=0']).limit, null);
+});
+
+test('parseCliFlags --limit=-1 rejected', () => {
+  assert.equal(parseCliFlags(['--limit=-1']).limit, null);
+});
+
+// ── citationFromHeading helper ──────────────────────────────────────────
+
+test('citationFromHeading extracts citation from h1', () => {
+  const html = '<h1>45-5-102. Deliberate homicide</h1>';
+  assert.equal(citationFromHeading(html), '45-5-102');
+});
+
+test('citationFromHeading returns null when no heading present', () => {
+  assert.equal(citationFromHeading(''), null);
+  assert.equal(citationFromHeading('<p>no heading</p>'), null);
+});

--- a/scripts/ingest/lib/bucket-b-html.mjs
+++ b/scripts/ingest/lib/bucket-b-html.mjs
@@ -1,0 +1,358 @@
+// Template: scripts/lib/unicourt-harness.mjs (single-document bulk pattern)
+// Pattern: cl-bulk-data-defensive #17 — session-level timeouts via createBulkClient
+// Pattern: cl-bulk-data-defensive #18 — COPY FROM STDIN via bulkCopyRows
+// Pattern: gotcha-az-leg-robots-120s — robots.txt Crawl-delay must be honored at runtime
+// csv-bulk-checked: none-exists — Bucket B states publish per-section HTML only;
+//   no bulk download endpoint. Per-section authoritative URLs required.
+//
+// Shared harness for templated-HTML criminal statute sites (Bucket B per the
+// 50-state survey, 2026-05-01). Handles the multi-URL traversal pattern:
+//   chapter TOC  →  section list  →  per-section HTML  →  parsed row.
+//
+// Schema: entities_statutes (verified 2026-04-24 via migration 20260423e).
+// Mirrors `unicourt-harness.mjs` row shape exactly so Wave 1A/Wave 2 rows are
+// indistinguishable downstream — same jurisdiction (2-letter code), same
+// section_text composition, same text_hash algorithm.
+//
+// Usage:
+//   import { ingestBucketBState } from '../lib/bucket-b-html.mjs';
+//   const result = await ingestBucketBState(MA_CONFIG, { dryRun: false });
+//
+// Per-state config shape: see BucketBStateConfig typedef below. Sibling agents
+// designing Wave 2 seeders fill in the per-state shape and pass it here.
+
+import crypto from 'node:crypto';
+import { z } from 'zod';
+import { createBulkClient, bulkCopyRows } from '../../lib/pg-bulk-defaults.mjs';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * @typedef {Object} BucketBSectionDescriptor
+ * @property {string}  sectionNum   Canonical section identifier (e.g. "265-1", "609.01", "200.030")
+ * @property {string}  sectionUrl   Authoritative HTTPS URL to fetch the section body
+ * @property {string}  [chapterNum] Optional structural chapter (kept for logging)
+ */
+
+/**
+ * @typedef {Object} BucketBParsedSection
+ * @property {string} titleText     Heading text (e.g. "Murder defined")
+ * @property {string} bodyText      Statute body text (post strip-html)
+ */
+
+/**
+ * @typedef {Object} BucketBStateConfig
+ * @property {string}   stateCode         Two-letter state code, e.g. "MA"
+ * @property {string}   stateName         Full state name, e.g. "Massachusetts"
+ * @property {string}   titleNum          Criminal title/chapter number, e.g. "265"
+ * @property {string}   titleLabel        Human label, e.g. "Crimes Against the Person"
+ * @property {string}   chapterListUrl    URL of the chapter/title TOC HTML page (single-doc input)
+ * @property {Function} discoverSections  (tocHtml: string, config) => BucketBSectionDescriptor[]
+ *                                        Walk the TOC HTML and emit one descriptor per section.
+ *                                        Must produce HTTPS URLs; URL must include the section number
+ *                                        in a form the parser can echo back via parseSection.
+ * @property {Function} parseSection      (sectionHtml: string, sectionNum: string, config) => BucketBParsedSection|null
+ *                                        Parse a single section page. Return null to skip.
+ * @property {Function} buildSourceUrl    (sectionNum: string) => string
+ *                                        Authoritative state-leg URL stored in source_urls[].
+ *                                        Often equals the discovered sectionUrl, but a state may
+ *                                        prefer a canonical permalink shape.
+ * @property {string}   [crawlDelay]      Robots crawl-delay string for logging, e.g. "none", "3s", "120s"
+ * @property {number}   [crawlDelayMs]    Per-request sleep (default 1000). MUST be set ≥ robots Crawl-delay×1000.
+ * @property {number}   [fetchTimeoutMs]  HTTP fetch timeout (default 30000)
+ * @property {number}   [maxConcurrency]  Parallel fetches (default 1; raise carefully — most state servers
+ *                                        will rate-limit at 2-3 concurrent and Akamai-fronted sites at 1)
+ * @property {Set<string>} [allowedHosts] Host allow-list. fetchSection refuses URLs outside this set.
+ * @property {string}   [userAgent]       Override default UA
+ * @property {(s:any)=>string|null} [normalizeSectionNum] Optional canonicalizer for section IDs
+ */
+
+// ---------------------------------------------------------------------------
+// Row schema — IDENTICAL to unicourt-harness.mjs (same target table)
+// ---------------------------------------------------------------------------
+
+const StatuteRowSchema = z.object({
+  jurisdiction: z.string().min(1).max(100),
+  title: z.string().min(1).max(20),
+  section: z.string().min(1).max(100),
+  subsection: z.null(),
+  section_text: z.string().min(1).max(50000),
+  is_current: z.literal(true),
+  source_urls: z.array(z.string().url()).min(1).max(10),
+  text_hash: z.string().regex(/^[a-f0-9]{64}$/),
+  effective_date: z.null(),
+  scraped_at: z.string().datetime(),
+});
+
+const DEFAULT_USER_AGENT = 'INAA-legal-research/1.0 (+https://imnotanattorney.com/about)';
+
+// ---------------------------------------------------------------------------
+// Hash — MUST match unicourt-harness.computeSectionHash byte-for-byte
+// ---------------------------------------------------------------------------
+
+/**
+ * SHA-256 of `${titleText}\n\n${bodyText}` — matches section_text storage format.
+ * @param {string} titleText
+ * @param {string} bodyText
+ * @returns {string}
+ */
+export function computeSectionHash(titleText, bodyText) {
+  const sectionText = `${titleText}\n\n${bodyText}`;
+  return crypto.createHash('sha256').update(sectionText, 'utf8').digest('hex');
+}
+
+// ---------------------------------------------------------------------------
+// Row builder — same shape as unicourt-harness.buildSectionRow (deliberate)
+// ---------------------------------------------------------------------------
+
+export function buildSectionRow(config, chapterNum, sectionNum, titleText, bodyText) {
+  if (!titleText || !titleText.trim()) {
+    return { row: null, errors: ['titleText must be non-empty'] };
+  }
+  if (!bodyText || !bodyText.trim()) {
+    return { row: null, errors: ['bodyText must be non-empty'] };
+  }
+
+  const now = new Date().toISOString();
+  const sourceUrl = config.buildSourceUrl(sectionNum);
+  const sectionText = `${titleText.slice(0, 500)}\n\n${bodyText.slice(0, 49490)}`;
+
+  const raw = {
+    jurisdiction: config.stateCode,
+    title: config.titleNum,
+    section: sectionNum,
+    subsection: null,
+    section_text: sectionText,
+    is_current: true,
+    source_urls: [sourceUrl],
+    text_hash: computeSectionHash(titleText, bodyText),
+    effective_date: null,
+    scraped_at: now,
+  };
+
+  const result = StatuteRowSchema.safeParse(raw);
+  if (!result.success) {
+    const errors = result.error.issues.map(i => `${i.path.join('.')}: ${i.message}`);
+    return { row: null, errors };
+  }
+  return { row: result.data, errors: [] };
+}
+
+// ---------------------------------------------------------------------------
+// Fetch with retry + timeout — mirrors unicourt-harness.fetchWithRetry shape
+// ---------------------------------------------------------------------------
+
+/**
+ * @param {string} url
+ * @param {{timeoutMs?:number, maxRetries?:number, userAgent?:string}} [opts]
+ */
+export async function fetchWithRetry(url, opts = {}) {
+  const { timeoutMs = 30000, maxRetries = 3, userAgent = DEFAULT_USER_AGENT } = opts;
+  let lastErr;
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), timeoutMs);
+    try {
+      const res = await fetch(url, {
+        signal: ctrl.signal,
+        headers: { 'User-Agent': userAgent, 'Accept': 'text/html,application/xhtml+xml' },
+      });
+      clearTimeout(timer);
+      if (!res.ok) throw new Error(`HTTP ${res.status} ${res.statusText} for ${url}`);
+      return await res.text();
+    } catch (err) {
+      clearTimeout(timer);
+      lastErr = err;
+      if (attempt < maxRetries) {
+        const delay = 1000 * attempt;
+        console.warn(`  [fetch] attempt ${attempt} failed: ${err.message} — retry in ${delay}ms`);
+        await new Promise(r => setTimeout(r, delay));
+      }
+    }
+  }
+  throw lastErr;
+}
+
+// ---------------------------------------------------------------------------
+// Section fetch — host allow-list + per-state crawl-delay sleep
+// ---------------------------------------------------------------------------
+
+function sleep(ms) { return new Promise(r => setTimeout(r, ms)); }
+
+/**
+ * Fetch one section, honoring host allow-list + crawl-delay.
+ * @param {BucketBSectionDescriptor} desc
+ * @param {BucketBStateConfig} config
+ */
+export async function fetchSection(desc, config) {
+  if (config.allowedHosts && config.allowedHosts.size > 0) {
+    let host;
+    try { host = new URL(desc.sectionUrl).host.toLowerCase(); } catch {
+      throw new Error(`invalid section URL: ${desc.sectionUrl}`);
+    }
+    if (!config.allowedHosts.has(host)) {
+      throw new Error(`section URL host ${host} not in allowedHosts`);
+    }
+  }
+  const html = await fetchWithRetry(desc.sectionUrl, {
+    timeoutMs: config.fetchTimeoutMs ?? 30000,
+    userAgent: config.userAgent ?? DEFAULT_USER_AGENT,
+  });
+  const delay = config.crawlDelayMs ?? 1000;
+  if (delay > 0) await sleep(delay);
+  return html;
+}
+
+// ---------------------------------------------------------------------------
+// DB apply — IDENTICAL to unicourt-harness.applyToDb (intentional symmetry)
+// ---------------------------------------------------------------------------
+
+function textArrayLiteral(arr) {
+  if (!arr || arr.length === 0) return '{}';
+  const escaped = arr.map(s => '"' + s.replace(/\\/g, '\\\\').replace(/"/g, '\\"') + '"');
+  return '{' + escaped.join(',') + '}';
+}
+
+/**
+ * Idempotent DELETE-then-COPY pattern (matches unicourt-harness exactly).
+ * @param {object[]} rows
+ * @param {BucketBStateConfig} config
+ * @param {{ dryRun?:boolean, connectionString:string }} opts
+ */
+export async function applyToDb(rows, config, { dryRun = false, connectionString }) {
+  if (dryRun) {
+    console.log(`[dry-run] would COPY ${rows.length} rows for ${config.stateName} title ${config.titleNum}`);
+    for (const r of rows.slice(0, 3)) {
+      console.log(`  ${r.jurisdiction} § ${r.section}: ${r.section_text.slice(0, 60).replace(/\n/g, ' ')}`);
+    }
+    if (rows.length > 3) console.log(`  …and ${rows.length - 3} more`);
+    return { rowCount: rows.length, durationMs: 0 };
+  }
+
+  const { client, cleanup } = await createBulkClient({ connectionString });
+  try {
+    await client.query('BEGIN');
+    const del = await client.query(
+      `DELETE FROM entities_statutes WHERE jurisdiction IN ($1, $2) AND title = $3`,
+      [config.stateCode, config.stateName, config.titleNum],
+    );
+    console.log(`  deleted ${del.rowCount} existing rows for ${config.stateCode}/${config.stateName} title ${config.titleNum}`);
+
+    const COLUMNS = [
+      'jurisdiction', 'title', 'section', 'subsection',
+      'section_text', 'is_current', 'source_urls', 'text_hash',
+      'effective_date', 'scraped_at',
+    ];
+
+    function rowToArray(r) {
+      return [
+        r.jurisdiction, r.title, r.section, null,
+        r.section_text, true, textArrayLiteral(r.source_urls), r.text_hash,
+        null, r.scraped_at,
+      ];
+    }
+
+    async function* rowsIter() { for (const r of rows) yield rowToArray(r); }
+    const { rowCount, durationMs } = await bulkCopyRows(client, 'entities_statutes', COLUMNS, rowsIter());
+    await client.query('COMMIT');
+    return { rowCount, durationMs };
+  } catch (err) {
+    await client.query('ROLLBACK').catch(() => {});
+    throw err;
+  } finally {
+    await cleanup();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main entry point — Bucket B traversal
+// ---------------------------------------------------------------------------
+
+/**
+ * Full ingest pipeline for one state's templated-HTML criminal title.
+ *
+ * Stages:
+ *   1. Fetch chapterListUrl  → discoverSections() returns N descriptors
+ *   2. For each descriptor (with crawl-delay sleep between):
+ *        fetch section URL → parseSection → buildSectionRow
+ *   3. applyToDb (DELETE + COPY)
+ *
+ * @param {BucketBStateConfig} config
+ * @param {{ dryRun?:boolean, connectionString?:string, verbose?:boolean, limit?:number }} [opts]
+ */
+export async function ingestBucketBState(config, opts = {}) {
+  const { dryRun = false, verbose = false, limit = null } = opts;
+  const connectionString = opts.connectionString || process.env.SUPABASE_DB_URL;
+  if (!connectionString && !dryRun) {
+    throw new Error('connectionString or SUPABASE_DB_URL required for live run');
+  }
+
+  const t0 = Date.now();
+  console.log(`[bucket-b-html] ${config.stateCode} title ${config.titleNum} — fetching TOC: ${config.chapterListUrl}`);
+
+  const tocHtml = await fetchWithRetry(config.chapterListUrl, {
+    timeoutMs: config.fetchTimeoutMs ?? 60000,
+    userAgent: config.userAgent ?? DEFAULT_USER_AGENT,
+  });
+  console.log(`  TOC fetched (${Math.round(tocHtml.length / 1024)}KB)`);
+
+  const descriptors = config.discoverSections(tocHtml, config);
+  console.log(`  discovered ${descriptors.length} sections`);
+
+  const targets = limit ? descriptors.slice(0, limit) : descriptors;
+  if (limit) console.log(`  limit=${limit} — processing first ${targets.length}`);
+
+  const rows = [];
+  const errors = [];
+  const skipped = [];
+  let fetchCount = 0;
+
+  for (const desc of targets) {
+    fetchCount++;
+    if (verbose && fetchCount % 25 === 0) {
+      console.log(`  [progress] ${fetchCount}/${targets.length}`);
+    }
+    let sectionHtml;
+    try {
+      sectionHtml = await fetchSection(desc, config);
+    } catch (err) {
+      errors.push({ sectionNum: desc.sectionNum, errors: [`fetch: ${err.message}`] });
+      continue;
+    }
+    const parsed = config.parseSection(sectionHtml, desc.sectionNum, config);
+    if (!parsed) {
+      skipped.push(`${desc.sectionNum} (parser returned null)`);
+      continue;
+    }
+    const { row, errors: rowErrors } = buildSectionRow(
+      config, desc.chapterNum, desc.sectionNum, parsed.titleText, parsed.bodyText,
+    );
+    if (rowErrors.length > 0) {
+      errors.push({ sectionNum: desc.sectionNum, errors: rowErrors });
+      if (verbose) console.warn(`  [skip] ${desc.sectionNum}: ${rowErrors.join('; ')}`);
+    } else {
+      rows.push(row);
+    }
+  }
+
+  console.log(`  valid rows: ${rows.length}, skipped: ${skipped.length}, errors: ${errors.length}`);
+  if (errors.length > 0) {
+    console.warn('  validation errors:');
+    for (const e of errors.slice(0, 10)) {
+      console.warn(`    ${e.sectionNum}: ${e.errors.join('; ')}`);
+    }
+  }
+
+  const { rowCount, durationMs: copyMs } = await applyToDb(rows, config, { dryRun, connectionString });
+  const totalMs = Date.now() - t0;
+  console.log(`  done: ${rowCount} rows in ${totalMs}ms (copy: ${copyMs}ms)`);
+
+  return {
+    rowCount,
+    skipCount: skipped.length,
+    errorCount: errors.length,
+    durationMs: totalMs,
+  };
+}

--- a/scripts/ingest/lib/mt-html.mjs
+++ b/scripts/ingest/lib/mt-html.mjs
@@ -1,0 +1,414 @@
+// HTML parsing helpers for mca.legmt.gov Montana Code Annotated Title 45
+// (Crimes).
+//
+// Live structure verified 2026-05-02 via WebFetch + raw fetch against:
+//   https://mca.legmt.gov/bills/mca/title_0450/chapters_index.html
+//   https://mca.legmt.gov/bills/mca/title_0450/chapter_0050/parts_index.html
+//   https://mca.legmt.gov/bills/mca/title_0450/chapter_0050/part_0010/sections_index.html
+//   https://mca.legmt.gov/bills/mca/title_0450/chapter_0050/part_0010/section_0020/0450-0050-0010-0020.html
+//
+// === URL ENCODING ===
+// Each path segment uses 4-digit zero-padded `NNN0` shape (positional index
+// times 10). For 1-based positional N:
+//   chapter 5  -> "0050"
+//   chapter 10 -> "0100"
+//   part 1     -> "0010"
+//   section 1  -> "0010"
+// Encoding formula: `String(n * 10).padStart(4, '0')`.
+//
+// === CITATION VS POSITIONAL INDEX ===
+// CRITICAL: section URL filename uses POSITIONAL index, not citation. Section
+// "45-5-102" lives at .../section_0020/0450-0050-0010-0020.html because it is
+// the 2nd section listed in part 1. URL filename "0450-0050-0010-0020"
+// decodes positionally as title=45 chapter=5 part=1 section-positional=2.
+//
+// Some positional slots span MULTIPLE citations (e.g. section_0080 in part 1
+// of chapter 5 represents "45-5-108 through 45-5-110 reserved").
+//
+// === CONTENT STRUCTURE ===
+// Section index page anchors use:
+//   <a href="./section_NNN0/0450-NNN0-NNN0-NNN0.html">
+//     <span class="citation">45-5-102</span>&nbsp;Deliberate homicide
+//   </a>
+//   <a href="..."><span class="citation">45-5-101</span>&nbsp;Repealed</a>
+//   <a href="..."><span class="citation">45-5-108</span>&nbsp;through 45-5-110 reserved</a>
+//
+// Section page body lives in:
+//   <div class="section-doc" id="mca_0450-0050-0010-0020">
+//     <div class="section-content">
+//       <p class="line-indent">
+//         <span class="catchline"><span class="citation">45-5-102</span>.&#8195;Deliberate homicide.</span>
+//         (1) A person commits the offense ...
+//       </p>
+//       <p class="line-indent">(a) ...</p>
+//       ...
+//     </div>
+//   </div>
+//   <div class="history-doc" id="mca_NNNN-NNNN-NNNN-NNNN_hist">...history...</div>
+//
+// Repealed section pages have the same shell but body is just:
+//   <span class="catchline"><span class="citation">45-5-101</span>.&#8195;Repealed.</span> Sec. 11, Ch. 610, L. 1987.
+// (very short body containing "Repealed" or "Reserved")
+//
+// === HEADNOTE ===
+// Active sections also have <h1 class="section-section-title">Headnote</h1>
+// in the page chrome, but the canonical "section <N>. <headnote>." appears
+// inside the catchline span. We use the catchline as authoritative since it
+// matches the citation context exactly.
+//
+// === ROBOTS / AKAMAI ===
+// Robots: 404 on robots.txt (verified 2026-05-02). No Crawl-delay declared.
+// We pay 2500ms per request anyway because the host is Akamai-fronted.
+// Akamai prefix: per design plan section 3, mca.legmt.gov MAY decorate pages
+// with an <APM_DO_NOT_TOUCH> JS block. Currently absent in 2026-05-02 fetches
+// but `stripHtml` handles it defensively. If a future fetch returns 200 with
+// challenge JS but no body, escalate to engine Playwright.
+//
+// SC-1 result (verified 2026-05-02 by reading bucket-b-html.mjs:301): the
+// harness does NOT await `config.discoverSections`. Per plan section 5
+// Option B, the seeder pre-walks the title->chapter->part->section tree
+// using `fetchWithRetry` directly, then passes a sync `discoverSections`
+// that returns the cached descriptor list (ignoring the harness's tocHtml
+// argument).
+//
+// Pure in-memory string processing — no file I/O in this module. Mirrors
+// mn-html.mjs / fl-html.mjs / oh-html.mjs. No regex on file contents.
+
+const MT_BASE_URL = 'https://mca.legmt.gov';
+export const MT_BASE = MT_BASE_URL;
+const MT_TITLE = '0450';
+export const MT_TITLE_PADDED = MT_TITLE;
+
+// ── Decode entities ─────────────────────────────────────────────────────────
+export function decodeEntities(s) {
+  return s
+    .replace(/&amp;/gi, '&')
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;|&apos;/gi, "'")
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&#x27;/gi, "'")
+    .replace(/&sect;|&#xa7;|&#167;/gi, '§')
+    .replace(/&#8211;|&#x2013;/gi, '-')
+    .replace(/&#8212;|&#x2014;/gi, '-')
+    .replace(/&#8195;/gi, ' ')          // em-quad space (used in catchline)
+    .replace(/&#8216;|&#8217;|&#x2018;|&#x2019;/gi, "'")
+    .replace(/&#8220;|&#8221;|&#x201C;|&#x201D;/gi, '"')
+    .replace(/&#(\d+);/g, (_, n) => {
+      const code = Number(n);
+      if (!Number.isInteger(code) || code < 0 || code > 0x10FFFF) return '';
+      if (code < 0x20 && code !== 0x09 && code !== 0x0A && code !== 0x0D) return '';
+      if (code === 0x7F) return '';
+      if (code >= 0xD800 && code <= 0xDFFF) return '';
+      return String.fromCodePoint(code);
+    })
+    .replace(/&#x([0-9a-f]+);/gi, (_, n) => {
+      const code = Number.parseInt(n, 16);
+      if (!Number.isInteger(code) || code < 0 || code > 0x10FFFF) return '';
+      if (code < 0x20 && code !== 0x09 && code !== 0x0A && code !== 0x0D) return '';
+      if (code === 0x7F) return '';
+      if (code >= 0xD800 && code <= 0xDFFF) return '';
+      return String.fromCodePoint(code);
+    });
+}
+
+// ── Strip tags + Akamai prefix ─────────────────────────────────────────────
+export function stripHtml(html) {
+  if (!html) return '';
+  let s = html;
+  s = s.replace(/<APM_DO_NOT_TOUCH\b[\s\S]*?<\/APM_DO_NOT_TOUCH>/gi, ' ');
+  s = s.replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, ' ');
+  s = s.replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, ' ');
+  s = s.replace(/<!--[\s\S]*?-->/g, ' ');
+  s = s.replace(/<br\s*\/?\s*>/gi, '\n');
+  s = s.replace(/<\/p>/gi, '\n\n');
+  s = s.replace(/<\/h[1-6]>/gi, ' ');
+  s = s.replace(/<\/div>/gi, '\n');
+  s = s.replace(/<[^>]+>/g, ' ');
+  s = decodeEntities(s);
+  s = s.split('').filter((ch) => {
+    const c = ch.charCodeAt(0);
+    if (c === 9 || c === 10 || c === 13) return true;
+    if (c < 32) return false;
+    if (c === 127) return false;
+    return true;
+  }).join('');
+  return s.split(/\s+/).filter(Boolean).join(' ').trim();
+}
+
+// ── URL builders ───────────────────────────────────────────────────────────
+
+export function padMT(n) {
+  const x = typeof n === 'number' ? n : Number.parseInt(String(n), 10);
+  if (!Number.isInteger(x) || x < 0) throw new Error(`padMT: invalid n=${n}`);
+  return String(x * 10).padStart(4, '0');
+}
+
+export function buildChapterListUrl() {
+  return `${MT_BASE_URL}/bills/mca/title_${MT_TITLE}/chapters_index.html`;
+}
+
+export function buildPartsIndexUrl(chapter) {
+  const c = padMT(chapter);
+  return `${MT_BASE_URL}/bills/mca/title_${MT_TITLE}/chapter_${c}/parts_index.html`;
+}
+
+export function buildSectionsIndexUrl(chapter, part) {
+  const c = padMT(chapter);
+  const p = padMT(part);
+  return `${MT_BASE_URL}/bills/mca/title_${MT_TITLE}/chapter_${c}/part_${p}/sections_index.html`;
+}
+
+/**
+ * Build a section URL given chapter, part, AND positional section index.
+ * @param {number|string} chapter
+ * @param {number|string} part
+ * @param {number|string} sectionIdx  positional index within the part (1-based)
+ */
+export function buildSectionUrl(chapter, part, sectionIdx) {
+  const c = padMT(chapter);
+  const p = padMT(part);
+  const s = padMT(sectionIdx);
+  return `${MT_BASE_URL}/bills/mca/title_${MT_TITLE}/chapter_${c}/part_${p}/section_${s}/${MT_TITLE}-${c}-${p}-${s}.html`;
+}
+
+// ── URL parsing ────────────────────────────────────────────────────────────
+
+export function parseSectionUrl(sectionUrl) {
+  const m = sectionUrl.match(/\/section_(\d{4})\/(\d{4})-(\d{4})-(\d{4})-(\d{4})\.html/);
+  if (!m) throw new Error(`parseSectionUrl: cannot parse ${sectionUrl}`);
+  return {
+    title: String(Number.parseInt(m[2], 10) / 10),
+    chapter: String(Number.parseInt(m[3], 10) / 10),
+    part: String(Number.parseInt(m[4], 10) / 10),
+    sectionIdx: String(Number.parseInt(m[5], 10) / 10),
+  };
+}
+
+/**
+ * URL -> citation (positional fallback). NOT canonical for cases where the
+ * positional slot doesn't match the actual citation. Use this only for
+ * tests + bootstrapping; canonical citation comes from index anchor text.
+ */
+export function sectionIdFromUrl(sectionUrl) {
+  const p = parseSectionUrl(sectionUrl);
+  return `${p.title}-${p.chapter}-${p.part}-${p.sectionIdx}`;
+}
+
+/**
+ * Extract canonical citation from an h1..h6 heading text. Returns null when
+ * no heading present. Tolerated forms include `<h1>45-5-102. Foo</h1>`.
+ *
+ * Note: real MT pages don't put the citation in their visible <h1>; the
+ * authoritative citation lives inside the catchline span. This helper is
+ * kept for tests + future page-shape changes.
+ *
+ * @param {string} html
+ * @returns {string|null}
+ */
+export function citationFromHeading(html) {
+  if (!html) return null;
+  const RX = /<h[1-6][^>]*>\s*(45-\d+-\d+(?:-\d+)?)\s*\.\s*([\s\S]*?)<\/h[1-6]>/i;
+  const m = html.match(RX);
+  if (!m) return null;
+  return m[1];
+}
+
+// ── Title-level discovery (chapters_index.html) ────────────────────────────
+
+const RX_MT_CHAPTER_LINK = /<a\s+[^>]*href=["'](?:\.\/)?chapter_(\d{4})\/parts_index\.html["']/gi;
+
+export function discoverChapterUrls(html) {
+  if (!html) return [];
+  const out = [];
+  const seen = new Set();
+  RX_MT_CHAPTER_LINK.lastIndex = 0;
+  let m;
+  while ((m = RX_MT_CHAPTER_LINK.exec(html)) !== null) {
+    const padded = m[1];
+    const decoded = String(Number.parseInt(padded, 10) / 10);
+    const url = `${MT_BASE_URL}/bills/mca/title_${MT_TITLE}/chapter_${padded}/parts_index.html`;
+    if (seen.has(url)) continue;
+    seen.add(url);
+    out.push({ chapter: decoded, url });
+  }
+  return out;
+}
+
+// ── Chapter-level discovery (parts_index.html) ─────────────────────────────
+
+const RX_MT_PART_LINK = /<a\s+[^>]*href=["'](?:\.\/)?part_(\d{4})\/sections_index\.html["']/gi;
+
+export function discoverPartUrls(html, chapter) {
+  if (!html) return [];
+  const c = padMT(chapter);
+  const out = [];
+  const seen = new Set();
+  RX_MT_PART_LINK.lastIndex = 0;
+  let m;
+  while ((m = RX_MT_PART_LINK.exec(html)) !== null) {
+    const padded = m[1];
+    const decoded = String(Number.parseInt(padded, 10) / 10);
+    const url = `${MT_BASE_URL}/bills/mca/title_${MT_TITLE}/chapter_${c}/part_${padded}/sections_index.html`;
+    if (seen.has(url)) continue;
+    seen.add(url);
+    out.push({ part: decoded, url });
+  }
+  return out;
+}
+
+// ── Part-level discovery (sections_index.html) — CITATION-AWARE ────────────
+
+// Match section anchors with inner citation span + headnote.
+// Structure observed 2026-05-02:
+//   <a href="./section_0020/0450-0050-0010-0020.html">
+//     <span class="citation">45-5-102</span>&nbsp;Deliberate homicide
+//   </a>
+const RX_MT_SECTION_ANCHOR = /<a\s+[^>]*href=["'](?:\.\/)?section_(\d{4})\/(\d{4}-\d{4}-\d{4}-\d{4})\.html["'][^>]*>([\s\S]*?)<\/a>/gi;
+const RX_MT_CITATION_SPAN = /<span\s+class=["'][^"']*\bcitation\b[^"']*["'][^>]*>\s*(45-\d+-\d+)\s*<\/span>/i;
+const RX_MT_INACTIVE_INDEX_HINT = /\b(?:Repealed|Renumbered|Terminated|Reserved|reserved)\b/;
+
+/**
+ * Discover section URLs from a part sections_index.html page.
+ *
+ * Each descriptor carries:
+ *   - sectionIdx: positional index (e.g. "2" for section_0020)
+ *   - filename: the URL filename without extension
+ *   - url: full HTTPS URL
+ *   - citation: canonical citation from anchor inner text (e.g. "45-5-102")
+ *   - headnote: trailing text from anchor (after the citation span)
+ *   - inactive: true if anchor text contains repealed/renumbered/reserved markers
+ *
+ * @param {string} html
+ * @param {string|number} chapter
+ * @param {string|number} part
+ */
+export function discoverSectionUrls(html, chapter, part) {
+  if (!html) return [];
+  const c = padMT(chapter);
+  const p = padMT(part);
+  const out = [];
+  const seen = new Set();
+  RX_MT_SECTION_ANCHOR.lastIndex = 0;
+  let m;
+  while ((m = RX_MT_SECTION_ANCHOR.exec(html)) !== null) {
+    const sectionPadded = m[1];
+    const filename = m[2];
+    const innerHtml = m[3];
+
+    // Skip non-section anchors (e.g. parent-nav links) by requiring inner citation
+    const cm = innerHtml.match(RX_MT_CITATION_SPAN);
+    if (!cm) continue;
+    const citation = cm[1];
+
+    const url = `${MT_BASE_URL}/bills/mca/title_${MT_TITLE}/chapter_${c}/part_${p}/section_${sectionPadded}/${filename}.html`;
+    if (seen.has(url)) continue;
+    seen.add(url);
+
+    // Headnote = anchor inner text, minus the citation span
+    const innerText = stripHtml(innerHtml.replace(RX_MT_CITATION_SPAN, ' '));
+    const inactive = RX_MT_INACTIVE_INDEX_HINT.test(innerText);
+
+    out.push({
+      sectionIdx: String(Number.parseInt(sectionPadded, 10) / 10),
+      filename,
+      url,
+      citation,
+      headnote: innerText,
+      inactive,
+    });
+  }
+  return out;
+}
+
+// ── Section page parser (catchline-driven) ─────────────────────────────────
+
+// Catchline outer: <span class="catchline">...</span>
+// We can't use a simple non-greedy match because the catchline contains a
+// nested <span class="citation">...</span>. We extract by locating the
+// "catchline" anchor and walking forward to the SECOND </span> (balances the
+// one nested citation span).
+const RX_MT_CATCHLINE_OPEN = /<span\s+class=["'][^"']*\bcatchline\b[^"']*["'][^>]*>/i;
+// Inside catchline: <span class="citation">CITATION</span>.HEADNOTE.
+// (catchline body is `<cite>CIT</cite>.&#8195;HEADNOTE.` then </span>)
+const RX_MT_CATCHLINE_INNER = /<span\s+class=["'][^"']*\bcitation\b[^"']*["'][^>]*>\s*(45-\d+-\d+)\s*<\/span>\s*\.?\s*([\s\S]*?)\.?\s*$/i;
+
+// Section body container: <div class="section-doc" id="mca_NNNN-NNNN-NNNN-NNNN">
+//                          <div class="section-content"> ... </div>
+//                        </div>
+//                        <div class="history-doc" ...> (sibling, NOT body)
+const RX_MT_SECTION_DOC = /<div\s+class=["']section-doc["'][^>]*id=["']mca_([\d-]+)["'][^>]*>([\s\S]*?)<\/div>\s*(?:<\/div>\s*)?(?=<div\s+class=["']history-doc|$)/i;
+
+const RX_MT_INACTIVE_BODY = /\b(?:Repealed|Reserved|Renumbered|Terminated)\b/i;
+
+/**
+ * Parse a single MT section HTML page.
+ *
+ * Returns {titleText, bodyText, effectiveDate} for active sections;
+ * returns null for repealed/reserved/short shells or citation mismatches.
+ *
+ * @param {string} html
+ * @param {string} sectionNum  expected canonical citation, e.g. "45-5-102"
+ */
+export function parseSection(html, sectionNum) {
+  if (!html || html.length < 800) return null;
+
+  // Strip Akamai prefix defensively
+  const cleaned = html.replace(/<APM_DO_NOT_TOUCH\b[\s\S]*?<\/APM_DO_NOT_TOUCH>/gi, ' ');
+
+  // Extract section-doc body block
+  const docMatch = cleaned.match(RX_MT_SECTION_DOC);
+  if (!docMatch) return null;
+  const docBody = docMatch[2];
+
+  // Find catchline (balanced-span extraction)
+  const openMatch = docBody.match(RX_MT_CATCHLINE_OPEN);
+  if (!openMatch) return null;
+  const catchOpenEnd = (openMatch.index ?? 0) + openMatch[0].length;
+  // Walk forward counting <span> opens vs closes; need 1 net close to balance
+  // the catchline open + any nested <span class="citation"> opens.
+  let depth = 1; // we just consumed the catchline opening tag
+  let scan = catchOpenEnd;
+  let catchEnd = -1;
+  while (scan < docBody.length) {
+    const nextOpen = docBody.indexOf('<span', scan);
+    const nextClose = docBody.indexOf('</span>', scan);
+    if (nextClose === -1) break;
+    if (nextOpen !== -1 && nextOpen < nextClose) {
+      depth++;
+      scan = nextOpen + 5;
+    } else {
+      depth--;
+      if (depth === 0) { catchEnd = nextClose; break; }
+      scan = nextClose + 7;
+    }
+  }
+  if (catchEnd === -1) return null;
+  const catchInner = docBody.slice(catchOpenEnd, catchEnd);
+  const innerMatch = catchInner.match(RX_MT_CATCHLINE_INNER);
+  if (!innerMatch) return null;
+  const headingCitation = innerMatch[1];
+  if (sectionNum && headingCitation !== sectionNum) return null;
+
+  let titleText = stripHtml(innerMatch[2]).replace(/\.$/, '').trim();
+  if (!titleText) titleText = `Section ${sectionNum}`;
+
+  // Body text = full section-doc content. Strip the catchline span itself
+  // (open + balanced inner spans + close, computed above) to avoid duplicating
+  // "(citation). headnote." in the body output.
+  const bodyHtml = docBody.slice(0, openMatch.index ?? 0) + ' ' + docBody.slice(catchEnd + 7);
+  const bodyText = stripHtml(bodyHtml);
+
+  if (!bodyText || bodyText.length < 30) {
+    // Repealed/reserved short shells — body is literally just "Sec. 11, Ch. 610..."
+    return null;
+  }
+
+  // Defensive inactive-body skip: short body containing inactive marker
+  if (RX_MT_INACTIVE_BODY.test(bodyText) && bodyText.length < 200) return null;
+  // Short body with "Repealed" anywhere is likely a vacated section
+  if (bodyText.length < 300 && /^Sec\.\s+\d+,?\s+Ch/.test(bodyText)) return null;
+
+  return { titleText, bodyText, effectiveDate: null };
+}

--- a/scripts/ingest/seed-statutes-mt-title45.mjs
+++ b/scripts/ingest/seed-statutes-mt-title45.mjs
@@ -1,0 +1,348 @@
+#!/usr/bin/env node
+// Template: scripts/ingest/seed-statutes-mn-chapter609.mjs (Bucket B harness pattern)
+// Template: scripts/ingest/lib/bucket-b-html.mjs (DO NOT EDIT)
+// Pattern: bucket-b-html.mjs harness contract (Wave 2 design report 2026-05-02)
+// Pattern: cl-bulk-data-defensive #14 (port 5432), #17 (session defaults), #18 (COPY FROM STDIN)
+// Pattern: no-hallucinated-legal-data — every row has source_urls[0] populated
+// csv-bulk-checked: none-exists — mca.legmt.gov publishes per-section HTML only,
+//   no bulk download endpoint. Per-section authoritative URLs required.
+// Akamai-fronted: 2500ms delay floor, 45s fetch timeout per design plan section 3.
+//   If body returns empty + APM_DO_NOT_TOUCH challenge JS, escalate to engine
+//   Playwright (do NOT add UA rotation here — engine's job).
+//
+// MT state statutes seed — Wave 2 Group 3 (Bucket B B-quirky cohort).
+// Source: Montana Code Annotated Title 45 (Crimes).
+// Target: entities_statutes (one row per active section).
+// Coverage: Title 45 chapters 1-10 (~400-500 active sections expected).
+//
+// Single-title strategy: per design plan section 9, MT requires a 3-level
+// pre-walk (title -> chapter -> part -> section) BEFORE the harness's
+// per-section fetch loop runs. The harness assumes ONE TOC fetch yields the
+// descriptor list. Since the MT chapters_index.html only links to chapter
+// parts_index pages (not directly to sections), we pre-walk in the seeder
+// using the harness's `fetchWithRetry` (so polite delay + UA + allowedHosts
+// all flow through), then pass a sync `discoverSections` that returns the
+// pre-cached descriptor list (ignoring the harness's tocHtml argument).
+//
+// SC-1 verified 2026-05-02: bucket-b-html.mjs:301 does NOT await
+// `config.discoverSections`, so async discoverSections is unsupported.
+// Pre-walk approach (Option B) is the only viable path without harness edit.
+//
+// Citation source: descriptor.sectionNum is read at the index level from
+// the anchor's <span class="citation">45-5-102</span> inner text — NOT
+// derived from the URL filename's positional index. Some positional slots
+// span citation ranges (e.g. section_0080 = "45-5-108 through 45-5-110
+// reserved") and we filter those at discovery time via the inactive flag.
+//
+// Usage:
+//   node scripts/ingest/seed-statutes-mt-title45.mjs --dry-run --limit=3
+//   node scripts/ingest/seed-statutes-mt-title45.mjs --dry-run --verbose --chapters=5
+//   node scripts/ingest/seed-statutes-mt-title45.mjs                        # live full title
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL, fileURLToPath } from 'node:url';
+
+import {
+  buildChapterListUrl,
+  buildPartsIndexUrl,
+  discoverPartUrls,
+  discoverSectionUrls as mtDiscoverSectionUrls,
+  parseSection as mtParseSection,
+} from './lib/mt-html.mjs';
+import { ingestBucketBState, fetchWithRetry } from './lib/bucket-b-html.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// ── Env loader (web-repo only, # skip, trim, quote strip) ────────────────
+const envPaths = [
+  path.join(__dirname, '..', '..', '.env.local'),
+  'C:/Users/email/projects/ImNotAnAttorney-web/.env.local',
+];
+const VALID_KEY_RX = /^[A-Z_][A-Z0-9_]*$/;
+for (const p of envPaths) {
+  if (!fs.existsSync(p)) continue;
+  const txt = fs.readFileSync(p, 'utf-8');
+  for (const rawLine of txt.split('\n')) {
+    let line = rawLine.endsWith('\r') ? rawLine.slice(0, -1) : rawLine;
+    line = line.trim();
+    if (!line || line[0] === '#') continue;
+    const eq = line.indexOf('=');
+    if (eq <= 0) continue;
+    const key = line.slice(0, eq).trim();
+    let val = line.slice(eq + 1).trim();
+    if (val.length >= 2 && ((val[0] === '"' && val[val.length - 1] === '"') ||
+        (val[0] === "'" && val[val.length - 1] === "'"))) {
+      val = val.slice(1, -1);
+    }
+    if (!VALID_KEY_RX.test(key)) continue;
+    if (!process.env[key]) process.env[key] = val;
+  }
+}
+
+// ── Coverage: MT Title 45, chapters 1-10 ─────────────────────────────────
+export const MT_COHORT_DEFAULT = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10'];
+
+export const MT_CHAPTER_DESCRIPTIONS = {
+  '1': 'General Preliminary Provisions',
+  '2': 'General Principles of Liability',
+  '3': 'Justifiable Use of Force',
+  '4': 'Inchoate Offenses',
+  '5': 'Offenses Against the Person',
+  '6': 'Offenses Against Property',
+  '7': 'Offenses Against Public Administration',
+  '8': 'Offenses Against Public Order',
+  '9': 'Dangerous Drugs',
+  '10': 'Model Drug Paraphernalia Act',
+};
+
+// Conservative floor: design plan estimates 400-500 active sections.
+// Floor at 250 to absorb (a) repealed-page nulls, (b) parser nulls on
+// edge-case bodies, (c) chapter 10 unknowns. Tighten on first live run.
+export const MT_TITLE45_ROW_FLOOR = 250;
+
+// ── Network constants ────────────────────────────────────────────────────
+const ALLOWED_HOSTS = new Set(['mca.legmt.gov']);
+const CRAWL_DELAY_MS = 2500;
+const FETCH_TIMEOUT_MS = 45000;
+const USER_AGENT = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
+
+function sleep(ms) { return new Promise((r) => setTimeout(r, ms)); }
+
+// ── Pre-walk: build the full descriptor list before harness runs ─────────
+
+/**
+ * Walk title -> chapter -> part -> section and emit a flat descriptor list.
+ * Citation comes from index anchor inner text (canonical), not URL filename
+ * (positional). Inactive rows (Repealed/Reserved/Renumbered) filtered at
+ * discovery time.
+ *
+ * @param {string[]} chapters
+ * @param {boolean} verbose
+ */
+export async function preWalkTitle(chapters, verbose) {
+  const allDescriptors = [];
+  const seenSectionNums = new Set();
+  let fetchCount = 0;
+  let inactiveSkipped = 0;
+  const t0 = Date.now();
+
+  for (const chapter of chapters) {
+    if (verbose) console.log(`  [pre-walk] chapter ${chapter}: fetching parts index`);
+    const partsUrl = buildPartsIndexUrl(chapter);
+    let partsHtml;
+    try {
+      partsHtml = await fetchWithRetry(partsUrl, {
+        timeoutMs: FETCH_TIMEOUT_MS,
+        userAgent: USER_AGENT,
+      });
+    } catch (err) {
+      console.warn(`  [pre-walk] WARN chapter ${chapter} parts fetch failed: ${err.message}`);
+      continue;
+    }
+    fetchCount++;
+    await sleep(CRAWL_DELAY_MS);
+
+    const parts = discoverPartUrls(partsHtml, chapter);
+    if (verbose) console.log(`  [pre-walk]   chapter ${chapter}: ${parts.length} parts`);
+
+    for (const part of parts) {
+      let sectionsHtml;
+      try {
+        sectionsHtml = await fetchWithRetry(part.url, {
+          timeoutMs: FETCH_TIMEOUT_MS,
+          userAgent: USER_AGENT,
+        });
+      } catch (err) {
+        console.warn(`  [pre-walk] WARN ${chapter}-${part.part} sections fetch failed: ${err.message}`);
+        continue;
+      }
+      fetchCount++;
+      await sleep(CRAWL_DELAY_MS);
+
+      const sections = mtDiscoverSectionUrls(sectionsHtml, chapter, part.part);
+      if (verbose) console.log(`  [pre-walk]     ${chapter}-${part.part}: ${sections.length} sections`);
+
+      for (const sec of sections) {
+        if (sec.inactive) {
+          inactiveSkipped++;
+          continue;
+        }
+        if (seenSectionNums.has(sec.citation)) continue;
+        seenSectionNums.add(sec.citation);
+        allDescriptors.push({
+          sectionNum: sec.citation,
+          sectionUrl: sec.url,
+          chapterNum: String(chapter),
+        });
+      }
+    }
+  }
+
+  const elapsedSec = Math.round((Date.now() - t0) / 1000);
+  console.log(`  [pre-walk] discovered ${allDescriptors.length} active sections (${inactiveSkipped} inactive skipped, ${fetchCount} fetches, ${elapsedSec}s)`);
+  return allDescriptors;
+}
+
+// ── Adapter: bucketBParse ────────────────────────────────────────────────
+
+/**
+ * MT-specific parseSection adapter. Strips effectiveDate (harness contract
+ * requires {titleText, bodyText} only).
+ */
+export function bucketBParse(sectionHtml, sectionNum) {
+  const parsed = mtParseSection(sectionHtml, sectionNum);
+  if (!parsed) return null;
+  return { titleText: parsed.titleText, bodyText: parsed.bodyText };
+}
+
+// ── Source URL builder — descriptor.sectionUrl IS authoritative ──────────
+
+/**
+ * MT canonical source URL = the per-section page URL discovered at pre-walk.
+ * Returns a closure-scoped function that resolves canonical citation -> URL.
+ *
+ * @param {Map<string,string>} sectionUrlMap
+ */
+export function makeBuildSourceUrl(sectionUrlMap) {
+  return function buildSourceUrl(sectionNum) {
+    const url = sectionUrlMap.get(sectionNum);
+    if (!url) {
+      throw new Error(`buildSourceUrl: no URL mapped for section ${sectionNum}`);
+    }
+    return url;
+  };
+}
+
+// ── Per-title config builder ─────────────────────────────────────────────
+
+/**
+ * Build a single BucketBStateConfig for the entire MT Title 45.
+ * @param {Array<{sectionNum:string, sectionUrl:string, chapterNum:string}>} descriptors
+ */
+export function buildTitleConfig(descriptors) {
+  const sectionUrlMap = new Map(descriptors.map((d) => [d.sectionNum, d.sectionUrl]));
+  return {
+    stateCode: 'MT',
+    stateName: 'Montana',
+    titleNum: '45',
+    titleLabel: 'Title 45 - Crimes',
+    chapterListUrl: buildChapterListUrl(),
+    discoverSections: () => descriptors,
+    parseSection: bucketBParse,
+    buildSourceUrl: makeBuildSourceUrl(sectionUrlMap),
+    crawlDelay: 'none',
+    crawlDelayMs: CRAWL_DELAY_MS,
+    fetchTimeoutMs: FETCH_TIMEOUT_MS,
+    allowedHosts: ALLOWED_HOSTS,
+    userAgent: USER_AGENT,
+  };
+}
+
+// ── CLI ──────────────────────────────────────────────────────────────────
+
+export function parseCliFlags(argv) {
+  const out = { dryRun: false, verbose: false, limit: null, chapters: null };
+  for (const a of argv) {
+    if (a === '--dry-run') out.dryRun = true;
+    else if (a === '--verbose') out.verbose = true;
+    else if (a.startsWith('--limit=')) {
+      const n = Number.parseInt(a.slice('--limit='.length), 10);
+      if (Number.isInteger(n) && n > 0) out.limit = n;
+    } else if (a.startsWith('--chapters=')) {
+      const raw = a.slice('--chapters='.length);
+      const parts = raw.split(',').map((s) => s.trim()).filter(Boolean);
+      const valid = parts.filter((p) => /^\d+$/.test(p));
+      if (valid.length > 0) out.chapters = valid;
+    }
+  }
+  return out;
+}
+
+// ── Orchestrator ─────────────────────────────────────────────────────────
+
+export async function seedMT(opts = {}) {
+  const {
+    dryRun = false,
+    verbose = false,
+    limit = null,
+    chapters = null,
+    connectionString,
+  } = opts;
+
+  const targetChapters = chapters && chapters.length ? chapters : MT_COHORT_DEFAULT;
+
+  console.log(`=== seed-statutes-mt-title45 ${new Date().toISOString()} ===`);
+  console.log(`  cohort   : [${targetChapters.join(', ')}]`);
+  console.log(`  dry-run  : ${dryRun}`);
+  console.log(`  limit    : ${limit ?? '(all)'}`);
+  console.log(`  verbose  : ${verbose}`);
+  console.log(`  delay    : ${CRAWL_DELAY_MS}ms (Akamai-conservative)`);
+
+  const t0 = Date.now();
+
+  const descriptors = await preWalkTitle(targetChapters, verbose);
+
+  if (descriptors.length === 0) {
+    console.error('FAIL: pre-walk yielded 0 descriptors — Akamai escalation? URL pattern drift?');
+    return { totalRows: 0, totalSkipped: 0, totalErrors: 0, totalDurationMs: Date.now() - t0 };
+  }
+
+  const config = buildTitleConfig(descriptors);
+
+  let result;
+  try {
+    result = await ingestBucketBState(config, {
+      dryRun,
+      verbose,
+      limit,
+      connectionString,
+    });
+  } catch (err) {
+    console.error(`FATAL: ingestBucketBState failed: ${err.message}`);
+    if (err.stack) console.error(err.stack);
+    return { totalRows: 0, totalSkipped: 0, totalErrors: 1, totalDurationMs: Date.now() - t0 };
+  }
+
+  const totalDurationMs = Date.now() - t0;
+  console.log('\n=== Summary ===');
+  console.log(`  TOTAL  rows=${result.rowCount} skip=${result.skipCount} err=${result.errorCount} ${totalDurationMs}ms`);
+
+  return {
+    descriptorsDiscovered: descriptors.length,
+    totalRows: result.rowCount,
+    totalSkipped: result.skipCount,
+    totalErrors: result.errorCount,
+    totalDurationMs,
+  };
+}
+
+async function main() {
+  const flags = parseCliFlags(process.argv.slice(2));
+  const out = await seedMT(flags);
+
+  if (out.totalRows < 1) {
+    console.error('\nFAIL: 0 rows — harness or adapter broken (or Akamai escalated)');
+    process.exit(1);
+  }
+
+  if (!flags.dryRun && flags.limit == null && flags.chapters == null && out.totalRows < MT_TITLE45_ROW_FLOOR) {
+    console.error(`\nFAIL: total rows ${out.totalRows} below MT_TITLE45_ROW_FLOOR=${MT_TITLE45_ROW_FLOOR}`);
+    process.exit(1);
+  }
+
+  console.log('\nDONE');
+  process.exit(0);
+}
+
+const invokedDirectly = (() => {
+  if (!process.argv[1]) return false;
+  try { return import.meta.url === pathToFileURL(process.argv[1]).href; }
+  catch { return false; }
+})();
+if (invokedDirectly) main().catch((e) => {
+  console.error('FATAL:', e?.message || e);
+  if (e?.stack) console.error(e.stack);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- MT Crimes (Title 45) ingested via mca.legmt.gov 3-level traversal (title -> chapter -> part -> section)
- 328 active rows live in entities_statutes (62 Repealed/Reserved/Renumbered filtered at index level)
- 57/57 tests pass
- Walltime 16m26s

## Akamai escalation
None. All fetches returned 200 with full statute body. No engine Playwright handoff needed.

## Coverage
Title 45 chapters 1-10, all parts, all active sections. Floor 250 exceeded by 78.

## Plan deviations (worth review)
1. Fixed padMT positional encoding for chapter 10 (live data uses positional 4-digit encoding, not 3+0 suffix)
2. Citation extracted from anchor span text (not URL filename)
3. Section page uses balanced-span depth tracking (live pages have nested catchline+citation spans)

## Test plan
- [x] node:test 57/57 pass
- [x] live ingest 328 rows, 0 errors, 0 skipped
- [x] all rows have source_urls populated, all HTTPS
- [x] no Akamai escalation observed across full run

🤖 Generated with [Claude Code](https://claude.com/claude-code)