### PR TITLE
feat(ussc): shared sentencing-distribution helper + CD/IB/X-Ray/JRC wiring (TICKET-17)

### DIFF
--- a/src/app/api/generate/xray-sections/route.ts
+++ b/src/app/api/generate/xray-sections/route.ts
@@ -108,21 +108,24 @@ export async function POST(req: NextRequest) {
     x2Markdown = renderXrayJudgeHistogram(x2Data);
   }
 
-  // X3 — sentencing-distribution overlay (TICKET-17). Federal-only (uses
-  // USSC offguide mapping). Sample-size floor of 100 cases enforced by
-  // getSentencingDistribution at xray tier; below floor falls back to
-  // national without lying about district outliers.
-  let x3Data = null;
-  let x3Markdown = "";
+  // sentencingDistribution — TICKET-17 — sentencing-distribution overlay.
+  // Federal-only (uses USSC offguide mapping). Sample-size floor of 100 cases
+  // enforced by getSentencingDistribution at xray tier; below floor falls back
+  // to national without lying about district outliers.
+  //
+  // Response key is "sentencingDistribution" (not "x3") to avoid collision
+  // with the "juryInstructions" key added by TICKET-8 on the same route.
+  let sentencingDistributionData = null;
+  let sentencingDistributionMarkdown = "";
   if (chargeType && chargeType.length > 0) {
     const sb = createAdminClient();
-    x3Data = await getSentencingDistribution(sb, {
+    sentencingDistributionData = await getSentencingDistribution(sb, {
       charge: chargeType,
       district,
       tier: "xray",
       criminalHistoryCategory,
     });
-    x3Markdown = renderSentencingDistribution(x3Data);
+    sentencingDistributionMarkdown = renderSentencingDistribution(sentencingDistributionData);
   }
 
   return NextResponse.json(
@@ -140,12 +143,12 @@ export async function POST(req: NextRequest) {
         markdown: x2Markdown,
         data: x2Data,
       },
-      x3: {
+      sentencingDistribution: {
         enabled: Boolean(chargeType),
-        isEmpty: !x3Data || x3Data.coverage_status === "no-data-anywhere",
-        coverage_status: x3Data?.coverage_status ?? null,
-        markdown: x3Markdown,
-        data: x3Data,
+        isEmpty: !sentencingDistributionData || sentencingDistributionData.coverage_status === "no-data-anywhere",
+        coverage_status: sentencingDistributionData?.coverage_status ?? null,
+        markdown: sentencingDistributionMarkdown,
+        data: sentencingDistributionData,
       },
     },
     { status: 200 },

--- a/src/app/api/generate/xray-sections/route.ts
+++ b/src/app/api/generate/xray-sections/route.ts
@@ -24,6 +24,7 @@
  */
 import { NextRequest, NextResponse } from "next/server";
 import { requireOperatorSecret } from "@/lib/auth/guards";
+import { createAdminClient } from "@/lib/supabase/admin";
 import {
   queryXrayFederalPjiCrossRef,
   renderXrayFederalPjiCrossRef,
@@ -32,6 +33,10 @@ import {
   queryXrayJudgeHistogram,
   renderXrayJudgeHistogram,
 } from "@/lib/xray-sections/judge-motion-histogram";
+import {
+  getSentencingDistribution,
+  renderSentencingDistribution,
+} from "@/lib/ussc/distribution";
 
 export const runtime = "nodejs";
 export const maxDuration = 60;
@@ -43,6 +48,14 @@ interface XraySectionsBody {
   judgeName?: string | null;
   judgeAuthorId?: number | null;
   caseId?: string | null;
+  /** Optional charge slug used for the X3 sentencing-distribution lookup.
+   *  Distinct from `federalCharge` (free-text) — chargeType is the INAA
+   *  slug `getSentencingDistribution` understands. */
+  chargeType?: string | null;
+  /** Optional federal district USSC code for the X3 lookup. */
+  district?: string | null;
+  /** Optional USSC criminal history category for the X3 lookup. */
+  criminalHistoryCategory?: string | null;
 }
 
 export async function POST(req: NextRequest) {
@@ -63,6 +76,9 @@ export async function POST(req: NextRequest) {
     judgeName = null,
     judgeAuthorId = null,
     caseId = null,
+    chargeType = null,
+    district = null,
+    criminalHistoryCategory = null,
   } = body ?? {};
 
   // X1 — federal PJI cross-reference (federal charges only; query returns
@@ -92,6 +108,23 @@ export async function POST(req: NextRequest) {
     x2Markdown = renderXrayJudgeHistogram(x2Data);
   }
 
+  // X3 — sentencing-distribution overlay (TICKET-17). Federal-only (uses
+  // USSC offguide mapping). Sample-size floor of 100 cases enforced by
+  // getSentencingDistribution at xray tier; below floor falls back to
+  // national without lying about district outliers.
+  let x3Data = null;
+  let x3Markdown = "";
+  if (chargeType && chargeType.length > 0) {
+    const sb = createAdminClient();
+    x3Data = await getSentencingDistribution(sb, {
+      charge: chargeType,
+      district,
+      tier: "xray",
+      criminalHistoryCategory,
+    });
+    x3Markdown = renderSentencingDistribution(x3Data);
+  }
+
   return NextResponse.json(
     {
       x1: {
@@ -106,6 +139,13 @@ export async function POST(req: NextRequest) {
         isEmpty: x2Data?.isEmpty ?? true,
         markdown: x2Markdown,
         data: x2Data,
+      },
+      x3: {
+        enabled: Boolean(chargeType),
+        isEmpty: !x3Data || x3Data.coverage_status === "no-data-anywhere",
+        coverage_status: x3Data?.coverage_status ?? null,
+        markdown: x3Markdown,
+        data: x3Data,
       },
     },
     { status: 200 },

--- a/src/app/api/reports/mechanical/[caseId]/route.ts
+++ b/src/app/api/reports/mechanical/[caseId]/route.ts
@@ -14,6 +14,10 @@ import { NextResponse, NextRequest, after } from "next/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { requireOperatorSecret } from "@/lib/auth/guards";
 import { renderCaseDecoderMechanical } from "@/lib/report/mechanical/render-case-decoder";
+import {
+  getSentencingDistribution,
+  renderSentencingDistribution,
+} from "@/lib/ussc/distribution";
 
 export const runtime = "nodejs";
 export const maxDuration = 60;
@@ -49,19 +53,42 @@ export async function POST(
 
   after(async () => {
     try {
-      const r = renderCaseDecoderMechanical({
-        first_name: intake.first_name,
-        charge_type: intake.charge_type,
-        state: intake.state,
-        jurisdiction_level: intake.jurisdiction_level,
-        arrest_date: intake.arrest_date,
-        court_date: intake.court_date,
-        plea_offered: intake.plea_offered,
-        co_defendants: intake.co_defendants,
-        filled_out_by: intake.filled_out_by,
-        situation: intake.situation,
-        specific_question: intake.specific_question,
-      });
+      // TICKET-17 — pre-fetch federal sentencing-distribution overlay (CD
+      // tier — 20-case district floor). Non-fatal on error: the lib
+      // returns an empty string when there's no usable bucket, and the
+      // mechanical renderer gracefully omits the section.
+      let sentencingDistributionText = "";
+      try {
+        const dist = await getSentencingDistribution(sb, {
+          charge: intake.charge_type,
+          district:
+            typeof intake.federal_district === "string" &&
+            intake.federal_district.length > 0
+              ? intake.federal_district
+              : null,
+          tier: "case-decoder",
+        });
+        sentencingDistributionText = renderSentencingDistribution(dist);
+      } catch (distErr) {
+        // eslint-disable-next-line no-console
+        console.warn("[mechanical] sentencing-distribution fetch failed", distErr);
+      }
+      const r = renderCaseDecoderMechanical(
+        {
+          first_name: intake.first_name,
+          charge_type: intake.charge_type,
+          state: intake.state,
+          jurisdiction_level: intake.jurisdiction_level,
+          arrest_date: intake.arrest_date,
+          court_date: intake.court_date,
+          plea_offered: intake.plea_offered,
+          co_defendants: intake.co_defendants,
+          filled_out_by: intake.filled_out_by,
+          situation: intake.situation,
+          specific_question: intake.specific_question,
+        },
+        { sentencingDistributionText },
+      );
       // The renderer emits {{SLOT:...}} markers as its contract with the
       // future verified-opus path (Haiku hybrid was removed 2026-04-24).
       // For pure-mechanical delivery, replace each marker with a neutral

--- a/src/app/api/reports/mechanical/[caseId]/route.ts
+++ b/src/app/api/reports/mechanical/[caseId]/route.ts
@@ -57,8 +57,12 @@ export async function POST(
       // tier — 20-case district floor). Non-fatal on error: the lib
       // returns an empty string when there's no usable bucket, and the
       // mechanical renderer gracefully omits the section.
+      // Guard: skip entirely when charge_type is absent so we don't pass
+      // null/undefined into getSentencingDistribution (which expects a
+      // non-empty slug for the USSC offguide mapping lookup).
       let sentencingDistributionText = "";
       try {
+        if (!intake.charge_type) throw new Error("charge_type absent — skip");
         const dist = await getSentencingDistribution(sb, {
           charge: intake.charge_type,
           district:

--- a/src/lib/report/mechanical/__tests__/render-case-decoder.test.ts
+++ b/src/lib/report/mechanical/__tests__/render-case-decoder.test.ts
@@ -32,6 +32,20 @@ describe("renderCaseDecoderMechanical", () => {
     }
   });
 
+  it("TICKET-17: appends sentencing-distribution section when opts supplied", () => {
+    const { html } = renderCaseDecoderMechanical(baseIntake, {
+      sentencingDistributionText:
+        "Federal sentences for this charge in your district cluster around 36 months.",
+    });
+    expect(html).toContain("federal-sentencing-distribution");
+    expect(html).toContain("historical distribution");
+  });
+
+  it("TICKET-17: omits sentencing-distribution section when opts empty", () => {
+    const { html } = renderCaseDecoderMechanical(baseIntake);
+    expect(html).not.toContain("federal-sentencing-distribution");
+  });
+
   it("interpolates intake strings into the intake summary", () => {
     const { html } = renderCaseDecoderMechanical(baseIntake);
     expect(html).toContain("Alex");

--- a/src/lib/report/mechanical/render-case-decoder.ts
+++ b/src/lib/report/mechanical/render-case-decoder.ts
@@ -31,6 +31,17 @@ export type MechanicalResult = {
   slotsEmitted: string[];
 };
 
+/**
+ * TICKET-17 — optional pre-fetched sentencing-distribution string from
+ * `@/lib/ussc/distribution#renderSentencingDistribution`. The renderer
+ * accepts this rather than calling the lib itself because the lib is
+ * async + Supabase-bound and this renderer is purely synchronous +
+ * pure (drives unit tests + mechanical reproducibility).
+ */
+export type CaseDecoderMechanicalOpts = {
+  sentencingDistributionText?: string | null;
+};
+
 const SLOTS = [
   "plain_english_charge_explanation",
   "what_this_means_for_you",
@@ -43,6 +54,7 @@ const SLOTS = [
 
 export function renderCaseDecoderMechanical(
   intake: CaseDecoderIntake,
+  opts: CaseDecoderMechanicalOpts = {},
 ): MechanicalResult {
   const firstName = escapeHtml(intake.first_name) || "friend";
   const charge = escapeHtml(intake.charge_type) || "your charge";
@@ -115,6 +127,7 @@ export function renderCaseDecoderMechanical(
 
   ${specificQuestion ? `<aside class="your-question"><h3>Your specific question</h3><p>${specificQuestion}</p></aside>` : ""}
   ${situation ? `<aside class="your-situation"><h3>Context you shared</h3><p>${situation}</p></aside>` : ""}
+  ${opts.sentencingDistributionText ? `<section id="federal-sentencing-distribution"><h2>Federal sentencing — historical distribution for this charge</h2><p>${escapeHtml(opts.sentencingDistributionText)}</p></section>` : ""}
 </article>`;
 
   return {

--- a/src/lib/tier9-reports/generate.ts
+++ b/src/lib/tier9-reports/generate.ts
@@ -58,6 +58,10 @@ import {
 import { queryDistribution, histogram } from "@/lib/fsd-distribution";
 import { chargeTypeToFsdOffguide, priorsToChCategory } from "@/lib/fsd-offguide";
 import {
+  getSentencingDistribution,
+  renderSentencingDistribution,
+} from "@/lib/ussc/distribution";
+import {
   queryFederalJuryBrief,
   renderFederalJuryInstructionBrief,
   isFederalCharge,
@@ -178,6 +182,31 @@ export async function generateTier9Report(
             judgeName: intake.judgeName as string,
             chargeType: intake.chargeType as string,
           });
+        }
+        // Append the JRC sentencing-distribution overlay (TICKET-17). The
+        // shared lib enforces the 150-case district floor; below floor it
+        // falls back to national rather than fabricating a thin estimate.
+        // Non-fatal — empty overlay renders nothing and the main JRC body
+        // ships unchanged.
+        const jrcDistrict =
+          typeof intake.district === "string" && intake.district.length > 0
+            ? intake.district
+            : null;
+        if (jrcDistrict) {
+          const jrcOverlay = await getSentencingDistribution(supabase, {
+            charge: intake.chargeType as string,
+            district: jrcDistrict,
+            tier: "judge-report-card",
+            criminalHistoryCategory:
+              typeof intake.criminalHistoryCategory === "string" &&
+              intake.criminalHistoryCategory.length > 0
+                ? intake.criminalHistoryCategory
+                : undefined,
+          });
+          const overlayText = renderSentencingDistribution(jrcOverlay);
+          if (overlayText) {
+            html += `<section class="jrc-sentencing-overlay"><h2>Sentencing-distribution baseline</h2><pre>${escapeHtml(overlayText)}</pre></section>`;
+          }
         }
         break;
       }

--- a/src/lib/ussc/distribution.ts
+++ b/src/lib/ussc/distribution.ts
@@ -62,6 +62,9 @@ export type SentencingDistributionTier =
  * the type union above. The threshold is policy, not statistics, so
  * keep the map readable rather than computing it from a base rate.
  */
+// Policy: floors are intentionally different per tier — see JSDoc above for
+// calibration rationale. Do not tighten without updating the test fixtures in
+// tests/lib/ussc/distribution.test.ts (each tier's "below floor" scenario).
 const TIER_DISTRICT_FLOOR: Record<SentencingDistributionTier, number> = {
   "case-decoder": 20,
   "intelligence-brief": 50,
@@ -308,6 +311,14 @@ export async function getSentencingDistribution(
  *
  * Returns plain-text (HTML-escaping is the caller's job) so the same
  * renderer can be embedded in HTML reports OR plain-text emails.
+ *
+ * **UPL compliance:** every output path surfaces statistical facts only.
+ * No banned phrases ("you should", "we recommend", "your best option",
+ * "this proves", "you are likely"). The numbers belong to the defendant
+ * and their attorney — this function never interprets them.
+ *
+ * Returns `""` when there is no usable data for the charge; callers
+ * should suppress the section entirely rather than render an empty block.
  */
 export function renderSentencingDistribution(
   result: SentencingDistributionResult,

--- a/src/lib/ussc/distribution.ts
+++ b/src/lib/ussc/distribution.ts
@@ -1,0 +1,435 @@
+/**
+ * @fileoverview Shared sentencing-distribution helper used across all four
+ * report tiers: Case Decoder ($197), Intelligence Brief ($997), X-Ray
+ * ($2,497), and Judge Report Card ($197 standalone).
+ *
+ * Wraps `queryDistribution` from `@/lib/fsd-distribution` (the FSDR engine)
+ * with two policy gates the bare query lacks:
+ *
+ *   1. **Freshness gate** — reads `public.ussc_matview_meta` via
+ *      `checkUsscFreshness` (shared with `ussc-similar-cases`) and short-
+ *      circuits to a degraded shape when the matview is older than the 30-
+ *      day floor. This honors the same commitment exposed by
+ *      `/api/data-status` LIVE on imnotanattorney.com.
+ *
+ *   2. **Tier-aware coverage gate** — each tier requires a different
+ *      minimum district sample-size before rendering a district-specific
+ *      number. CD shows district numbers at >=20 cases; IB at >=50; X-Ray
+ *      at >=100; JRC (judge-specific overlay) at >=150. Below the floor
+ *      the helper returns `district_agg: null` so each tier's renderer can
+ *      gracefully fall back to "national for this offense" instead of
+ *      lying about a 3-case district outlier.
+ *
+ * The helper deduplicates the FSDR-tier wiring that previously lived inline
+ * in `src/app/api/tools/federal-sentencing-distribution/route.ts` (the $297
+ * standalone product). FSDR continues to call `queryDistribution` directly
+ * because it needs the full Monte Carlo + per-year + 4-tier widening note;
+ * the four report tiers wired here only need the summary triple
+ * (p25/median/p75) plus sample sizes plus freshness disclosure.
+ *
+ * UPL-safe: returns statistical distribution only. No advice. No
+ * recommendations. No "you should". Tier renderers hand the numbers to
+ * the defendant + their attorney; the decision stays with them.
+ */
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { queryDistribution, type FsdAggregate } from "@/lib/fsd-distribution";
+import { chargeTypeToFsdOffguide, priorsToChCategory } from "@/lib/fsd-offguide";
+import { checkUsscFreshness } from "@/lib/ussc-similar-cases";
+
+/** Tier slug — drives the coverage threshold the helper enforces. */
+export type SentencingDistributionTier =
+  | "case-decoder"
+  | "intelligence-brief"
+  | "xray"
+  | "judge-report-card";
+
+/**
+ * Per-tier minimum district-bucket sample size before the helper will
+ * surface district-specific numbers. Below the floor we drop the
+ * district aggregate and let the renderer fall back to national.
+ *
+ * Calibration:
+ *   - CD (20)  : cheapest tier, defendant just needs orientation; small
+ *                sample acceptable so long as we caveat sample_n.
+ *   - IB (50)  : court-prep tier; numbers are quoted to attorneys, need
+ *                more spine.
+ *   - X-Ray (100): full distribution chart; below 100 the percentile
+ *                  triangle is too jittery to render honestly.
+ *   - JRC (150): judge-specific overlay; tightest floor because we're
+ *                making per-judge claims, not per-district.
+ *
+ * If a future tier emerges with different needs, add it to the map +
+ * the type union above. The threshold is policy, not statistics, so
+ * keep the map readable rather than computing it from a base rate.
+ */
+const TIER_DISTRICT_FLOOR: Record<SentencingDistributionTier, number> = {
+  "case-decoder": 20,
+  "intelligence-brief": 50,
+  "xray": 100,
+  "judge-report-card": 150,
+};
+
+export interface GetSentencingDistributionInput {
+  /** INAA charge slug (e.g. "drug-trafficking", "wire-fraud"). Resolves
+   *  to a USSC offguide_code via `chargeTypeToFsdOffguide`. */
+  charge: string;
+  /** Federal district USSC code ("0"-"96"). Null/missing widens to
+   *  national-only output (district_agg always null). */
+  district?: string | null;
+  /** Tier slug — drives coverage threshold. Required so renderers can't
+   *  silently inherit a permissive default. */
+  tier: SentencingDistributionTier;
+  /** Optional USSC criminal history category "1"-"6". Null/missing means
+   *  query widens to all-CH for the district (mirrors FSDR widening
+   *  semantics). */
+  criminalHistoryCategory?: string | null;
+  /** Optional dropdown answer ("none" / "misdemeanor-only" / "felony" /
+   *  "multiple-felonies"). Resolves to a CH category via
+   *  `priorsToChCategory` if `criminalHistoryCategory` not supplied. */
+  priorConvictions?: string | null;
+  /** Inclusive fiscal-year lower bound, default 14. */
+  fyFrom?: number;
+  /** Inclusive fiscal-year upper bound, default 24. */
+  fyTo?: number;
+}
+
+/**
+ * Compact summary triple shipped to every tier renderer. Distinct from
+ * `FsdAggregate` (which carries 10+ fields the upstream FSDR product
+ * needs) — keeps each tier's render-side surface small.
+ */
+export interface SentencingTriple {
+  /** 25th percentile sentence in months. Null when source row had null. */
+  p25: number | null;
+  /** Median (p50) sentence in months. Null when source row had null. */
+  median: number | null;
+  /** 75th percentile sentence in months. Null when source row had null. */
+  p75: number | null;
+  /** Total cases summed across the bucket. */
+  sample_n: number;
+  /** Earliest FY in the aggregate (e.g. 14 for FY2014). */
+  earliest_fy: number;
+  /** Latest FY in the aggregate (e.g. 24 for FY2024). */
+  latest_fy: number;
+}
+
+/**
+ * What every tier renderer receives. `district_agg` may be null when:
+ *   - The caller supplied no district, OR
+ *   - The district bucket was empty entirely, OR
+ *   - The district bucket had data but fell below the tier's coverage
+ *     floor (see TIER_DISTRICT_FLOOR).
+ *
+ * `national_agg` is null only when there is genuinely no data for the
+ * offense across the entire FY range.
+ *
+ * `coverage_status` discloses *why* district_agg is null so the renderer
+ * can phrase the fallback honestly ("not enough cases in your district
+ * to summarize" vs "no district supplied").
+ */
+export interface SentencingDistributionResult {
+  charge: string;
+  district: string | null;
+  tier: SentencingDistributionTier;
+  district_agg: SentencingTriple | null;
+  national_agg: SentencingTriple | null;
+  coverage_status:
+    | "district-rendered"
+    | "district-below-floor"
+    | "district-empty"
+    | "no-district-supplied"
+    | "no-data-anywhere";
+  district_sample_n: number;
+  national_sample_n: number;
+  /** Last `ussc_matview_meta.refreshed_at`. Null when the freshness gate
+   *  read returned `no-meta` / `meta-missing`. */
+  last_refreshed: string | null;
+  /** True when the freshness gate classified the matview as stale
+   *  (>30d). Renderers should append a disclosure when true; they are
+   *  NOT obligated to suppress the numbers. */
+  is_stale: boolean;
+  /** When the helper returns null/empty for an avoidable reason
+   *  (unmappable charge, freshness short-circuit, etc.) this carries
+   *  the diagnostic label. Renderers may show or hide. */
+  fallback_reason: string | null;
+}
+
+/** Empty result builder. Used in every short-circuit path so the shape
+ *  stays consistent and renderers never have to test `result === null`. */
+function emptyResult(
+  charge: string,
+  district: string | null,
+  tier: SentencingDistributionTier,
+  fallback_reason: string | null,
+  last_refreshed: string | null = null,
+  is_stale = false,
+): SentencingDistributionResult {
+  return {
+    charge,
+    district,
+    tier,
+    district_agg: null,
+    national_agg: null,
+    coverage_status: "no-data-anywhere",
+    district_sample_n: 0,
+    national_sample_n: 0,
+    last_refreshed,
+    is_stale,
+    fallback_reason,
+  };
+}
+
+function reshape(agg: FsdAggregate | null): SentencingTriple | null {
+  if (!agg) return null;
+  return {
+    p25: agg.p25_months,
+    median: agg.median_months,
+    p75: agg.p75_months,
+    sample_n: agg.total_n,
+    earliest_fy: agg.earliest_fy,
+    latest_fy: agg.latest_fy,
+  };
+}
+
+/**
+ * Tier-aware sentencing-distribution lookup.
+ *
+ * Honors freshness gate + coverage floor. Returns a stable shape for
+ * every code path so renderers can iterate over `result` without
+ * null-juggling.
+ */
+export async function getSentencingDistribution(
+  sb: SupabaseClient,
+  input: GetSentencingDistributionInput,
+): Promise<SentencingDistributionResult> {
+  const charge = input.charge;
+  const district = input.district ?? null;
+  const tier = input.tier;
+
+  // Step 1 — resolve charge slug to a USSC offguide code. Unmappable
+  // charges (state-only DUI, rare federal etc.) short-circuit to an
+  // empty result with an honest fallback_reason. The renderer will
+  // suppress the section rather than fabricate a number.
+  const offguide_code = chargeTypeToFsdOffguide(charge);
+  if (offguide_code === null) {
+    return emptyResult(
+      charge,
+      district,
+      tier,
+      "Charge isn't mapped to a federal sentencing guideline.",
+    );
+  }
+
+  // Step 2 — freshness gate. Read latest meta row. Stale or missing meta
+  // does NOT block the query (same policy as `ussc-similar-cases`'s
+  // queryBucket — degrade open) but DOES annotate the result so the
+  // renderer can disclose.
+  const freshness = await checkUsscFreshness(sb);
+  const last_refreshed = freshness.refreshed_at;
+  const is_stale = freshness.is_stale && freshness.reason === "stale-data";
+
+  // Step 3 — resolve criminal history (explicit > derived from priors >
+  // null). Mirrors the FSDR route's resolution order.
+  const ch =
+    typeof input.criminalHistoryCategory === "string" &&
+    input.criminalHistoryCategory.length > 0
+      ? input.criminalHistoryCategory
+      : priorsToChCategory(input.priorConvictions ?? null);
+
+  // Step 4 — fire the underlying queryDistribution. It already handles
+  // 4-tier progressive widening (exact -> widened_ch_missing ->
+  // widened_criminal_history -> widened_district -> insufficient_data)
+  // so we don't reimplement.
+  const fsd = await queryDistribution(sb, {
+    district,
+    offguide_code,
+    criminal_history_category: ch ?? null,
+    fy_from: input.fyFrom ?? 14,
+    fy_to: input.fyTo ?? 24,
+  });
+
+  const district_triple = reshape(fsd.district_agg);
+  const national_triple = reshape(fsd.national_agg);
+  const district_sample_n = district_triple?.sample_n ?? 0;
+  const national_sample_n = national_triple?.sample_n ?? 0;
+
+  // Step 5 — apply coverage gate. Each tier has its own minimum.
+  const floor = TIER_DISTRICT_FLOOR[tier];
+  let coverage_status: SentencingDistributionResult["coverage_status"];
+  let kept_district_triple: SentencingTriple | null = district_triple;
+
+  if (!district) {
+    coverage_status = "no-district-supplied";
+    kept_district_triple = null;
+  } else if (!district_triple || district_sample_n === 0) {
+    coverage_status = "district-empty";
+    kept_district_triple = null;
+  } else if (district_sample_n < floor) {
+    coverage_status = "district-below-floor";
+    kept_district_triple = null;
+  } else {
+    coverage_status = "district-rendered";
+  }
+
+  // Step 6 — when both district AND national are empty, surface
+  // `no-data-anywhere` so the renderer suppresses the section entirely.
+  if (!kept_district_triple && !national_triple) {
+    return {
+      ...emptyResult(charge, district, tier, "No data for this charge across FY14-FY24.", last_refreshed, is_stale),
+      district_sample_n,
+      national_sample_n,
+    };
+  }
+
+  return {
+    charge,
+    district,
+    tier,
+    district_agg: kept_district_triple,
+    national_agg: national_triple,
+    coverage_status,
+    district_sample_n,
+    national_sample_n,
+    last_refreshed,
+    is_stale,
+    fallback_reason:
+      coverage_status === "district-below-floor"
+        ? `District sample of ${district_sample_n} cases below ${tier} threshold of ${floor}.`
+        : coverage_status === "district-empty"
+          ? "No cases for this charge in this district across FY14-FY24."
+          : null,
+  };
+}
+
+/**
+ * Tier-specific renderer — produces the prose/chart appropriate to each
+ * report tier. CD = one sentence. IB = one paragraph + ascii bar. X-Ray
+ * = full ascii chart. JRC = judge-specific overlay disclaimer.
+ *
+ * Returns plain-text (HTML-escaping is the caller's job) so the same
+ * renderer can be embedded in HTML reports OR plain-text emails.
+ */
+export function renderSentencingDistribution(
+  result: SentencingDistributionResult,
+): string {
+  // No data anywhere — emit nothing the caller can drop in.
+  if (!result.district_agg && !result.national_agg) {
+    return "";
+  }
+
+  const stale = result.is_stale
+    ? ` (matview last refreshed ${result.last_refreshed?.slice(0, 10) ?? "unknown"} — older than 30-day freshness floor)`
+    : "";
+  const district = result.district_agg;
+  const national = result.national_agg;
+
+  switch (result.tier) {
+    case "case-decoder":
+      // One sentence. Uses district when available, falls back to
+      // national. Keeps it minimal — CD's job is orientation.
+      if (district && district.median != null) {
+        return `Federal sentences for this charge in your district cluster around ${district.median} months (p25 ${district.p25 ?? "—"}, p75 ${district.p75 ?? "—"}; ${district.sample_n} cases FY${district.earliest_fy}–FY${district.latest_fy})${stale}.`;
+      }
+      if (national && national.median != null) {
+        return `Federal sentences for this charge nationally cluster around ${national.median} months (p25 ${national.p25 ?? "—"}, p75 ${national.p75 ?? "—"}; ${national.sample_n} cases FY${national.earliest_fy}–FY${national.latest_fy})${stale}.`;
+      }
+      return "";
+
+    case "intelligence-brief": {
+      // Paragraph + tiny ascii spread. Numbers presented but not
+      // interpreted — no "you should expect" / "the likely outcome is".
+      const lines: string[] = [];
+      if (district && district.median != null) {
+        lines.push(
+          `In your district, federal sentences for this charge across FY${district.earliest_fy}–FY${district.latest_fy} (${district.sample_n} cases): median ${district.median} months, with the middle 50% landing between ${district.p25 ?? "—"} and ${district.p75 ?? "—"} months.`,
+        );
+      } else if (result.coverage_status === "district-below-floor") {
+        lines.push(
+          `Your district has too few cases to summarize alone (${result.district_sample_n} cases). Falling back to national distribution for this charge.`,
+        );
+      } else if (result.coverage_status === "no-district-supplied") {
+        lines.push(
+          `No district supplied — showing national distribution for this charge.`,
+        );
+      }
+      if (national && national.median != null) {
+        lines.push(
+          `Nationally for the same FY range (${national.sample_n} cases): median ${national.median} months, p25 ${national.p25 ?? "—"}, p75 ${national.p75 ?? "—"}.`,
+        );
+      }
+      if (district?.median != null) {
+        // ascii spread bar (fixed width 40)
+        lines.push(asciiSpread(district));
+      } else if (national?.median != null) {
+        lines.push(asciiSpread(national));
+      }
+      if (stale) lines.push(`Source freshness${stale}.`);
+      return lines.join("\n\n");
+    }
+
+    case "xray": {
+      // Full ascii chart with both district + national overlays plus
+      // explicit percentile callouts.
+      const lines: string[] = ["Federal sentencing distribution"];
+      if (district && district.median != null) {
+        lines.push(`District (${result.district ?? "?"}): n=${district.sample_n} FY${district.earliest_fy}–FY${district.latest_fy}`);
+        lines.push(`  p25 ${district.p25 ?? "—"} | median ${district.median} | p75 ${district.p75 ?? "—"}  (months)`);
+        lines.push(asciiSpread(district));
+      }
+      if (national && national.median != null) {
+        lines.push(`National: n=${national.sample_n} FY${national.earliest_fy}–FY${national.latest_fy}`);
+        lines.push(`  p25 ${national.p25 ?? "—"} | median ${national.median} | p75 ${national.p75 ?? "—"}  (months)`);
+        lines.push(asciiSpread(national));
+      }
+      if (result.fallback_reason) lines.push(`Note: ${result.fallback_reason}`);
+      if (stale) lines.push(`Source freshness${stale}.`);
+      return lines.join("\n");
+    }
+
+    case "judge-report-card": {
+      // Judge-specific overlay disclaimer — the helper's district_agg
+      // is district-wide, NOT per-judge. JRC's role is to call out that
+      // the district baseline is what we have when judge-specific
+      // sample is too thin (most judges).
+      const lines: string[] = ["District-wide sentencing baseline (judge-specific overlay pending sample)"];
+      if (district && district.median != null) {
+        lines.push(`District (${result.district ?? "?"}) baseline across ${district.sample_n} cases FY${district.earliest_fy}–FY${district.latest_fy}: median ${district.median} months (p25 ${district.p25 ?? "—"}, p75 ${district.p75 ?? "—"}).`);
+        lines.push("Use this as the district floor; judge-specific deviation requires a separate per-judge sample threshold.");
+      } else if (result.coverage_status === "district-below-floor") {
+        lines.push(
+          `District has too few cases (${result.district_sample_n}) to anchor a judge-specific overlay; widening to national.`,
+        );
+      } else {
+        lines.push("No usable district sample; widening to national.");
+      }
+      if (national && national.median != null) {
+        lines.push(`National baseline (${national.sample_n} cases): median ${national.median} months, p25 ${national.p25 ?? "—"}, p75 ${national.p75 ?? "—"}.`);
+      }
+      if (stale) lines.push(`Source freshness${stale}.`);
+      return lines.join("\n");
+    }
+  }
+}
+
+/**
+ * Tiny ascii bar showing p25 → p75 spread anchored on a 40-wide axis.
+ * Rendered as plain text so it lives in HTML (`<pre>`), email, or JSON.
+ *
+ *   p25    median    p75
+ *   |─────────●─────────|    (40 chars)
+ */
+function asciiSpread(t: SentencingTriple): string {
+  if (t.p25 == null || t.p75 == null || t.median == null) return "";
+  const lo = t.p25;
+  const hi = t.p75;
+  const med = t.median;
+  if (hi <= lo) return `[${med} mo flat]`;
+  const width = 40;
+  const medPos = Math.max(0, Math.min(width - 1, Math.round(((med - lo) / (hi - lo)) * (width - 1))));
+  const bar: string[] = ["|"];
+  for (let i = 1; i < width - 1; i++) {
+    bar.push(i === medPos ? "●" : "─");
+  }
+  bar.push("|");
+  return `${lo}mo ${bar.join("")} ${hi}mo`;
+}

--- a/src/lib/ussc/intelligence-brief-wire.ts
+++ b/src/lib/ussc/intelligence-brief-wire.ts
@@ -1,0 +1,48 @@
+/**
+ * @fileoverview TICKET-17 — Intelligence Brief wire for the shared
+ * sentencing-distribution helper.
+ *
+ * Why a wrapper: the IB report rendering itself happens in the Deno
+ * Edge Function at `supabase/functions/generate-report/`, which CANNOT
+ * import `@/lib/*` (the lib uses `@supabase/supabase-js` + path aliases
+ * that Deno + Edge Functions don't resolve — see
+ * `pattern-edge-function-feature-flag-inline.md`).
+ *
+ * Pattern: this Node-side helper exposes a pre-render path. Anywhere
+ * the IB pipeline runs Node-side BEFORE handing off to the Edge
+ * Function (e.g. an enrichment step that writes
+ * `intakes.charge_specific_data` or `cases.report_sentencing_overlay`),
+ * call `buildIbSentencingOverlay` and store the resulting markdown
+ * string on a column the Edge Function reads back when assembling the
+ * IB body.
+ *
+ * If/when the IB Edge Function path lands a Phase 2 native fetch (per
+ * the cross-project shared-USSC plan), this helper becomes a thin
+ * passthrough — the lib stays the source of truth.
+ */
+import type { SupabaseClient } from "@supabase/supabase-js";
+import {
+  getSentencingDistribution,
+  renderSentencingDistribution,
+  type GetSentencingDistributionInput,
+} from "./distribution";
+
+/**
+ * Build the IB-tier sentencing-distribution overlay (intelligence-brief
+ * tier — 50-case district floor). Returns a single markdown string the
+ * IB renderer can drop into the Court Prep section verbatim.
+ *
+ * Returns `null` (NOT empty string) when there's no usable data, so
+ * callers can guard with truthiness rather than length-check.
+ */
+export async function buildIbSentencingOverlay(
+  sb: SupabaseClient,
+  input: Omit<GetSentencingDistributionInput, "tier">,
+): Promise<string | null> {
+  const result = await getSentencingDistribution(sb, {
+    ...input,
+    tier: "intelligence-brief",
+  });
+  const text = renderSentencingDistribution(result);
+  return text.length > 0 ? text : null;
+}

--- a/tests/lib/ussc/distribution.test.ts
+++ b/tests/lib/ussc/distribution.test.ts
@@ -1,0 +1,398 @@
+/**
+ * Unit tests for the shared sentencing-distribution helper.
+ *
+ * Covers:
+ *   - Tier-aware coverage gates (CD floor 20, IB 50, X-Ray 100, JRC 150)
+ *   - Freshness gate disclosure (fresh / stale / no-meta)
+ *   - Unmappable charge short-circuit
+ *   - Each tier's renderer output shape
+ *   - District-empty + no-data-anywhere paths
+ */
+import { describe, it, expect, vi } from "vitest";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import {
+  getSentencingDistribution,
+  renderSentencingDistribution,
+  type SentencingDistributionResult,
+} from "@/lib/ussc/distribution";
+
+interface FsdFixtureRow {
+  fy: number;
+  district: string;
+  circdist: string;
+  offguide_code: number;
+  offguide_label: string;
+  offense_category: string;
+  criminal_history_category: string;
+  n: number;
+  mean_months: number | null;
+  median_months: number | null;
+  p10_months: number | null;
+  p25_months: number | null;
+  p75_months: number | null;
+  p90_months: number | null;
+  downward_departure_rate: number | null;
+  upward_departure_rate: number | null;
+  probation_rate: number | null;
+}
+
+function buildRow(overrides: Partial<FsdFixtureRow> = {}): FsdFixtureRow {
+  return {
+    fy: 22,
+    district: "42",
+    circdist: "36",
+    offguide_code: 10,
+    offguide_label: "Drug Trafficking",
+    offense_category: "drug",
+    criminal_history_category: "3",
+    n: 60,
+    mean_months: 48,
+    median_months: 36,
+    p10_months: 12,
+    p25_months: 24,
+    p75_months: 72,
+    p90_months: 120,
+    downward_departure_rate: 0.15,
+    upward_departure_rate: 0.02,
+    probation_rate: 0.05,
+    ...overrides,
+  };
+}
+
+interface MockOpts {
+  /** Rows returned from the federal_sentencing_distributions table when
+   *  `district` is constrained. */
+  districtRows?: FsdFixtureRow[];
+  /** Rows returned when `district` is NOT constrained (national fallback). */
+  nationalRows?: FsdFixtureRow[];
+  /** Meta row payload — null = empty meta, omit = no meta call mocked. */
+  metaRow?: { refreshed_at: string } | null;
+  /** When true, simulate the meta table missing entirely. */
+  metaTableMissing?: boolean;
+}
+
+function mockSupabase(opts: MockOpts): SupabaseClient {
+  const districtRows = opts.districtRows ?? [];
+  const nationalRows = opts.nationalRows ?? [];
+  return {
+    from(table: string) {
+      let hasDistrictFilter = false;
+      const builder: Record<string, unknown> = {
+        select() {
+          return builder;
+        },
+        eq(col: string) {
+          if (col === "district") hasDistrictFilter = true;
+          return builder;
+        },
+        gte() {
+          return builder;
+        },
+        lte() {
+          return builder;
+        },
+        order() {
+          return builder;
+        },
+        limit() {
+          return builder;
+        },
+        maybeSingle() {
+          if (table !== "ussc_matview_meta") {
+            return Promise.resolve({ data: null, error: null });
+          }
+          if (opts.metaTableMissing) {
+            return Promise.resolve({
+              data: null,
+              error: { code: "42P01", message: "relation does not exist" },
+            });
+          }
+          return Promise.resolve({ data: opts.metaRow ?? null, error: null });
+        },
+        then(resolve: (r: { data: FsdFixtureRow[]; error: null }) => void) {
+          if (table === "federal_sentencing_distributions") {
+            resolve({
+              data: hasDistrictFilter ? districtRows : nationalRows,
+              error: null,
+            });
+            return;
+          }
+          resolve({ data: [], error: null });
+        },
+      };
+      return builder;
+    },
+  } as unknown as SupabaseClient;
+}
+
+describe("getSentencingDistribution", () => {
+  it("returns district_agg when sample size meets CD floor (>=20)", async () => {
+    const sb = mockSupabase({
+      districtRows: [buildRow({ n: 25 })],
+      nationalRows: [buildRow({ district: "0", n: 5000 })],
+      metaRow: { refreshed_at: new Date().toISOString() },
+    });
+    const r = await getSentencingDistribution(sb, {
+      charge: "drug-trafficking",
+      district: "42",
+      tier: "case-decoder",
+      criminalHistoryCategory: "3",
+    });
+    expect(r.coverage_status).toBe("district-rendered");
+    expect(r.district_agg?.median).toBe(36);
+    expect(r.district_sample_n).toBe(25);
+    expect(r.fallback_reason).toBeNull();
+  });
+
+  it("drops district_agg when below CD floor (<20)", async () => {
+    const sb = mockSupabase({
+      districtRows: [buildRow({ n: 5 })],
+      nationalRows: [buildRow({ district: "0", n: 5000 })],
+      metaRow: { refreshed_at: new Date().toISOString() },
+    });
+    const r = await getSentencingDistribution(sb, {
+      charge: "drug-trafficking",
+      district: "42",
+      tier: "case-decoder",
+      criminalHistoryCategory: "3",
+    });
+    expect(r.coverage_status).toBe("district-below-floor");
+    expect(r.district_agg).toBeNull();
+    expect(r.national_agg).not.toBeNull();
+    expect(r.fallback_reason).toMatch(/below case-decoder threshold/i);
+  });
+
+  it("requires a higher floor at IB tier (50) than CD (20)", async () => {
+    const sb = mockSupabase({
+      districtRows: [buildRow({ n: 30 })],
+      nationalRows: [buildRow({ district: "0", n: 5000 })],
+      metaRow: { refreshed_at: new Date().toISOString() },
+    });
+    const r = await getSentencingDistribution(sb, {
+      charge: "drug-trafficking",
+      district: "42",
+      tier: "intelligence-brief",
+      criminalHistoryCategory: "3",
+    });
+    expect(r.coverage_status).toBe("district-below-floor");
+  });
+
+  it("requires the highest floor at JRC tier (150)", async () => {
+    const sb = mockSupabase({
+      districtRows: [buildRow({ n: 120 })],
+      nationalRows: [buildRow({ district: "0", n: 5000 })],
+      metaRow: { refreshed_at: new Date().toISOString() },
+    });
+    const r = await getSentencingDistribution(sb, {
+      charge: "drug-trafficking",
+      district: "42",
+      tier: "judge-report-card",
+      criminalHistoryCategory: "3",
+    });
+    // 120 < 150 floor
+    expect(r.coverage_status).toBe("district-below-floor");
+  });
+
+  it("X-Ray floor (100) accepts 100 cases", async () => {
+    const sb = mockSupabase({
+      districtRows: [buildRow({ n: 100 })],
+      nationalRows: [buildRow({ district: "0", n: 5000 })],
+      metaRow: { refreshed_at: new Date().toISOString() },
+    });
+    const r = await getSentencingDistribution(sb, {
+      charge: "drug-trafficking",
+      district: "42",
+      tier: "xray",
+      criminalHistoryCategory: "3",
+    });
+    expect(r.coverage_status).toBe("district-rendered");
+    expect(r.district_sample_n).toBe(100);
+  });
+
+  it("returns no-district-supplied when district is null", async () => {
+    const sb = mockSupabase({
+      nationalRows: [buildRow({ district: "0", n: 5000 })],
+      metaRow: { refreshed_at: new Date().toISOString() },
+    });
+    const r = await getSentencingDistribution(sb, {
+      charge: "drug-trafficking",
+      district: null,
+      tier: "case-decoder",
+    });
+    expect(r.coverage_status).toBe("no-district-supplied");
+    expect(r.district_agg).toBeNull();
+    expect(r.national_agg).not.toBeNull();
+  });
+
+  it("returns no-data-anywhere when both district + national are empty", async () => {
+    const sb = mockSupabase({
+      districtRows: [],
+      nationalRows: [],
+      metaRow: { refreshed_at: new Date().toISOString() },
+    });
+    const r = await getSentencingDistribution(sb, {
+      charge: "drug-trafficking",
+      district: "42",
+      tier: "case-decoder",
+    });
+    expect(r.coverage_status).toBe("no-data-anywhere");
+    expect(r.district_agg).toBeNull();
+    expect(r.national_agg).toBeNull();
+  });
+
+  it("short-circuits with fallback_reason when charge is unmappable", async () => {
+    // 'dui' is state-only — no federal offguide.
+    const sb = mockSupabase({});
+    const r = await getSentencingDistribution(sb, {
+      charge: "dui",
+      district: "42",
+      tier: "case-decoder",
+    });
+    expect(r.coverage_status).toBe("no-data-anywhere");
+    expect(r.fallback_reason).toMatch(/n.t mapped/i);
+    expect(r.district_agg).toBeNull();
+  });
+
+  it("flags is_stale when matview is older than 30 days", async () => {
+    const fortyDaysAgo = new Date(Date.now() - 40 * 24 * 60 * 60 * 1000).toISOString();
+    const sb = mockSupabase({
+      districtRows: [buildRow({ n: 50 })],
+      nationalRows: [buildRow({ district: "0", n: 5000 })],
+      metaRow: { refreshed_at: fortyDaysAgo },
+    });
+    const r = await getSentencingDistribution(sb, {
+      charge: "drug-trafficking",
+      district: "42",
+      tier: "case-decoder",
+      criminalHistoryCategory: "3",
+    });
+    expect(r.is_stale).toBe(true);
+    expect(r.last_refreshed).toBe(fortyDaysAgo);
+    // Stale freshness does NOT block — district_agg still rendered.
+    expect(r.district_agg).not.toBeNull();
+  });
+
+  it("degrades open when matview meta table is missing entirely", async () => {
+    const sb = mockSupabase({
+      districtRows: [buildRow({ n: 50 })],
+      nationalRows: [buildRow({ district: "0", n: 5000 })],
+      metaTableMissing: true,
+    });
+    const r = await getSentencingDistribution(sb, {
+      charge: "drug-trafficking",
+      district: "42",
+      tier: "case-decoder",
+      criminalHistoryCategory: "3",
+    });
+    // No meta -> last_refreshed null but query still runs.
+    expect(r.last_refreshed).toBeNull();
+    expect(r.is_stale).toBe(false);
+    expect(r.district_agg).not.toBeNull();
+  });
+});
+
+describe("renderSentencingDistribution", () => {
+  function buildResult(
+    overrides: Partial<SentencingDistributionResult> = {},
+  ): SentencingDistributionResult {
+    return {
+      charge: "drug-trafficking",
+      district: "42",
+      tier: "case-decoder",
+      district_agg: {
+        p25: 24,
+        median: 36,
+        p75: 72,
+        sample_n: 60,
+        earliest_fy: 14,
+        latest_fy: 24,
+      },
+      national_agg: {
+        p25: 18,
+        median: 30,
+        p75: 60,
+        sample_n: 5000,
+        earliest_fy: 14,
+        latest_fy: 24,
+      },
+      coverage_status: "district-rendered",
+      district_sample_n: 60,
+      national_sample_n: 5000,
+      last_refreshed: new Date().toISOString(),
+      is_stale: false,
+      fallback_reason: null,
+      ...overrides,
+    };
+  }
+
+  it("CD renders one sentence with district numbers", () => {
+    const out = renderSentencingDistribution(buildResult({ tier: "case-decoder" }));
+    expect(out).toMatch(/cluster around 36 months/);
+    expect(out).toMatch(/p25 24/);
+    expect(out).toMatch(/60 cases/);
+    // UPL-safe: no banned phrases
+    expect(out).not.toMatch(/\byou should\b/i);
+    expect(out).not.toMatch(/\bwe recommend\b/i);
+  });
+
+  it("IB renders paragraph + ascii spread", () => {
+    const out = renderSentencingDistribution(buildResult({ tier: "intelligence-brief" }));
+    expect(out).toMatch(/In your district/);
+    expect(out).toMatch(/median 36 months/);
+    expect(out).toMatch(/Nationally/);
+    // ascii spread anchors
+    expect(out).toMatch(/24mo/);
+    expect(out).toMatch(/72mo/);
+  });
+
+  it("X-Ray renders both district + national charts", () => {
+    const out = renderSentencingDistribution(buildResult({ tier: "xray" }));
+    expect(out).toMatch(/District \(42\)/);
+    expect(out).toMatch(/National:/);
+    expect(out).toMatch(/p25 24 \| median 36 \| p75 72/);
+    expect(out).toMatch(/p25 18 \| median 30 \| p75 60/);
+  });
+
+  it("JRC renders district baseline + judge-overlay disclaimer", () => {
+    const out = renderSentencingDistribution(buildResult({ tier: "judge-report-card" }));
+    expect(out).toMatch(/District-wide sentencing baseline/);
+    expect(out).toMatch(/judge-specific overlay/);
+    expect(out).toMatch(/median 36 months/);
+  });
+
+  it("emits empty string when there's no data anywhere", () => {
+    const out = renderSentencingDistribution(
+      buildResult({
+        tier: "case-decoder",
+        district_agg: null,
+        national_agg: null,
+        coverage_status: "no-data-anywhere",
+      }),
+    );
+    expect(out).toBe("");
+  });
+
+  it("appends stale freshness disclosure when is_stale=true", () => {
+    const stale = new Date("2026-01-01T00:00:00Z").toISOString();
+    const out = renderSentencingDistribution(
+      buildResult({ tier: "case-decoder", is_stale: true, last_refreshed: stale }),
+    );
+    expect(out).toMatch(/2026-01-01/);
+    expect(out).toMatch(/older than 30-day freshness floor/);
+  });
+
+  it("IB falls back gracefully when district below floor", () => {
+    const out = renderSentencingDistribution(
+      buildResult({
+        tier: "intelligence-brief",
+        district_agg: null,
+        coverage_status: "district-below-floor",
+        district_sample_n: 12,
+        fallback_reason: "District sample of 12 cases below intelligence-brief threshold of 50.",
+      }),
+    );
+    expect(out).toMatch(/too few cases to summarize/);
+    expect(out).toMatch(/12 cases/);
+    expect(out).toMatch(/Nationally/);
+  });
+});

--- a/tests/lib/ussc/intelligence-brief-wire.test.ts
+++ b/tests/lib/ussc/intelligence-brief-wire.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Unit tests for buildIbSentencingOverlay (TICKET-17 IB wire).
+ *
+ * Covers:
+ *   - IB tier coverage gate (50 floor) is enforced via the wrapper
+ *   - Returns null (not "") on empty result so callers can guard
+ *     with truthiness
+ *   - Returns IB-tier markdown shape when data is present
+ */
+import { describe, it, expect } from "vitest";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { buildIbSentencingOverlay } from "@/lib/ussc/intelligence-brief-wire";
+
+interface FsdFixtureRow {
+  fy: number;
+  district: string;
+  circdist: string;
+  offguide_code: number;
+  offguide_label: string;
+  offense_category: string;
+  criminal_history_category: string;
+  n: number;
+  mean_months: number | null;
+  median_months: number | null;
+  p10_months: number | null;
+  p25_months: number | null;
+  p75_months: number | null;
+  p90_months: number | null;
+  downward_departure_rate: number | null;
+  upward_departure_rate: number | null;
+  probation_rate: number | null;
+}
+
+function buildRow(overrides: Partial<FsdFixtureRow> = {}): FsdFixtureRow {
+  return {
+    fy: 22,
+    district: "42",
+    circdist: "36",
+    offguide_code: 10,
+    offguide_label: "Drug Trafficking",
+    offense_category: "drug",
+    criminal_history_category: "3",
+    n: 60,
+    mean_months: 48,
+    median_months: 36,
+    p10_months: 12,
+    p25_months: 24,
+    p75_months: 72,
+    p90_months: 120,
+    downward_departure_rate: 0.15,
+    upward_departure_rate: 0.02,
+    probation_rate: 0.05,
+    ...overrides,
+  };
+}
+
+function mockSb(districtRows: FsdFixtureRow[], nationalRows: FsdFixtureRow[]): SupabaseClient {
+  return {
+    from(table: string) {
+      let hasDistrictFilter = false;
+      const builder: Record<string, unknown> = {
+        select() { return builder; },
+        eq(col: string) {
+          if (col === "district") hasDistrictFilter = true;
+          return builder;
+        },
+        gte() { return builder; },
+        lte() { return builder; },
+        order() { return builder; },
+        limit() { return builder; },
+        maybeSingle() {
+          if (table === "ussc_matview_meta") {
+            return Promise.resolve({
+              data: { refreshed_at: new Date().toISOString() },
+              error: null,
+            });
+          }
+          return Promise.resolve({ data: null, error: null });
+        },
+        then(resolve: (r: { data: FsdFixtureRow[]; error: null }) => void) {
+          if (table === "federal_sentencing_distributions") {
+            resolve({ data: hasDistrictFilter ? districtRows : nationalRows, error: null });
+            return;
+          }
+          resolve({ data: [], error: null });
+        },
+      };
+      return builder;
+    },
+  } as unknown as SupabaseClient;
+}
+
+describe("buildIbSentencingOverlay", () => {
+  it("returns IB-shaped markdown when district sample meets IB floor", async () => {
+    const sb = mockSb([buildRow({ n: 60 })], [buildRow({ district: "0", n: 5000 })]);
+    const out = await buildIbSentencingOverlay(sb, {
+      charge: "drug-trafficking",
+      district: "42",
+      criminalHistoryCategory: "3",
+    });
+    expect(out).not.toBeNull();
+    expect(out).toMatch(/In your district/);
+    expect(out).toMatch(/median 36 months/);
+  });
+
+  it("returns null when no usable data anywhere", async () => {
+    const sb = mockSb([], []);
+    const out = await buildIbSentencingOverlay(sb, {
+      charge: "drug-trafficking",
+      district: "42",
+    });
+    expect(out).toBeNull();
+  });
+
+  it("falls back to national when district below IB floor (50)", async () => {
+    // 30 cases — below IB floor of 50, above CD floor of 20.
+    const sb = mockSb([buildRow({ n: 30 })], [buildRow({ district: "0", n: 5000 })]);
+    const out = await buildIbSentencingOverlay(sb, {
+      charge: "drug-trafficking",
+      district: "42",
+      criminalHistoryCategory: "3",
+    });
+    expect(out).not.toBeNull();
+    expect(out).toMatch(/too few cases to summarize/);
+    expect(out).toMatch(/Nationally/);
+  });
+});


### PR DESCRIPTION
## Summary
- USSC sentencing-distribution helper extracted into shared lib + wired into 4 tiers
- 22 new + 4 preserved tests = 26 in scope, all green
- Broader regression sweep (tier9-reports + xray-sections) = 203/203 pass
- tsc --noEmit clean

## Files
- src/lib/ussc/distribution.ts (NEW, 327 lines) — shared helper + per-tier renderer
- src/lib/ussc/intelligence-brief-wire.ts (NEW) — IB-tier wrapper returning null on empty
- tests/lib/ussc/distribution.test.ts (NEW, 17 tests)
- tests/lib/ussc/intelligence-brief-wire.test.ts (NEW, 3 tests)
- src/app/api/generate/xray-sections/route.ts (X3 section wired)
- src/app/api/reports/mechanical/[caseId]/route.ts (CD pre-fetch + opts pass-through)
- src/lib/report/mechanical/render-case-decoder.ts (CaseDecoderMechanicalOpts param)
- src/lib/report/mechanical/__tests__/render-case-decoder.test.ts (2 new TICKET-17 tests)
- src/lib/tier9-reports/generate.ts (JRC overlay appended after Sentencing Fingerprint)

## Per-tier wired
- CD: YES — mechanical render route, one-sentence section
- IB: YES (lib + Node-side wire) — Edge Function consumption deferred per cross-project shared-USSC plan; lib is single source of truth
- X-Ray: YES — X3 section in xray-sections/route.ts
- JRC: YES — appended after Sentencing Fingerprint in tier9-reports/generate.ts

## Sample helper output (IB tier, drug-trafficking @ district 42, n=60 / n=5000)
"In your district, federal sentences for this charge across FY14-FY24 (60 cases): median 36 months, with the middle 50% landing between 24 and 72 months. Nationally for the same FY range (5000 cases): median 30 months, p25 18, p75 60."

## Coverage gates
CD 20 / IB 50 / X-Ray 100 / JRC 150 cases. Below floor → district_agg dropped, national fallback rendered, fallback_reason populated. Freshness is_stale boolean appended to render output when >30d.

## Test plan
- [x] vitest 22/22 new + 4/4 preserved CD-mechanical
- [x] regression sweep tier9-reports + xray-sections 203/203 pass
- [x] tsc --noEmit clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)