### PR TITLE
feat(fars): county DUI stats matview + Case Decoder + DUI Playbook (TICKET-11)

### DIFF
--- a/src/app/api/reports/mechanical/[caseId]/route.ts
+++ b/src/app/api/reports/mechanical/[caseId]/route.ts
@@ -14,6 +14,10 @@ import { NextResponse, NextRequest, after } from "next/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { requireOperatorSecret } from "@/lib/auth/guards";
 import { renderCaseDecoderMechanical } from "@/lib/report/mechanical/render-case-decoder";
+import {
+  getCountyDuiContextByName,
+  renderCdCountyAsideHtml,
+} from "@/lib/fars/county-dui";
 
 export const runtime = "nodejs";
 export const maxDuration = 60;
@@ -29,7 +33,7 @@ export async function POST(
   const sb = createAdminClient();
   const { data: caseRow } = await sb
     .from("cases")
-    .select("id, tier, intake_id, status")
+    .select("id, tier, intake_id, status, court_county, court_state")
     .eq("id", caseId)
     .maybeSingle();
   if (!caseRow)
@@ -66,10 +70,42 @@ export async function POST(
       // future verified-opus path (Haiku hybrid was removed 2026-04-24).
       // For pure-mechanical delivery, replace each marker with a neutral
       // placeholder comment so the HTML ships self-contained.
-      const filledHtml = r.slotsEmitted.reduce(
+      let filledHtml = r.slotsEmitted.reduce(
         (h, slot) => h.split(`{{SLOT:${slot}}}`).join("<!-- mechanical: slot omitted -->"),
         r.html,
       );
+
+      // TICKET-11: append FARS county DUI context for DUI cases.
+      // Skips silently when:
+      //   - charge isn't DUI-shaped
+      //   - county/state aren't on the case row
+      //   - county doesn't resolve to a known FIPS pair
+      //   - matview has no rows for this (state, county)
+      // Failure here MUST NOT block the report write.
+      try {
+        const chargeText = String(intake.charge_type ?? "").toLowerCase();
+        const isDui = /\b(dui|dwi|owi|oui)\b/.test(chargeText);
+        const stateText = caseRow.court_state ?? intake.state ?? null;
+        const countyText = caseRow.court_county ?? null;
+        if (isDui && stateText && countyText) {
+          const ctx = await getCountyDuiContextByName(stateText, countyText);
+          const aside = renderCdCountyAsideHtml(ctx);
+          if (aside) {
+            // Insert aside immediately before </article> to keep it
+            // visible inside the report container.
+            const closeTag = "</article>";
+            const idx = filledHtml.lastIndexOf(closeTag);
+            if (idx >= 0) {
+              filledHtml = filledHtml.slice(0, idx) + "\n  " + aside + "\n" + filledHtml.slice(idx);
+            } else {
+              filledHtml = filledHtml + "\n" + aside;
+            }
+          }
+        }
+      } catch (farsErr) {
+        // eslint-disable-next-line no-console
+        console.warn("[mechanical] FARS county aside skipped", farsErr);
+      }
       const { error: writeError } = await sb
         .from("cases")
         .update({

--- a/src/app/playbook/[slug]/page.tsx
+++ b/src/app/playbook/[slug]/page.tsx
@@ -16,10 +16,19 @@ import { TIER_CORE } from "@/lib/tiers";
 import type { TierSlug } from "@/lib/tiers";
 import { SITE_URL } from "@/lib/site";
 import PlaybookSalesPage from "@/components/PlaybookSalesPage";
+import DuiPlaybookCountySidebar from "@/components/DuiPlaybookCountySidebar";
 
 interface PageProps {
   params: Promise<{ slug: string }>;
+  searchParams?: Promise<{ state?: string; county?: string }>;
 }
+
+/** Slugs eligible for the FARS county sidebar (DUI variants only). */
+const DUI_PLAYBOOK_SLUGS = new Set<string>([
+  "dui-first-offense",
+  "dui-second-offense",
+  "felony-dui",
+]);
 
 export async function generateStaticParams() {
   return allPlaybookSlugs().map((slug) => ({ slug }));
@@ -50,7 +59,7 @@ export async function generateMetadata({
   };
 }
 
-export default async function PlaybookPage({ params }: PageProps) {
+export default async function PlaybookPage({ params, searchParams }: PageProps) {
   const { slug } = await params;
   const config = getPlaybookConfig(slug);
 
@@ -59,6 +68,12 @@ export default async function PlaybookPage({ params }: PageProps) {
   }
 
   const tier = TIER_CORE[config.slug as TierSlug];
+
+  // TICKET-11: optional FARS county sidebar for DUI variants when
+  // ?state=X&county=Y are present. Sidebar self-renders null when
+  // params absent or county doesn't resolve.
+  const sp = searchParams ? await searchParams : undefined;
+  const showCountySidebar = DUI_PLAYBOOK_SLUGS.has(slug);
 
   return (
     <>
@@ -136,6 +151,11 @@ export default async function PlaybookPage({ params }: PageProps) {
         }}
       />
       <PlaybookSalesPage config={config} />
+      {showCountySidebar ? (
+        <div className="mx-auto max-w-3xl px-4 pb-12">
+          <DuiPlaybookCountySidebar state={sp?.state} county={sp?.county} />
+        </div>
+      ) : null}
     </>
   );
 }

--- a/src/components/DuiPlaybookCountySidebar.tsx
+++ b/src/components/DuiPlaybookCountySidebar.tsx
@@ -1,0 +1,57 @@
+/**
+ * DUI Playbook county sidebar (TICKET-11).
+ *
+ * Server component. Reads optional `state` and `county` search params,
+ * resolves them to a FIPS pair via ACS, fetches FARS county DUI rows
+ * from the matview, and renders a compact sidebar block. Returns null
+ * silently when:
+ *   - search params absent
+ *   - state/county don't resolve
+ *   - matview has no rows for the resolved county
+ *
+ * UPL: same constraints as the helper — historical / informational
+ * only, never predictive. Source line surfaces NHTSA FARS publicly.
+ */
+import {
+  getCountyDuiContextByName,
+  renderDuiPlaybookCountySidebar,
+} from "@/lib/fars/county-dui";
+
+export type DuiPlaybookCountySidebarProps = {
+  state?: string | null;
+  county?: string | null;
+};
+
+export default async function DuiPlaybookCountySidebar({
+  state,
+  county,
+}: DuiPlaybookCountySidebarProps) {
+  if (!state || !county) return null;
+  const ctx = await getCountyDuiContextByName(state, county);
+  const lines = renderDuiPlaybookCountySidebar(ctx);
+  if (!lines || lines.length === 0) return null;
+
+  // First line is the county/state header; rest are stat rows.
+  const [header, ...rows] = lines;
+  return (
+    <aside
+      className="rounded-lg border border-amber-500/30 bg-amber-500/5 p-4 text-sm text-amber-100/90"
+      data-source="fars"
+      aria-label="County DUI history"
+    >
+      <p className="text-xs uppercase tracking-wider text-amber-300/70">
+        County DUI history (NHTSA FARS)
+      </p>
+      <p className="mt-1 font-semibold text-amber-100">{header}</p>
+      <ul className="mt-2 space-y-1 text-amber-100/80">
+        {rows.map((line) => (
+          <li key={line}>{line}</li>
+        ))}
+      </ul>
+      <p className="mt-3 text-xs text-amber-100/50">
+        Denominator: ACS driving-age adult population. Historical /
+        informational only.
+      </p>
+    </aside>
+  );
+}

--- a/src/lib/fars/__tests__/county-dui.test.ts
+++ b/src/lib/fars/__tests__/county-dui.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Unit tests for FARS county DUI helpers (TICKET-11).
+ *
+ * Covers:
+ *   - FIPS normalization edge cases (null / negative / 5-digit GEOID)
+ *   - Percentile bucketing boundaries
+ *   - Mercer-voice prose render shape
+ *   - UPL banned-phrase parity (every rendered surface scanned)
+ *   - Null-row graceful degradation
+ *
+ * Does NOT exercise the live Supabase fetch — that's covered by the
+ * post-apply matview verification (see commit message). This file is
+ * pure-render tests so it runs offline.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  describePercentileBucket,
+  FARS_COUNTY_DENOMINATOR_LABEL,
+  FARS_COUNTY_RECENT_WINDOW_YEARS,
+  normalizeCountyFips,
+  normalizeStateFips,
+  renderCdCountyParagraph,
+  renderDuiPlaybookCountySidebar,
+  splitCountyGeoid,
+  type CountyDuiContext,
+} from "../county-dui";
+import { UPL_BANNED_PHRASES } from "@/lib/charge-slug-maps";
+
+// ------------------------------------------------------------
+// Fixtures
+// ------------------------------------------------------------
+
+function mkContext(over: Partial<CountyDuiContext> = {}): CountyDuiContext {
+  // Pinellas FL — values mirror real matview rows captured at apply time.
+  const recentYears = [
+    { year: 2020, duiCrashes: 27, duiFatalities: 32, fatalitiesPer100kAdults: 4.15, stateYearPercentile: 23.3 },
+    { year: 2019, duiCrashes: 20, duiFatalities: 20, fatalitiesPer100kAdults: 2.59, stateYearPercentile: 9.8 },
+    { year: 2018, duiCrashes: 26, duiFatalities: 28, fatalitiesPer100kAdults: 3.63, stateYearPercentile: 23.0 },
+    { year: 2017, duiCrashes: 27, duiFatalities: 28, fatalitiesPer100kAdults: 3.63, stateYearPercentile: 17.7 },
+    { year: 2016, duiCrashes: 28, duiFatalities: 34, fatalitiesPer100kAdults: 4.41, stateYearPercentile: 30.6 },
+  ];
+  return {
+    stateFips: "12",
+    countyFips: "103",
+    countyName: "Pinellas County",
+    stateName: "Florida",
+    latestYear: 2020,
+    recentYears,
+    recentYearsFatalities: recentYears.reduce((a, r) => a + r.duiFatalities, 0),
+    recentYearsCount: recentYears.length,
+    ...over,
+  };
+}
+
+// ------------------------------------------------------------
+// FIPS normalization
+// ------------------------------------------------------------
+
+describe("normalizeStateFips", () => {
+  it("zero-pads single digit", () => {
+    expect(normalizeStateFips(1)).toBe("01");
+    expect(normalizeStateFips("1")).toBe("01");
+  });
+  it("preserves valid 2-digit", () => {
+    expect(normalizeStateFips("12")).toBe("12");
+    expect(normalizeStateFips(99)).toBe("99");
+  });
+  it("rejects null/undefined/0/negative/3-digit/non-numeric", () => {
+    expect(normalizeStateFips(null)).toBeNull();
+    expect(normalizeStateFips(undefined)).toBeNull();
+    expect(normalizeStateFips(0)).toBeNull();
+    expect(normalizeStateFips(-1)).toBeNull();
+    expect(normalizeStateFips(100)).toBeNull();
+    expect(normalizeStateFips("ab")).toBeNull();
+    expect(normalizeStateFips("12 ")).toBe("12"); // trim
+  });
+});
+
+describe("normalizeCountyFips", () => {
+  it("zero-pads to 3", () => {
+    expect(normalizeCountyFips(1)).toBe("001");
+    expect(normalizeCountyFips(81)).toBe("081");
+    expect(normalizeCountyFips(103)).toBe("103");
+  });
+  it("rejects 0/4-digit/non-numeric", () => {
+    expect(normalizeCountyFips(0)).toBeNull();
+    expect(normalizeCountyFips(1000)).toBeNull();
+    expect(normalizeCountyFips("xyz")).toBeNull();
+  });
+});
+
+describe("splitCountyGeoid", () => {
+  it("splits 5-digit GEOID", () => {
+    expect(splitCountyGeoid("12103")).toEqual({ stateFips: "12", countyFips: "103" });
+    expect(splitCountyGeoid("01001")).toEqual({ stateFips: "01", countyFips: "001" });
+  });
+  it("rejects non-5-digit", () => {
+    expect(splitCountyGeoid("1234")).toBeNull();
+    expect(splitCountyGeoid("123456")).toBeNull();
+    expect(splitCountyGeoid(null)).toBeNull();
+  });
+});
+
+// ------------------------------------------------------------
+// Bucketing
+// ------------------------------------------------------------
+
+describe("describePercentileBucket", () => {
+  it("buckets each quartile", () => {
+    expect(describePercentileBucket(0)).toMatch(/lowest quartile/);
+    expect(describePercentileBucket(24.9)).toMatch(/lowest quartile/);
+    expect(describePercentileBucket(25)).toMatch(/second quartile/);
+    expect(describePercentileBucket(49.9)).toMatch(/second quartile/);
+    expect(describePercentileBucket(50)).toMatch(/third quartile/);
+    expect(describePercentileBucket(74.9)).toMatch(/third quartile/);
+    expect(describePercentileBucket(75)).toMatch(/top quartile/);
+    expect(describePercentileBucket(100)).toMatch(/top quartile/);
+  });
+  it("returns null for null/out-of-range", () => {
+    expect(describePercentileBucket(null)).toBeNull();
+    expect(describePercentileBucket(-1)).toBeNull();
+    expect(describePercentileBucket(101)).toBeNull();
+  });
+});
+
+// ------------------------------------------------------------
+// CD paragraph
+// ------------------------------------------------------------
+
+describe("renderCdCountyParagraph", () => {
+  it("renders the Pinellas fixture", () => {
+    const para = renderCdCountyParagraph(mkContext());
+    expect(para).not.toBeNull();
+    expect(para).toContain("Pinellas County");
+    expect(para).toContain("Florida");
+    expect(para).toContain("FARS");
+    expect(para).toContain("driving-age adults");
+    expect(para).toContain("142"); // 32+20+28+28+34 = 142 fatalities
+    expect(para).toContain("2016-2020");
+    expect(para).toContain("4.15");
+    expect(para).toContain("lowest quartile");
+  });
+  it("returns null for null context or empty rows", () => {
+    expect(renderCdCountyParagraph(null)).toBeNull();
+    expect(renderCdCountyParagraph(mkContext({ recentYears: [], recentYearsCount: 0, recentYearsFatalities: 0 }))).toBeNull();
+  });
+  it("falls back when per-100K rate is null", () => {
+    const ctx = mkContext({
+      recentYears: [{ year: 2020, duiCrashes: 5, duiFatalities: 7, fatalitiesPer100kAdults: null, stateYearPercentile: null }],
+      recentYearsCount: 1,
+      recentYearsFatalities: 7,
+    });
+    const para = renderCdCountyParagraph(ctx);
+    expect(para).toContain("per-capita rate unavailable");
+    expect(para).not.toContain("per 100K");
+  });
+  it("uses fallback names when ACS row missing", () => {
+    const para = renderCdCountyParagraph(mkContext({ countyName: null, stateName: null }));
+    expect(para).toContain("this county");
+    expect(para).toContain("this state");
+  });
+  it("never emits any UPL banned phrase", () => {
+    const para = renderCdCountyParagraph(mkContext()) ?? "";
+    const lower = para.toLowerCase();
+    for (const phrase of UPL_BANNED_PHRASES) {
+      expect(lower.includes(phrase), `CD paragraph must not contain banned phrase "${phrase}"`).toBe(false);
+    }
+  });
+  it("never claims licensed-driver denominator", () => {
+    const para = (renderCdCountyParagraph(mkContext()) ?? "").toLowerCase();
+    expect(para).not.toContain("licensed driver");
+    expect(para).not.toContain("licensed drivers");
+  });
+});
+
+// ------------------------------------------------------------
+// DUI Playbook sidebar
+// ------------------------------------------------------------
+
+describe("renderDuiPlaybookCountySidebar", () => {
+  it("returns 5 lines for fully-populated context", () => {
+    const lines = renderDuiPlaybookCountySidebar(mkContext());
+    expect(lines).not.toBeNull();
+    expect(lines!.length).toBe(5);
+    expect(lines![0]).toContain("Pinellas County");
+    expect(lines![1]).toContain("142");
+    expect(lines![2]).toContain("4.15");
+    expect(lines![2]).toContain("driving-age adults");
+    expect(lines![3]).toContain("lowest quartile");
+    expect(lines![4]).toContain("NHTSA FARS");
+  });
+  it("returns null when no context", () => {
+    expect(renderDuiPlaybookCountySidebar(null)).toBeNull();
+  });
+  it("never emits banned UPL phrases", () => {
+    const text = (renderDuiPlaybookCountySidebar(mkContext()) ?? []).join("\n").toLowerCase();
+    for (const phrase of UPL_BANNED_PHRASES) {
+      expect(text.includes(phrase), `sidebar must not contain banned phrase "${phrase}"`).toBe(false);
+    }
+  });
+  it("never claims licensed-driver denominator", () => {
+    const text = (renderDuiPlaybookCountySidebar(mkContext()) ?? []).join("\n").toLowerCase();
+    expect(text).not.toContain("licensed driver");
+  });
+});
+
+// ------------------------------------------------------------
+// Constants sanity
+// ------------------------------------------------------------
+
+describe("constants", () => {
+  it("recent-window default is 5 years", () => {
+    expect(FARS_COUNTY_RECENT_WINDOW_YEARS).toBe(5);
+  });
+  it("denominator label is locked to driving-age adults", () => {
+    expect(FARS_COUNTY_DENOMINATOR_LABEL).toBe("driving-age adults");
+  });
+});

--- a/src/lib/fars/county-dui.ts
+++ b/src/lib/fars/county-dui.ts
@@ -1,0 +1,424 @@
+/**
+ * FARS County DUI Stats — Mercer voice helpers.
+ *
+ * Reads from the `public.fars_county_dui_stats` materialized view
+ * (migration 20260503a_fars_county_dui_stats.sql) to render historical
+ * DUI fatality context for a given county. Powers:
+ *
+ *   - Case Decoder ($197) county-context paragraph (DUI charge only)
+ *   - DUI Playbook county sidebar (sales-page section)
+ *
+ * UPL (HARD):
+ *   - Output is strictly historical / informational. No outcome
+ *     prediction. No advice. No "you should". No "your case will".
+ *   - Denominator label is "driving-age adults", NEVER
+ *     "licensed drivers" — county-level licensed-driver counts are
+ *     not in our schema; the matview uses ACS pop_18_plus.
+ *   - Rendered prose is reviewed against UPL_BANNED_PHRASES in tests.
+ *
+ * Voice:
+ *   - Mercer mode CHARM (defendant-facing, second-person "you / your").
+ *   - Composed measured cadence; no urgency; no hype.
+ *
+ * Source row shape (from matview):
+ *   state_fips char(2), county_fips char(3), year smallint,
+ *   county_name text, state_name text,
+ *   dui_crashes int, dui_fatalities int, pop_18_plus int,
+ *   fatalities_per_100k_adults numeric(10,2),  -- nullable
+ *   state_year_percentile numeric(4,1)         -- nullable
+ *
+ * Source: TICKET-11.
+ */
+import { createAdminClient } from "@/lib/supabase/admin";
+
+// ------------------------------------------------------------
+// Public types
+// ------------------------------------------------------------
+
+export type CountyDuiYearRow = {
+  year: number;
+  duiCrashes: number;
+  duiFatalities: number;
+  fatalitiesPer100kAdults: number | null;
+  stateYearPercentile: number | null;
+};
+
+export type CountyDuiContext = {
+  /** Two-char zero-padded state FIPS, e.g. "12". */
+  stateFips: string;
+  /** Three-char zero-padded county FIPS, e.g. "103". */
+  countyFips: string;
+  /** Display name from ACS, e.g. "Pinellas County". May be null when ACS row missing. */
+  countyName: string | null;
+  /** Display state name, e.g. "Florida". */
+  stateName: string | null;
+  /** Most recent year present in the matview for this county. */
+  latestYear: number | null;
+  /** Up-to-5 most-recent year rows, newest first. */
+  recentYears: CountyDuiYearRow[];
+  /**
+   * Sum of DUI fatalities across `recentYears`.
+   * Calculated client-side so callers can render either the bare
+   * sum (if all 5 are present) or the partial sum (if FARS coverage
+   * is thin) without re-walking the rows.
+   */
+  recentYearsFatalities: number;
+  /**
+   * Number of years actually summed into `recentYearsFatalities`
+   * (matview presence, NOT calendar gap).
+   */
+  recentYearsCount: number;
+};
+
+// ------------------------------------------------------------
+// Constants
+// ------------------------------------------------------------
+
+/** How many recent years to include in the customer-facing window. */
+export const FARS_COUNTY_RECENT_WINDOW_YEARS = 5;
+
+/** Denominator label — locked to ACS pop_18_plus, NOT licensed drivers. */
+export const FARS_COUNTY_DENOMINATOR_LABEL = "driving-age adults" as const;
+
+// ------------------------------------------------------------
+// FIPS normalization
+// ------------------------------------------------------------
+
+/**
+ * Normalize a state FIPS code into the matview's char(2) zero-padded
+ * form. Accepts numbers, integer strings, or already-padded strings.
+ * Returns null on invalid input.
+ */
+export function normalizeStateFips(input: string | number | null | undefined): string | null {
+  if (input === null || input === undefined) return null;
+  const s = String(input).trim();
+  if (!/^\d{1,2}$/.test(s)) return null;
+  const n = Number(s);
+  if (n < 1 || n > 99) return null;
+  return s.padStart(2, "0");
+}
+
+/**
+ * Normalize a county FIPS code into the matview's char(3) zero-padded
+ * form. Accepts the 3-digit county portion ONLY (NOT the 5-digit GEOID).
+ * Use `splitCountyGeoid` if you have a 5-digit GEOID.
+ */
+export function normalizeCountyFips(input: string | number | null | undefined): string | null {
+  if (input === null || input === undefined) return null;
+  const s = String(input).trim();
+  if (!/^\d{1,3}$/.test(s)) return null;
+  const n = Number(s);
+  if (n < 1 || n > 999) return null;
+  return s.padStart(3, "0");
+}
+
+/**
+ * Split a 5-digit GEOID (state(2) + county(3)) into its two parts.
+ * Returns null on invalid input.
+ */
+export function splitCountyGeoid(geoid: string | null | undefined): { stateFips: string; countyFips: string } | null {
+  if (geoid === null || geoid === undefined) return null;
+  const s = String(geoid).trim();
+  if (!/^\d{5}$/.test(s)) return null;
+  return { stateFips: s.slice(0, 2), countyFips: s.slice(2, 5) };
+}
+
+/**
+ * State name + abbrev → FIPS lookup.
+ * Intake `state` field is messy in the wild ("Florida", "FL", garbage),
+ * so the helper accepts either form. Returns null when input doesn't
+ * match a known US state.
+ */
+const STATE_NAME_TO_FIPS: Readonly<Record<string, string>> = Object.freeze({
+  alabama: "01", alaska: "02", arizona: "04", arkansas: "05", california: "06",
+  colorado: "08", connecticut: "09", delaware: "10", "district of columbia": "11",
+  florida: "12", georgia: "13", hawaii: "15", idaho: "16", illinois: "17",
+  indiana: "18", iowa: "19", kansas: "20", kentucky: "21", louisiana: "22",
+  maine: "23", maryland: "24", massachusetts: "25", michigan: "26", minnesota: "27",
+  mississippi: "28", missouri: "29", montana: "30", nebraska: "31", nevada: "32",
+  "new hampshire": "33", "new jersey": "34", "new mexico": "35", "new york": "36",
+  "north carolina": "37", "north dakota": "38", ohio: "39", oklahoma: "40",
+  oregon: "41", pennsylvania: "42", "rhode island": "44", "south carolina": "45",
+  "south dakota": "46", tennessee: "47", texas: "48", utah: "49", vermont: "50",
+  virginia: "51", washington: "53", "west virginia": "54", wisconsin: "55", wyoming: "56",
+});
+
+const STATE_ABBREV_TO_FIPS: Readonly<Record<string, string>> = Object.freeze({
+  AL: "01", AK: "02", AZ: "04", AR: "05", CA: "06", CO: "08", CT: "09",
+  DE: "10", DC: "11", FL: "12", GA: "13", HI: "15", ID: "16", IL: "17",
+  IN: "18", IA: "19", KS: "20", KY: "21", LA: "22", ME: "23", MD: "24",
+  MA: "25", MI: "26", MN: "27", MS: "28", MO: "29", MT: "30", NE: "31",
+  NV: "32", NH: "33", NJ: "34", NM: "35", NY: "36", NC: "37", ND: "38",
+  OH: "39", OK: "40", OR: "41", PA: "42", RI: "44", SC: "45", SD: "46",
+  TN: "47", TX: "48", UT: "49", VT: "50", VA: "51", WA: "53", WV: "54",
+  WI: "55", WY: "56",
+});
+
+export function stateInputToFips(input: string | null | undefined): string | null {
+  if (input === null || input === undefined) return null;
+  const raw = String(input).trim();
+  if (!raw) return null;
+  // Already FIPS?
+  if (/^\d{1,2}$/.test(raw)) return normalizeStateFips(raw);
+  // Abbreviation?
+  if (raw.length === 2) {
+    const abbrev = raw.toUpperCase();
+    return STATE_ABBREV_TO_FIPS[abbrev] ?? null;
+  }
+  // Full name (case-insensitive)?
+  const key = raw.toLowerCase();
+  return STATE_NAME_TO_FIPS[key] ?? null;
+}
+
+// ------------------------------------------------------------
+// Data fetch
+// ------------------------------------------------------------
+
+/**
+ * Load county DUI context from the matview.
+ *
+ * Returns null when:
+ *   - FIPS inputs are malformed
+ *   - The matview has no rows for this (state, county)
+ *
+ * Callers MUST handle null — counties with FIPS codes that retired
+ * between FARS year and ACS vintage produce no matview row.
+ */
+export async function getCountyDuiContext(
+  stateFipsInput: string | number | null | undefined,
+  countyFipsInput: string | number | null | undefined,
+  opts: { windowYears?: number } = {},
+): Promise<CountyDuiContext | null> {
+  const stateFips = normalizeStateFips(stateFipsInput);
+  const countyFips = normalizeCountyFips(countyFipsInput);
+  if (!stateFips || !countyFips) return null;
+
+  const window = Math.max(1, Math.min(20, opts.windowYears ?? FARS_COUNTY_RECENT_WINDOW_YEARS));
+
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("fars_county_dui_stats")
+    .select(
+      "state_fips, county_fips, year, county_name, state_name, dui_crashes, dui_fatalities, fatalities_per_100k_adults, state_year_percentile",
+    )
+    .eq("state_fips", stateFips)
+    .eq("county_fips", countyFips)
+    .order("year", { ascending: false })
+    .limit(window);
+
+  if (error) {
+    // Don't throw — the report layer must keep rendering even if FARS
+    // is unavailable. Caller handles the null and skips the section.
+    return null;
+  }
+  if (!data || data.length === 0) return null;
+
+  const recentYears: CountyDuiYearRow[] = data.map((r) => ({
+    year: Number(r.year),
+    duiCrashes: Number(r.dui_crashes ?? 0),
+    duiFatalities: Number(r.dui_fatalities ?? 0),
+    fatalitiesPer100kAdults: r.fatalities_per_100k_adults === null || r.fatalities_per_100k_adults === undefined
+      ? null
+      : Number(r.fatalities_per_100k_adults),
+    stateYearPercentile: r.state_year_percentile === null || r.state_year_percentile === undefined
+      ? null
+      : Number(r.state_year_percentile),
+  }));
+
+  const recentYearsFatalities = recentYears.reduce((acc, r) => acc + r.duiFatalities, 0);
+
+  return {
+    stateFips,
+    countyFips,
+    countyName: data[0].county_name ?? null,
+    stateName: data[0].state_name ?? null,
+    latestYear: recentYears[0]?.year ?? null,
+    recentYears,
+    recentYearsFatalities,
+    recentYearsCount: recentYears.length,
+  };
+}
+
+/**
+ * Resolve (stateText, countyText) → matview row keys via ACS lookup.
+ * Returns null when either input is unrecognized or no ACS row exists.
+ *
+ * The `countyText` is matched case-insensitively with optional
+ * "County" suffix tolerance ("Pinellas" and "Pinellas County" both
+ * resolve to FIPS 12-103).
+ */
+export async function resolveCountyByName(
+  stateText: string | null | undefined,
+  countyText: string | null | undefined,
+): Promise<{ stateFips: string; countyFips: string } | null> {
+  const stateFips = stateInputToFips(stateText ?? null);
+  if (!stateFips) return null;
+  const ct = (countyText ?? "").trim();
+  if (!ct) return null;
+
+  // Tolerate "Pinellas" / "Pinellas County" / "PINELLAS COUNTY" / etc.
+  const normalized = ct.replace(/\s+county\s*$/i, "").trim();
+  if (!normalized) return null;
+
+  const supabase = createAdminClient();
+  // Use ILIKE prefix match on county_name with explicit state_fips bound.
+  const { data, error } = await supabase
+    .from("acs_county_demographics")
+    .select("state_fips, county_fips, county_name")
+    .eq("state_fips", stateFips)
+    .ilike("county_name", `${normalized}%`)
+    .limit(2);
+  if (error) return null;
+  if (!data || data.length === 0) return null;
+  // If multiple matches, prefer exact (post-strip) name match.
+  const exact = data.find((r) => (r.county_name ?? "").replace(/\s+county\s*$/i, "").toLowerCase() === normalized.toLowerCase());
+  const pick = exact ?? data[0];
+  return { stateFips: pick.state_fips, countyFips: pick.county_fips };
+}
+
+/**
+ * Convenience wrapper for the report-render call site: resolve then
+ * fetch in one call. Returns null on any failure (unknown state /
+ * unknown county / no FARS rows / DB error). Caller skips the
+ * county section when null.
+ */
+export async function getCountyDuiContextByName(
+  stateText: string | null | undefined,
+  countyText: string | null | undefined,
+  opts: { windowYears?: number } = {},
+): Promise<CountyDuiContext | null> {
+  const fips = await resolveCountyByName(stateText, countyText);
+  if (!fips) return null;
+  return getCountyDuiContext(fips.stateFips, fips.countyFips, opts);
+}
+
+// ------------------------------------------------------------
+// Quartile bucketing — strictly descriptive, no advice
+// ------------------------------------------------------------
+
+/**
+ * Map a state-year percentile (0-100) into a coarse descriptive bucket.
+ * The buckets are deliberately neutral — "lowest quartile" / "second
+ * quartile" / etc. — and never say "best" or "worst" or "high risk".
+ */
+export function describePercentileBucket(percentile: number | null): string | null {
+  if (percentile === null) return null;
+  if (percentile < 0 || percentile > 100) return null;
+  if (percentile < 25) return "the lowest quartile for DUI fatality density";
+  if (percentile < 50) return "the second quartile for DUI fatality density";
+  if (percentile < 75) return "the third quartile for DUI fatality density";
+  return "the top quartile for DUI fatality density";
+}
+
+// ------------------------------------------------------------
+// Mercer-voice prose renderers
+// ------------------------------------------------------------
+
+function pluralize(n: number, singular: string, plural?: string): string {
+  return n === 1 ? singular : (plural ?? singular + "s");
+}
+
+/**
+ * Render the Case Decoder county-context paragraph (Mercer CHARM).
+ *
+ * Returns plain prose suitable for inlining into the CD report body
+ * inside an aside or paragraph block. Returns null when the context
+ * has no usable rows (caller should skip the section entirely).
+ *
+ * UPL constraints:
+ *   - Strictly historical (NEVER "you will", "you should", "likely")
+ *   - Denominator is "driving-age adults" only
+ *   - Percentile is described as a state cohort position, not a risk
+ *     prediction
+ *
+ * Output shape (single paragraph):
+ *   "{County}, {State}: {N} DUI fatalities over the last {K} years
+ *    of FARS data ({first}-{last}). Most recent year on file
+ *    ({latest}): {R} fatalities per 100K driving-age adults — {bucket}
+ *    in {state} that year."
+ */
+export function renderCdCountyParagraph(ctx: CountyDuiContext | null): string | null {
+  if (!ctx || ctx.recentYearsCount === 0) return null;
+  const county = ctx.countyName?.trim() || "this county";
+  const state = ctx.stateName?.trim() || "this state";
+
+  const earliest = ctx.recentYears[ctx.recentYears.length - 1].year;
+  const latestRow = ctx.recentYears[0];
+
+  const headline =
+    `${county}, ${state}: ${ctx.recentYearsFatalities} DUI ${pluralize(ctx.recentYearsFatalities, "fatality", "fatalities")} ` +
+    `recorded across the last ${ctx.recentYearsCount} ${pluralize(ctx.recentYearsCount, "year")} of FARS data ` +
+    `(${earliest}-${latestRow.year}).`;
+
+  const rateClause = (() => {
+    if (latestRow.fatalitiesPer100kAdults === null) {
+      return ` Most recent year on file (${latestRow.year}): ${latestRow.duiFatalities} ${pluralize(latestRow.duiFatalities, "fatality", "fatalities")} (per-capita rate unavailable for this county).`;
+    }
+    const rate = latestRow.fatalitiesPer100kAdults.toFixed(2);
+    const bucket = describePercentileBucket(latestRow.stateYearPercentile);
+    const bucketClause = bucket ? ` That places ${county} in ${bucket} for ${state} that year.` : "";
+    return ` Most recent year on file (${latestRow.year}): ${rate} ${FARS_COUNTY_DENOMINATOR_LABEL === "driving-age adults" ? "fatalities per 100K driving-age adults" : "fatalities per capita"}.${bucketClause}`;
+  })();
+
+  return headline + rateClause;
+}
+
+/**
+ * Render the CD county aside as escaped HTML — safe to inline into
+ * the mechanical CD skeleton. Returns null when no paragraph would
+ * render (caller MUST omit the section to keep the report tight).
+ *
+ * UPL: same constraints as renderCdCountyParagraph — historical and
+ * informational only. Source line surfaces NHTSA FARS publicly.
+ */
+export function renderCdCountyAsideHtml(ctx: CountyDuiContext | null): string | null {
+  const para = renderCdCountyParagraph(ctx);
+  if (!para) return null;
+  // The paragraph contains only county name, state name, integers,
+  // numerics — no user input — but escape defensively to keep the
+  // sanitize-html invariant (Architectural Invariant 12) happy.
+  const safe = String(para)
+    .split("&").join("&amp;")
+    .split("<").join("&lt;")
+    .split(">").join("&gt;");
+  return `<aside class="county-context" data-source="fars">
+  <h3>County DUI history (NHTSA FARS)</h3>
+  <p>${safe}</p>
+  <p class="source-note"><small>Source: National Highway Traffic Safety Administration, Fatality Analysis Reporting System. Denominator: ACS driving-age adult population. Historical / informational only.</small></p>
+</aside>`;
+}
+
+/**
+ * Render a compact county sidebar block for the DUI Playbook sales
+ * page. Returns plain text lines (no HTML) — caller wraps in markup.
+ *
+ * Sidebar shape (4-6 short lines, scan-friendly):
+ *   "{County}, {State}"
+ *   "DUI fatalities, last {K} years: {N}"
+ *   "{latest} rate: {R} per 100K driving-age adults"
+ *   "Position vs. {state} counties ({latest}): {bucket}"
+ *   "Source: NHTSA FARS"
+ */
+export function renderDuiPlaybookCountySidebar(ctx: CountyDuiContext | null): string[] | null {
+  if (!ctx || ctx.recentYearsCount === 0) return null;
+  const county = ctx.countyName?.trim() || "This county";
+  const state = ctx.stateName?.trim() || "this state";
+  const latestRow = ctx.recentYears[0];
+
+  const lines: string[] = [];
+  lines.push(`${county}, ${state}`);
+  lines.push(
+    `DUI fatalities, last ${ctx.recentYearsCount} ${pluralize(ctx.recentYearsCount, "year")}: ${ctx.recentYearsFatalities}`,
+  );
+  if (latestRow.fatalitiesPer100kAdults !== null) {
+    lines.push(`${latestRow.year} rate: ${latestRow.fatalitiesPer100kAdults.toFixed(2)} per 100K driving-age adults`);
+    const bucket = describePercentileBucket(latestRow.stateYearPercentile);
+    if (bucket) {
+      lines.push(`Position vs. ${state} counties (${latestRow.year}): ${bucket}`);
+    }
+  } else {
+    lines.push(`${latestRow.year}: ${latestRow.duiFatalities} ${pluralize(latestRow.duiFatalities, "fatality", "fatalities")} (per-capita rate unavailable)`);
+  }
+  lines.push("Source: NHTSA FARS");
+  return lines;
+}

--- a/supabase/migrations/20260503a_fars_county_dui_stats.sql
+++ b/supabase/migrations/20260503a_fars_county_dui_stats.sql
@@ -128,3 +128,8 @@ CREATE INDEX IF NOT EXISTS fars_county_dui_stats_state_year_idx
 
 COMMENT ON MATERIALIZED VIEW public.fars_county_dui_stats IS
   'Per-county / per-year DUI fatality stats from NHTSA FARS, with ACS pop_18_plus denominator. Powers Case Decoder county paragraph + DUI Playbook county sidebar (TICKET-11). Denominator = driving-age adults (NOT licensed drivers — county-level licensed-driver counts are not in the schema). Refresh annually after FARS release: REFRESH MATERIALIZED VIEW CONCURRENTLY public.fars_county_dui_stats. Source: 20260503a_fars_county_dui_stats.sql.';
+
+-- Access control: paid-tier data — explicit revoke from anon + grant to authenticated only.
+-- RLS not available on materialized views (PostgreSQL limitation); GRANT/REVOKE is sole protection layer.
+REVOKE ALL ON public.fars_county_dui_stats FROM anon;
+GRANT SELECT ON public.fars_county_dui_stats TO authenticated, service_role;

--- a/supabase/migrations/20260503a_fars_county_dui_stats.sql
+++ b/supabase/migrations/20260503a_fars_county_dui_stats.sql
@@ -1,0 +1,130 @@
+-- TICKET-11 — FARS County DUI Stats Materialized View
+--
+-- Per-county / per-year DUI fatality counts, density vs. driving-age
+-- population, and intra-state percentile rank. Powers the Case Decoder
+-- ($197) county-context paragraph and the DUI Playbook county-stat
+-- sidebar.
+--
+-- Source data:
+--   public.fars_crashes  — NHTSA Fatality Analysis Reporting System,
+--     2010-2024, 510K rows, ~101K alcohol-involved (drunk_drivers > 0).
+--     state_code = SMALLINT FIPS (1, 12, ...).
+--     county_code = SMALLINT FIPS (1, 81, 113, ...).
+--
+--   public.acs_county_demographics — Census ACS 2022 5-year, 3,144
+--     counties. geoid = char(5) zero-padded FIPS (state(2)+county(3)).
+--     pop_18_plus is used as the driving-age denominator.
+--
+-- Denominator note (UPL-relevant): the ticket asks for "fatalities per
+-- 100K licensed drivers" but FHWA county-level licensed-driver counts
+-- are not in our schema. pop_18_plus is the closest proxy already
+-- loaded (driving-age population). The matview labels the column
+-- `fatalities_per_100k_adults` so callers stay honest about what the
+-- denominator actually is. Wording in customer-facing copy MUST match
+-- — "per 100K driving-age adults", never "per 100K licensed drivers".
+--
+-- The percentile column ranks each (state, year) bucket so a county can
+-- be described as "in the top quartile for DUI fatality density in
+-- [state] in [year]" without making any outcome prediction.
+--
+-- Refresh cadence: annual (after each FARS release; FARS lags ~18mo).
+--   REFRESH MATERIALIZED VIEW CONCURRENTLY public.fars_county_dui_stats;
+-- (CONCURRENTLY requires the unique index defined below.)
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS public.fars_county_dui_stats AS
+WITH crash_county AS (
+  -- Project FARS crash rows into the ACS-compatible (state_fips,
+  -- county_fips) char-padded shape, filtering to alcohol-involved
+  -- crashes (drunk_drivers > 0) and rows with a usable county code.
+  SELECT
+    LPAD(state_code::text,  2, '0') AS state_fips,
+    LPAD(county_code::text, 3, '0') AS county_fips,
+    year,
+    fatalities,
+    1 AS dui_crash
+  FROM public.fars_crashes
+  WHERE drunk_drivers > 0
+    AND county_code IS NOT NULL
+    AND county_code > 0
+    AND state_code  IS NOT NULL
+    AND state_code  > 0
+),
+county_year AS (
+  -- Aggregate to (state, county, year): DUI crash count + DUI fatalities.
+  SELECT
+    state_fips,
+    county_fips,
+    year,
+    SUM(dui_crash)::int  AS dui_crashes,
+    SUM(fatalities)::int AS dui_fatalities
+  FROM crash_county
+  GROUP BY state_fips, county_fips, year
+),
+joined AS (
+  -- Left-join ACS demographics for the denominator + display name.
+  -- Counties without ACS coverage (e.g., FIPS code retired between
+  -- FARS year and ACS vintage) keep the row but produce a NULL
+  -- per-100k-adults rate — caller must handle NULL.
+  SELECT
+    cy.state_fips,
+    cy.county_fips,
+    cy.year,
+    cy.dui_crashes,
+    cy.dui_fatalities,
+    acs.county_name,
+    acs.state_name,
+    acs.pop_18_plus,
+    CASE
+      WHEN acs.pop_18_plus IS NOT NULL AND acs.pop_18_plus > 0
+        THEN ROUND(
+          (cy.dui_fatalities::numeric / acs.pop_18_plus) * 100000,
+          2
+        )
+      ELSE NULL
+    END AS fatalities_per_100k_adults
+  FROM county_year cy
+  LEFT JOIN public.acs_county_demographics acs
+    ON acs.state_fips  = cy.state_fips
+   AND acs.county_fips = cy.county_fips
+)
+SELECT
+  state_fips,
+  county_fips,
+  year,
+  county_name,
+  state_name,
+  dui_crashes,
+  dui_fatalities,
+  pop_18_plus,
+  fatalities_per_100k_adults,
+  -- Within-state percentile for the same year. Counties with NULL
+  -- per-100k get NULL percentile so callers cannot accidentally rank
+  -- them. Window partitions by (state, year) so ranks are bounded
+  -- inside the comparable cohort.
+  CASE
+    WHEN fatalities_per_100k_adults IS NOT NULL THEN
+      ROUND(
+        (PERCENT_RANK() OVER (
+          PARTITION BY state_fips, year
+          ORDER BY fatalities_per_100k_adults
+        ))::numeric * 100,
+        1
+      )
+    ELSE NULL
+  END AS state_year_percentile
+FROM joined;
+
+-- Unique index supports REFRESH MATERIALIZED VIEW CONCURRENTLY.
+CREATE UNIQUE INDEX IF NOT EXISTS fars_county_dui_stats_pk
+  ON public.fars_county_dui_stats (state_fips, county_fips, year);
+
+-- Lookup index for the helper (single county across years).
+CREATE INDEX IF NOT EXISTS fars_county_dui_stats_county_year_idx
+  ON public.fars_county_dui_stats (state_fips, county_fips, year DESC);
+
+-- Lookup index for state-year leaderboards (used by quartile context).
+CREATE INDEX IF NOT EXISTS fars_county_dui_stats_state_year_idx
+  ON public.fars_county_dui_stats (state_fips, year, fatalities_per_100k_adults DESC NULLS LAST);
+
+COMMENT ON MATERIALIZED VIEW public.fars_county_dui_stats IS
+  'Per-county / per-year DUI fatality stats from NHTSA FARS, with ACS pop_18_plus denominator. Powers Case Decoder county paragraph + DUI Playbook county sidebar (TICKET-11). Denominator = driving-age adults (NOT licensed drivers — county-level licensed-driver counts are not in the schema). Refresh annually after FARS release: REFRESH MATERIALIZED VIEW CONCURRENTLY public.fars_county_dui_stats. Source: 20260503a_fars_county_dui_stats.sql.';


### PR DESCRIPTION
## Summary
- FARS county-level DUI stats matview built from NHTSA Fatality data
- 23,647 matview rows / 51 states / 3,111 counties / years 2010-2020
- 21 new vitest pass (FARS helper) + 4 affected CD render tests still green
- tsc --noEmit clean
- Pre-commit hook passed

## Sample render (Pinellas FL 2020)
27 DUI crashes, 32 DUI fatalities, 4.15 per 100K driving-age adults, 23.3rd state-year percentile.

## Files
- supabase/migrations/20260503a_fars_county_dui_stats.sql — matview with FIPS normalization, ACS join, percent-rank percentile
- src/lib/fars/county-dui.ts — getCountyDuiContext, render helpers
- src/lib/fars/__tests__/county-dui.test.ts — 21 tests
- src/components/DuiPlaybookCountySidebar.tsx — server component sidebar
- src/app/api/reports/mechanical/[caseId]/route.ts — appends FARS aside to CD report when DUI charge + court_county present (try/catch isolated, never blocks write)
- src/app/playbook/[slug]/page.tsx — wires sidebar into DUI playbook variants only via ?state=&county=

## UPL guardrails
- Banned-phrase parity test scans both render paths
- "Driving-age adults" denominator (county-level licensed-driver counts not in our schema — explicit denominator-label lock)
- Percentile bucketing descriptive ("lowest quartile / second / third / top quartile for DUI fatality density") — never predictive
- CD aside renders only for DUI/DWI/OWI/OUI charges with both court_state and court_county populated

## Coverage notes
2021-2024 lacked county-level data after FIPS-normalization filtering; 2010-2020 covered.

## Test plan
- [x] vitest 21/21 new + 4/4 affected CD tests
- [x] tsc --noEmit clean
- [x] UPL banned-phrases parity asserted
- [x] CD report append isolated in try/catch

🤖 Generated with [Claude Code](https://claude.com/claude-code)