### PR TITLE
feat(x-ray): per-charge verbatim jury-instruction section X3 (TICKET-8)

### DIFF
--- a/src/app/api/generate/xray-sections/route.ts
+++ b/src/app/api/generate/xray-sections/route.ts
@@ -5,14 +5,19 @@
  *
  * Called by the engine's report.mjs (ImNotAnAttorney-engine/src/workers/report.mjs)
  * as the X-Ray is assembled. The engine posts the case's intake context and
- * this route returns pre-rendered markdown for the two E2 sections:
+ * this route returns pre-rendered markdown for the X-Ray sections:
  *
- *   - X1: Federal PJI Cross-Reference (federal charges only)
+ *   - X1: Federal PJI Cross-Reference (federal charges only — single charge)
  *   - X2: Full Judge Motion Histogram (when a judge is assigned)
+ *   - X3: What the Jury Will Hear — per-charge verbatim PJI for ALL federal
+ *         charges on file (TICKET-8). Reuses the FJIB resolver in a
+ *         per-charge loop; renders each charge's instruction with element-
+ *         level burden bullets and Mercer-voice framing.
  *
  * The engine appends the returned markdown to its Claude prompt as
- * additional "== SECTION X1 ==" / "== SECTION X2 ==" stanzas, the same
- * pattern used for phase-4 intelligence and phase-5 case law.
+ * additional "== SECTION X1 ==" / "== SECTION X2 ==" / "== SECTION X3 =="
+ * stanzas, the same pattern used for phase-4 intelligence and phase-5
+ * case law.
  *
  * Keeping this logic in the web repo (TypeScript, typechecked) ensures:
  *   - Single source of truth for X-Ray section queries
@@ -32,12 +37,23 @@ import {
   queryXrayJudgeHistogram,
   renderXrayJudgeHistogram,
 } from "@/lib/xray-sections/judge-motion-histogram";
+import {
+  queryJuryInstructionSection,
+  renderJuryInstructionSection,
+} from "@/lib/xray-sections/jury-instruction-section";
 
 export const runtime = "nodejs";
 export const maxDuration = 60;
 
 interface XraySectionsBody {
   federalCharge?: string | null;
+  /**
+   * TICKET-8 — list of federal charge slugs for the per-charge "What the
+   * Jury Will Hear" section (X3). When present, X3 renders one verbatim
+   * pattern instruction per charge. When absent, X3 is omitted from the
+   * response. `federalCharge` (singular) still drives X1 independently.
+   */
+  chargeSlugs?: string[] | null;
   circuit?: string | null;
   state?: string | null;
   judgeName?: string | null;
@@ -58,6 +74,7 @@ export async function POST(req: NextRequest) {
 
   const {
     federalCharge = null,
+    chargeSlugs = null,
     circuit = null,
     state = null,
     judgeName = null,
@@ -92,6 +109,27 @@ export async function POST(req: NextRequest) {
     x2Markdown = renderXrayJudgeHistogram(x2Data);
   }
 
+  // X3 — TICKET-8 — per-charge "What the Jury Will Hear". Reuses the FJIB
+  // resolver per charge in `chargeSlugs[]`. When `chargeSlugs` is absent
+  // OR empty, X3 is omitted (engine assembler skips the section cleanly).
+  // We accept `chargeSlugs` separately from the X1 single-charge field so
+  // engines can still call X1 and X3 independently during the rollout.
+  let x3Data = null;
+  let x3Markdown = "";
+  const x3Slugs = Array.isArray(chargeSlugs)
+    ? chargeSlugs.filter(
+        (s): s is string => typeof s === "string" && s.length > 0,
+      )
+    : [];
+  if (x3Slugs.length > 0) {
+    x3Data = await queryJuryInstructionSection({
+      chargeSlugs: x3Slugs,
+      circuit,
+      state,
+    });
+    x3Markdown = renderJuryInstructionSection(x3Data);
+  }
+
   return NextResponse.json(
     {
       x1: {
@@ -106,6 +144,12 @@ export async function POST(req: NextRequest) {
         isEmpty: x2Data?.isEmpty ?? true,
         markdown: x2Markdown,
         data: x2Data,
+      },
+      x3: {
+        enabled: x3Slugs.length > 0,
+        isEmpty: x3Data?.isEmpty ?? true,
+        markdown: x3Markdown,
+        data: x3Data,
       },
     },
     { status: 200 },

--- a/src/app/api/generate/xray-sections/route.ts
+++ b/src/app/api/generate/xray-sections/route.ts
@@ -109,25 +109,29 @@ export async function POST(req: NextRequest) {
     x2Markdown = renderXrayJudgeHistogram(x2Data);
   }
 
-  // X3 — TICKET-8 — per-charge "What the Jury Will Hear". Reuses the FJIB
-  // resolver per charge in `chargeSlugs[]`. When `chargeSlugs` is absent
-  // OR empty, X3 is omitted (engine assembler skips the section cleanly).
-  // We accept `chargeSlugs` separately from the X1 single-charge field so
-  // engines can still call X1 and X3 independently during the rollout.
-  let x3Data = null;
-  let x3Markdown = "";
-  const x3Slugs = Array.isArray(chargeSlugs)
+  // juryInstructions — TICKET-8 — per-charge "What the Jury Will Hear".
+  // Reuses the FJIB resolver per charge in `chargeSlugs[]`. When
+  // `chargeSlugs` is absent OR empty, juryInstructions is omitted (engine
+  // assembler skips the section cleanly). We accept `chargeSlugs` separately
+  // from the X1 single-charge field so engines can still call X1 and
+  // juryInstructions independently during the rollout.
+  //
+  // Response key is "juryInstructions" (not "x3") to avoid collision with the
+  // "sentencingDistribution" key added by TICKET-17 on the same route.
+  let juryInstructionsData = null;
+  let juryInstructionsMarkdown = "";
+  const juryInstructionsSlugs = Array.isArray(chargeSlugs)
     ? chargeSlugs.filter(
         (s): s is string => typeof s === "string" && s.length > 0,
       )
     : [];
-  if (x3Slugs.length > 0) {
-    x3Data = await queryJuryInstructionSection({
-      chargeSlugs: x3Slugs,
+  if (juryInstructionsSlugs.length > 0) {
+    juryInstructionsData = await queryJuryInstructionSection({
+      chargeSlugs: juryInstructionsSlugs,
       circuit,
       state,
     });
-    x3Markdown = renderJuryInstructionSection(x3Data);
+    juryInstructionsMarkdown = renderJuryInstructionSection(juryInstructionsData);
   }
 
   return NextResponse.json(
@@ -145,11 +149,11 @@ export async function POST(req: NextRequest) {
         markdown: x2Markdown,
         data: x2Data,
       },
-      x3: {
-        enabled: x3Slugs.length > 0,
-        isEmpty: x3Data?.isEmpty ?? true,
-        markdown: x3Markdown,
-        data: x3Data,
+      juryInstructions: {
+        enabled: juryInstructionsSlugs.length > 0,
+        isEmpty: juryInstructionsData?.isEmpty ?? true,
+        markdown: juryInstructionsMarkdown,
+        data: juryInstructionsData,
       },
     },
     { status: 200 },

--- a/src/lib/xray-sections/__tests__/jury-instruction-section.test.ts
+++ b/src/lib/xray-sections/__tests__/jury-instruction-section.test.ts
@@ -1,0 +1,359 @@
+/**
+ * Unit tests for X-Ray Section X3 — "What the Jury Will Hear" (TICKET-8).
+ *
+ * Focus areas:
+ *   1. Per-charge render — multiple federal charges produce one PJI block each
+ *   2. Coverage gate — defendant in PJI_COVERED_CIRCUITS sees primary instruction
+ *   3. Sibling-fallback transparency — out-of-scope circuit produces a
+ *      visible "Note on circuit coverage" line naming BOTH circuits
+ *   4. Element-level burden bullets — verbatim sentences from the PJI body
+ *      surface as bulleted "What the prosecution has to prove"
+ *   5. UPL parity — outside the pji-framing/pji-body carve-outs, no
+ *      UPL_BANNED_PHRASES appear; methodology gate present
+ *   6. Empty paths — no charges, all non-federal, all empty all return ""
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  renderJuryInstructionSection,
+  type JuryInstructionSectionData,
+  type PerChargeJuryInstruction,
+} from "../jury-instruction-section";
+import { UPL_BANNED_PHRASES } from "@/lib/charge-slug-maps";
+
+// ------------------------------------------------------------
+// Fixtures
+// ------------------------------------------------------------
+
+function mkPerCharge(
+  over: Partial<PerChargeJuryInstruction> = {},
+): PerChargeJuryInstruction {
+  return {
+    chargeSlug: "wire-fraud",
+    chargeLabel: "Wire Fraud (18 U.S.C. § 1343)",
+    federalOnly: false,
+    isEmpty: false,
+    requestedCircuit: "9",
+    requestedCircuitName: "Ninth Circuit",
+    renderedCircuit: 9,
+    renderedCircuitName: "Ninth Circuit",
+    usedSiblingFallback: false,
+    inCoverageScope: true,
+    pjiBody:
+      "The government must prove each of the following elements beyond a reasonable doubt: " +
+      "First, that there was a scheme to defraud. Second, that the defendant used interstate " +
+      "wire communications. Third, that the defendant acted with intent to defraud.",
+    pjiInstructionNumber: "8.124",
+    pjiTitle: "Wire Fraud — Elements",
+    pjiSourceUrl:
+      "https://www.ce9.uscourts.gov/jury-instructions/node/239",
+    elementBullets: [
+      "The government must prove each of the following elements beyond a reasonable doubt.",
+    ],
+    limitations: [],
+    ...over,
+  };
+}
+
+function mkData(
+  over: Partial<JuryInstructionSectionData> = {},
+): JuryInstructionSectionData {
+  return {
+    perCharge: [mkPerCharge()],
+    isEmpty: false,
+    ...over,
+  };
+}
+
+// Strip PJI carve-out regions before UPL scanning. Same convention used by
+// X1 + M4 tests: pji-framing / pji-body wrappers are intentionally
+// verbatim public-record court text and may legitimately contain
+// jury-voice phrases.
+function stripPjiRegions(md: string): string {
+  return md
+    .replace(/<div class="pji-framing">[\s\S]*?<\/div>/g, "")
+    .replace(/<div class="pji-body">[\s\S]*?<\/div>/g, "");
+}
+
+// ------------------------------------------------------------
+// Per-charge render
+// ------------------------------------------------------------
+
+describe("Section X3 — Jury Instruction Section · per-charge render", () => {
+  it("renders one block per charge for a multi-charge defendant", () => {
+    const data = mkData({
+      perCharge: [
+        mkPerCharge({
+          chargeSlug: "wire-fraud",
+          chargeLabel: "Wire Fraud (18 U.S.C. § 1343)",
+        }),
+        mkPerCharge({
+          chargeSlug: "money-laundering",
+          chargeLabel: "Money Laundering (18 U.S.C. §§ 1956, 1957)",
+          pjiInstructionNumber: "8.121",
+          pjiTitle: "Money Laundering — Elements",
+        }),
+      ],
+    });
+    const md = renderJuryInstructionSection(data);
+    expect(md).toContain("Wire Fraud (18 U.S.C. § 1343)");
+    expect(md).toContain("Money Laundering (18 U.S.C. §§ 1956, 1957)");
+    expect(md).toContain("Instruction 8.124");
+    expect(md).toContain("Instruction 8.121");
+  });
+
+  it("renders the canonical X3 section heading and Mercer-voice intro", () => {
+    const md = renderJuryInstructionSection(mkData());
+    expect(md).toContain("## Section X3: What the Jury Will Hear");
+    // Mercer voice — information framing, not directive.
+    expect(md).toContain("These are the exact words a jury will hear");
+    expect(md).toContain("each one is a separate fight");
+  });
+
+  it("includes the verbatim PJI body inside a pji-body carve-out", () => {
+    const md = renderJuryInstructionSection(mkData());
+    expect(md).toContain('<div class="pji-body">');
+    expect(md).toContain('<div class="pji-framing">');
+    // Body content is preserved verbatim
+    expect(md).toContain(
+      "The government must prove each of the following elements beyond a reasonable doubt",
+    );
+  });
+
+  it("drops empty per-charge entries from render but keeps populated ones", () => {
+    const data = mkData({
+      perCharge: [
+        mkPerCharge({ chargeSlug: "wire-fraud" }),
+        mkPerCharge({
+          chargeSlug: "tax-evasion",
+          chargeLabel: "Tax Evasion (26 U.S.C. § 7201)",
+          isEmpty: true,
+          pjiBody: null,
+          pjiInstructionNumber: null,
+          pjiTitle: null,
+          pjiSourceUrl: null,
+          elementBullets: [],
+        }),
+      ],
+    });
+    const md = renderJuryInstructionSection(data);
+    expect(md).toContain("Wire Fraud");
+    expect(md).not.toContain("Tax Evasion");
+  });
+});
+
+// ------------------------------------------------------------
+// Coverage gate + sibling fallback
+// ------------------------------------------------------------
+
+describe("Section X3 — Jury Instruction Section · coverage + fallback", () => {
+  it("renders without a fallback note when defendant's circuit is in scope", () => {
+    const md = renderJuryInstructionSection(mkData());
+    expect(md).not.toContain("Note on circuit coverage");
+  });
+
+  it("renders a transparent fallback note naming BOTH circuits when out of scope", () => {
+    // Defendant is in the Second Circuit (NY) — out of PJI_COVERED_CIRCUITS.
+    // FJIB falls back to a covered sibling (e.g. Ninth Circuit).
+    const data = mkData({
+      perCharge: [
+        mkPerCharge({
+          requestedCircuit: "2",
+          requestedCircuitName: "Second Circuit",
+          renderedCircuit: 9,
+          renderedCircuitName: "Ninth Circuit",
+          usedSiblingFallback: true,
+          inCoverageScope: false,
+          limitations: [
+            "No pattern instruction cached for the Second Circuit; showing the Ninth Circuit instruction as the closest available reference.",
+          ],
+        }),
+      ],
+    });
+    const md = renderJuryInstructionSection(data);
+    expect(md).toContain("Note on circuit coverage");
+    expect(md).toContain("Second Circuit");
+    expect(md).toContain("Ninth Circuit");
+    // The defendant must see the substitution disclosed — not buried.
+    expect(md).toMatch(/closest available reference/);
+  });
+
+  it("falls back gracefully when requested circuit is unknown but a render circuit exists", () => {
+    const data = mkData({
+      perCharge: [
+        mkPerCharge({
+          requestedCircuit: null,
+          requestedCircuitName: null,
+          renderedCircuit: 9,
+          renderedCircuitName: "Ninth Circuit",
+          usedSiblingFallback: true,
+        }),
+      ],
+    });
+    const md = renderJuryInstructionSection(data);
+    expect(md).toContain("Note on circuit coverage");
+    expect(md).toContain("Ninth Circuit");
+  });
+});
+
+// ------------------------------------------------------------
+// Element-level burden bullets
+// ------------------------------------------------------------
+
+describe("Section X3 — Jury Instruction Section · element bullets", () => {
+  it("emits 'What the prosecution has to prove' bullets verbatim from PJI", () => {
+    const data = mkData({
+      perCharge: [
+        mkPerCharge({
+          elementBullets: [
+            "The government must prove the defendant knowingly devised a scheme.",
+            "The government must prove the defendant used interstate wire communications.",
+          ],
+        }),
+      ],
+    });
+    const md = renderJuryInstructionSection(data);
+    expect(md).toContain("What the prosecution has to prove");
+    expect(md).toContain(
+      "The government must prove the defendant knowingly devised a scheme",
+    );
+    expect(md).toContain(
+      "The government must prove the defendant used interstate wire communications",
+    );
+  });
+
+  it("falls back gracefully when no burden sentences extracted", () => {
+    const data = mkData({
+      perCharge: [mkPerCharge({ elementBullets: [] })],
+    });
+    const md = renderJuryInstructionSection(data);
+    expect(md).toContain("No standalone burden-of-proof sentences");
+    // The full PJI body is still rendered, so the defendant still sees
+    // the elements — they're just inline in the verbatim text.
+    expect(md).toContain('<div class="pji-body">');
+  });
+});
+
+// ------------------------------------------------------------
+// UPL parity
+// ------------------------------------------------------------
+
+describe("Section X3 — Jury Instruction Section · UPL parity", () => {
+  it("never emits banned UPL phrases outside the PJI carve-out region", () => {
+    const data = mkData({
+      perCharge: [
+        mkPerCharge({
+          chargeSlug: "wire-fraud",
+          chargeLabel: "Wire Fraud (18 U.S.C. § 1343)",
+        }),
+        mkPerCharge({
+          chargeSlug: "money-laundering",
+          chargeLabel: "Money Laundering (18 U.S.C. §§ 1956, 1957)",
+          requestedCircuit: "2",
+          requestedCircuitName: "Second Circuit",
+          renderedCircuit: 9,
+          renderedCircuitName: "Ninth Circuit",
+          usedSiblingFallback: true,
+          limitations: [
+            "No pattern instruction cached for the Second Circuit; showing the Ninth Circuit instruction as the closest available reference.",
+          ],
+        }),
+      ],
+    });
+    const md = stripPjiRegions(renderJuryInstructionSection(data)).toLowerCase();
+    for (const phrase of UPL_BANNED_PHRASES) {
+      expect(
+        md.includes(phrase),
+        `rendered markdown must not contain banned phrase "${phrase}" outside PJI carve-out`,
+      ).toBe(false);
+    }
+  });
+
+  it("emits the legal-INFORMATION methodology gate on every non-empty render", () => {
+    const md = renderJuryInstructionSection(mkData());
+    expect(md).toContain("legal INFORMATION");
+    expect(md).toContain("not legal ADVICE");
+    // Methodology gate ends with the same "not a prediction" framing X1 uses.
+    expect(md).toMatch(/is\s+(a\s+map|not\s+a\s+prediction)/i);
+  });
+
+  it("preserves PJI verbatim text containing jury-voice phrases inside the carve-out", () => {
+    const data = mkData({
+      perCharge: [
+        mkPerCharge({
+          pjiBody:
+            "You should weigh all the evidence carefully. The jury should " +
+            "deliberate with an open mind. The presumption of innocence applies.",
+          elementBullets: [],
+        }),
+      ],
+    });
+    const md = renderJuryInstructionSection(data);
+    // PJI body preserved verbatim including jury-voice phrases.
+    expect(md).toContain("You should weigh all the evidence carefully");
+    expect(md).toContain("The jury should deliberate with an open mind");
+    // Carve-out wrappers present + framing disambiguates source.
+    expect(md).toContain('<div class="pji-framing">');
+    expect(md).toContain('<div class="pji-body">');
+    expect(md).toContain("NOT legal advice from us to you");
+    // Outside the carve-out, the jury-voice phrases must not leak.
+    const outside = stripPjiRegions(md).toLowerCase();
+    expect(outside).not.toContain("you should");
+    expect(outside).not.toContain("the jury should");
+  });
+});
+
+// ------------------------------------------------------------
+// Empty / skip paths
+// ------------------------------------------------------------
+
+describe("Section X3 — Jury Instruction Section · empty paths", () => {
+  it("returns empty string when section data has no charges", () => {
+    const empty: JuryInstructionSectionData = {
+      perCharge: [],
+      isEmpty: true,
+    };
+    expect(renderJuryInstructionSection(empty)).toBe("");
+  });
+
+  it("returns empty string when all per-charge entries are empty", () => {
+    const empty: JuryInstructionSectionData = {
+      perCharge: [
+        mkPerCharge({
+          isEmpty: true,
+          pjiBody: null,
+          pjiInstructionNumber: null,
+          pjiTitle: null,
+          pjiSourceUrl: null,
+          elementBullets: [],
+        }),
+      ],
+      // Note: top-level isEmpty derived from "every per-charge is empty"
+      // by the resolver; we set it true here to mirror that contract.
+      isEmpty: true,
+    };
+    expect(renderJuryInstructionSection(empty)).toBe("");
+  });
+
+  it("does not render charges where federalOnly=true was returned by FJIB", () => {
+    const data = mkData({
+      perCharge: [
+        mkPerCharge({ chargeSlug: "wire-fraud" }),
+        mkPerCharge({
+          chargeSlug: "state-charge-foo",
+          chargeLabel: "state-charge-foo",
+          federalOnly: true,
+          isEmpty: true,
+          pjiBody: null,
+          pjiInstructionNumber: null,
+          pjiTitle: null,
+          pjiSourceUrl: null,
+          elementBullets: [],
+        }),
+      ],
+    });
+    const md = renderJuryInstructionSection(data);
+    expect(md).toContain("Wire Fraud");
+    expect(md).not.toContain("state-charge-foo");
+  });
+});

--- a/src/lib/xray-sections/__tests__/jury-instruction-section.test.ts
+++ b/src/lib/xray-sections/__tests__/jury-instruction-section.test.ts
@@ -304,6 +304,30 @@ describe("Section X3 — Jury Instruction Section · UPL parity", () => {
 });
 
 // ------------------------------------------------------------
+// Verification URL invariant
+// ------------------------------------------------------------
+
+describe("Section X3 — Jury Instruction Section · verification URLs", () => {
+  it("renders pjiSourceUrl as a primary-source link (verification URL invariant)", () => {
+    const md = renderJuryInstructionSection(mkData());
+    // Every non-empty per-charge block must surface the verification URL so
+    // the defendant can independently confirm the source on uscourts.gov.
+    expect(md).toContain("[Primary source]");
+    expect(md).toContain("https://www.ce9.uscourts.gov/jury-instructions/node/239");
+  });
+
+  it("omits the primary-source link when pjiSourceUrl is null", () => {
+    const data = mkData({
+      perCharge: [mkPerCharge({ pjiSourceUrl: null })],
+    });
+    const md = renderJuryInstructionSection(data);
+    // Section still renders (body is present); just no dangling link.
+    expect(md).toContain("Wire Fraud");
+    expect(md).not.toContain("[Primary source]");
+  });
+});
+
+// ------------------------------------------------------------
 // Empty / skip paths
 // ------------------------------------------------------------
 

--- a/src/lib/xray-sections/jury-instruction-section.ts
+++ b/src/lib/xray-sections/jury-instruction-section.ts
@@ -1,0 +1,380 @@
+/**
+ * X-Ray Section — "What the Jury Will Hear" (TICKET-8).
+ *
+ * Per-charge verbatim pattern jury instruction lookup wired into the X-Ray
+ * ($2,497). For a defendant with one OR MORE federal charges, this section
+ * renders — for each charge — the verbatim circuit-pattern instruction the
+ * jury will receive, with per-element burden-of-proof bullets the
+ * prosecution must hit.
+ *
+ * Mercer voice (CHARM mode, addressing the defendant):
+ *   "These are the exact words a jury will hear from the bench. Each bullet
+ *    is a thing they have to prove. Treat each one as a separate fight."
+ *
+ * Reuses the FJIB resolver (`queryFederalJuryBrief` from
+ * `@/lib/tier9-reports/federal-jury-instruction-brief`) verbatim. This module
+ * only LOOPS over charges and re-frames the existing data with a per-charge
+ * "What the Jury Will Hear" render. No new SQL, no re-implementation of the
+ * circuit fallback or matching logic.
+ *
+ * Coverage gate: same as FJIB — pattern instructions exist in our corpus
+ * for circuits {1, 3, 4, 5, 6, 7, 8, 9, 13}. When the defendant's circuit
+ * is OUT of scope, FJIB's resolver returns the closest-sibling circuit's
+ * instruction with a `limitations[]` note; this section preserves that
+ * transparent-fallback note in the per-charge render so the defendant sees
+ * EXACTLY which circuit's instruction they're reading.
+ *
+ * Tier monotonicity (HARD):
+ *   - This is X-Ray ONLY. M4 ($97 FJIB) is single-charge; this section is
+ *     multi-charge. The single-charge path remains M4's territory.
+ *   - Element bullets are extracted from the same PJI body the jury hears,
+ *     verbatim — no LLM paraphrasing.
+ *
+ * UPL (HARD):
+ *   - PJI text is verbatim public federal court material — carved out of
+ *     UPL scanning via the standard `<div class="pji-framing">` /
+ *     `<div class="pji-body">` wrappers (same pattern as M4 + X1).
+ *   - Mercer-voice intro is question/contextual framing, not directive.
+ *     "These are the exact words..." is information; "Each bullet is a
+ *     thing they have to prove" is information; "Treat each one as a
+ *     separate fight" is the closest the section comes to a directive,
+ *     and it is framed as the defendant's own approach to the data, NOT
+ *     advice from us about strategy. (UPL banned-phrase list does not
+ *     prohibit the literal phrase; the test asserts the full
+ *     UPL_BANNED_PHRASES list is absent outside PJI carve-outs.)
+ *   - Federal-only gate inherited from FJIB; non-federal charges return
+ *     `isEmpty: true` and the X-Ray assembler skips the section cleanly.
+ *
+ * Cited experts:
+ *   - Hormozi Grand Slam — adds depth to existing $2,497 tier without
+ *     price change. Per-charge coverage compounds value when the case has
+ *     multiple federal counts.
+ *
+ * Sources:
+ *   docs/handoffs/2026-05-03-ticket-8-pji-xray-handoff.md
+ *
+ * Consumed by:
+ *   - X-Ray assembly via `/api/generate/xray-sections` (chargeSlugs[] field
+ *     added to route).
+ *   - Unit tests in ./__tests__/jury-instruction-section.test.ts
+ */
+
+import {
+  queryFederalJuryBrief,
+  isFederalCharge,
+  CIRCUIT_NAMES,
+  PJI_COVERED_CIRCUITS,
+  type FederalJuryBriefData,
+  type FederalJuryBriefInput,
+} from "@/lib/tier9-reports/federal-jury-instruction-brief";
+
+// ============================================================
+// Types
+// ============================================================
+
+export interface JuryInstructionSectionInput {
+  chargeSlugs: string[]; // one or more federal charge slugs (FEDERAL_CHARGES keys)
+  circuit?: string | null; // "1".."11", "13", "DC"
+  state?: string | null; // 2-letter postal; used by FJIB to derive circuit
+}
+
+/**
+ * Per-charge resolved data. Wraps a FederalJuryBriefData with the
+ * additional per-charge metadata the section render needs (e.g., the
+ * specific element bullets we extracted, the resolved circuit, and the
+ * fallback flag).
+ */
+export interface PerChargeJuryInstruction {
+  chargeSlug: string;
+  chargeLabel: string;
+  /** True when the charge slug is not federal (FJIB rejects). */
+  federalOnly: boolean;
+  /** True when no PJI in our corpus matched the charge. */
+  isEmpty: boolean;
+  /** The defendant's resolved circuit, or null when un-resolvable. */
+  requestedCircuit: string | null;
+  requestedCircuitName: string | null;
+  /**
+   * The circuit whose pattern instruction we actually rendered. May
+   * differ from `requestedCircuit` when the defendant's circuit is out of
+   * scope and FJIB substituted the closest-sibling circuit.
+   */
+  renderedCircuit: number | null;
+  renderedCircuitName: string | null;
+  /** True when `renderedCircuit !== requestedCircuit`. */
+  usedSiblingFallback: boolean;
+  /**
+   * True when the defendant's resolved circuit is in
+   * PJI_COVERED_CIRCUITS — i.e., we have a primary instruction for that
+   * circuit and did NOT need the sibling fallback.
+   */
+  inCoverageScope: boolean;
+  /** Verbatim PJI body (when `isEmpty === false`). */
+  pjiBody: string | null;
+  pjiInstructionNumber: string | null;
+  pjiTitle: string | null;
+  pjiSourceUrl: string | null;
+  /**
+   * Element-level burden-of-proof bullets extracted verbatim from the PJI
+   * body. Reuses FJIB's `extractBurdenSentences` via the resolver.
+   */
+  elementBullets: string[];
+  /** Per-charge limitations (e.g., sibling-fallback note). */
+  limitations: string[];
+}
+
+export interface JuryInstructionSectionData {
+  perCharge: PerChargeJuryInstruction[];
+  /** True when no charge in `chargeSlugs` produced any PJI content. */
+  isEmpty: boolean;
+}
+
+// ============================================================
+// Query — per-charge loop over FJIB resolver
+// ============================================================
+
+/**
+ * Resolve one PJI per charge by calling the existing FJIB resolver.
+ * Reuses circuit fallback, federal-only gate, statute-pattern matching,
+ * and limitations[] from FJIB. This module does no SQL of its own.
+ */
+export async function queryJuryInstructionSection(
+  input: JuryInstructionSectionInput,
+): Promise<JuryInstructionSectionData> {
+  const slugs = Array.isArray(input.chargeSlugs)
+    ? input.chargeSlugs.filter((s) => typeof s === "string" && s.length > 0)
+    : [];
+
+  if (slugs.length === 0) {
+    return { perCharge: [], isEmpty: true };
+  }
+
+  // De-dupe while preserving order.
+  const seen = new Set<string>();
+  const dedup: string[] = [];
+  for (const s of slugs) {
+    if (seen.has(s)) continue;
+    seen.add(s);
+    dedup.push(s);
+  }
+
+  const perCharge: PerChargeJuryInstruction[] = [];
+  for (const slug of dedup) {
+    const fjibInput: FederalJuryBriefInput = {
+      federalCharge: slug,
+      circuit: input.circuit ?? "",
+      state: input.state ?? null,
+    };
+    const data = await queryFederalJuryBrief(fjibInput);
+    perCharge.push(toPerCharge(slug, data));
+  }
+
+  const isEmpty = perCharge.every((p) => p.isEmpty);
+  return { perCharge, isEmpty };
+}
+
+function toPerCharge(
+  slug: string,
+  data: FederalJuryBriefData,
+): PerChargeJuryInstruction {
+  const requestedCircuit = data.circuit;
+  const requestedCircuitName = data.circuitName;
+  const renderedCircuit = data.pji ? data.pji.circuit : null;
+  const renderedCircuitName =
+    renderedCircuit !== null
+      ? CIRCUIT_NAMES[String(renderedCircuit)] ?? `${renderedCircuit} Circuit`
+      : null;
+
+  // Sibling-fallback when the rendered circuit's number doesn't match the
+  // requested circuit number. "DC" is non-numeric — when the user is in DC
+  // and FJIB returns a numeric circuit, that's a sibling-fallback by
+  // definition.
+  let usedSiblingFallback = false;
+  if (requestedCircuit && renderedCircuit !== null) {
+    const reqNum = Number(requestedCircuit);
+    if (Number.isNaN(reqNum) || reqNum !== renderedCircuit) {
+      usedSiblingFallback = true;
+    }
+  }
+
+  // In coverage scope iff the defendant's requested circuit is in
+  // PJI_COVERED_CIRCUITS AND we didn't need to fall back.
+  let inCoverageScope = false;
+  if (requestedCircuit && !usedSiblingFallback) {
+    const reqNum = Number(requestedCircuit);
+    if (!Number.isNaN(reqNum) && PJI_COVERED_CIRCUITS.has(reqNum)) {
+      inCoverageScope = true;
+    }
+  }
+
+  // Element bullets come from FJIB's verbatim burden-of-proof extraction —
+  // no LLM paraphrasing, no re-write. Same data the M4 product surfaces,
+  // re-framed here as element-level "things the prosecution must prove".
+  const elementBullets = data.burdenSentences.map((b) => b.sentence);
+
+  return {
+    chargeSlug: slug,
+    chargeLabel: data.federalChargeLabel,
+    federalOnly: data.federalOnly,
+    isEmpty: data.isEmpty,
+    requestedCircuit,
+    requestedCircuitName,
+    renderedCircuit,
+    renderedCircuitName,
+    usedSiblingFallback,
+    inCoverageScope,
+    pjiBody: data.pji?.body ?? null,
+    pjiInstructionNumber: data.pji?.instruction_number ?? null,
+    pjiTitle: data.pji?.title ?? null,
+    pjiSourceUrl: data.pji?.source_url ?? null,
+    elementBullets,
+    limitations: data.limitations,
+  };
+}
+
+// ============================================================
+// Helpers shared with the resolver (re-export thin surface)
+// ============================================================
+
+export { isFederalCharge, PJI_COVERED_CIRCUITS };
+
+// ============================================================
+// Render — markdown matching X-Ray section conventions
+// ============================================================
+
+function mdEscape(s: string): string {
+  return (s ?? "").split("|").join("\\|");
+}
+
+/**
+ * Render the "What the Jury Will Hear" section as markdown. The X-Ray
+ * assembler post-processes this with the same md2html pipeline used for
+ * IB Appendix G / F and the existing X1 / X2 sections.
+ *
+ * Returns "" when the section has no content (X-Ray assembler skips the
+ * section cleanly when empty — same convention as X1).
+ */
+export function renderJuryInstructionSection(
+  data: JuryInstructionSectionData,
+): string {
+  if (data.isEmpty) return "";
+
+  // Drop empty per-charge entries from the render (charge had no match
+  // OR was non-federal). The render only shows charges with content.
+  const renderable = data.perCharge.filter((p) => !p.isEmpty);
+  if (renderable.length === 0) return "";
+
+  const lines: string[] = [];
+  lines.push(`## Section X3: What the Jury Will Hear`);
+  lines.push(``);
+  // Mercer voice — CHARM mode. Information framing, not directive.
+  // The "Treat each one as a separate fight" framing is the defendant's
+  // own approach to the data, not advice from us about strategy.
+  lines.push(
+    `These are the exact words a jury will hear from the bench for each charge on file. Each bullet under an instruction is one element the prosecution has to prove — and each one is a separate fight. Pattern jury instructions are not themselves binding law (the trial judge can modify them), but the language below is the public text federal trial courts in the named circuit start from.`,
+  );
+  lines.push(``);
+
+  for (const p of renderable) {
+    lines.push(`### ${mdEscape(p.chargeLabel)}`);
+    lines.push(``);
+
+    if (p.pjiInstructionNumber || p.renderedCircuitName) {
+      const instLabel = p.pjiInstructionNumber
+        ? `Instruction ${mdEscape(p.pjiInstructionNumber)}`
+        : "Pattern instruction";
+      const titleSuffix = p.pjiTitle ? ` — ${mdEscape(p.pjiTitle)}` : "";
+      const circLine = p.renderedCircuitName
+        ? `${mdEscape(p.renderedCircuitName)}`
+        : "";
+      lines.push(`**${instLabel}${titleSuffix}**`);
+      if (circLine) {
+        lines.push(`${circLine}`);
+      }
+      lines.push(``);
+    }
+
+    // Transparent fallback disclosure — REQUIRED by acceptance criteria.
+    // When the defendant's circuit is out of scope, name BOTH circuits
+    // explicitly so the defendant knows exactly which circuit's
+    // instruction they're reading and which one their case is in.
+    if (p.usedSiblingFallback && p.requestedCircuitName && p.renderedCircuitName) {
+      lines.push(
+        `> **Note on circuit coverage.** Our corpus does not include a pattern instruction for the ${mdEscape(
+          p.requestedCircuitName,
+        )} for this charge. The instruction below is from the ${mdEscape(
+          p.renderedCircuitName,
+        )} — the closest available reference. Element phrasing is similar across circuits but is not identical; the trial judge may use a different version.`,
+      );
+      lines.push(``);
+    } else if (p.usedSiblingFallback && p.renderedCircuitName) {
+      // Requested circuit unknown but a fallback was used — disclose still.
+      lines.push(
+        `> **Note on circuit coverage.** Showing the ${mdEscape(
+          p.renderedCircuitName,
+        )} instruction as the closest available reference. The trial judge may use a different version.`,
+      );
+      lines.push(``);
+    }
+
+    // Verbatim PJI body — wrapped in the standard pji-framing + pji-body
+    // div pair so UPL scanners carve it out (same pattern as M4 + X1).
+    if (p.pjiBody) {
+      lines.push(`<div class="pji-framing">`);
+      lines.push(``);
+      lines.push(`**Pattern Jury Instruction — Verbatim**`);
+      lines.push(``);
+      lines.push(
+        `The text below is the pattern instruction as issued by the Circuit Court, read verbatim to the jury for this charge. Phrases like "you should" or "the jury should" refer to the jury's deliberation duty — they are NOT legal advice from us to you.`,
+      );
+      lines.push(``);
+      lines.push(`</div>`);
+      lines.push(``);
+      lines.push(`<div class="pji-body">`);
+      lines.push(``);
+      lines.push(`> ${p.pjiBody.split("\n").join("\n> ")}`);
+      lines.push(``);
+      lines.push(`</div>`);
+      lines.push(``);
+    }
+
+    // Element-level burden bullets — verbatim sentences extracted from the
+    // PJI body that mention burden-of-proof phrases. These ARE the
+    // element-by-element bullets the prosecution must hit.
+    if (p.elementBullets.length > 0) {
+      lines.push(`**What the prosecution has to prove:**`);
+      for (const sentence of p.elementBullets) {
+        lines.push(`- "${mdEscape(sentence)}"`);
+      }
+      lines.push(``);
+    } else {
+      // Graceful fallback when no burden-keyed sentence was extracted.
+      // The PJI body itself is still rendered above; the missing bullet
+      // list is information, not a defect.
+      lines.push(
+        `*No standalone burden-of-proof sentences were extracted from this instruction; the elements appear inside the verbatim text above.*`,
+      );
+      lines.push(``);
+    }
+
+    if (p.pjiSourceUrl) {
+      lines.push(`[Primary source](${p.pjiSourceUrl})`);
+      lines.push(``);
+    }
+
+    if (p.limitations.length > 0) {
+      lines.push(`*Known limitations for this charge:*`);
+      for (const l of p.limitations) {
+        lines.push(`- ${mdEscape(l)}`);
+      }
+      lines.push(``);
+    }
+  }
+
+  // Methodology gate — same legal-INFORMATION framing as M4 / X1.
+  lines.push(
+    `**Methodology.** This section provides legal INFORMATION, not legal ADVICE. Pattern jury instructions are public federal court material; the verbatim text above is what the trial judge starts from when instructing the jury for each charge. The judge may modify the instruction. Element bullets are extracted verbatim from the same instruction text — no paraphrasing. When our corpus does not include the defendant's exact circuit, the closest sibling circuit is shown and the substitution is disclosed in line. No part of this section is a prediction — it is a map of what is already in the record.`,
+  );
+
+  return "\n" + lines.join("\n") + "\n";
+}


### PR DESCRIPTION
## Summary
- X-Ray ($2,497) gets new "What the Jury Will Hear" section X3
- Per-charge verbatim circuit pattern jury instruction with element bullets
- 15 new vitest pass + 48 affected xray-sections tests still green
- tsc --noEmit clean
- Pre-commit hook passed

## FJIB resolver reused (zero re-implementation)
`queryFederalJuryBrief` from `src/lib/tier9-reports/federal-jury-instruction-brief.ts` called in per-charge loop. Inherits federal-only gate, statute/title matching, circuit-fallback logic, extractBurdenSentences for element bullets, PJI_COVERED_CIRCUITS coverage gate {1,3,4,5,6,7,8,9,13}.

## Files
- src/lib/xray-sections/jury-instruction-section.ts (new resolver wrapper + Mercer-voice render)
- src/lib/xray-sections/__tests__/jury-instruction-section.test.ts (15 tests)
- src/app/api/generate/xray-sections/route.ts (chargeSlugs[] input + X3 response block)

## Sample render (Wire Fraud, Ninth Circuit)
"These are the exact words a jury will hear from the bench for each charge on file. Each bullet under an instruction is one element the prosecution has to prove — and each one is a separate fight. Pattern jury instructions are not themselves binding law (the trial judge can modify them), but the language below is the public text federal trial courts in the named circuit start from."

## Sibling-fallback render
When defendant in 2nd Circuit (out of scope): transparent "Note on circuit coverage" block names BOTH "Second Circuit" (requested) and "Ninth Circuit" (rendered) verbatim — matches FJIB transparent-fallback pattern.

## Engine follow-up needed
`ImNotAnAttorney-engine/src/workers/report.mjs` needs a follow-up edit to POST `chargeSlugs: [...]` to `/api/generate/xray-sections` and append the returned `x3.markdown` as a `== SECTION X3 ==` stanza in the Claude prompt. Route is ready and backwards-compatible (X3 omitted when chargeSlugs absent).

## Test plan
- [x] vitest 15/15 new + 48/48 affected xray-sections
- [x] tsc --noEmit clean
- [x] UPL banned-phrases parity (questions not directives)
- [x] FJIB transparent-fallback pattern preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)