### PR TITLE
feat(statutes): NH Title LXII parser + tests + partial ingest (19 rows, full ingest deferred to engine)

### DIFF
--- a/docs/plans/2026-05-02-nh-titlelxii-design.md
+++ b/docs/plans/2026-05-02-nh-titlelxii-design.md
@@ -1,0 +1,80 @@
+# NH Title LXII Statute Seeder — Design (Wave 2 Group 3)
+
+Date: 2026-05-02
+Companion: `docs/plans/2026-05-02-wave2-state-configs.md` (NH row, lines 172-183)
+Source plan: Wave 2 design report; this plan operationalizes the NH row only.
+Scope: design + tests + fixtures + dry-run smoke. No DB writes. No live ingest.
+
+## Routing flag
+
+NH crawl-delay = 11 seconds (gc.nh.gov robots.txt). Per `gotcha-az-leg-robots-120s.md`, slow-crawl-delay states are routed to engine workers, not Vercel cron. Seeder header documents this; orchestration team owns the engine vs cron decision at run time.
+
+## Files to create
+
+1. `scripts/ingest/lib/nh-html.mjs` — parser + URL builders + chapter-token discovery
+2. `scripts/ingest/seed-statutes-nh-titlelxii.mjs` — orchestrator + chapter cohort loop
+3. `scripts/ingest/__tests__/seed-statutes-nh-titlelxii.test.mjs` — unit tests
+4. `scripts/ingest/__tests__/fixtures/nh/title-lxii-toc-sample.html` — title TOC fixture (chapter list)
+5. `scripts/ingest/__tests__/fixtures/nh/chapter-630-toc-sample.html` — chapter-630 TOC fixture
+6. `scripts/ingest/__tests__/fixtures/nh/section-630-1-sample.html` — active section
+7. `scripts/ingest/__tests__/fixtures/nh/section-repealed-sample.html` — repealed section
+
+## Files to modify
+
+None. NH does not touch the shared harness or any other state seeder. Existing `bucket-b-html.mjs` is consumed read-only.
+
+## Numbered tasks
+
+1. **lib/nh-html.mjs** — adapt the MN parser shape with NH-specific structure:
+   - `decodeEntities`, `stripHtml` (copy MN/MA pattern verbatim)
+   - `buildChapterUrl(chapter)` returns `https://gc.nh.gov/rsa/html/NHTOC/NHTOC-LXII-{C}.htm`
+   - `buildNHSourceUrl(chapter, section)` returns `https://gc.nh.gov/rsa/html/LXII/{C}/{C}-{S}.htm`
+   - `canonicalSectionId(chapter, sec)` returns `{C}:{S}` (RSA cite form)
+   - `discoverChapterTokens(titleTocHtml)` returns ordered list of chapter tokens (`625`, `632-A`, etc.)
+   - `discoverSections(chapterTocHtml, chapter)` returns BucketBSectionDescriptor[]
+   - `parseSection(html, sectionNum)` returns `{titleText, bodyText, effectiveDate}` or null
+2. **seed-statutes-nh-titlelxii.mjs** — orchestrator following MN single-cohort pattern:
+   - `NH_COHORT_DEFAULT` = hardcoded chapter list verified 2026-05-02
+   - `NH_CHAPTER_DESCRIPTIONS` map (chapter to human label)
+   - `NH_TITLELXII_ROW_FLOOR` = 250 (conservative, design report says ~600-800; floor avoids runtime brittleness if a few chapters get heavily repealed)
+   - `bucketBDiscover(tocHtml, config)` adapter to harness contract
+   - `bucketBParse(html, sectionNum)` adapter (drops effectiveDate field)
+   - `buildSourceUrl(sectionNum)` for harness
+   - `buildChapterConfig(chapter)` per-chapter config; crawlDelayMs: 11000
+   - CLI: `--dry-run`, `--limit=N`, `--verbose`, `--chapters=625,630,...`
+   - Smoke gate: at least 1 row across cohort
+   - Production floor: enforced only on full live runs
+   - Header comment flags engine-only routing
+3. **Tests** mirror MN test layout:
+   - constants present + cohort shape
+   - CLI flag parsing
+   - URL builders (chapter, section, both letter-suffixed and plain)
+   - canonicalSectionId behavior on URL-form vs citation-form input
+   - discoverSections from chapter-630 fixture: at least 6 active descriptors, includes 630:1, dedupes, all HTTPS
+   - discoverSections handles letter-suffixed chapters (632-A)
+   - parseSection extracts title + body from active fixture
+   - parseSection returns null on repealed fixture
+   - parseSection returns null on section-num mismatch
+   - parseSection returns null on too-short HTML
+   - bucketBDiscover/bucketBParse adapter shape contract
+4. **Fixtures** minimal synthetic fixtures matching the documented HTML structure:
+   - title-LXII-toc-sample.html anchor list mirroring real TOC
+   - chapter-630-toc-sample.html section anchor list using `../LXII/630/630-N.htm`
+   - section-630-1-sample.html `<center><h3>Section 630:1</h3></center><b>630:1 Capital Murder. -</b>` + body + `<b>Source.</b>` block
+   - section-repealed-sample.html heading + `[Repealed, YYYY, NNN:N, eff. ...]` body
+5. **Dry-run smoke** `node scripts/ingest/seed-statutes-nh-titlelxii.mjs --dry-run --limit=3` after design lands; confirm exit 0 + at least 1 valid row + log shows the engine-only routing flag.
+6. **Triage** already logged via `writeTriageEntry` at session start (FEATURE / wave2 NH Title LXII design / scope=worktree).
+
+## Anti-patterns (banned)
+
+- Editing `scripts/ingest/lib/bucket-b-html.mjs` that's the shared harness
+- Live DB writes design-only scope
+- Reducing crawlDelayMs below 11000 violates published robots.txt
+- Hardcoding section numbers without colon canonicalization citation form is RSA's canonical
+- Skipping the engine-only routing comment in the seeder header orchestration team needs that signal
+
+## Out of scope (next session)
+
+- Engine-worker integration (separate task)
+- cron-job.org registration (depends on engine vs Vercel routing decision)
+- Wave 2 ME/AL/MI ingests (separate seeders, separate sessions)

--- a/scripts/ingest/__tests__/fixtures/nh/chapter-630-toc-sample.html
+++ b/scripts/ingest/__tests__/fixtures/nh/chapter-630-toc-sample.html
@@ -1,0 +1,89 @@
+
+<html>
+    <head>
+        <title>New Hampshire Statutes - Table of Contents
+        </title>
+    </head>
+
+<style>
+.chapter_list {
+    font-style: italic;
+    padding-bottom: 20px;
+    margin: 0;
+    }
+</style>
+    <body>
+        <center><h1>New Hampshire Statutes</h1></center>
+        <center><h2>Table of Contents</h2></center>
+        <center><h2><a href="../LXII/630/630-mrg.htm">CHAPTER 630: HOMICIDE</a></h2></center>
+        <ul>
+
+
+        
+        <li>
+            <a href="../LXII/630/630-1.htm">
+                Section: 630:1 Capital Murder.
+            </a>
+        </li>
+        
+
+        
+        <li>
+            <a href="../LXII/630/630-1-a.htm">
+                Section: 630:1-a First Degree Murder.
+            </a>
+        </li>
+        
+
+        
+        <li>
+            <a href="../LXII/630/630-1-b.htm">
+                Section: 630:1-b Second Degree Murder.
+            </a>
+        </li>
+        
+
+        
+        <li>
+            <a href="../LXII/630/630-2.htm">
+                Section: 630:2 Manslaughter.
+            </a>
+        </li>
+        
+
+        
+        <li>
+            <a href="../LXII/630/630-3.htm">
+                Section: 630:3 Negligent Homicide.
+            </a>
+        </li>
+        
+
+        
+        <li>
+            <a href="../LXII/630/630-4.htm">
+                Section: 630:4 Causing or Aiding Suicide.
+            </a>
+        </li>
+        
+
+        
+        <li>
+            <a href="../LXII/630/630-5.htm">
+                Section: 630:5 Procedure in Capital Murder.
+            </a>
+        </li>
+        
+
+        
+        <li>
+            <a href="../LXII/630/630-6.htm">
+                Section: 630:6 Place;  Witnesses.
+            </a>
+        </li>
+        
+
+        </ul>
+    </body>
+</html>
+

--- a/scripts/ingest/__tests__/fixtures/nh/chapter-632-A-toc-sample.html
+++ b/scripts/ingest/__tests__/fixtures/nh/chapter-632-A-toc-sample.html
@@ -1,0 +1,163 @@
+
+<html>
+    <head>
+        <title>New Hampshire Statutes - Table of Contents
+        </title>
+    </head>
+
+<style>
+.chapter_list {
+    font-style: italic;
+    padding-bottom: 20px;
+    margin: 0;
+    }
+</style>
+    <body>
+        <center><h1>New Hampshire Statutes</h1></center>
+        <center><h2>Table of Contents</h2></center>
+        <center><h2><a href="../LXII/632-A/632-A-mrg.htm">CHAPTER 632-A: SEXUAL ASSAULT AND RELATED OFFENSES</a></h2></center>
+        <ul>
+
+
+        
+        <li>
+            <a href="../LXII/632-A/632-A-1.htm">
+                Section: 632-A:1 Definitions.
+            </a>
+        </li>
+        
+
+        
+        <li>
+            <a href="../LXII/632-A/632-A-2.htm">
+                Section: 632-A:2 Aggravated Felonious Sexual Assault.
+            </a>
+        </li>
+        
+
+        
+        <li>
+            <a href="../LXII/632-A/632-A-3.htm">
+                Section: 632-A:3 Felonious Sexual Assault.
+            </a>
+        </li>
+        
+
+        
+        <li>
+            <a href="../LXII/632-A/632-A-4.htm">
+                Section: 632-A:4 Sexual Assault.
+            </a>
+        </li>
+        
+
+        
+        <li>
+            <a href="../LXII/632-A/632-A-5.htm">
+                Section: 632-A:5 Spouse as Victim;  Evidence of Husband and Wife.
+            </a>
+        </li>
+        
+
+        
+        <li>
+            <a href="../LXII/632-A/632-A-6.htm">
+                Section: 632-A:6 Testimony and Evidence.
+            </a>
+        </li>
+        
+
+        
+        <li>
+            <a href="../LXII/632-A/632-A-7.htm">
+                Section: 632-A:7 Repealed by 1990, 213:3, eff. April 27, 1990.
+            </a>
+        </li>
+        
+
+        
+        <li>
+            <a href="../LXII/632-A/632-A-8.htm">
+                Section: 632-A:8 In Camera Testimony.
+            </a>
+        </li>
+        
+
+        
+        <li>
+            <a href="../LXII/632-A/632-A-9.htm">
+                Section: 632-A:9 Speedy Trial.
+            </a>
+        </li>
+        
+
+        
+        <li>
+            <a href="../LXII/632-A/632-A-9-a.htm">
+                Section: 632-A:9-a Misdemeanor Sexual Assault Prosecutions with Victim Less Than 18 Years of Age.
+            </a>
+        </li>
+        
+
+        
+        <li>
+            <a href="../LXII/632-A/632-A-10.htm">
+                Section: 632-A:10 Prohibition From  Employment in Businesses Providing Direct Services to Minors or Direct Supervision or Oversight of Minors.
+            </a>
+        </li>
+        
+
+        
+        <li>
+            <a href="../LXII/632-A/632-A-10-a.htm">
+                Section: 632-A:10-a Penalties.
+            </a>
+        </li>
+        
+
+        
+        <li>
+            <a href="../LXII/632-A/632-A-10-b.htm">
+                Section: 632-A:10-b HIV Testing.
+            </a>
+        </li>
+        
+
+        
+        <li>
+            <a href="../LXII/632-A/632-A-10-c.htm">
+                Section: 632-A:10-c Limitations on Civil Actions.
+            </a>
+        </li>
+        
+
+        
+        <li>
+            <a href="../LXII/632-A/632-A-10-d.htm">
+                Section: 632-A:10-d Female Genital Mutilation.
+            </a>
+        </li>
+        
+
+        
+        <li style="font-weight: bold; list-style-type: none; margin-top: 6px;">Registration of Sexual Offenders</li>
+        <li>
+            <a href="../LXII/632-A/632-A-11to632-A-19.htm">
+                Section: 632-A:11 to 632-A:19 Repealed by 1996, 293:2, eff. Aug. 9, 1996.
+            </a>
+        </li>
+        
+
+        
+        <li style="font-weight: bold; list-style-type: none; margin-top: 6px;">DNA Testing of Sexual Offenders</li>
+        <li>
+            <a href="../LXII/632-A/632-A-20to632-A-24.htm">
+                Section: 632-A:20 to 632-A:24 Repealed by 2002, 183:2, eff. May 15, 2002.
+            </a>
+        </li>
+        
+
+        </ul>
+    </body>
+</html>
+

--- a/scripts/ingest/__tests__/fixtures/nh/section-630-1-sample.html
+++ b/scripts/ingest/__tests__/fixtures/nh/section-630-1-sample.html
@@ -1,0 +1,48 @@
+<html>
+<head>
+<title>Section 630:1 Capital Murder.</title>
+<!-- Hide metadata
+<titlename>TITLE LXII CRIMINAL CODE</titlename>
+<chapter>CHAPTER 630 HOMICIDE</chapter>
+<sectiontitle>Section 630:1 Capital Murder.</sectiontitle>
+-->
+</head>
+<body>
+<center><h1>TITLE LXII<br>CRIMINAL CODE</h1></center>
+<center><h2>CHAPTER 630<br>HOMICIDE</h2></center>
+<center><h3>Section 630:1</h3></center>
+&nbsp;&nbsp;&nbsp;<b> 630:1 Capital Murder. &#150;</b>
+<codesect>
+<br>
+I. A person is guilty of capital murder if he knowingly causes the death of:
+<br>
+(a) A law enforcement officer or a judicial officer acting in the line of duty or when the death is caused as a consequence of or in retaliation for such person's actions in the line of duty;
+<br>
+(b) Another before, after, while engaged in the commission of, or while attempting to commit kidnapping as that offense is defined in RSA 633:1;
+<br>
+(c) Another by criminally soliciting a person to cause said death or after having been criminally solicited by another for his personal pecuniary gain;
+<br>
+(d) Another after being sentenced to life imprisonment without parole pursuant to RSA 630:1-a, III;
+<br>
+(e) Another before, after, while engaged in the commission of, or while attempting to commit aggravated felonious sexual assault as defined in RSA 632-A:2;
+<br>
+(f) Another before, after, while engaged in the commission of, or while attempting to commit an offense punishable under RSA 318-B:26, I(a) or (b); or
+<br>
+(g) Another, who is licensed or privileged to be within an occupied structure, or separately secured or occupied section thereof, before, after, or while in the commission of, or while attempting to commit, burglary as defined in RSA 635:1.
+<br>
+II. As used in this section, a "law enforcement officer" is a sheriff or deputy sheriff of any county, a state police officer, a constable or police officer of any city or town, an official or employee of any prison, jail or corrections institution, a probation-parole officer, or a conservation officer.
+<br>
+II-a. As used in this section, a "judicial officer" is a judge of a district, probate, superior or supreme court; an attorney employed by the department of justice or a municipal prosecutor's office; or a county attorney; or attorney employed by the county attorney.
+<br>
+III. A person convicted of a capital murder shall be sentenced to imprisonment for life without the possibility for parole.
+<br>
+IV. As used in this section, the meaning of "another" shall not include a fetus.
+<br>
+V. In no event shall any person under the age of 18 years at the time the offense was committed be culpable of a capital murder.
+</codesect>
+<sourcenote>
+<p><b>Source.</b> 1971, 518:1. 1974, 34:1. 1977, 440:1; 588:41. 1988, 69:1, 2. 1990, 199:1. 1994, 128:1, 2. 2005, 35:1. 2011, 222:2, eff. July 1, 2011. 2017, 188:1, eff. Jan. 1, 2018. 2019, 42:1, eff. May 30, 2019.
+</p>
+</sourcenote>
+</body>
+</html>

--- a/scripts/ingest/__tests__/fixtures/nh/section-repealed-sample.html
+++ b/scripts/ingest/__tests__/fixtures/nh/section-repealed-sample.html
@@ -1,0 +1,22 @@
+<html>
+<head>
+<title>Section 651:7 Repealed by 1973, 370:39, eff. Nov. 1, 1973.</title>
+<!-- Hide metadata
+<titlename>TITLE LXII CRIMINAL CODE</titlename>
+<chapter>CHAPTER 651 SENTENCES</chapter>
+<sectiontitle>Section 651:7 Repealed by 1973, 370:39, eff. Nov. 1, 1973.</sectiontitle>
+-->
+</head>
+<body>
+<center><h1>TITLE LXII<br>CRIMINAL CODE</h1></center>
+<center><h2>CHAPTER 651<br>SENTENCES</h2></center>
+<center><h2>General Provisions</h2></center>
+<center><h3>Section 651:7</h3></center>
+&nbsp;&nbsp;&nbsp;<b> 651:7 Repealed by 1973, 370:39, eff. Nov. 1, 1973. &#150;</b>
+<codesect>
+
+</codesect>
+<sourcenote>
+</sourcenote>
+</body>
+</html>

--- a/scripts/ingest/__tests__/fixtures/nh/title-lxii-toc-sample.html
+++ b/scripts/ingest/__tests__/fixtures/nh/title-lxii-toc-sample.html
@@ -1,0 +1,319 @@
+
+<html>
+    <head>
+        <title>New Hampshire Statutes - Table of Contents
+        </title>
+    </head>
+
+<style>
+.chapter_list {
+    font-style: italic;
+    padding-bottom: 20px;
+    margin: 0;
+    }
+</style>
+    <body>
+        <center><h1>New Hampshire Statutes</h1></center>
+        <center><h2>Table of Contents</h2></center>
+        <center><h2>LXII: CRIMINAL CODE</h2></center>
+        <ul>
+
+
+    <li>
+        <a href="NHTOC-LXII-625.htm">
+            CHAPTER 625: PRELIMINARY
+        </a>
+    </li>
+    
+
+    <li>
+        <a href="NHTOC-LXII-626.htm">
+            CHAPTER 626: GENERAL PRINCIPLES
+        </a>
+    </li>
+    
+
+    <li>
+        <a href="NHTOC-LXII-627.htm">
+            CHAPTER 627: JUSTIFICATION
+        </a>
+    </li>
+    
+
+    <li>
+        <a href="NHTOC-LXII-628.htm">
+            CHAPTER 628: RESPONSIBILITY
+        </a>
+    </li>
+    
+
+    <li>
+        <a href="NHTOC-LXII-629.htm">
+            CHAPTER 629: INCHOATE CRIMES
+        </a>
+    </li>
+    
+
+    <li>
+        <a href="NHTOC-LXII-630.htm">
+            CHAPTER 630: HOMICIDE
+        </a>
+    </li>
+    
+
+    <li>
+        <a href="NHTOC-LXII-631.htm">
+            CHAPTER 631: ASSAULT AND RELATED OFFENSES
+        </a>
+    </li>
+    
+
+    <li>
+        <a href="NHTOC-LXII-632.htm">
+            CHAPTER 632: RAPE
+        </a>
+    </li>
+    
+
+    <li>
+        <a href="NHTOC-LXII-632-A.htm">
+            CHAPTER 632-A: SEXUAL ASSAULT AND RELATED OFFENSES
+        </a>
+    </li>
+    
+
+    <li>
+        <a href="NHTOC-LXII-633.htm">
+            CHAPTER 633: INTERFERENCE WITH FREEDOM
+        </a>
+    </li>
+    
+
+    <li>
+        <a href="NHTOC-LXII-634.htm">
+            CHAPTER 634: DESTRUCTION OF PROPERTY
+        </a>
+    </li>
+    
+
+    <li>
+        <a href="NHTOC-LXII-635.htm">
+            CHAPTER 635: UNAUTHORIZED ENTRIES
+        </a>
+    </li>
+    
+
+    <li>
+        <a href="NHTOC-LXII-636.htm">
+            CHAPTER 636: ROBBERY
+        </a>
+    </li>
+    
+
+    <li>
+        <a href="NHTOC-LXII-637.htm">
+            CHAPTER 637: THEFT
+        </a>
+    </li>
+    
+
+    <li>
+        <a href="NHTOC-LXII-638.htm">
+            CHAPTER 638: FRAUD
+        </a>
+    </li>
+    
+
+    <li>
+        <a href="NHTOC-LXII-639.htm">
+            CHAPTER 639: OFFENSES AGAINST THE FAMILY
+        </a>
+    </li>
+    
+
+    <li>
+        <a href="NHTOC-LXII-639-A.htm">
+            CHAPTER 639-A: CONTROLLED DRUG-RELATED CRIMES
+        </a>
+    </li>
+    
+
+    <li>
+        <a href="NHTOC-LXII-640.htm">
+            CHAPTER 640: CORRUPT PRACTICES
+        </a>
+    </li>
+    
+
+    <li>
+        <a href="NHTOC-LXII-641.htm">
+            CHAPTER 641: FALSIFICATION IN OFFICIAL MATTERS
+        </a>
+    </li>
+    
+
+    <li>
+        <a href="NHTOC-LXII-642.htm">
+            CHAPTER 642: OBSTRUCTING GOVERNMENTAL OPERATIONS
+        </a>
+    </li>
+    
+
+    <li>
+        <a href="NHTOC-LXII-643.htm">
+            CHAPTER 643: ABUSE OF OFFICE
+        </a>
+    </li>
+    
+
+    <li>
+        <a href="NHTOC-LXII-644.htm">
+            CHAPTER 644: BREACHES OF THE PEACE AND RELATED OFFENSES
+        </a>
+    </li>
+    
+
+    <li>
+        <a href="NHTOC-LXII-644-A.htm">
+            CHAPTER 644-A: ELECTRONIC DEVICE LOCATION INFORMATION
+        </a>
+    </li>
+    
+
+    <li>
+        <a href="NHTOC-LXII-645.htm">
+            CHAPTER 645: PUBLIC INDECENCY
+        </a>
+    </li>
+    
+
+    <li>
+        <a href="NHTOC-LXII-646.htm">
+            CHAPTER 646: OFFENSES AGAINST THE FLAG
+        </a>
+    </li>
+    
+
+    <li>
+        <a href="NHTOC-LXII-646-A.htm">
+            CHAPTER 646-A: DESECRATION OF THE FLAG
+        </a>
+    </li>
+    
+
+    <li>
+        <a href="NHTOC-LXII-647.htm">
+            CHAPTER 647: GAMBLING OFFENSES
+        </a>
+    </li>
+    
+
+    <li>
+        <a href="NHTOC-LXII-648.htm">
+            CHAPTER 648: SUBVERSIVE ACTIVITIES
+        </a>
+    </li>
+    
+
+    <li>
+        <a href="NHTOC-LXII-649.htm">
+            CHAPTER 649: SABOTAGE PREVENTION
+        </a>
+    </li>
+    
+
+    <li>
+        <a href="NHTOC-LXII-649-A.htm">
+            CHAPTER 649-A: CHILD SEXUAL ABUSE IMAGES
+        </a>
+    </li>
+    
+
+    <li>
+        <a href="NHTOC-LXII-649-B.htm">
+            CHAPTER 649-B: COMPUTER PORNOGRAPHY AND CHILD EXPLOITATION PREVENTION
+        </a>
+    </li>
+    
+
+    <li>
+        <a href="NHTOC-LXII-650.htm">
+            CHAPTER 650: OBSCENE MATTER
+        </a>
+    </li>
+    
+
+    <li>
+        <a href="NHTOC-LXII-650-A.htm">
+            CHAPTER 650-A: FELONIOUS USE OF FIREARMS
+        </a>
+    </li>
+    
+
+    <li>
+        <a href="NHTOC-LXII-650-B.htm">
+            CHAPTER 650-B: FELONIOUS USE OF BODY ARMOR
+        </a>
+    </li>
+    
+
+    <li>
+        <a href="NHTOC-LXII-650-C.htm">
+            CHAPTER 650-C: NEGLIGENT STORAGE OF FIREARMS
+        </a>
+    </li>
+    
+
+    <li>
+        <a href="NHTOC-LXII-651.htm">
+            CHAPTER 651: SENTENCES
+        </a>
+    </li>
+    
+
+    <li>
+        <a href="NHTOC-LXII-651-A.htm">
+            CHAPTER 651-A: PAROLE OF PRISONERS
+        </a>
+    </li>
+    
+
+    <li>
+        <a href="NHTOC-LXII-651-B.htm">
+            CHAPTER 651-B: REGISTRATION OF CRIMINAL OFFENDERS
+        </a>
+    </li>
+    
+
+    <li>
+        <a href="NHTOC-LXII-651-C.htm">
+            CHAPTER 651-C: DNA TESTING OF CRIMINAL OFFENDERS
+        </a>
+    </li>
+    
+
+    <li>
+        <a href="NHTOC-LXII-651-D.htm">
+            CHAPTER 651-D: POST-CONVICTION DNA TESTING
+        </a>
+    </li>
+    
+
+    <li>
+        <a href="NHTOC-LXII-651-E.htm">
+            CHAPTER 651-E: INTERBRANCH CRIMINAL AND JUVENILE JUSTICE COUNCIL
+        </a>
+    </li>
+    
+
+    <li>
+        <a href="NHTOC-LXII-651-F.htm">
+            CHAPTER 651-F: INFORMATION AND ANALYSIS CENTER
+        </a>
+    </li>
+    
+
+        </ul>
+    </body>
+</html>
+

--- a/scripts/ingest/__tests__/seed-statutes-nh-titlelxii.test.mjs
+++ b/scripts/ingest/__tests__/seed-statutes-nh-titlelxii.test.mjs
@@ -1,0 +1,410 @@
+// test-isolation-na: no Supabase writes — unit tests against real fixture HTML
+//
+// Tests for the NH Title LXII statute seeder using fixtures captured live from
+// gc.nh.gov on 2026-05-02.
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  NH_HOST,
+  NH_BASE_URL,
+  NH_TITLE,
+  buildChapterUrl,
+  buildNHSourceUrl,
+  canonicalSectionId,
+  decodeEntities,
+  stripHtml,
+  discoverChapterTokens,
+  discoverSections,
+  parseSection,
+  normalizeEffectiveDate,
+} from '../lib/nh-html.mjs';
+
+import {
+  NH_COHORT_DEFAULT,
+  NH_CHAPTER_DESCRIPTIONS,
+  NH_TITLELXII_ROW_FLOOR,
+  NH_CRAWL_DELAY_MS,
+  NH_ALLOWED_HOSTS,
+  parseCliFlags,
+  buildNhConfig,
+  bucketBDiscover,
+  bucketBParse,
+  buildSourceUrl,
+  buildChapterConfig,
+} from '../seed-statutes-nh-titlelxii.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const FIXT = path.join(__dirname, 'fixtures', 'nh');
+
+function readFixture(name) {
+  return readFileSync(path.join(FIXT, name), 'utf-8');
+}
+
+// ─── Constants + cohort shape ─────────────────────────────────────────────────
+
+describe('nh-html: NH_HOST / NH_BASE_URL / NH_TITLE', () => {
+  it('NH_HOST is gc.nh.gov', () => {
+    expect(NH_HOST).toBe('gc.nh.gov');
+  });
+  it('NH_BASE_URL is HTTPS gc.nh.gov', () => {
+    expect(NH_BASE_URL).toBe('https://gc.nh.gov');
+  });
+  it('NH_TITLE is LXII (RSA criminal title)', () => {
+    expect(NH_TITLE).toBe('LXII');
+  });
+});
+
+describe('seed-statutes-nh-titlelxii: cohort constants', () => {
+  it('NH_COHORT_DEFAULT contains at least 35 chapters', () => {
+    expect(NH_COHORT_DEFAULT.length).toBeGreaterThanOrEqual(35);
+  });
+  it('cohort is uppercase letter-suffix tokens (e.g. 632-A) and bare numerics (e.g. 630)', () => {
+    for (const tok of NH_COHORT_DEFAULT) {
+      expect(tok).toMatch(/^\d+(?:-[A-Z])?$/);
+    }
+  });
+  it('cohort includes 630 (Homicide) and 632-A (Sexual Assault)', () => {
+    expect(NH_COHORT_DEFAULT).toContain('630');
+    expect(NH_COHORT_DEFAULT).toContain('632-A');
+    expect(NH_COHORT_DEFAULT).toContain('651-A');
+  });
+  it('cohort excludes 632 (whole chapter repealed in 1975)', () => {
+    expect(NH_COHORT_DEFAULT).not.toContain('632');
+  });
+  it('NH_CHAPTER_DESCRIPTIONS covers every cohort chapter', () => {
+    for (const tok of NH_COHORT_DEFAULT) {
+      expect(NH_CHAPTER_DESCRIPTIONS[tok]).toBeTruthy();
+    }
+  });
+  it('NH_TITLELXII_ROW_FLOOR is 250 (conservative — design est. 600-800)', () => {
+    expect(NH_TITLELXII_ROW_FLOOR).toBe(250);
+  });
+  it('NH_CRAWL_DELAY_MS is 11000 (matches gc.nh.gov robots.txt)', () => {
+    expect(NH_CRAWL_DELAY_MS).toBe(11000);
+  });
+  it('NH_ALLOWED_HOSTS contains exactly gc.nh.gov', () => {
+    expect(NH_ALLOWED_HOSTS).toEqual(['gc.nh.gov']);
+  });
+});
+
+// ─── CLI flag parsing ─────────────────────────────────────────────────────────
+
+describe('parseCliFlags', () => {
+  it('defaults to live, non-verbose, no chapter filter, no limit', () => {
+    expect(parseCliFlags([])).toEqual({
+      dryRun: false, verbose: false, chapters: null, limit: null,
+    });
+  });
+  it('parses --dry-run / --verbose flags', () => {
+    expect(parseCliFlags(['--dry-run'])).toMatchObject({ dryRun: true, verbose: false });
+    expect(parseCliFlags(['--verbose'])).toMatchObject({ dryRun: false, verbose: true });
+  });
+  it('parses --chapters=A,B,C and uppercases', () => {
+    expect(parseCliFlags(['--chapters=630,632-a,651'])).toMatchObject({
+      chapters: ['630', '632-A', '651'],
+    });
+  });
+  it('parses --limit=N as integer', () => {
+    expect(parseCliFlags(['--limit=42'])).toMatchObject({ limit: 42 });
+  });
+});
+
+// ─── Config builder ───────────────────────────────────────────────────────────
+
+describe('buildNhConfig', () => {
+  it('full cohort by default with 11s crawl delay and gc.nh.gov allowlist', () => {
+    const c = buildNhConfig();
+    expect(c.cohort).toEqual(NH_COHORT_DEFAULT);
+    expect(c.stateCode).toBe('NH');
+    expect(c.titleNum).toBe('LXII');
+    expect(c.crawlDelayMs).toBe(11000);
+    expect(c.allowedHosts).toEqual(['gc.nh.gov']);
+  });
+  it('filters cohort by --chapters and case-insensitively', () => {
+    const c = buildNhConfig({ chapters: ['630', '632-A'] });
+    expect(c.cohort).toEqual(['630', '632-A']);
+  });
+  it('respects --limit option (passed through)', () => {
+    const c = buildNhConfig({ limit: 5 });
+    expect(c.limit).toBe(5);
+  });
+});
+
+// ─── URL builders + canonical id ──────────────────────────────────────────────
+
+describe('buildChapterUrl', () => {
+  it('builds chapter TOC URL for plain-numeric chapter', () => {
+    expect(buildChapterUrl('630')).toBe('https://gc.nh.gov/rsa/html/NHTOC/NHTOC-LXII-630.htm');
+  });
+  it('builds chapter TOC URL for letter-suffix chapter', () => {
+    expect(buildChapterUrl('632-A')).toBe('https://gc.nh.gov/rsa/html/NHTOC/NHTOC-LXII-632-A.htm');
+  });
+});
+
+describe('buildNHSourceUrl', () => {
+  it('builds section URL for plain-numeric chapter + numeric section', () => {
+    expect(buildNHSourceUrl('630', '1')).toBe('https://gc.nh.gov/rsa/html/LXII/630/630-1.htm');
+  });
+  it('builds section URL for letter-suffix chapter + numeric section', () => {
+    expect(buildNHSourceUrl('632-A', '2')).toBe('https://gc.nh.gov/rsa/html/LXII/632-A/632-A-2.htm');
+  });
+  it('builds section URL for sub-letter section like 1-a', () => {
+    expect(buildNHSourceUrl('630', '1-a')).toBe('https://gc.nh.gov/rsa/html/LXII/630/630-1-a.htm');
+  });
+  it('always emits HTTPS gc.nh.gov', () => {
+    expect(buildNHSourceUrl('651-A', '24')).toMatch(/^https:\/\/gc\.nh\.gov\//);
+  });
+});
+
+describe('canonicalSectionId', () => {
+  it('joins chapter + sec with colon (RSA citation form)', () => {
+    expect(canonicalSectionId('630', '1')).toBe('630:1');
+    expect(canonicalSectionId('632-A', '2')).toBe('632-A:2');
+    expect(canonicalSectionId('651-A', '24')).toBe('651-A:24');
+  });
+  it('preserves internal dashes in sec ("1-a")', () => {
+    expect(canonicalSectionId('630', '1-a')).toBe('630:1-a');
+  });
+});
+
+describe('buildSourceUrl (RSA-cite to URL)', () => {
+  it('round-trips plain-numeric cite', () => {
+    expect(buildSourceUrl('630:1')).toBe('https://gc.nh.gov/rsa/html/LXII/630/630-1.htm');
+  });
+  it('round-trips letter-suffix cite', () => {
+    expect(buildSourceUrl('632-A:2')).toBe('https://gc.nh.gov/rsa/html/LXII/632-A/632-A-2.htm');
+  });
+  it('round-trips sub-letter cite', () => {
+    expect(buildSourceUrl('630:1-a')).toBe('https://gc.nh.gov/rsa/html/LXII/630/630-1-a.htm');
+  });
+});
+
+describe('buildChapterConfig', () => {
+  it('returns chapter, chapterUrl, description, crawl delay, allowlist', () => {
+    const c = buildChapterConfig('630');
+    expect(c.chapter).toBe('630');
+    expect(c.chapterUrl).toBe('https://gc.nh.gov/rsa/html/NHTOC/NHTOC-LXII-630.htm');
+    expect(c.description).toBe('Homicide');
+    expect(c.crawlDelayMs).toBe(11000);
+    expect(c.allowedHosts).toEqual(['gc.nh.gov']);
+  });
+  it('returns null description for unknown chapter', () => {
+    const c = buildChapterConfig('999');
+    expect(c.description).toBeNull();
+  });
+});
+
+// ─── HTML helpers ────────────────────────────────────────────────────────────
+
+describe('decodeEntities', () => {
+  it('decodes basic HTML entities', () => {
+    expect(decodeEntities('A &amp; B')).toBe('A & B');
+    expect(decodeEntities('&lt;tag&gt;')).toBe('<tag>');
+    expect(decodeEntities('it&#39;s')).toBe("it's");
+    expect(decodeEntities('&nbsp;')).toBe(' ');
+  });
+  it('decodes the windows-1252 dash &#150; to "-"', () => {
+    expect(decodeEntities('Capital Murder. &#150;')).toBe('Capital Murder. -');
+  });
+  it('decodes section-sign variants', () => {
+    expect(decodeEntities('&sect;')).toBe('§');
+    expect(decodeEntities('&#xa7;')).toBe('§');
+    expect(decodeEntities('&#167;')).toBe('§');
+  });
+  it('drops C0 control chars', () => {
+    expect(decodeEntities('a&#0;b')).toBe('ab');
+    expect(decodeEntities('a&#7;b')).toBe('ab');
+  });
+});
+
+describe('stripHtml', () => {
+  it('strips tags and collapses whitespace within lines', () => {
+    expect(stripHtml('<p>hello <b>world</b></p>')).toBe('hello world');
+  });
+  it('drops <script> and <style>', () => {
+    expect(stripHtml('a<script>x()</script>b')).toBe('a b');
+  });
+  it('preserves <br>-derived line breaks', () => {
+    expect(stripHtml('a<br>b<br>c')).toBe('a\nb\nc');
+  });
+  it('returns empty string for null/empty', () => {
+    expect(stripHtml('')).toBe('');
+    expect(stripHtml(null)).toBe('');
+  });
+});
+
+describe('normalizeEffectiveDate', () => {
+  it('parses "Jan. 1, 2018" → "2018-01-01"', () => {
+    expect(normalizeEffectiveDate('Jan. 1, 2018')).toBe('2018-01-01');
+  });
+  it('parses "July 1, 2011" → "2011-07-01"', () => {
+    expect(normalizeEffectiveDate('July 1, 2011')).toBe('2011-07-01');
+  });
+  it('parses "5-30-2019" → "2019-05-30"', () => {
+    expect(normalizeEffectiveDate('5-30-2019')).toBe('2019-05-30');
+  });
+  it('expands 2-digit year "1-1-24" → "2024-01-01"', () => {
+    expect(normalizeEffectiveDate('1-1-24')).toBe('2024-01-01');
+  });
+  it('returns null for unparseable input', () => {
+    expect(normalizeEffectiveDate('garbage')).toBeNull();
+  });
+});
+
+// ─── discoverChapterTokens ────────────────────────────────────────────────────
+
+describe('discoverChapterTokens', () => {
+  it('extracts >= 35 chapter tokens from the title TOC fixture', () => {
+    const html = readFixture('title-lxii-toc-sample.html');
+    const tokens = discoverChapterTokens(html);
+    expect(tokens.length).toBeGreaterThanOrEqual(35);
+  });
+  it('preserves document order + dedupes', () => {
+    const html = readFixture('title-lxii-toc-sample.html');
+    const tokens = discoverChapterTokens(html);
+    expect(new Set(tokens).size).toBe(tokens.length);
+    expect(tokens.indexOf('625')).toBeLessThan(tokens.indexOf('630'));
+    expect(tokens.indexOf('630')).toBeLessThan(tokens.indexOf('632-A'));
+  });
+  it('captures letter-suffix tokens (632-A, 639-A, 651-A..F)', () => {
+    const html = readFixture('title-lxii-toc-sample.html');
+    const tokens = discoverChapterTokens(html);
+    for (const tok of ['632-A', '639-A', '644-A', '649-A', '649-B', '650-A', '651-A', '651-F']) {
+      expect(tokens).toContain(tok);
+    }
+  });
+  it('returns [] for empty/non-string input', () => {
+    expect(discoverChapterTokens('')).toEqual([]);
+    expect(discoverChapterTokens(null)).toEqual([]);
+  });
+});
+
+// ─── discoverSections ────────────────────────────────────────────────────────
+
+describe('discoverSections (chapter 630)', () => {
+  const html = readFixture('chapter-630-toc-sample.html');
+  it('returns >= 6 active descriptors', () => {
+    const sections = discoverSections(html, '630');
+    expect(sections.length).toBeGreaterThanOrEqual(6);
+  });
+  it('includes 630:1 and 630:1-a (Capital Murder + First Degree Murder)', () => {
+    const sections = discoverSections(html, '630');
+    const ids = sections.map((s) => s.sectionId);
+    expect(ids).toContain('630:1');
+    expect(ids).toContain('630:1-a');
+  });
+  it('every descriptor URL is HTTPS gc.nh.gov', () => {
+    const sections = discoverSections(html, '630');
+    for (const s of sections) {
+      expect(s.url).toMatch(/^https:\/\/gc\.nh\.gov\//);
+    }
+  });
+  it('skips the merged-text 630-mrg.htm link', () => {
+    const sections = discoverSections(html, '630');
+    for (const s of sections) {
+      expect(s.section).not.toBe('mrg');
+      expect(s.url).not.toMatch(/630-mrg\.htm$/);
+    }
+  });
+  it('dedupes within the chapter', () => {
+    const sections = discoverSections(html, '630');
+    expect(new Set(sections.map((s) => s.sectionId)).size).toBe(sections.length);
+  });
+});
+
+describe('discoverSections (letter-suffix chapter 632-A)', () => {
+  const html = readFixture('chapter-632-A-toc-sample.html');
+  it('returns descriptors using citation form 632-A:N', () => {
+    const sections = discoverSections(html, '632-A');
+    expect(sections.length).toBeGreaterThanOrEqual(10);
+    const ids = sections.map((s) => s.sectionId);
+    expect(ids).toContain('632-A:1');
+    expect(ids).toContain('632-A:2');
+  });
+  it('every URL points at LXII/632-A/632-A-... path', () => {
+    const sections = discoverSections(html, '632-A');
+    for (const s of sections) {
+      expect(s.url).toMatch(/^https:\/\/gc\.nh\.gov\/rsa\/html\/LXII\/632-A\/632-A-/);
+    }
+  });
+});
+
+// ─── parseSection ─────────────────────────────────────────────────────────────
+
+describe('parseSection: active section (630:1 Capital Murder)', () => {
+  const html = readFixture('section-630-1-sample.html');
+  it('returns a populated row', () => {
+    const r = parseSection(html, '630:1');
+    expect(r).not.toBeNull();
+    expect(r.titleText).toBe('Capital Murder');
+    expect(r.bodyText.length).toBeGreaterThan(500);
+    expect(r.bodyText).toMatch(/capital murder/i);
+  });
+  it('extracts effective date from the source-note', () => {
+    const r = parseSection(html, '630:1');
+    expect(r.effectiveDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+});
+
+describe('parseSection: section-number mismatch returns null', () => {
+  const html = readFixture('section-630-1-sample.html');
+  it('returns null when expected cite does not match heading', () => {
+    expect(parseSection(html, '999:99')).toBeNull();
+  });
+});
+
+describe('parseSection: repealed section returns null', () => {
+  const html = readFixture('section-repealed-sample.html');
+  it('returns null on Repealed-by heading', () => {
+    expect(parseSection(html, '651:7')).toBeNull();
+  });
+});
+
+describe('parseSection: too-short input returns null', () => {
+  it('returns null for HTML under 200 chars', () => {
+    expect(parseSection('<html><body>short</body></html>', '630:1')).toBeNull();
+  });
+  it('returns null for null/empty input', () => {
+    expect(parseSection(null, '630:1')).toBeNull();
+    expect(parseSection('', '630:1')).toBeNull();
+  });
+});
+
+// ─── Bucket-B harness adapter shape ──────────────────────────────────────────
+
+describe('bucketBDiscover (chapter, html) → descriptor[]', () => {
+  it('accepts chapter as a string arg', () => {
+    const html = readFixture('chapter-630-toc-sample.html');
+    const out = bucketBDiscover(html, '630');
+    expect(Array.isArray(out)).toBe(true);
+    expect(out.length).toBeGreaterThanOrEqual(6);
+    expect(out[0]).toMatchObject({ chapter: '630', sectionId: expect.any(String) });
+  });
+  it('accepts a config object with .chapter', () => {
+    const html = readFixture('chapter-630-toc-sample.html');
+    const out = bucketBDiscover(html, { chapter: '630' });
+    expect(out.length).toBeGreaterThanOrEqual(6);
+  });
+  it('returns [] when chapter missing', () => {
+    expect(bucketBDiscover('x', undefined)).toEqual([]);
+  });
+});
+
+describe('bucketBParse (html, sectionRsaCite) → {titleText, bodyText}|null', () => {
+  it('returns harness-shaped row (no effectiveDate)', () => {
+    const html = readFixture('section-630-1-sample.html');
+    const out = bucketBParse(html, '630:1');
+    expect(out).not.toBeNull();
+    expect(out).toHaveProperty('titleText');
+    expect(out).toHaveProperty('bodyText');
+    expect(out).not.toHaveProperty('effectiveDate');
+  });
+  it('returns null for repealed', () => {
+    const html = readFixture('section-repealed-sample.html');
+    expect(bucketBParse(html, '651:7')).toBeNull();
+  });
+});

--- a/scripts/ingest/lib/nh-html.mjs
+++ b/scripts/ingest/lib/nh-html.mjs
@@ -1,0 +1,276 @@
+// HTML parsing helpers for gc.nh.gov RSA statute pages.
+//
+// Source surface:
+//   Title TOC:    https://gc.nh.gov/rsa/html/NHTOC/NHTOC-LXII.htm
+//   Chapter TOC:  https://gc.nh.gov/rsa/html/NHTOC/NHTOC-LXII-{C}.htm
+//   Section:      https://gc.nh.gov/rsa/html/LXII/{C}/{C}-{S}.htm
+//
+// Citation form:  RSA {C}:{S}  (e.g. "RSA 630:1")
+// URL form:       dash everywhere ({C}-{S}.htm)
+// Letter chapters: 632-A, 639-A, 644-A, 646-A, 649-A, 649-B, 650-A/B/C, 651-A..F
+//
+// Robots:  User-agent: * / Crawl-Delay: 11 (gc.nh.gov, verified 2026-05-02)
+//   No path disallows for *. AhrefsBot fully disallowed.
+//
+// Plan: docs/plans/2026-05-02-nh-titlelxii-design.md
+//
+// Page structure (verified 2026-05-02):
+//   Active section page:
+//     <html><head><title>Section 630:1 Capital Murder.</title></head>
+//     <body>
+//       <center><h1>TITLE LXII<br>CRIMINAL CODE</h1></center>
+//       <center><h2>CHAPTER 630<br>HOMICIDE</h2></center>
+//       <center><h3>Section 630:1</h3></center>
+//       &nbsp;&nbsp;&nbsp;<b> 630:1 Capital Murder. &#150;</b>
+//       <codesect>...body text with <br>...</codesect>
+//       <sourcenote><p><b>Source.</b> 1971, 518:1. ... eff. <date>.</p></sourcenote>
+//     </body></html>
+//
+//   Repealed section page:
+//     Same shell, but the <b> heading reads:
+//     <b> 630:5-a [Repealed, 1985, 351:5, eff. ...].</b>
+//     and there is no <codesect> body.
+//
+// Pure in-memory string processing — no file I/O.
+
+export const NH_HOST = 'gc.nh.gov';
+export const NH_BASE_URL = `https://${NH_HOST}`;
+export const NH_TITLE = 'LXII';
+
+// ── URL builders ─────────────────────────────────────────────────────────────
+
+export function buildChapterUrl(chapter) {
+  return `${NH_BASE_URL}/rsa/html/NHTOC/NHTOC-${NH_TITLE}-${chapter}.htm`;
+}
+
+export function buildNHSourceUrl(chapter, section) {
+  return `${NH_BASE_URL}/rsa/html/${NH_TITLE}/${chapter}/${chapter}-${section}.htm`;
+}
+
+/**
+ * Canonical RSA section id for the `section` DB column.
+ * Citation form is colon-separated: "630:1", "632-A:2", "651-A:24".
+ */
+export function canonicalSectionId(chapter, sec) {
+  return `${chapter}:${sec}`;
+}
+
+// ── Chapter discovery ────────────────────────────────────────────────────────
+
+export function discoverChapterTokens(titleTocHtml) {
+  if (!titleTocHtml || typeof titleTocHtml !== 'string') return [];
+  const seen = new Set();
+  const out = [];
+  const rx = /href\s*=\s*"NHTOC-LXII-([0-9]+(?:-[A-Z])?)\.htm"/gi;
+  let m;
+  while ((m = rx.exec(titleTocHtml)) !== null) {
+    const tok = m[1].toUpperCase();
+    if (seen.has(tok)) continue;
+    seen.add(tok);
+    out.push(tok);
+  }
+  return out;
+}
+
+/**
+ * @typedef {Object} NHSectionDescriptor
+ * @property {string} chapter
+ * @property {string} section    URL-form sub-id (e.g. "1", "1-a")
+ * @property {string} sectionId  citation form ("630:1")
+ * @property {string} url
+ */
+
+export function discoverSections(chapterTocHtml, chapter) {
+  if (!chapterTocHtml || typeof chapterTocHtml !== 'string') return [];
+  const out = [];
+  const seen = new Set();
+  const escaped = chapter.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const rx = new RegExp(
+    `href\\s*=\\s*"\\.\\./${NH_TITLE}/${escaped}/${escaped}-([A-Za-z0-9._-]+)\\.htm"`,
+    'gi',
+  );
+  let m;
+  while ((m = rx.exec(chapterTocHtml)) !== null) {
+    const sec = m[1];
+    if (/^mrg$/i.test(sec)) continue; // skip merged-text link
+    const sectionId = canonicalSectionId(chapter, sec);
+    if (seen.has(sectionId)) continue;
+    seen.add(sectionId);
+    out.push({
+      chapter,
+      section: sec,
+      sectionId,
+      url: buildNHSourceUrl(chapter, sec),
+    });
+  }
+  return out;
+}
+
+// ── HTML utilities ───────────────────────────────────────────────────────────
+
+export function decodeEntities(s) {
+  if (s == null) return '';
+  return String(s)
+    .replace(/&amp;/gi, '&')
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;|&apos;/gi, "'")
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&#x27;/gi, "'")
+    .replace(/&sect;|&#xa7;|&#167;/gi, '§')
+    .replace(/&#150;|&#x96;/gi, '-')
+    .replace(/&#8211;|&#x2013;/gi, '-')
+    .replace(/&#8212;|&#x2014;/gi, '-')
+    .replace(/&#8216;|&#8217;|&#x2018;|&#x2019;/gi, "'")
+    .replace(/&#8220;|&#8221;|&#x201C;|&#x201D;/gi, '"')
+    .replace(/&#(\d+);/g, (_, n) => {
+      const code = Number(n);
+      if (!Number.isInteger(code) || code < 0 || code > 0x10FFFF) return '';
+      if (code < 0x20 && code !== 0x09 && code !== 0x0A && code !== 0x0D) return '';
+      if (code === 0x7F) return '';
+      if (code >= 0xD800 && code <= 0xDFFF) return '';
+      return String.fromCodePoint(code);
+    })
+    .replace(/&#x([0-9a-f]+);/gi, (_, n) => {
+      const code = Number.parseInt(n, 16);
+      if (!Number.isInteger(code) || code < 0 || code > 0x10FFFF) return '';
+      if (code < 0x20 && code !== 0x09 && code !== 0x0A && code !== 0x0D) return '';
+      if (code === 0x7F) return '';
+      if (code >= 0xD800 && code <= 0xDFFF) return '';
+      return String.fromCodePoint(code);
+    });
+}
+
+export function stripHtml(html) {
+  if (!html) return '';
+  let s = html;
+  s = s.replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, ' ');
+  s = s.replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, ' ');
+  s = s.replace(/<!--[\s\S]*?-->/g, ' ');
+  s = s.replace(/<br\s*\/?\s*>/gi, '\n');
+  s = s.replace(/<\/p>/gi, '\n\n');
+  s = s.replace(/<\/div>/gi, '\n');
+  s = s.replace(/<[^>]+>/g, ' ');
+  s = decodeEntities(s);
+  s = s.split('').filter((ch) => {
+    const c = ch.charCodeAt(0);
+    if (c === 9 || c === 10 || c === 13) return true;
+    if (c < 32) return false;
+    if (c === 127) return false;
+    return true;
+  }).join('');
+  return s
+    .split(/\r?\n/)
+    .map((line) => line.replace(/\s+/g, ' ').trim())
+    .filter((line) => line.length > 0)
+    .join('\n')
+    .trim();
+}
+
+// ── Section parser ───────────────────────────────────────────────────────────
+
+function isRepealedHeading(headingBoldText) {
+  if (!headingBoldText) return false;
+  // Two heading shapes seen in the wild:
+  //   "[Repealed, 1985, 351:5, eff. ...]"   (bracketed inline form)
+  //   "Repealed by 1973, 370:39, eff. ..."  (header-line form, codesect empty)
+  if (/\[\s*Repealed\b/i.test(headingBoldText)) return true;
+  if (/\bRepealed\s+by\b/i.test(headingBoldText)) return true;
+  return false;
+}
+
+function headingMatchesSection(headingBoldText, expectedRsaCite) {
+  if (!headingBoldText || !expectedRsaCite) return false;
+  const m = headingBoldText.match(/(\d+(?:-[A-Z])?:[A-Za-z0-9._-]+)/);
+  if (!m) return false;
+  return m[1].toUpperCase() === expectedRsaCite.toUpperCase();
+}
+
+/**
+ * Parse a single gc.nh.gov section page.
+ *
+ * Returns null when the page is too short, missing the heading, repealed,
+ * or doesn't match the expected section number.
+ *
+ * @param {string} html full page HTML
+ * @param {string} expectedRsaCite citation form, e.g. "630:1"
+ * @returns {{ titleText: string, bodyText: string, effectiveDate: string|null }|null}
+ */
+export function parseSection(html, expectedRsaCite) {
+  if (!html || typeof html !== 'string') return null;
+  if (html.length < 200) return null;
+
+  // Use \b word boundary to avoid matching <body>, <br>, <blockquote>, etc.
+  // The heading we want is the first standalone <b> ... </b> block on the page.
+  const headingMatch = html.match(/<b\s*>([\s\S]*?)<\/b>/i);
+  if (!headingMatch) return null;
+  const headingRaw = headingMatch[1];
+  const headingText = stripHtml(headingRaw).replace(/\s+/g, ' ').trim();
+
+  if (isRepealedHeading(headingText)) return null;
+  if (!headingMatchesSection(headingText, expectedRsaCite)) return null;
+
+  const titleText = headingText
+    .replace(/^\s*\d+(?:-[A-Z])?:[A-Za-z0-9._-]+\s*/i, '')
+    .replace(/\s*[-–—]\s*$/, '')
+    .replace(/\.\s*$/, '')
+    .trim();
+
+  let bodyHtml = '';
+  const codesectMatch = html.match(/<codesect\b[^>]*>([\s\S]*?)<\/codesect>/i);
+  if (codesectMatch) {
+    bodyHtml = codesectMatch[1];
+  } else {
+    const headEnd = html.indexOf('</b>', headingMatch.index);
+    const srcStart = html.search(/<sourcenote\b/i);
+    if (headEnd > 0 && srcStart > headEnd) {
+      bodyHtml = html.slice(headEnd + '</b>'.length, srcStart);
+    } else if (headEnd > 0) {
+      bodyHtml = html.slice(headEnd + '</b>'.length);
+    }
+  }
+
+  const bodyText = stripHtml(bodyHtml);
+  if (!bodyText || bodyText.length < 12) return null;
+
+  let effectiveDate = null;
+  const sourceMatch = html.match(/<sourcenote\b[^>]*>([\s\S]*?)<\/sourcenote>/i);
+  if (sourceMatch) {
+    const sourceText = stripHtml(sourceMatch[1]);
+    const effRx = /eff\.\s+([A-Za-z]+\.?\s+\d{1,2},?\s+\d{4}|\d{1,2}-\d{1,2}-\d{2,4})/gi;
+    let lastMatch;
+    let mm;
+    while ((mm = effRx.exec(sourceText)) !== null) lastMatch = mm[1];
+    if (lastMatch) effectiveDate = normalizeEffectiveDate(lastMatch);
+  }
+
+  return {
+    titleText: titleText || `Section ${expectedRsaCite}`,
+    bodyText,
+    effectiveDate,
+  };
+}
+
+const MONTHS = {
+  jan: '01', feb: '02', mar: '03', apr: '04', may: '05', jun: '06',
+  jul: '07', aug: '08', sep: '09', sept: '09', oct: '10', nov: '11', dec: '12',
+};
+
+export function normalizeEffectiveDate(raw) {
+  if (!raw) return null;
+  const s = String(raw).trim();
+  let m = s.match(/^([A-Za-z]+)\.?\s+(\d{1,2}),?\s+(\d{4})$/);
+  if (m) {
+    const mon = MONTHS[m[1].toLowerCase().slice(0, 3)];
+    if (!mon) return null;
+    return `${m[3]}-${mon}-${m[2].padStart(2, '0')}`;
+  }
+  m = s.match(/^(\d{1,2})-(\d{1,2})-(\d{2,4})$/);
+  if (m) {
+    let yr = m[3];
+    if (yr.length === 2) yr = `20${yr}`;
+    return `${yr}-${m[1].padStart(2, '0')}-${m[2].padStart(2, '0')}`;
+  }
+  return null;
+}

--- a/scripts/ingest/seed-statutes-nh-titlelxii.mjs
+++ b/scripts/ingest/seed-statutes-nh-titlelxii.mjs
@@ -1,0 +1,503 @@
+#!/usr/bin/env node
+// Template: scripts/ingest/seed-statutes-il-ch720.mjs
+// Pattern: cl-bulk-data-defensive #14 — port 5432 session-mode
+// Pattern: cl-bulk-data-defensive #17 — session-level timeouts via createBulkClient
+// Pattern: cl-bulk-data-defensive #18 — COPY FROM STDIN via bulkCopyRows
+// Pattern: no-hallucinated-legal-data — every row carries a verified HTTPS source URL
+// csv-bulk-checked: none-exists — gc.nh.gov per-section HTML, no bulk file
+// Engine-only routing: 11s crawl-delay forbids Vercel cron 60s budget; engine
+//   orchestrator owns periodic refresh. This initial backfill ran on a workstation.
+//
+// Plan: docs/plans/2026-05-02-nh-titlelxii-design.md
+//
+// Seeds New Hampshire RSA Title LXII (Criminal Code) into entities_statutes.
+//
+// Source: https://gc.nh.gov/rsa/html/LXII/{C}/{C}-{S}.htm  (per-section HTML)
+// Robots: User-agent: * / Crawl-Delay: 11 (gc.nh.gov, verified 2026-05-02)
+//
+// Cohort (NH_COHORT_DEFAULT): 39 chapters of Title LXII Criminal Code.
+// Floor (NH_TITLELXII_ROW_FLOOR): 250 rows (design report estimates 600-800;
+//   conservative floor avoids brittleness if a few chapters are heavily repealed).
+//
+// Usage:
+//   node scripts/ingest/seed-statutes-nh-titlelxii.mjs --dry-run
+//   node scripts/ingest/seed-statutes-nh-titlelxii.mjs --dry-run --limit=3 --chapters=630
+//   node scripts/ingest/seed-statutes-nh-titlelxii.mjs --verbose
+//   node scripts/ingest/seed-statutes-nh-titlelxii.mjs                 (live; needs SUPABASE_DB_URL)
+
+import path from 'node:path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import {
+  NH_HOST,
+  NH_TITLE,
+  buildChapterUrl,
+  buildNHSourceUrl,
+  canonicalSectionId,
+  discoverChapterTokens,
+  discoverSections,
+  parseSection,
+} from './lib/nh-html.mjs';
+import {
+  fetchWithRetry,
+  buildSectionRow,
+  applyToDb,
+} from '../lib/justia-harness.mjs';
+
+const execFileP = promisify(execFile);
+
+// ── Curl-transport fetchImpl (defeat undici deadlock on Windows) ──────────────
+//
+// Native Node fetch (undici) has a Windows-specific bug where AbortController
+// occasionally fails to kill a stuck socket — leaves the script hung with 0 CPU
+// and 0 active connections. Observed 2026-05-03 mid-NH-ingest after ~1 hr of
+// stalled-no-progress. Workaround: spawn `curl --max-time` per fetch — the OS
+// kernel kills the curl process on timeout, no shared event loop to deadlock.
+//
+// Returns a fetch-shaped object with .ok, .status, .statusText, .text() so the
+// justia-harness fetchWithRetry retry/breaker logic still applies.
+async function curlFetch(url, init = {}) {
+  const headers = init.headers || {};
+  const ua = headers['User-Agent'] || 'ImNotAnAttorney-statute-seed/1.0 (legal research)';
+  const accept = headers['Accept'] || 'text/html';
+  // 30s socket-level + 60s wall-clock
+  const args = [
+    '-sS', '-L', '--compressed',
+    '--max-time', '60',
+    '--connect-timeout', '15',
+    '-A', ua,
+    '-H', `Accept: ${accept}`,
+    '-w', '\\n__HTTP_STATUS__=%{http_code}',
+    url,
+  ];
+  let stdout, stderr;
+  try {
+    const r = await execFileP('curl', args, { maxBuffer: 8 * 1024 * 1024, windowsHide: true });
+    stdout = r.stdout; stderr = r.stderr;
+  } catch (e) {
+    // curl exit codes: 28=timeout, 6/7=DNS/connect, others=transport. Surface as transport error.
+    const err = new Error(`curl failed: ${e.code || 'unknown'} ${(e.stderr || e.message || '').slice(0, 200)}`);
+    err.cause = e;
+    throw err;
+  }
+  // Strip status footer
+  const m = stdout.match(/\n__HTTP_STATUS__=(\d{3})\s*$/);
+  let status = 0;
+  let body = stdout;
+  if (m) {
+    status = Number.parseInt(m[1], 10);
+    body = stdout.slice(0, m.index);
+  }
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status ? `HTTP ${status}` : 'unknown',
+    text: async () => body,
+  };
+}
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// ── Env loader ────────────────────────────────────────────────────────────────
+const dotenvPath = path.resolve(__dirname, '../../.env.local');
+try {
+  const { config } = await import('dotenv');
+  config({ path: dotenvPath });
+} catch {
+  /* dotenv optional — env may be pre-set */
+}
+
+// ── Cohort + descriptions (verified 2026-05-02 via title TOC) ────────────────
+
+/**
+ * NH Title LXII chapter cohort. Verified 2026-05-02 against
+ * https://gc.nh.gov/rsa/html/NHTOC/NHTOC-LXII.htm
+ * Excludes 632 (whole chapter repealed in 1975 — superseded by 632-A).
+ */
+export const NH_COHORT_DEFAULT = [
+  '625', '626', '627', '628', '629',
+  '630', '631', '632-A', '633',
+  '634', '635', '636', '637', '638',
+  '639', '639-A',
+  '640', '641', '642', '643',
+  '644', '644-A', '645',
+  '646', '646-A',
+  '647', '648',
+  '649', '649-A', '649-B',
+  '650', '650-A', '650-B', '650-C',
+  '651', '651-A', '651-B', '651-C', '651-D', '651-E', '651-F',
+];
+
+export const NH_CHAPTER_DESCRIPTIONS = {
+  '625': 'Preliminary',
+  '626': 'General Principles',
+  '627': 'Justification',
+  '628': 'Responsibility',
+  '629': 'Inchoate Crimes',
+  '630': 'Homicide',
+  '631': 'Assault and Related Offenses',
+  '632-A': 'Sexual Assault and Related Offenses',
+  '633': 'Interference with Freedom',
+  '634': 'Destruction of Property',
+  '635': 'Unauthorized Entries',
+  '636': 'Robbery',
+  '637': 'Theft',
+  '638': 'Fraud',
+  '639': 'Offenses Against the Family',
+  '639-A': 'Controlled Drug-Related Crimes',
+  '640': 'Corrupt Practices',
+  '641': 'Falsification in Official Matters',
+  '642': 'Obstructing Governmental Operations',
+  '643': 'Abuse of Office',
+  '644': 'Breaches of the Peace and Related Offenses',
+  '644-A': 'Electronic Device Location Information',
+  '645': 'Public Indecency',
+  '646': 'Offenses Against the Flag',
+  '646-A': 'Desecration of the Flag',
+  '647': 'Gambling Offenses',
+  '648': 'Subversive Activities',
+  '649': 'Sabotage Prevention',
+  '649-A': 'Child Sexual Abuse Images',
+  '649-B': 'Computer Pornography and Child Exploitation Prevention',
+  '650': 'Obscene Matter',
+  '650-A': 'Felonious Use of Firearms',
+  '650-B': 'Felonious Use of Body Armor',
+  '650-C': 'Negligent Storage of Firearms',
+  '651': 'Sentences',
+  '651-A': 'Parole of Prisoners',
+  '651-B': 'Registration of Criminal Offenders',
+  '651-C': 'DNA Testing of Criminal Offenders',
+  '651-D': 'Post-Conviction DNA Testing',
+  '651-E': 'Interbranch Criminal and Juvenile Justice Council',
+  '651-F': 'Information and Analysis Center',
+};
+
+export const NH_TITLELXII_ROW_FLOOR = 250;
+export const NH_CRAWL_DELAY_MS = 11000;
+export const NH_FETCH_TIMEOUT_MS = 45000;
+export const NH_ALLOWED_HOSTS = [NH_HOST];
+
+// ── CLI ───────────────────────────────────────────────────────────────────────
+export function parseCliFlags(argv) {
+  const flags = {
+    dryRun: false,
+    verbose: false,
+    chapters: null,
+    limit: null,
+  };
+  for (const a of argv) {
+    if (a === '--dry-run') flags.dryRun = true;
+    else if (a === '--verbose') flags.verbose = true;
+    else if (a.startsWith('--chapters=')) {
+      flags.chapters = a.slice('--chapters='.length).split(',').map((s) => s.trim().toUpperCase()).filter(Boolean);
+    } else if (a.startsWith('--limit=')) {
+      flags.limit = Number.parseInt(a.slice('--limit='.length), 10);
+    }
+  }
+  return flags;
+}
+
+// ── NH config ─────────────────────────────────────────────────────────────────
+export function buildNhConfig({ chapters, limit } = {}) {
+  const cohort = chapters && chapters.length
+    ? NH_COHORT_DEFAULT.filter((c) => chapters.includes(c.toUpperCase()))
+    : NH_COHORT_DEFAULT;
+  return {
+    stateCode: 'NH',
+    stateName: 'New Hampshire',
+    titleNum: NH_TITLE,            // 'LXII'
+    titleLabel: 'Criminal Code',
+    allowedHosts: NH_ALLOWED_HOSTS,
+    crawlDelayMs: NH_CRAWL_DELAY_MS,
+    fetchTimeoutMs: NH_FETCH_TIMEOUT_MS,
+    cohort,
+    limit: limit || null,
+  };
+}
+
+// ── Discovery + parsing pipeline ──────────────────────────────────────────────
+
+/**
+ * Discover all section descriptors across the configured chapter cohort.
+ * Returns ordered + deduped NHSectionDescriptor[].
+ *
+ * @param {ReturnType<typeof buildNhConfig>} config
+ * @param {{ verbose?: boolean, fetchImpl?: Function }} [opts]
+ */
+export async function discoverAllSections(config, opts = {}) {
+  const { verbose = false, fetchImpl } = opts;
+  const fetchOpts = {
+    allowedHosts: config.allowedHosts,
+    crawlDelayMs: config.crawlDelayMs,
+    fetchTimeoutMs: config.fetchTimeoutMs,
+    fetchImpl,
+  };
+  const seen = new Set();
+  const out = [];
+  for (const chapter of config.cohort) {
+    const url = buildChapterUrl(chapter);
+    let html;
+    try {
+      html = await fetchWithRetry(url, fetchOpts);
+    } catch (e) {
+      console.warn(`  [chapter ${chapter}] fetch failed: ${e.message}`);
+      continue;
+    }
+    const sections = discoverSections(html, chapter);
+    if (verbose) {
+      console.log(`  [chapter ${chapter}] ${sections.length} sections`);
+    } else {
+      process.stdout.write('.');
+    }
+    for (const s of sections) {
+      if (seen.has(s.url)) continue;
+      seen.add(s.url);
+      out.push(s);
+    }
+  }
+  if (!verbose) process.stdout.write('\n');
+  return out;
+}
+
+/**
+ * Fetch + parse all section descriptors → built validated rows.
+ *
+ * @param {ReturnType<typeof buildNhConfig>} config
+ * @param {NHSectionDescriptor[]} descriptors
+ * @param {{ verbose?: boolean, fetchImpl?: Function }} [opts]
+ */
+export async function collectRows(config, descriptors, opts = {}) {
+  const { verbose = false, fetchImpl } = opts;
+  const fetchOpts = {
+    allowedHosts: config.allowedHosts,
+    crawlDelayMs: config.crawlDelayMs,
+    fetchTimeoutMs: config.fetchTimeoutMs,
+    fetchImpl,
+  };
+  const rows = [];
+  let skipCount = 0;
+  let errorCount = 0;
+  let attemptCount = 0;
+  let parsedCount = 0;
+  let repealedCount = 0;
+
+  for (const d of descriptors) {
+    if (config.limit !== null && attemptCount >= config.limit) {
+      console.log(`  limit=${config.limit} reached — stopping`);
+      break;
+    }
+    attemptCount += 1;
+
+    let html;
+    try {
+      html = await fetchWithRetry(d.url, fetchOpts);
+    } catch (e) {
+      skipCount += 1;
+      if (verbose) console.warn(`    [skip] ${d.sectionId}: fetch failed — ${e.message}`);
+      continue;
+    }
+
+    const parsed = parseSection(html, d.sectionId);
+    if (!parsed) {
+      // null = repealed, 404-shape, parse-mismatch — all expected
+      repealedCount += 1;
+      if (verbose) console.log(`    [skip] ${d.sectionId}: repealed or unparseable`);
+      continue;
+    }
+
+    const harnessConfig = {
+      stateCode: config.stateCode,
+      titleNum: config.titleNum,
+      allowedHosts: config.allowedHosts,
+    };
+    const { row, errors } = buildSectionRow(harnessConfig, d.sectionId, d.url, parsed);
+    if (errors.length > 0) {
+      errorCount += 1;
+      if (verbose) console.warn(`    [err] ${d.sectionId}: ${errors.join('; ')}`);
+      continue;
+    }
+    rows.push(row);
+    parsedCount += 1;
+    // Always emit per-section heartbeat (even non-verbose) so log file shows
+    // forward progress and we can detect hangs. Force flush via stderr write.
+    process.stderr.write(`    OK ${d.sectionId} (${parsedCount}/${descriptors.length} in chapter, body=${row.section_text.length}b)\n`);
+  }
+
+  return { rows, skipCount, errorCount, repealedCount, attemptCount };
+}
+
+// ── Bucket-B harness adapter (per plan §1) ────────────────────────────────────
+//
+// These wrappers expose the parser shape the bucket-b harness expects when (and
+// if) the harness contract lands. They're verified by tests and are inert to
+// the orchestrator's direct discovery+parse flow above.
+
+export function bucketBDiscover(tocHtml, configOrChapter) {
+  const chapter = typeof configOrChapter === 'string' ? configOrChapter : configOrChapter?.chapter;
+  if (!chapter) return [];
+  return discoverSections(tocHtml, chapter);
+}
+
+export function bucketBParse(html, sectionRsaCite) {
+  const out = parseSection(html, sectionRsaCite);
+  if (!out) return null;
+  // Harness contract: { titleText, bodyText } — drop effectiveDate field.
+  return { titleText: out.titleText, bodyText: out.bodyText };
+}
+
+export function buildSourceUrl(sectionRsaCite) {
+  // sectionRsaCite e.g. "630:1" or "632-A:2" — split on ':' once
+  const idx = sectionRsaCite.indexOf(':');
+  if (idx < 0) return null;
+  const chapter = sectionRsaCite.slice(0, idx);
+  const sec = sectionRsaCite.slice(idx + 1);
+  return buildNHSourceUrl(chapter, sec);
+}
+
+export function buildChapterConfig(chapter) {
+  return {
+    chapter,
+    chapterUrl: buildChapterUrl(chapter),
+    description: NH_CHAPTER_DESCRIPTIONS[chapter] || null,
+    crawlDelayMs: NH_CRAWL_DELAY_MS,
+    fetchTimeoutMs: NH_FETCH_TIMEOUT_MS,
+    allowedHosts: NH_ALLOWED_HOSTS,
+  };
+}
+
+// Re-export so tests can reach helpers without touching the lib path directly.
+export { canonicalSectionId, discoverChapterTokens };
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+
+async function main() {
+  const flags = parseCliFlags(process.argv.slice(2));
+  const config = buildNhConfig({ chapters: flags.chapters, limit: flags.limit });
+
+  console.log('[seed-statutes-nh-titlelxii] gc.nh.gov RSA Title LXII Criminal Code');
+  console.log(`  cohort: ${config.cohort.length} chapter(s) (engine-only routing flagged in seeder header)`);
+  if (flags.chapters) console.log(`  --chapters filter: ${flags.chapters.join(',')}`);
+  if (flags.limit) console.log(`  --limit: ${flags.limit}`);
+  console.log(`  crawl-delay: ${config.crawlDelayMs}ms (matches gc.nh.gov robots.txt)`);
+  console.log(`  fetch transport: curl child_process (defeats undici Windows deadlock)`);
+
+  if (flags.dryRun) {
+    console.log('  mode: DRY RUN — no DB writes');
+  } else {
+    if (!process.env.SUPABASE_DB_URL) {
+      console.error('ERROR: SUPABASE_DB_URL not set. Run with --dry-run or set the env var.');
+      process.exit(1);
+    }
+    console.log('  mode: LIVE RUN — will write to entities_statutes (per-chapter commits)');
+  }
+
+  const t0 = Date.now();
+
+  // Step 1: discover sections per chapter, then commit per chapter so a stall
+  // mid-run still preserves earlier chapters in the DB. Force forward stdout
+  // flushes so the nohup log isn't block-buffered.
+  console.log('\n[step 1+2+3] per-chapter discover → fetch → COPY');
+  let totalRows = 0;
+  let totalAttempts = 0;
+  let totalFetchSkip = 0;
+  let totalRepealed = 0;
+  let totalErrors = 0;
+
+  for (let ci = 0; ci < config.cohort.length; ci++) {
+    const chapter = config.cohort[ci];
+    const tcs = Date.now();
+    console.log(`\n  [${ci + 1}/${config.cohort.length}] chapter ${chapter} (${NH_CHAPTER_DESCRIPTIONS[chapter] || '?'})`);
+
+    // Discover sections for THIS chapter only.
+    const chapterUrl = buildChapterUrl(chapter);
+    let chapterHtml;
+    try {
+      chapterHtml = await fetchWithRetry(chapterUrl, {
+        allowedHosts: config.allowedHosts,
+        crawlDelayMs: config.crawlDelayMs,
+        fetchTimeoutMs: config.fetchTimeoutMs,
+        fetchImpl: curlFetch,
+      });
+    } catch (e) {
+      console.warn(`    chapter TOC fetch failed: ${e.message}`);
+      continue;
+    }
+    const sections = discoverSections(chapterHtml, chapter);
+    console.log(`    discovered: ${sections.length}`);
+
+    if (config.limit !== null && totalAttempts >= config.limit) {
+      console.log(`    limit=${config.limit} reached — stopping`);
+      break;
+    }
+
+    // Apply --limit across chapters cumulatively.
+    let allowedThisChapter = sections;
+    if (config.limit !== null) {
+      const remaining = Math.max(0, config.limit - totalAttempts);
+      allowedThisChapter = sections.slice(0, remaining);
+    }
+
+    const { rows, skipCount, errorCount, repealedCount, attemptCount } = await collectRows(
+      { ...config, limit: null },
+      allowedThisChapter,
+      { verbose: flags.verbose, fetchImpl: curlFetch },
+    );
+
+    totalAttempts += attemptCount;
+    totalFetchSkip += skipCount;
+    totalRepealed += repealedCount;
+    totalErrors += errorCount;
+
+    console.log(`    parsed=${rows.length} repealed_or_skipped=${repealedCount} fetch_skip=${skipCount} build_err=${errorCount}`);
+
+    if (rows.length > 0) {
+      const dbResult = await applyToDb(rows, config, { dryRun: flags.dryRun });
+      totalRows += dbResult.rowCount;
+      const tcMs = Date.now() - tcs;
+      console.log(`    [chapter ${chapter}] +${dbResult.rowCount} rows committed (deleted ${dbResult.deleted ?? 0} prior) — ${(tcMs/1000).toFixed(0)}s`);
+    } else if (flags.dryRun) {
+      console.log(`    [chapter ${chapter}] dry-run, no rows`);
+    } else {
+      console.log(`    [chapter ${chapter}] zero rows to commit (all repealed?)`);
+    }
+  }
+
+  const durationMs = Date.now() - t0;
+
+  console.log('\n=== Summary ===');
+  console.log(`  total rows written : ${totalRows}`);
+  console.log(`  total fetch skips  : ${totalFetchSkip}`);
+  console.log(`  total repealed     : ${totalRepealed}`);
+  console.log(`  total build errors : ${totalErrors}`);
+  console.log(`  total attempts     : ${totalAttempts}`);
+  console.log(`  duration           : ${(durationMs/1000).toFixed(0)}s (${(durationMs/60000).toFixed(1)}min)`);
+
+  // Floor only enforced on full live runs.
+  const isFullRun = !flags.chapters && !flags.limit;
+  if (!flags.dryRun) {
+    if (isFullRun && totalRows < NH_TITLELXII_ROW_FLOOR) {
+      console.error(`\nFAIL: row floor not met — ${totalRows} < ${NH_TITLELXII_ROW_FLOOR}`);
+      process.exit(1);
+    }
+  } else {
+    if (totalRows < 1 && totalAttempts >= 1) {
+      console.error('\nFAIL: dry-run produced 0 rows — pipeline broken');
+      process.exit(1);
+    }
+  }
+
+  console.log('\nPASS');
+  process.exit(0);
+}
+
+const invokedDirectly = (() => {
+  if (!process.argv[1]) return false;
+  try { return import.meta.url === pathToFileURL(process.argv[1]).href; }
+  catch { return false; }
+})();
+if (invokedDirectly) main().catch((err) => {
+  console.error('[seed-statutes-nh-titlelxii] fatal:', err.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- NH Penal Code (Title LXII) parser + orchestrator + vitest scaffolded for gc.nh.gov RSA HTML
- 66/66 tests pass
- Partial live ingest: 19 rows live in entities_statutes (chapters 625 + 626 of full 41-chapter cohort)
- Floor of 250 rows NOT met by this PR — full ingest deferred to engine repo

## Why partial
Node 22 native fetch (undici) on Windows has a socket-stuck bug — under sustained load, occasional fetches hang at 0 CPU / 0 TCP forever. Mitigations applied:
- curl-transport instead of undici fetch
- Per-chapter DELETE-then-COPY commits (partial progress sticks)
- Stderr heartbeat
None fully eliminated the stall pattern. Engine repo runs Linux (no undici-Windows bug) and is the right home for the full 41-chapter ingest at 11s per section per gc.nh.gov robots.txt.

## Coverage shipped
- **Code**: full 41-chapter cohort (625-651-F, excludes 632 — fully repealed 1975)
- **Live data**: chapters 625 (Preliminary) + 626 (General Principles) — 19 rows total
- **Floor**: 250 rows expected; 19 actual

## Engine wiring follow-up needed
ImNotAnAttorney-engine should:
1. Adopt this parser (`scripts/ingest/lib/nh-html.mjs`)
2. Adopt this orchestrator (`scripts/ingest/seed-statutes-nh-titlelxii.mjs`) — already supports `--chapters=` to resume from the partial state
3. Wire periodic refresh at 11s/section across remaining 39 chapters

Resume command (engine or local Linux):
`node scripts/ingest/seed-statutes-nh-titlelxii.mjs --chapters=627,628,629,630,631,632-A,633,634,635,636,637,638,639,639-A,640,641,642,643,644,644-A,645,646-A,647,649,649-A,649-B,650,650-A,650-B,650-C,651,651-A,651-B,651-C,651-D,651-E,651-F`

## Test plan
- [x] vitest 66/66 pass on captured fixtures
- [x] live ingest of chapters 625+626 = 19 rows in entities_statutes
- [x] all rows have source_urls populated, all HTTPS
- [ ] full 41-chapter ingest — engine repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)