### PR TITLE
fix(db): add keepalive to pg client (TICKET-6)

### DIFF
--- a/scripts/lib/db.mjs
+++ b/scripts/lib/db.mjs
@@ -41,6 +41,8 @@ async function getClient() {
     _client = new pg.Client({
       connectionString: loadDbUrl(),
       ssl: { rejectUnauthorized: false },
+      keepAlive: true,
+      keepAliveInitialDelayMillis: 10000,
     });
     await _client.connect();
   }

--- a/scripts/lib/db.test.mjs
+++ b/scripts/lib/db.test.mjs
@@ -1,0 +1,68 @@
+/**
+ * scripts/lib/db.test.mjs
+ *
+ * Verifies that the shared Postgres client in db.mjs is constructed
+ * with TCP keepalive options enabled, so long-running bulk extractions
+ * (e.g. bulk-extract-charge-types.mjs streaming the 45GB criminal
+ * opinions CSV) survive idle periods without the connection being
+ * silently dropped by Supavisor / NATs / corporate firewalls.
+ *
+ * TICKET-6: keepalive defense for bulk pipelines.
+ *
+ * No DB connection is opened — we read the source file and assert the
+ * constructor options are present. Per project rule "No regex on file
+ * contents", we use string includes / split-based scanning.
+ *
+ * Run: `npm test -- --run db`
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const DB_MJS_PATH = path.resolve(__dirname, 'db.mjs');
+
+describe('scripts/lib/db.mjs — pg client construction', () => {
+  const source = fs.readFileSync(DB_MJS_PATH, 'utf8');
+
+  it('passes keepAlive: true to the pg.Client constructor', () => {
+    expect(source.includes('keepAlive: true')).toBe(true);
+  });
+
+  it('sets keepAliveInitialDelayMillis to a positive integer', () => {
+    expect(source.includes('keepAliveInitialDelayMillis')).toBe(true);
+
+    // Locate the option, then validate the literal that follows is a
+    // positive integer (no regex — split + token scan).
+    const key = 'keepAliveInitialDelayMillis:';
+    const idx = source.indexOf(key);
+    expect(idx).toBeGreaterThan(-1);
+
+    const tail = source.slice(idx + key.length).trimStart();
+    // Read digits until a non-digit (comma / whitespace).
+    let i = 0;
+    while (i < tail.length && tail.charCodeAt(i) >= 48 && tail.charCodeAt(i) <= 57) i++;
+    const numStr = tail.slice(0, i);
+    expect(numStr.length).toBeGreaterThan(0);
+    const value = Number(numStr);
+    expect(Number.isInteger(value)).toBe(true);
+    expect(value).toBeGreaterThan(0);
+  });
+
+  it('keepalive options are inside the pg.Client constructor block', () => {
+    // Both options must appear AFTER `new pg.Client({` and BEFORE the
+    // matching `});` so they actually get passed to the driver.
+    const ctorStart = source.indexOf('new pg.Client({');
+    expect(ctorStart).toBeGreaterThan(-1);
+
+    const ctorTail = source.slice(ctorStart);
+    const ctorEnd = ctorTail.indexOf('});');
+    expect(ctorEnd).toBeGreaterThan(-1);
+
+    const ctorBlock = ctorTail.slice(0, ctorEnd);
+    expect(ctorBlock.includes('keepAlive: true')).toBe(true);
+    expect(ctorBlock.includes('keepAliveInitialDelayMillis')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `keepAlive: true, keepAliveInitialDelayMillis: 10000` to pg.Client config in `scripts/lib/db.mjs`
- 3/3 vitest cases pass on the new co-located test file `scripts/lib/db.test.mjs`
- Unblocks long-running bulk extractions that were dying mid-run

## TICKET-6 context
Per backlog at PR #280, this is the unblock for charge-extraction over the full classified_opinions corpus. Pre-flight DB query confirms baseline:
- Total `classified_opinions`: 1,462,909
- Currently with `charge_types[]` populated: 4,121 (0.28%)
- Target after bulk re-run: 60,000+ (15x the current footprint)

## Bulk re-run NOT yet launched
Input CSV at `/d/inaa-bulk/cl-bulk/opinions-criminal.csv` lives on the D: external drive, which is not mounted on the host that ran this fix. Re-run resume command preserved in the commit body for whoever next has D: mounted:
`node scripts/bulk-extract-charge-types.mjs --apply --verbose`

## Test plan
- [x] 3/3 vitest pass on db.test.mjs (validates keepAlive option present in pg.Client config)
- [x] No regression to existing db.mjs consumers (single-line additive change)
- [ ] Bulk re-run pending D: drive remount on extractor host

🤖 Generated with [Claude Code](https://claude.com/claude-code)