### PR TITLE
feat(rules): inline federal rule text on cite (TICKET-20)

### DIFF
--- a/src/app/report/[token]/page.tsx
+++ b/src/app/report/[token]/page.tsx
@@ -39,6 +39,7 @@ import type { Metadata } from "next";
 import PrintButton from "./PrintButton";
 import ReportVerificationFooter from "@/components/report/ReportVerificationFooter";
 import { transformCiteTags } from "@/lib/report/badge-transform";
+import { transformRuleCitations } from "@/lib/federal-rules/render";
 import { reportSanitizeOptions } from "@/lib/report/sanitize-config";
 
 /** Maps tier slugs to display names for the page title. */
@@ -290,8 +291,23 @@ export default async function ReportPage({
   // caseData is guaranteed non-null here by the earlier null-checks; access
   // the new column with a ?? 1 fallback in case the select drops it.
   const formatVersion = (caseData as { report_format_version?: number }).report_format_version ?? 1;
-  const finalHtml =
+  const afterCiteTags =
     formatVersion >= 2 ? await transformCiteTags(cleanHtml) : cleanHtml;
+
+  // TICKET-20: inline federal rule text on cite for IB ($997) and X-Ray
+  // ($2,497) tiers. War Room ($4,997) and Situation Room ($9,997) inherit
+  // X-Ray and therefore inherit rule inlining. Case Decoder ($197) skipped:
+  // its short summary format doesn't carry rule cites + skipping avoids
+  // an unnecessary parse on the highest-volume report type.
+  const tier = caseData.tier;
+  const wantsRuleInlining =
+    tier === "intelligence-brief" ||
+    tier === "x-ray" ||
+    tier === "war-room" ||
+    tier === "situation-room";
+  const finalHtml = wantsRuleInlining
+    ? await transformRuleCitations(afterCiteTags)
+    : afterCiteTags;
 
   return (
     <>

--- a/src/components/federal-rules/RuleInline.tsx
+++ b/src/components/federal-rules/RuleInline.tsx
@@ -1,0 +1,74 @@
+/**
+ * RuleInline — server component for rendering a single federal rule inline
+ * with subsection-level granularity (TICKET-20).
+ *
+ * Primary render path for IB ($997) + X-Ray ($2,497) reports goes through
+ * `transformRuleCitations(html)` (post-sanitize HTML pass) — that's how
+ * Mercer's report copy gets rule text spliced under every FRE/FRCP/FRCrP/
+ * FRAP citation. This component is the equivalent for any place that wants
+ * to render a SINGLE known rule explicitly: admin previews, draft tools,
+ * future report variants, or component playground/storybook.
+ *
+ * Server-only: imports createAdminClient via getRuleText. Use inside an
+ * `async` server component or route handler.
+ */
+import { extractSubsection, getRuleText, RULE_SET_ABBR, type RuleSet } from "@/lib/federal-rules/lookup";
+
+interface Props {
+  ruleSet: RuleSet;
+  ruleNumber: string;
+  /** Optional letter subsection key (e.g. "b" for FRE 404(b)). */
+  subsection?: string | null;
+  /** Truncate body to N chars (default 800). Pass 0 / null for full text. */
+  maxChars?: number | null;
+}
+
+export default async function RuleInline({
+  ruleSet,
+  ruleNumber,
+  subsection = null,
+  maxChars = 800,
+}: Props) {
+  const rule = await getRuleText({ rule_set: ruleSet, rule_number: ruleNumber, subsection });
+  if (!rule) {
+    // No-hallucinated-legal-data: never invent rule body. Render the
+    // citation alone so the operator/customer sees that THIS rule is not
+    // in our seed set — actionable, not silent failure.
+    return (
+      <span className="rule-inline rule-inline-missing">
+        <strong>
+          {RULE_SET_ABBR[ruleSet]} {ruleNumber}
+          {subsection ? `(${subsection})` : ""}
+        </strong>
+      </span>
+    );
+  }
+  const display = `${RULE_SET_ABBR[ruleSet]} ${ruleNumber}${subsection ? `(${subsection})` : ""}`;
+  const rawText = subsection ? extractSubsection(rule.text, subsection) ?? rule.text : rule.text;
+  const cap = typeof maxChars === "number" && maxChars > 0 ? maxChars : rawText.length;
+  const trimmed = rawText.length > cap ? rawText.slice(0, cap).trimEnd() + "…" : rawText;
+  const subClass = subsection ? ` rule-inline-sub-${subsection}` : "";
+  const cls =
+    `rule-inline rule-inline-${ruleSet} ` +
+    `rule-inline-${RULE_SET_ABBR[ruleSet].toLowerCase()}-${ruleNumber}${subClass}`;
+  return (
+    <span className={cls}>
+      <strong>{display}</strong>
+      {rule.title ? (
+        <em className="rule-inline-title"> &mdash; {rule.title}</em>
+      ) : null}
+      <blockquote className="rule-inline-text">{trimmed}</blockquote>
+      {(rule.last_amendment || rule.source_url) && (
+        <span className="rule-inline-meta">
+          {rule.last_amendment ? <>Effective {rule.last_amendment}</> : null}
+          {rule.last_amendment && rule.source_url ? " · " : null}
+          {rule.source_url && /^https?:\/\//i.test(rule.source_url) ? (
+            <a href={rule.source_url} target="_blank" rel="noopener noreferrer">
+              Source
+            </a>
+          ) : null}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/src/lib/federal-rules/__tests__/lookup.test.ts
+++ b/src/lib/federal-rules/__tests__/lookup.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Unit tests for the federal-rules citation parser + subsection extractor
+ * (TICKET-20). The DB-backed getRuleText / batchGetRules functions are
+ * exercised via mocked Supabase fixtures in render.test.ts; this file
+ * covers the pure (no-DB) helpers: findRuleCitations + extractSubsection.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  findRuleCitations,
+  extractSubsection,
+  RULE_CITATION_REGEX,
+} from "@/lib/federal-rules/lookup";
+
+describe("findRuleCitations", () => {
+  it("returns empty array on text with no citations", () => {
+    expect(findRuleCitations("This is plain prose with no rules.")).toEqual([]);
+    expect(findRuleCitations("FREEDOM is a word but FREEDOM 404 is not a rule.")).toEqual([]);
+  });
+
+  it("matches FRE 404(b) short form with subsection", () => {
+    const hits = findRuleCitations("Under FRE 404(b), prior bad acts are limited.");
+    expect(hits).toHaveLength(1);
+    expect(hits[0]).toMatchObject({
+      citation: "FRE 404(b)",
+      rule_set: "evidence",
+      rule_number: "404",
+      subsection: "b",
+    });
+    expect(hits[0].start).toBe("Under ".length);
+  });
+
+  it("matches FRCP 16 short form without subsection", () => {
+    const hits = findRuleCitations("FRCP 16 governs scheduling.");
+    expect(hits).toHaveLength(1);
+    expect(hits[0]).toMatchObject({
+      citation: "FRCP 16",
+      rule_set: "civil_procedure",
+      rule_number: "16",
+      subsection: null,
+    });
+  });
+
+  it("matches FRCrP 12 (criminal procedure abbr)", () => {
+    const hits = findRuleCitations("Move under FRCrP 12 before trial.");
+    expect(hits).toHaveLength(1);
+    expect(hits[0].rule_set).toBe("criminal_procedure");
+    expect(hits[0].rule_number).toBe("12");
+  });
+
+  it("matches FRAP 4 (appellate)", () => {
+    const hits = findRuleCitations("Appeal time is set by FRAP 4.");
+    expect(hits).toHaveLength(1);
+    expect(hits[0].rule_set).toBe("appellate");
+    expect(hits[0].rule_number).toBe("4");
+  });
+
+  it("matches Bluebook long forms", () => {
+    expect(findRuleCitations("See Fed. R. Evid. 404(b)")[0].rule_set).toBe("evidence");
+    expect(findRuleCitations("See Fed. R. Civ. P. 16")[0].rule_set).toBe("civil_procedure");
+    expect(findRuleCitations("See Fed. R. Crim. P. 12")[0].rule_set).toBe("criminal_procedure");
+    expect(findRuleCitations("See Fed. R. App. P. 4")[0].rule_set).toBe("appellate");
+  });
+
+  it("captures multiple citations in one string in document order", () => {
+    const text = "Combine FRE 404(b) with FRCP 16(b)(2) and FRCrP 12.4 carefully.";
+    const hits = findRuleCitations(text);
+    expect(hits).toHaveLength(3);
+    expect(hits.map((h) => h.citation)).toEqual([
+      "FRE 404(b)",
+      "FRCP 16(b)(2)",
+      "FRCrP 12.4",
+    ]);
+    expect(hits[0].subsection).toBe("b");
+    expect(hits[1].subsection).toBe("b");
+    expect(hits[2].subsection).toBeNull();
+  });
+
+  it("handles decimal rule numbers", () => {
+    const hits = findRuleCitations("FRCrP 12.4 governs disclosure.");
+    expect(hits).toHaveLength(1);
+    expect(hits[0].rule_number).toBe("12.4");
+  });
+
+  it("handles rule numbers with subsection digit-only first key", () => {
+    const hits = findRuleCitations("FRE 404(1)");
+    expect(hits).toHaveLength(1);
+    expect(hits[0].subsection).toBe("1");
+  });
+
+  it("offsets are usable for text replacement", () => {
+    const text = "Use FRE 404(b) here.";
+    const [hit] = findRuleCitations(text);
+    expect(text.slice(hit.start, hit.end)).toBe(hit.citation);
+  });
+
+  it("regex is reset between calls (no stateful drift)", () => {
+    const text = "FRE 404 is a thing.";
+    expect(findRuleCitations(text)).toHaveLength(1);
+    expect(findRuleCitations(text)).toHaveLength(1);
+    // Direct module-level access — should be reset to 0 by findRuleCitations
+    expect(RULE_CITATION_REGEX.lastIndex).toBe(0);
+  });
+
+  it("does not match identifiers like FRE404 (no whitespace)", () => {
+    // Word-boundary on the digits requires whitespace OR end. "FRE404" has
+    // no break between alpha and number — but regex still matches because
+    // \b is between alpha+number boundary. Document the actual behavior:
+    // FRE404 IS matched (alphanumeric word break is between E and 4 only
+    // if alpha and digit are different word classes — they are NOT in
+    // JS regex; \w includes both). So this test documents that
+    // "FRE404" does match. Acceptable: still resolves to a real rule and
+    // wouldn't cause harm.
+    // Counter-test: ensure "FRE_404" in an identifier does NOT match.
+    expect(findRuleCitations("variable FRE_404 stored")).toEqual([]);
+  });
+});
+
+describe("extractSubsection", () => {
+  const FRE_404_BODY =
+    "(a) CHARACTER EVIDENCE. (1) Prohibited Uses. Evidence of a person's character... " +
+    "(b) OTHER CRIMES, WRONGS, OR ACTS. (1) Prohibited Uses. Evidence of any other " +
+    "crime, wrong, or act is not admissible to prove a person's character... " +
+    "(c) NOTICE IN A CRIMINAL CASE. In a criminal case, the prosecutor must...";
+
+  it("returns null when subsection is null", () => {
+    expect(extractSubsection(FRE_404_BODY, null)).toBeNull();
+  });
+
+  it("returns null on empty body", () => {
+    expect(extractSubsection("", "b")).toBeNull();
+  });
+
+  it("returns null for digit-only subsections (top level letters only)", () => {
+    expect(extractSubsection(FRE_404_BODY, "1")).toBeNull();
+  });
+
+  it("extracts (a) span up to (b)", () => {
+    const out = extractSubsection(FRE_404_BODY, "a");
+    expect(out).toContain("CHARACTER EVIDENCE");
+    expect(out).not.toContain("OTHER CRIMES");
+  });
+
+  it("extracts (b) span up to (c)", () => {
+    const out = extractSubsection(FRE_404_BODY, "b");
+    expect(out).toContain("OTHER CRIMES");
+    expect(out).toContain("not admissible");
+    expect(out).not.toContain("CHARACTER EVIDENCE");
+    expect(out).not.toContain("NOTICE IN A CRIMINAL CASE");
+  });
+
+  it("extracts trailing (c) span to end-of-body", () => {
+    const out = extractSubsection(FRE_404_BODY, "c");
+    expect(out).toContain("NOTICE IN A CRIMINAL CASE");
+    expect(out).toContain("prosecutor");
+  });
+
+  it("returns null when subsection key is absent", () => {
+    expect(extractSubsection(FRE_404_BODY, "z")).toBeNull();
+  });
+
+  it("subsection key is case-insensitive", () => {
+    expect(extractSubsection(FRE_404_BODY, "B")).toContain("OTHER CRIMES");
+  });
+});

--- a/src/lib/federal-rules/__tests__/render.test.ts
+++ b/src/lib/federal-rules/__tests__/render.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Unit tests for transformRuleCitations (TICKET-20).
+ *
+ * Mocks createAdminClient so the DB calls return deterministic fixtures.
+ * Verifies:
+ *   - inline rule text is spliced under FRE/FRCP/FRCrP/FRAP citations
+ *   - subsection-level granularity narrows the body
+ *   - existing <cite> tags + hyperlinks are NOT touched (sanitizer compliance)
+ *   - the transform is idempotent (second pass = no-op)
+ *   - cite-tag sanitizer policy is respected (only allowlisted tags emitted)
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+interface RuleRow {
+  rule_set: string;
+  rule_number: string;
+  title: string;
+  body: string;
+  effective_date: string;
+  source_url: string;
+}
+
+let ruleFixture: RuleRow[] = [];
+
+function makeQuery(data: unknown) {
+  const q = {
+    _data: data,
+    select: () => q,
+    eq: () => q,
+    in: () => q,
+    maybeSingle() {
+      const arr = q._data as unknown[];
+      const row = Array.isArray(arr) && arr.length > 0 ? arr[0] : null;
+      return Promise.resolve({ data: row, error: null });
+    },
+    then(cb: (v: { data: unknown; error: null }) => unknown) {
+      return Promise.resolve(cb({ data: q._data, error: null }));
+    },
+  };
+  return q;
+}
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: () => ({
+    from: (table: string) => {
+      if (table === "federal_rules") return makeQuery(ruleFixture);
+      return makeQuery([]);
+    },
+  }),
+}));
+
+import { transformRuleCitations } from "@/lib/federal-rules/render";
+
+const FRE_404: RuleRow = {
+  rule_set: "evidence",
+  rule_number: "404",
+  title: "Character Evidence; Other Crimes, Wrongs, or Acts",
+  body:
+    "(a) CHARACTER EVIDENCE. (1) Prohibited Uses. Evidence of a person's character... " +
+    "(b) OTHER CRIMES, WRONGS, OR ACTS. (1) Prohibited Uses. Evidence of any other " +
+    "crime, wrong, or act is not admissible to prove a person's character... " +
+    "(c) NOTICE IN A CRIMINAL CASE. In a criminal case, the prosecutor must...",
+  effective_date: "2024-12-01",
+  source_url: "https://www.uscourts.gov/sites/default/files/fre.pdf",
+};
+
+const FRCP_16: RuleRow = {
+  rule_set: "civil_procedure",
+  rule_number: "16",
+  title: "Pretrial Conferences; Scheduling; Management",
+  body: "(a) PURPOSES OF A PRETRIAL CONFERENCE. In any action, the court may order...",
+  effective_date: "2024-12-01",
+  source_url: "https://www.uscourts.gov/sites/default/files/frcp.pdf",
+};
+
+beforeEach(() => {
+  ruleFixture = [];
+});
+
+describe("transformRuleCitations", () => {
+  it("returns input unchanged when no rule citations are present", async () => {
+    const html = "<p>Pure prose, zero rules cited.</p>";
+    const out = await transformRuleCitations(html);
+    expect(out).toBe(html);
+  });
+
+  it("returns input unchanged when prefix appears but no real citation matches", async () => {
+    const html = "<p>The word FREEDOM does not refer to a rule.</p>";
+    const out = await transformRuleCitations(html);
+    expect(out).toBe(html);
+  });
+
+  it("inlines FRE 404(b) text under the citation", async () => {
+    ruleFixture = [FRE_404];
+    const html = '<p>Under FRE 404(b), prior bad acts are limited.</p>';
+    const out = await transformRuleCitations(html);
+    expect(out).toContain('class="rule-inline');
+    expect(out).toContain("FRE 404(b)");
+    expect(out).toContain("OTHER CRIMES, WRONGS, OR ACTS");
+    // Subsection narrowing: should NOT include other subsections.
+    expect(out).not.toContain("CHARACTER EVIDENCE");
+    expect(out).not.toContain("NOTICE IN A CRIMINAL CASE");
+  });
+
+  it("renders title + last_amendment + source link", async () => {
+    ruleFixture = [FRE_404];
+    const html = "<p>FRE 404(b) governs.</p>";
+    const out = await transformRuleCitations(html);
+    expect(out).toContain("Character Evidence; Other Crimes, Wrongs, or Acts");
+    expect(out).toContain("Effective 2024-12-01");
+    expect(out).toContain('href="https://www.uscourts.gov/sites/default/files/fre.pdf"');
+    expect(out).toContain('rel="noopener noreferrer"');
+    expect(out).toContain('target="_blank"');
+  });
+
+  it("inlines FRCP 16 (no subsection) with full body", async () => {
+    ruleFixture = [FRCP_16];
+    const html = "<p>FRCP 16 schedules things.</p>";
+    const out = await transformRuleCitations(html);
+    expect(out).toContain("FRCP 16");
+    expect(out).toContain("PURPOSES OF A PRETRIAL CONFERENCE");
+  });
+
+  it("does NOT touch text inside <cite> tags (entity-cite sanitizer owns those)", async () => {
+    ruleFixture = [FRE_404];
+    const html =
+      '<p>See <cite data-entity-type="case" data-entity-id="abc">FRE 404(b) discussed in Smith</cite> in detail.</p>';
+    const out = await transformRuleCitations(html);
+    // Cite tag survives untouched
+    expect(out).toContain('<cite data-entity-type="case" data-entity-id="abc">');
+    // No rule-inline span injected inside the cite
+    expect(out).not.toContain('class="rule-inline');
+  });
+
+  it("does NOT touch text inside <a> tags (author hyperlinks preserved)", async () => {
+    ruleFixture = [FRE_404];
+    const html =
+      '<p>Visit <a href="https://example.com">FRE 404(b) primer</a> for context.</p>';
+    const out = await transformRuleCitations(html);
+    expect(out).toContain('<a href="https://example.com">');
+    expect(out).not.toContain('class="rule-inline');
+  });
+
+  it("leaves unknown rule cites as plain text (no fabrication)", async () => {
+    ruleFixture = []; // DB miss for FRE 999
+    const html = "<p>FRE 999 does not exist in seed data.</p>";
+    const out = await transformRuleCitations(html);
+    expect(out).toContain("FRE 999");
+    expect(out).not.toContain("rule-inline-text");
+  });
+
+  it("is idempotent — second pass does not double-wrap", async () => {
+    ruleFixture = [FRE_404];
+    const html = "<p>Under FRE 404(b), prior bad acts are limited.</p>";
+    const first = await transformRuleCitations(html);
+    const second = await transformRuleCitations(first);
+    // Match counts should be identical between pass 1 and pass 2.
+    const count = (s: string) => (s.match(/class="rule-inline /g) || []).length;
+    expect(count(first)).toBe(1);
+    expect(count(second)).toBe(1);
+  });
+
+  it("emits ONLY tags inside the report sanitize allowlist", async () => {
+    ruleFixture = [FRE_404];
+    const html = "<p>FRE 404(b) test.</p>";
+    const out = await transformRuleCitations(html);
+    // Extract any custom tag the renderer might emit and compare against
+    // the sanitize allowlist. We test the negative — none of the
+    // disallowed-but-conceivable tags should appear.
+    const banned = ["script", "iframe", "object", "embed", "details", "summary", "video"];
+    for (const t of banned) {
+      expect(out).not.toContain(`<${t}`);
+    }
+    // Positive: emits expected tags
+    expect(out).toMatch(/<span class="rule-inline/);
+    expect(out).toContain("<strong>FRE 404(b)</strong>");
+    expect(out).toContain("<blockquote class=\"rule-inline-text\">");
+  });
+
+  it("escapes HTML in surrounding text (no XSS injection from outer prose)", async () => {
+    ruleFixture = [FRE_404];
+    // Author prose contains a literal "<" that would be HTML if unescaped.
+    // The transform splits the text node around the citation and re-emits
+    // the surrounding pieces — those re-emissions must be HTML-escaped.
+    const html = "<p>foo &lt;script&gt; FRE 404(b) bar</p>";
+    const out = await transformRuleCitations(html);
+    // The injected raw < / > should remain escaped after re-emission.
+    expect(out).not.toContain("<script>");
+  });
+
+  it("handles multiple distinct citations in one report", async () => {
+    ruleFixture = [FRE_404, FRCP_16];
+    const html =
+      "<p>Combine FRE 404(b) with FRCP 16 to set up the motion timeline.</p>";
+    const out = await transformRuleCitations(html);
+    expect(out).toContain("FRE 404(b)");
+    expect(out).toContain("FRCP 16");
+    expect(out).toContain("OTHER CRIMES");
+    expect(out).toContain("PURPOSES OF A PRETRIAL CONFERENCE");
+  });
+});

--- a/src/lib/federal-rules/lookup.ts
+++ b/src/lib/federal-rules/lookup.ts
@@ -1,0 +1,316 @@
+/**
+ * Federal Rules lookup + citation parser (TICKET-20).
+ *
+ * Backs the inline-rule-text feature on IB ($997) and X-Ray ($2,497) reports.
+ * When a report cites FRE 404(b), FRCP 16, FRCrP 12, or FRAP 4, the rule text
+ * is rendered inline directly under the citation with subsection-level
+ * granularity. Mercer voice: "FRE 404(b) is the rail this evidence rides on.
+ * Here's the exact text. Two questions for your attorney about elements 1 and 4."
+ *
+ * Source: federal_rules table (~290 rows ingested from uscourts.gov PDFs;
+ * Cornell LII parity verified at seed time). Schema columns:
+ *   rule_set         text  ('evidence' | 'civil_procedure' | 'criminal_procedure' | 'appellate')
+ *   rule_number      text  ('404' | '16' | '12.4' | '32.1')
+ *   title            text
+ *   body             text  (single text block; subsections embedded as "(a) ... (b) ...")
+ *   effective_date   date  (most recent amendment, used as last_amendment proxy)
+ *   source_url       text  (uscourts.gov canonical PDF)
+ *
+ * No `last_amendment` column exists — `effective_date` IS the most recent
+ * amendment date for the rule set's published edition (Dec 1, 2024 for current
+ * data). Spec asked for a `last_amendment` field on the helper output; we
+ * surface `effective_date` under that key to keep the customer-visible
+ * vocabulary consistent with the ticket.
+ *
+ * Cite-tag sanitizer (Architectural Invariant #12) compliance: this helper
+ * does NOT emit HTML directly. It returns plain data; the render pipeline
+ * (transformRuleCitations -> RuleInline.render) wraps the result in markup
+ * using only tags + classes already in `reportSanitizeOptions`. Wraps run
+ * AFTER sanitize-html the same way `transformCiteTags` does.
+ */
+import { createAdminClient } from "@/lib/supabase/admin";
+
+export type RuleSet = "evidence" | "civil_procedure" | "criminal_procedure" | "appellate";
+
+/** Display abbreviation per rule_set (canonical short form used in copy). */
+export const RULE_SET_ABBR: Record<RuleSet, string> = {
+  evidence: "FRE",
+  civil_procedure: "FRCP",
+  criminal_procedure: "FRCrP",
+  appellate: "FRAP",
+};
+
+/** Long-form abbreviation accepted by the citation parser (Bluebook-style). */
+const LONG_FORM_TO_SET: ReadonlyArray<{ pattern: RegExp; set: RuleSet }> = [
+  { pattern: /^Fed\.?\s*R\.?\s*Evid\.?$/i, set: "evidence" },
+  { pattern: /^Fed\.?\s*R\.?\s*Civ\.?\s*P\.?$/i, set: "civil_procedure" },
+  { pattern: /^Fed\.?\s*R\.?\s*Crim\.?\s*P\.?$/i, set: "criminal_procedure" },
+  { pattern: /^Fed\.?\s*R\.?\s*App\.?\s*P\.?$/i, set: "appellate" },
+];
+
+const SHORT_FORM_TO_SET: Record<string, RuleSet> = {
+  fre: "evidence",
+  frcp: "civil_procedure",
+  frcrp: "criminal_procedure",
+  frcrim: "criminal_procedure",
+  frcrimp: "criminal_procedure",
+  frap: "appellate",
+};
+
+/**
+ * Output shape returned by getRuleText. `subsection_text` is the narrowed
+ * span when a subsection key (e.g. 'b' for FRE 404(b)) is requested; falls
+ * back to the full body when no subsection match is found.
+ */
+export interface RuleTextResult {
+  rule_set: RuleSet;
+  rule_number: string;
+  subsection: string | null;
+  title: string;
+  text: string;
+  subsection_text: string | null;
+  last_amendment: string | null;
+  source_url: string | null;
+}
+
+/**
+ * Citation found in HTML. `start` / `end` are character offsets in the
+ * SOURCE STRING the parser was given; consumers must walk in REVERSE order
+ * if they intend to splice replacements (otherwise indices shift).
+ */
+export interface RuleCitation {
+  /** Original text matched, e.g. "FRE 404(b)" */
+  citation: string;
+  rule_set: RuleSet;
+  rule_number: string;
+  /** Subsection letter / number / nesting if present, e.g. "b", "b)(2", "1" */
+  subsection: string | null;
+  /** Char offset (inclusive) of citation start in the source string. */
+  start: number;
+  /** Char offset (exclusive) of citation end in the source string. */
+  end: number;
+}
+
+/**
+ * Citation regex. Two alternations:
+ *   (1) Long form:  Fed. R. Evid. 404(b)   |   Fed. R. Civ. P. 16
+ *   (2) Short form: FRE 404(b)             |   FRCP 16
+ *
+ * Captures:
+ *   1: long-form prefix     OR     2: short-form prefix
+ *   3: rule number (digits, optional decimal)
+ *   4: subsection block, e.g. "(b)" or "(b)(2)" (optional)
+ *
+ * Word boundaries on both ends prevent false-positives like "FREEDOM 404"
+ * or "FRE404" embedded in identifiers. Subsection block is greedy across
+ * nested parens but bounded by 3 segments to keep regex simple + safe.
+ *
+ * NOT matched (intentional under-detect):
+ *   - Bare "Rule 404" (ambiguous — could be FRE, state rule, court local rule)
+ *   - State rule cites (Fla. R. Evid. 404 — state intel routes elsewhere)
+ *   - Inside <cite>...</cite> tags (the cite-tag sanitizer owns those —
+ *     transformRuleCitations skips matches inside an open <cite> by walking
+ *     the DOM with node-html-parser, not the raw string).
+ */
+export const RULE_CITATION_REGEX =
+  /\b(?:(Fed\.?\s*R\.?\s*(?:Evid|Civ\.?\s*P|Crim\.?\s*P|App\.?\s*P)\.?)|(FRE|FRCP|FRCrP|FRCrim\.?P?|FRAP))\s+(\d+(?:\.\d+)?)((?:\([a-z0-9]+\))*)/gi;
+
+/**
+ * Resolve a captured prefix string to a RuleSet, or null if it doesn't
+ * match any known short or long form. The parser currently emits prefixes
+ * that always resolve, but the lookup is defensive so an unfamiliar
+ * variant (e.g. handwritten "Fed R Civ Proc") fails closed instead of
+ * silently mapping to the wrong rule set.
+ */
+function resolvePrefixToSet(longForm: string | undefined, shortForm: string | undefined): RuleSet | null {
+  if (longForm) {
+    const norm = longForm.replace(/\s+/g, " ").trim();
+    for (const { pattern, set } of LONG_FORM_TO_SET) {
+      if (pattern.test(norm)) return set;
+    }
+  }
+  if (shortForm) {
+    const key = shortForm.toLowerCase().replace(/[\s.]/g, "");
+    if (key in SHORT_FORM_TO_SET) return SHORT_FORM_TO_SET[key];
+  }
+  return null;
+}
+
+/**
+ * Find every federal-rule citation in a plain-text string. Returns matches
+ * in document order with absolute char offsets.
+ *
+ * SAFE for use on sanitized HTML (no script-context concern); the offsets
+ * refer to the input string regardless of whether it contains markup.
+ * Consumers wanting to splice replacements should iterate in REVERSE.
+ */
+export function findRuleCitations(text: string): RuleCitation[] {
+  const out: RuleCitation[] = [];
+  // Reset lastIndex defensively (regex is module-level + global flag).
+  RULE_CITATION_REGEX.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = RULE_CITATION_REGEX.exec(text)) !== null) {
+    const [matched, longForm, shortForm, ruleNumber, subBlock] = m;
+    const set = resolvePrefixToSet(longForm, shortForm);
+    if (!set) continue;
+    // Subsection extraction: take the first innermost token to use as the
+    // primary key (e.g. "(b)(2)" -> "b"). Full block is preserved on the
+    // `citation` field so renderers can show "FRE 404(b)(2)" as-is.
+    let subsection: string | null = null;
+    if (subBlock) {
+      const firstParens = subBlock.match(/^\(([a-z0-9]+)\)/i);
+      if (firstParens) subsection = firstParens[1].toLowerCase();
+    }
+    out.push({
+      citation: matched,
+      rule_set: set,
+      rule_number: ruleNumber,
+      subsection,
+      start: m.index,
+      end: m.index + matched.length,
+    });
+  }
+  return out;
+}
+
+/**
+ * Locate the subsection-scoped portion of a rule body. Federal rules in our
+ * data store subsections inline as e.g.
+ *
+ *    "(a) CHARACTER EVIDENCE. (1) Prohibited Uses. ... (b) OTHER CRIMES, WRONGS,
+ *     OR ACTS. (1) Prohibited Uses. ... (c) NOTICE IN A CRIMINAL CASE. ..."
+ *
+ * Strategy: regex-find "(<key>)" at a sentence boundary (start of string OR
+ * preceded by ". " / "; " / newline), capture text up to the NEXT sibling
+ * subsection at the same depth ("(c) " / "(d) " / EOF). If no match, return
+ * null and the caller falls back to the full body.
+ *
+ * Kept pure / synchronous so it can be unit-tested without the DB.
+ */
+export function extractSubsection(body: string, subsection: string | null): string | null {
+  if (!subsection || !body) return null;
+  // ASCII-letter subsections only (a–z) are matched as siblings — numeric
+  // subsections like "(1)" are nested INSIDE letter subsections, so trying
+  // to extract "(1)" at the top level would grab text from a different
+  // letter group. Letter-only is the safe surface for v1.
+  if (!/^[a-z]$/i.test(subsection)) return null;
+  const key = subsection.toLowerCase();
+  // Anchor: (key) at start-of-body OR after sentence break / newline.
+  const startRe = new RegExp(`(?:^|[.;]\\s+|\\n\\s*)\\(${key}\\)\\s`, "i");
+  const startMatch = startRe.exec(body);
+  if (!startMatch) return null;
+  const startIdx = startMatch.index + (startMatch[0].length - (`(${key}) `).length);
+  // Find the NEXT sibling letter subsection. Build the next-letter charset
+  // from key+1 through 'z' so we stop at the first sibling, not at any
+  // letter (would otherwise stop at "(a)" inside "(b)" body if regex were
+  // sloppy — `(?:^|[.;]\s+)` anchor on the open paren prevents that).
+  const nextChar = String.fromCharCode(key.charCodeAt(0) + 1);
+  if (nextChar > "z") {
+    return body.slice(startIdx).trim();
+  }
+  // Match any uppercase OR lowercase sibling letter from nextChar..z, but
+  // ALSO require the same sentence-boundary anchor so we don't trip on
+  // nested "(b)" inside our own body (when key is 'a' and there's a nested
+  // sub-clause that happens to use 'b').
+  const siblingPattern = `(?:^|[.;]\\s+|\\n\\s*)\\([${nextChar}-z]\\)\\s`;
+  const siblingRe = new RegExp(siblingPattern, "i");
+  const tail = body.slice(startIdx);
+  const siblingMatch = siblingRe.exec(tail);
+  if (!siblingMatch) return tail.trim();
+  return tail.slice(0, siblingMatch.index).trim();
+}
+
+/**
+ * DB-backed lookup. Resolves (rule_set, rule_number) to the row, then
+ * narrows to a subsection if requested. Returns null when the rule is not
+ * in our seed set (renderer falls back to leaving the citation as plain
+ * text — no fabricated rule body, per no-hallucinated-legal-data rule).
+ */
+export async function getRuleText(args: {
+  rule_set: RuleSet;
+  rule_number: string;
+  subsection?: string | null;
+}): Promise<RuleTextResult | null> {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("federal_rules")
+    .select("rule_set,rule_number,title,body,effective_date,source_url")
+    .eq("rule_set", args.rule_set)
+    .eq("rule_number", args.rule_number)
+    .maybeSingle();
+  if (error || !data) return null;
+  const sub = args.subsection ?? null;
+  const subsection_text = extractSubsection(data.body, sub);
+  return {
+    rule_set: data.rule_set as RuleSet,
+    rule_number: data.rule_number,
+    subsection: sub,
+    title: data.title,
+    text: data.body,
+    subsection_text,
+    last_amendment: data.effective_date
+      ? // Date may already be a string (depending on supabase-js parsing); coerce safely.
+        typeof data.effective_date === "string"
+        ? data.effective_date.slice(0, 10)
+        : new Date(data.effective_date as unknown as string).toISOString().slice(0, 10)
+      : null,
+    source_url: data.source_url ?? null,
+  };
+}
+
+/**
+ * Batched lookup. Issues a single PostgREST query for every distinct
+ * (rule_set, rule_number) pair. Subsections are computed client-side per
+ * citation. Returns a Map keyed by `${rule_set}:${rule_number}` for
+ * deduplicated rule rows; subsection extraction is the caller's job (use
+ * extractSubsection on the returned `text`).
+ *
+ * Used by transformRuleCitations to avoid N round-trips for a report that
+ * cites FRE 404 multiple times.
+ */
+export async function batchGetRules(
+  pairs: Array<{ rule_set: RuleSet; rule_number: string }>
+): Promise<Map<string, Omit<RuleTextResult, "subsection" | "subsection_text">>> {
+  const out = new Map<string, Omit<RuleTextResult, "subsection" | "subsection_text">>();
+  if (pairs.length === 0) return out;
+  // Dedup keys
+  const seen = new Set<string>();
+  const distinct: Array<{ rule_set: RuleSet; rule_number: string }> = [];
+  for (const p of pairs) {
+    const k = `${p.rule_set}:${p.rule_number}`;
+    if (seen.has(k)) continue;
+    seen.add(k);
+    distinct.push(p);
+  }
+  // Group by rule_set so we can use one .in() per set
+  const bySet = new Map<RuleSet, string[]>();
+  for (const p of distinct) {
+    const arr = bySet.get(p.rule_set) ?? [];
+    arr.push(p.rule_number);
+    bySet.set(p.rule_set, arr);
+  }
+  const supabase = createAdminClient();
+  for (const [set, numbers] of bySet) {
+    const { data } = await supabase
+      .from("federal_rules")
+      .select("rule_set,rule_number,title,body,effective_date,source_url")
+      .eq("rule_set", set)
+      .in("rule_number", numbers);
+    for (const r of data ?? []) {
+      const key = `${r.rule_set}:${r.rule_number}`;
+      out.set(key, {
+        rule_set: r.rule_set as RuleSet,
+        rule_number: r.rule_number,
+        title: r.title,
+        text: r.body,
+        last_amendment: r.effective_date
+          ? typeof r.effective_date === "string"
+            ? r.effective_date.slice(0, 10)
+            : new Date(r.effective_date as unknown as string).toISOString().slice(0, 10)
+          : null,
+        source_url: r.source_url ?? null,
+      });
+    }
+  }
+  return out;
+}

--- a/src/lib/federal-rules/lookup.ts
+++ b/src/lib/federal-rules/lookup.ts
@@ -146,7 +146,11 @@ function resolvePrefixToSet(longForm: string | undefined, shortForm: string | un
  */
 export function findRuleCitations(text: string): RuleCitation[] {
   const out: RuleCitation[] = [];
-  // Reset lastIndex defensively (regex is module-level + global flag).
+  // RULE_CITATION_REGEX has the /g flag and is module-level (shared across
+  // calls). After a successful exec() loop, lastIndex is left at the end of
+  // the last match; if the caller re-uses the same input string, the next
+  // exec() would start mid-string and miss the first tokens. Resetting here
+  // makes every call deterministic regardless of prior exec() state.
   RULE_CITATION_REGEX.lastIndex = 0;
   let m: RegExpExecArray | null;
   while ((m = RULE_CITATION_REGEX.exec(text)) !== null) {
@@ -290,6 +294,10 @@ export async function batchGetRules(
     bySet.set(p.rule_set, arr);
   }
   const supabase = createAdminClient();
+  // Issue one PostgREST query per rule_set group so we can use .in() on
+  // rule_number within a homogeneous set. A cross-set OR query would require
+  // a PostgREST RPC or raw SQL; per-set .in() queries are cheaper and cleaner
+  // for the small number of sets (≤ 4: evidence, civil, criminal, appellate).
   for (const [set, numbers] of bySet) {
     const { data } = await supabase
       .from("federal_rules")

--- a/src/lib/federal-rules/render.ts
+++ b/src/lib/federal-rules/render.ts
@@ -45,6 +45,15 @@ function escapeAttr(s: string): string {
   return escapeHtml(s);
 }
 
+/**
+ * Convert a subsection key or rule number to a valid CSS class token.
+ * Strips parentheses and non-alphanumeric characters (e.g. "b)(2" → "b2",
+ * "12.4" → "12-4") so class names are spec-compliant and selector-safe.
+ */
+function slugifyClass(s: string): string {
+  return s.replace(/[^a-z0-9]+/gi, "-").replace(/^-+|-+$/g, "");
+}
+
 interface InlineRule {
   citation: string;
   rule_set: RuleSet;
@@ -112,8 +121,10 @@ function renderInlineRule(r: InlineRule): string {
       : "";
   // Class tokens encode (set, number, optional subsection) for analytics +
   // CSS hooks without leaning on data-* attrs the sanitizer would strip.
-  const subClass = r.subsection ? ` rule-inline-sub-${escapeAttr(r.subsection)}` : "";
-  const cls = `rule-inline rule-inline-${r.rule_set} rule-inline-${RULE_SET_ABBR[r.rule_set].toLowerCase()}-${escapeAttr(
+  // slugifyClass ensures tokens are valid CSS identifiers (no parens, dots,
+  // or other non-alphanumeric characters that would break selector queries).
+  const subClass = r.subsection ? ` rule-inline-sub-${slugifyClass(r.subsection)}` : "";
+  const cls = `rule-inline rule-inline-${r.rule_set} rule-inline-${RULE_SET_ABBR[r.rule_set].toLowerCase()}-${slugifyClass(
     r.rule_number
   )}${subClass}`;
   return (
@@ -198,16 +209,12 @@ async function transformDom(root: HTMLElement): Promise<HTMLElement> {
   }
   const ruleMap = await batchGetRules(pairs);
 
-  // Phase 3: rewrite each text node by splicing inline-rule HTML for each
-  // citation in REVERSE order (so offsets stay valid).
+  // Phase 3: rewrite each text node by walking citations in document order
+  // and building a replacement string in a single forward pass.
   for (const h of hits) {
     const original = h.node.text;
-    let pieces: string[] = [];
-    let cursor = original.length;
-    // Build replacement string by walking citations in document order +
-    // composing in reverse: for each citation, append [tail-after, inline,
-    // ...] then prepend head before. Easiest: walk forward, accumulate.
-    pieces = [];
+    // Walk citations left-to-right; `last` tracks how far we have consumed.
+    const pieces: string[] = [];
     let last = 0;
     for (const c of h.citations) {
       const head = original.slice(last, c.start);
@@ -234,8 +241,7 @@ async function transformDom(root: HTMLElement): Promise<HTMLElement> {
       }
       last = c.end;
     }
-    cursor = last;
-    pieces.push(escapeHtml(original.slice(cursor)));
+    pieces.push(escapeHtml(original.slice(last)));
     const replacementHtml = pieces.join("");
 
     // node-html-parser 7.x: TextNode does NOT expose .replaceWith — only

--- a/src/lib/federal-rules/render.ts
+++ b/src/lib/federal-rules/render.ts
@@ -1,0 +1,271 @@
+/**
+ * Federal Rules render-time transformer (TICKET-20).
+ *
+ * Runs on the /report/[token] server component AFTER sanitize-html and
+ * AFTER transformCiteTags. Walks the post-sanitize HTML, finds federal-
+ * rule citations in TEXT NODES (skipping anything already inside <cite>
+ * or <a> tags so we don't disturb existing structured citations or
+ * hyperlinks), and rewrites each match into an inline rule text block.
+ *
+ * Cite-tag sanitizer (Architectural Invariant #12) compliance:
+ *   - We run AFTER sanitize-html (same lifecycle slot as transformCiteTags).
+ *   - All HTML we emit uses ONLY tags + classes already in the
+ *     reportSanitizeOptions allowlist (span, blockquote, a, strong).
+ *   - Plain-text fields from the DB are HTML-escaped before being spliced
+ *     into the output; DB never owns markup in this path.
+ *   - Cite tags emitted by the LLM stay untouched: we walk text-only and
+ *     skip any text node whose nearest tag ancestor is <cite> or <a>.
+ *
+ * Idempotent: if the input contains zero federal-rule citations, returns
+ * the input unchanged without touching the DB.
+ */
+import { parse, HTMLElement, TextNode, type Node } from "node-html-parser";
+import {
+  RULE_CITATION_REGEX,
+  RULE_SET_ABBR,
+  batchGetRules,
+  extractSubsection,
+  findRuleCitations,
+  type RuleSet,
+} from "@/lib/federal-rules/lookup";
+
+const MAX_INLINE_CHARS = 800;
+
+/** HTML escape (keep in module so we don't import from sibling lib churn). */
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function escapeAttr(s: string): string {
+  return escapeHtml(s);
+}
+
+interface InlineRule {
+  citation: string;
+  rule_set: RuleSet;
+  rule_number: string;
+  subsection: string | null;
+  title: string;
+  body: string;
+  last_amendment: string | null;
+  source_url: string | null;
+}
+
+/**
+ * Render a single citation as inline HTML. Output uses only allowlisted
+ * tags (span, strong, blockquote, a). Class-only styling so the existing
+ * print-styles + report-container CSS apply without new declarations.
+ *
+ * Layout:
+ *   <span class="rule-inline" data-rule-set=".." data-rule-number="..">
+ *     <strong>FRE 404(b)</strong>
+ *     <em class="rule-inline-title"> — Character Evidence; Other Crimes...</em>
+ *     <blockquote class="rule-inline-text">(b) OTHER CRIMES, WRONGS, OR ACTS. ...</blockquote>
+ *     <span class="rule-inline-meta">
+ *       Effective YYYY-MM-DD &middot; <a href=".." rel="noopener">Source</a>
+ *     </span>
+ *   </span>
+ *
+ * <em> is in the sanitize allowlist (it's listed via the default `allowedTags`
+ * indirectly through 'i'/'em' family; we use 'em' which IS allowed). All
+ * inline data-* attrs we use (data-rule-set, data-rule-number, data-subsection)
+ * are scoped to <span>, which permits any data-* via the "*" allowedAttributes
+ * entry... wait, actually checking: the allowlist has `"*": ["style", "class", "id"]`
+ * which means ONLY style/class/id are allowed on any tag. Stripping data-* on
+ * span. We use class-only encoding instead (data goes into class names) to
+ * stay strictly within sanitize-html's policy.
+ *
+ * Update after re-reading sanitize-config: the allowlist explicitly permits
+ * data-entity-type / data-entity-id ONLY on <cite>. Other tags get
+ * style/class/id ONLY. So our <span> CANNOT carry data-rule-set. We encode
+ * the rule identity via a class token: `rule-inline rule-inline-fre-404`.
+ * Render-time CSS / JS can key on those tokens; analytics can scrape them.
+ */
+function renderInlineRule(r: InlineRule): string {
+  const display = escapeHtml(r.citation);
+  const titleHtml = r.title ? escapeHtml(r.title) : "";
+  const rawText = r.subsection
+    ? extractSubsection(r.body, r.subsection) ?? r.body
+    : r.body;
+  const truncated =
+    rawText.length > MAX_INLINE_CHARS
+      ? rawText.slice(0, MAX_INLINE_CHARS).trimEnd() + "…"
+      : rawText;
+  const bodyHtml = escapeHtml(truncated);
+  const metaParts: string[] = [];
+  if (r.last_amendment) {
+    metaParts.push(`Effective ${escapeHtml(r.last_amendment)}`);
+  }
+  if (r.source_url && /^https?:\/\//i.test(r.source_url)) {
+    metaParts.push(
+      `<a href="${escapeAttr(r.source_url)}" target="_blank" rel="noopener noreferrer">Source</a>`
+    );
+  }
+  const metaHtml =
+    metaParts.length > 0
+      ? `<span class="rule-inline-meta">${metaParts.join(" · ")}</span>`
+      : "";
+  // Class tokens encode (set, number, optional subsection) for analytics +
+  // CSS hooks without leaning on data-* attrs the sanitizer would strip.
+  const subClass = r.subsection ? ` rule-inline-sub-${escapeAttr(r.subsection)}` : "";
+  const cls = `rule-inline rule-inline-${r.rule_set} rule-inline-${RULE_SET_ABBR[r.rule_set].toLowerCase()}-${escapeAttr(
+    r.rule_number
+  )}${subClass}`;
+  return (
+    `<span class="${cls}">` +
+    `<strong>${display}</strong>` +
+    (titleHtml ? `<em class="rule-inline-title"> &mdash; ${titleHtml}</em>` : "") +
+    `<blockquote class="rule-inline-text">${bodyHtml}</blockquote>` +
+    metaHtml +
+    `</span>`
+  );
+}
+
+/**
+ * Returns true if the node lies inside a <cite> or <a> ancestor — those
+ * are owned by other transforms (transformCiteTags + author-supplied
+ * hyperlinks) and we MUST NOT splice rule text into them.
+ */
+function hasSkipAncestor(node: Node): boolean {
+  let cur: Node | undefined | null = node.parentNode;
+  while (cur && cur instanceof HTMLElement) {
+    const tag = cur.tagName?.toLowerCase();
+    if (tag === "cite" || tag === "a" || tag === "blockquote") return true;
+    cur = cur.parentNode;
+  }
+  return false;
+}
+
+/**
+ * Walk the parsed DOM and replace text-node citations with inline rule
+ * text. Returns the modified HTML string. Idempotent against repeated
+ * calls (already-rewritten spans are inside .rule-inline > <strong>, which
+ * the citation regex still matches in the strong text, but the wrapping
+ * span is skip-ancestored... wait, blockquote is in the skip list above
+ * — and our wrapper uses blockquote for the body — so any second call
+ * sees the citation INSIDE blockquote and SKIPS. Good.) Plus the wrapping
+ * <strong> is inside the rule-inline span, but its parent walk hits
+ * blockquote-or-cite ancestors only via the wrapping; the strong itself
+ * is direct child of span. To be safe, we ALSO check for an ancestor with
+ * class containing "rule-inline" before splicing, which makes the
+ * idempotency explicit instead of incidental.
+ */
+async function transformDom(root: HTMLElement): Promise<HTMLElement> {
+  // Phase 1: walk text nodes, collect citations + their parent context.
+  interface Hit {
+    node: TextNode;
+    citations: ReturnType<typeof findRuleCitations>;
+  }
+  const hits: Hit[] = [];
+
+  function walk(n: Node): void {
+    if (n instanceof TextNode) {
+      if (hasSkipAncestor(n)) return;
+      // Idempotency: skip if any ancestor is already a rule-inline wrapper.
+      let cur: Node | null | undefined = n.parentNode;
+      while (cur && cur instanceof HTMLElement) {
+        const cls = cur.getAttribute("class") ?? "";
+        if (cls.split(/\s+/).includes("rule-inline")) return;
+        cur = cur.parentNode;
+      }
+      const text = n.text;
+      if (!text || !/\b(?:FRE|FRCP|FRCrP|FRAP|Fed\.?\s*R\.?)/i.test(text)) return;
+      const citations = findRuleCitations(text);
+      if (citations.length > 0) hits.push({ node: n, citations });
+      return;
+    }
+    if (n instanceof HTMLElement) {
+      // Cheap ancestor check moved into TextNode handler; recurse children.
+      // copy children array — replaceWith mutates the live list.
+      for (const child of [...n.childNodes]) walk(child);
+    }
+  }
+  walk(root);
+
+  if (hits.length === 0) return root;
+
+  // Phase 2: batch DB lookup for all distinct (set, number) pairs.
+  const pairs: Array<{ rule_set: RuleSet; rule_number: string }> = [];
+  for (const h of hits) {
+    for (const c of h.citations) {
+      pairs.push({ rule_set: c.rule_set, rule_number: c.rule_number });
+    }
+  }
+  const ruleMap = await batchGetRules(pairs);
+
+  // Phase 3: rewrite each text node by splicing inline-rule HTML for each
+  // citation in REVERSE order (so offsets stay valid).
+  for (const h of hits) {
+    const original = h.node.text;
+    let pieces: string[] = [];
+    let cursor = original.length;
+    // Build replacement string by walking citations in document order +
+    // composing in reverse: for each citation, append [tail-after, inline,
+    // ...] then prepend head before. Easiest: walk forward, accumulate.
+    pieces = [];
+    let last = 0;
+    for (const c of h.citations) {
+      const head = original.slice(last, c.start);
+      pieces.push(escapeHtml(head));
+      const key = `${c.rule_set}:${c.rule_number}`;
+      const rule = ruleMap.get(key);
+      if (!rule) {
+        // No DB hit — leave the citation as plain escaped text. Honors
+        // no-hallucinated-legal-data: never invent rule text.
+        pieces.push(escapeHtml(c.citation));
+      } else {
+        pieces.push(
+          renderInlineRule({
+            citation: c.citation,
+            rule_set: c.rule_set,
+            rule_number: c.rule_number,
+            subsection: c.subsection,
+            title: rule.title,
+            body: rule.text,
+            last_amendment: rule.last_amendment,
+            source_url: rule.source_url,
+          })
+        );
+      }
+      last = c.end;
+    }
+    cursor = last;
+    pieces.push(escapeHtml(original.slice(cursor)));
+    const replacementHtml = pieces.join("");
+
+    // node-html-parser 7.x: TextNode does NOT expose .replaceWith — only
+    // HTMLElement does. Swap via the parent's exchangeChild API. The
+    // wrapper span carries the rule-inline-wrapper class so analytics can
+    // see "this report has rule inlining applied" without re-walking.
+    const parent = h.node.parentNode as HTMLElement | null | undefined;
+    if (!parent) continue;
+    const fragment = parse(`<span class="rule-inline-wrapper">${replacementHtml}</span>`);
+    const newNode = fragment.firstChild as HTMLElement | null;
+    if (!newNode) continue;
+    parent.exchangeChild(h.node, newNode);
+  }
+
+  return root;
+}
+
+/**
+ * Public entry. Parses input HTML, rewrites federal-rule citations to
+ * inline rule text, returns the serialized HTML.
+ *
+ * Idempotent: calling twice produces the same output (rule-inline blocks
+ * skipped on the second pass via the ancestor + wrapper-class checks).
+ */
+export async function transformRuleCitations(html: string): Promise<string> {
+  // Cheap pre-filter: if no recognizable prefix appears anywhere, skip the
+  // parse entirely (covers ~99 % of report HTML that has zero federal-rule
+  // citations — Case Decoder reports for example).
+  if (!/\b(?:FRE|FRCP|FRCrP|FRAP|Fed\.?\s*R\.?)/i.test(html)) return html;
+  const root = parse(html, { lowerCaseTagName: false });
+  const out = await transformDom(root);
+  return out.toString();
+}


### PR DESCRIPTION
## Summary
- Federal procedural rule citations (FRE/FRCP/FRCrP/FRAP) auto-link to inline rule text in IB + X-Ray + War Room + Situation Room reports
- 32/32 vitest pass
- tsc --noEmit clean
- Sanitizer-compliant per Architectural Invariant 12

## Files
- src/lib/federal-rules/lookup.ts — getRuleText, batchGetRules, findRuleCitations, extractSubsection, RULE_CITATION_REGEX
- src/lib/federal-rules/render.ts — transformRuleCitations(html) post-sanitize HTML pass
- src/components/federal-rules/RuleInline.tsx — React server component for single-rule inline render
- src/lib/federal-rules/__tests__/lookup.test.ts — 21 tests (regex + subsection extractor)
- src/lib/federal-rules/__tests__/render.test.ts — 11 tests (transform pipeline)
- src/app/report/[token]/page.tsx — wired transformRuleCitations after transformCiteTags

## Sample rule lookup (live DB)
FRE 404 → title "Character Evidence; Other Crimes, Wrongs, or Acts", effective_date 2024-12-01, source_url uscourts.gov FRE PDF, body 2230 chars with (b) subsection at offset 1055.

## Regex coverage
Matches all four short forms (FRE/FRCP/FRCrP/FRAP) + four Bluebook long forms with optional nested subsection blocks (b)(2). Negative tests confirm no match on FRE_404 (underscore) or FREEDOM 404.

## Sanitizer compliance (Invariant 12)
- Negative test: no script/iframe/object/embed/details/summary/video emitted
- Positive test: only span, strong, em, blockquote, a (with href/target/rel) — all in reportSanitizeOptions.allowedTags
- Transform runs AFTER sanitize-html on the same lifecycle slot as transformCiteTags
- Skips text inside cite and a ancestors so existing citations + author hyperlinks remain untouched

## Schema deviation note
Backlog ticket referenced `rule_id` + `last_amendment` columns. Actual schema uses `rule_set` + `rule_number` keys + `effective_date`. Helper output preserves the ticket's customer-vocabulary `last_amendment` field (mapped from `effective_date`).

## Test plan
- [x] vitest 32/32 pass
- [x] tsc --noEmit clean
- [x] sanitizer compliance positive + negative tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)