### PR TITLE
feat(dpic): capital-adjacency context for sex-offense + federal playbooks + X-Ray (TICKET-19)

### DIFF
--- a/src/lib/dpic/__tests__/__snapshots__/capital-context.test.ts.snap
+++ b/src/lib/dpic/__tests__/__snapshots__/capital-context.test.ts.snap
@@ -1,0 +1,49 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`renderCapitalContextHtml — HTML snapshots > MA treason federal-carve-out snapshot (abolished state + federally eligible) 1`] = `
+"
+    <aside class="capital-context" data-eligible="true" data-state="MA" data-class="treason">
+      <h3 class="cap-context-title">Capital-Eligibility Check</h3>
+      <p class="cap-context-lead">
+        This charge class can theoretically reach the capital tier. That does not mean it will. It means the eligibility line is on the map for cases like this, and the calculation belongs in your file.
+      </p>
+      <ul class="cap-context-stats">
+        <li>MA has no death-penalty statute.</li>
+        <li>Past decade in MA: <strong>0</strong> executions.</li>
+        <li>MA has carried out no executions in the past decade.</li>
+      </ul>
+      <p class="cap-context-fed">Federal jurisdiction can pursue capital punishment for charges in this class regardless of state-level abolition. The Boston Marathon case is the canonical post-1976 example: the underlying state had no statute, the federal charge did.</p>
+      <p class="cap-context-handoff">
+        Your attorney will run this calculation for your specific case facts &mdash; the aggravators, the jurisdiction, the prosecution's stated theory. Mercer's job here is to make sure that calculation actually happens, not to substitute for it.
+      </p>
+      <p class="cap-context-sources">
+        Sources: DPIC executions database (<a href="http://deathpenaltyinfo.org/query/executions.csv" target="_blank" rel="noopener">executions.csv</a>); DPIC state-by-state policy table (<a href="https://deathpenaltyinfo.org/state-and-federal-info/state-by-state" target="_blank" rel="noopener">state-and-federal-info</a>). Both updated continuously by the Death Penalty Information Center.
+      </p>
+    </aside>
+  "
+`;
+
+exports[`renderCapitalContextHtml — HTML snapshots > TX murder-capital active-retention snapshot 1`] = `
+"
+    <aside class="capital-context" data-eligible="true" data-state="TX" data-class="murder-capital">
+      <h3 class="cap-context-title">Capital-Eligibility Check</h3>
+      <p class="cap-context-lead">
+        This charge class can theoretically reach the capital tier. That does not mean it will. It means the eligibility line is on the map for cases like this, and the calculation belongs in your file.
+      </p>
+      <ul class="cap-context-stats">
+        <li>TX retains the death penalty in statute.</li>
+        <li>Past decade in TX: <strong>73</strong> executions.</li>
+        <li>Last execution in TX: <strong>2025</strong>.</li>
+      </ul>
+      <p class="cap-context-fed">Federal jurisdiction can pursue capital punishment for charges in this class regardless of state-level abolition. The Boston Marathon case is the canonical post-1976 example: the underlying state had no statute, the federal charge did.</p>
+      <p class="cap-context-handoff">
+        Your attorney will run this calculation for your specific case facts &mdash; the aggravators, the jurisdiction, the prosecution's stated theory. Mercer's job here is to make sure that calculation actually happens, not to substitute for it.
+      </p>
+      <p class="cap-context-sources">
+        Sources: DPIC executions database (<a href="http://deathpenaltyinfo.org/query/executions.csv" target="_blank" rel="noopener">executions.csv</a>); DPIC state-by-state policy table (<a href="https://deathpenaltyinfo.org/state-and-federal-info/state-by-state" target="_blank" rel="noopener">state-and-federal-info</a>). Both updated continuously by the Death Penalty Information Center.
+      </p>
+    </aside>
+  "
+`;
+
+exports[`renderCapitalContextHtml — HTML snapshots > ineligible charge renders empty string (snapshot confirms no HTML emitted) 1`] = `""`;

--- a/src/lib/dpic/__tests__/capital-context.test.ts
+++ b/src/lib/dpic/__tests__/capital-context.test.ts
@@ -1,0 +1,440 @@
+/**
+ * Unit tests for TICKET-19 — capital-adjacency context helper.
+ *
+ * Coverage gates:
+ *   1. Helper logic — federal-eligible vs state-eligible vs neither
+ *   2. Render gate — output empty when eligibility=false (HARD)
+ *   3. UPL parity — rendered HTML never contains banned phrases
+ *   4. UPL parity — rendered HTML never contains predictive language
+ *   5. Charge-class extraction — strict mapping, returns null for unknown
+ *   6. Mercer voice parity — required theoretical/contextual phrases present
+ *   7. Source-URL chain — DPIC URL stored on every eligible context
+ *   8. State-by-state map — every entry has valid status
+ *   9. Tier surface predicate — only sex-offense + federal-criminal slugs
+ */
+import { describe, it, expect } from "vitest";
+import {
+  CAPITAL_SIDEBAR_PLAYBOOK_SLUGS,
+  DPIC_EXECUTIONS_SOURCE_URL,
+  DPIC_POLICY_SOURCE_URL,
+  FEDERAL_CAPITAL_ELIGIBLE_CLASSES,
+  STATE_CAPITAL_STATUS,
+  chargeClassForSlug,
+  getCapitalContext,
+  playbookSlugSupportsCapitalSidebar,
+  renderCapitalContextHtml,
+} from "../capital-context";
+import { UPL_BANNED_PHRASES } from "@/lib/charge-slug-maps";
+
+// ------------------------------------------------------------------
+// 1. Helper logic — eligibility paths
+// ------------------------------------------------------------------
+
+describe("getCapitalContext — eligibility logic", () => {
+  it("eligible=true when state retains active statute (TX + capital murder)", () => {
+    const ctx = getCapitalContext({
+      state: "TX",
+      chargeClass: "murder-capital",
+      surface: "playbook",
+    });
+    expect(ctx.eligible).toBe(true);
+    expect(ctx.stateCapitalEligibility).toBe("active");
+    expect(ctx.federalCapitalEligible).toBe(true);
+  });
+
+  it("eligible=true when state has moratorium (CA + capital murder)", () => {
+    const ctx = getCapitalContext({
+      state: "CA",
+      chargeClass: "murder-capital",
+      surface: "playbook",
+    });
+    expect(ctx.eligible).toBe(true);
+    expect(ctx.stateCapitalEligibility).toBe("moratorium");
+  });
+
+  it("eligible=true when state abolished BUT charge is federally eligible (MA + treason)", () => {
+    const ctx = getCapitalContext({
+      state: "MA",
+      chargeClass: "treason",
+      surface: "xray",
+    });
+    expect(ctx.eligible).toBe(true);
+    expect(ctx.stateCapitalEligibility).toBe("never");
+    expect(ctx.federalCapitalEligible).toBe(true);
+  });
+
+  it("eligible=true when state never had statute BUT charge is federally eligible (HI + terrorism-with-death)", () => {
+    const ctx = getCapitalContext({
+      state: "HI",
+      chargeClass: "terrorism-with-death",
+      surface: "xray",
+    });
+    expect(ctx.eligible).toBe(true);
+  });
+
+  it("eligible=false when state abolished AND charge class is felony-murder only", () => {
+    // felony-murder is a state-level class — not in FEDERAL_CAPITAL_ELIGIBLE_CLASSES.
+    const ctx = getCapitalContext({
+      state: "IL",
+      chargeClass: "felony-murder",
+      surface: "playbook",
+    });
+    expect(ctx.eligible).toBe(false);
+  });
+
+  it("eligible=false when state never had statute AND charge class is non-federal", () => {
+    const ctx = getCapitalContext({
+      state: "MN",
+      chargeClass: "felony-murder",
+      surface: "playbook",
+    });
+    expect(ctx.eligible).toBe(false);
+  });
+
+  it("captures lastDecadeExecutions + lastExecutionYear when supplied", () => {
+    const ctx = getCapitalContext({
+      state: "TX",
+      chargeClass: "murder-capital",
+      surface: "playbook",
+      lastDecadeExecutions: 73,
+      lastExecutionYear: 2025,
+    });
+    expect(ctx.lastDecadeExecutions).toBe(73);
+    expect(ctx.lastExecutionYear).toBe(2025);
+  });
+
+  it("defaults stats to 0 / null when not supplied", () => {
+    const ctx = getCapitalContext({
+      state: "TX",
+      chargeClass: "murder-capital",
+      surface: "playbook",
+    });
+    expect(ctx.lastDecadeExecutions).toBe(0);
+    expect(ctx.lastExecutionYear).toBeNull();
+  });
+
+  it("normalizes state input (lowercase, trimmed)", () => {
+    const ctx = getCapitalContext({
+      state: "  tx ",
+      chargeClass: "murder-capital",
+      surface: "playbook",
+    });
+    expect(ctx.state).toBe("TX");
+    expect(ctx.stateCapitalEligibility).toBe("active");
+  });
+
+  it("returns state=null when input is junk or wrong length", () => {
+    const ctx = getCapitalContext({
+      state: "California",
+      chargeClass: "murder-capital",
+      surface: "playbook",
+    });
+    expect(ctx.state).toBeNull();
+    expect(ctx.stateCapitalEligibility).toBeNull();
+  });
+});
+
+// ------------------------------------------------------------------
+// 2. Render gate — output empty when ineligible
+// ------------------------------------------------------------------
+
+describe("renderCapitalContextHtml — render gate", () => {
+  it("returns empty string when eligible=false (HARD)", () => {
+    const ctx = getCapitalContext({
+      state: "MN",
+      chargeClass: "felony-murder",
+      surface: "playbook",
+    });
+    expect(ctx.eligible).toBe(false);
+    const html = renderCapitalContextHtml(ctx);
+    expect(html).toBe("");
+  });
+
+  it("returns non-empty HTML when eligible=true (TX + murder-capital)", () => {
+    const ctx = getCapitalContext({
+      state: "TX",
+      chargeClass: "murder-capital",
+      surface: "playbook",
+      lastDecadeExecutions: 73,
+      lastExecutionYear: 2025,
+    });
+    const html = renderCapitalContextHtml(ctx);
+    expect(html.length).toBeGreaterThan(100);
+    expect(html).toContain("Capital-Eligibility Check");
+    expect(html).toContain("TX");
+    expect(html).toContain("73");
+  });
+
+  it("renders federal carve-out when state abolished but federal-eligible", () => {
+    const ctx = getCapitalContext({
+      state: "MA",
+      chargeClass: "treason",
+      surface: "xray",
+      lastDecadeExecutions: 0,
+      lastExecutionYear: null,
+    });
+    const html = renderCapitalContextHtml(ctx);
+    expect(html).toContain("Federal jurisdiction");
+    expect(html).toContain("Boston Marathon");
+  });
+});
+
+// ------------------------------------------------------------------
+// 3 + 4. UPL parity — banned + predictive phrases
+// ------------------------------------------------------------------
+
+describe("renderCapitalContextHtml — UPL parity", () => {
+  // Render every (state status x federal-eligible status) combo and confirm
+  // none of them ever produces banned-phrase output. This is the matrix
+  // gate: shape of the output text must stay UPL-clean across the table.
+  const eligibleSamples: Array<{
+    state: string;
+    chargeClass:
+      | "murder-capital"
+      | "treason"
+      | "terrorism-with-death"
+      | "sex-offense-resulting-in-death";
+    last: number;
+    yr: number | null;
+  }> = [
+    { state: "TX", chargeClass: "murder-capital", last: 73, yr: 2025 },
+    { state: "CA", chargeClass: "murder-capital", last: 0, yr: null },
+    { state: "MA", chargeClass: "treason", last: 0, yr: null },
+    { state: "HI", chargeClass: "terrorism-with-death", last: 0, yr: null },
+    { state: "FL", chargeClass: "sex-offense-resulting-in-death", last: 7, yr: 2023 },
+  ];
+
+  it.each(eligibleSamples)(
+    "never emits banned UPL phrases for $state / $chargeClass",
+    ({ state, chargeClass, last, yr }) => {
+      const ctx = getCapitalContext({
+        state,
+        chargeClass,
+        surface: "playbook",
+        lastDecadeExecutions: last,
+        lastExecutionYear: yr,
+      });
+      const html = renderCapitalContextHtml(ctx);
+      const lower = html.toLowerCase();
+      const hits = UPL_BANNED_PHRASES.filter((p) => lower.includes(p));
+      expect(hits, `Banned UPL phrases found: ${hits.join(", ")}`).toEqual([]);
+    },
+  );
+
+  it.each(eligibleSamples)(
+    "never emits predictive language for $state / $chargeClass",
+    ({ state, chargeClass, last, yr }) => {
+      const ctx = getCapitalContext({
+        state,
+        chargeClass,
+        surface: "playbook",
+        lastDecadeExecutions: last,
+        lastExecutionYear: yr,
+      });
+      const html = renderCapitalContextHtml(ctx);
+      const lower = html.toLowerCase();
+      // Predictive / outcome-promising phrases that, on a capital sidebar,
+      // would cross from information into advice. Bounded list.
+      const PREDICTIVE_BANNED = [
+        "you will be charged",
+        "you will face",
+        "death is likely",
+        "execution is likely",
+        "expect to be sentenced",
+        "you face execution",
+        "guaranteed outcome",
+        "prosecutors will pursue",
+        "the prosecution will seek",
+      ];
+      const hits = PREDICTIVE_BANNED.filter((p) => lower.includes(p));
+      expect(hits, `Predictive phrases found: ${hits.join(", ")}`).toEqual([]);
+    },
+  );
+
+  it("never emits predictive language even with junk state", () => {
+    const ctx = getCapitalContext({
+      state: null,
+      chargeClass: "treason",
+      surface: "xray",
+      lastDecadeExecutions: 0,
+      lastExecutionYear: null,
+    });
+    const html = renderCapitalContextHtml(ctx);
+    expect(html.toLowerCase()).not.toMatch(/will be charged|will face|likely (?:to be )?sentenced/);
+  });
+});
+
+// ------------------------------------------------------------------
+// 5. Charge-class extraction — strict mapping
+// ------------------------------------------------------------------
+
+describe("chargeClassForSlug", () => {
+  it("maps known capital-adjacent slugs", () => {
+    expect(chargeClassForSlug("first-degree-murder")).toBe("murder-capital");
+    expect(chargeClassForSlug("capital-murder")).toBe("murder-capital");
+    expect(chargeClassForSlug("murder")).toBe("murder-first-degree");
+    expect(chargeClassForSlug("felony-murder")).toBe("felony-murder");
+    expect(chargeClassForSlug("treason")).toBe("treason");
+    expect(chargeClassForSlug("espionage")).toBe("espionage");
+    expect(chargeClassForSlug("drug-trafficking-with-death")).toBe(
+      "drug-trafficking-with-death",
+    );
+    expect(chargeClassForSlug("terrorism-with-death")).toBe("terrorism-with-death");
+    expect(chargeClassForSlug("sex-offense-resulting-in-death")).toBe(
+      "sex-offense-resulting-in-death",
+    );
+  });
+
+  it("normalizes case + whitespace", () => {
+    expect(chargeClassForSlug("  Treason ")).toBe("treason");
+    expect(chargeClassForSlug("CAPITAL-MURDER")).toBe("murder-capital");
+  });
+
+  it("returns null for unrelated charges (under-render is safer than over-render)", () => {
+    expect(chargeClassForSlug("dui")).toBeNull();
+    expect(chargeClassForSlug("drug-possession-marijuana")).toBeNull();
+    expect(chargeClassForSlug("sex-offense")).toBeNull(); // Generic sex-offense NOT auto-eligible
+    expect(chargeClassForSlug("sexual-assault")).toBeNull();
+    expect(chargeClassForSlug("rape")).toBeNull(); // Per Kennedy v. Louisiana
+    expect(chargeClassForSlug("white-collar")).toBeNull();
+    expect(chargeClassForSlug("")).toBeNull();
+    expect(chargeClassForSlug(null)).toBeNull();
+    expect(chargeClassForSlug(undefined)).toBeNull();
+  });
+});
+
+// ------------------------------------------------------------------
+// 6. Mercer voice parity
+// ------------------------------------------------------------------
+
+describe("renderCapitalContextHtml — Mercer voice parity", () => {
+  const ctx = getCapitalContext({
+    state: "TX",
+    chargeClass: "murder-capital",
+    surface: "playbook",
+    lastDecadeExecutions: 73,
+    lastExecutionYear: 2025,
+  });
+  const html = renderCapitalContextHtml(ctx);
+
+  it("contains theoretical/contextual phrasing (HARD per ticket)", () => {
+    expect(html).toContain("can theoretically reach");
+  });
+
+  it("hands attorney decision back to attorney (CHARM mode)", () => {
+    expect(html).toMatch(/your attorney will run/i);
+  });
+
+  it("never claims to substitute for attorney judgment", () => {
+    expect(html).toMatch(/not to substitute for it/i);
+  });
+
+  it("never uses urgency/speed framing (anti-pattern per brand-voice.md)", () => {
+    const lower = html.toLowerCase();
+    expect(lower).not.toContain("act now");
+    expect(lower).not.toContain("don't wait");
+    expect(lower).not.toContain("time is running out");
+  });
+});
+
+// ------------------------------------------------------------------
+// 7. Source-URL chain
+// ------------------------------------------------------------------
+
+describe("source URLs", () => {
+  it("DPIC executions URL constant matches migration source_url", () => {
+    expect(DPIC_EXECUTIONS_SOURCE_URL).toBe(
+      "http://deathpenaltyinfo.org/query/executions.csv",
+    );
+  });
+
+  it("DPIC policy URL is HTTPS", () => {
+    expect(DPIC_POLICY_SOURCE_URL.startsWith("https://")).toBe(true);
+  });
+
+  it("eligible context always carries both source URLs", () => {
+    const ctx = getCapitalContext({
+      state: "TX",
+      chargeClass: "murder-capital",
+      surface: "playbook",
+    });
+    expect(ctx.sourceUrl).toBe(DPIC_EXECUTIONS_SOURCE_URL);
+    expect(ctx.policySourceUrl).toBe(DPIC_POLICY_SOURCE_URL);
+  });
+
+  it("rendered HTML cites both DPIC URLs", () => {
+    const ctx = getCapitalContext({
+      state: "TX",
+      chargeClass: "murder-capital",
+      surface: "playbook",
+      lastDecadeExecutions: 73,
+      lastExecutionYear: 2025,
+    });
+    const html = renderCapitalContextHtml(ctx);
+    expect(html).toContain(DPIC_EXECUTIONS_SOURCE_URL);
+    expect(html).toContain(DPIC_POLICY_SOURCE_URL);
+  });
+});
+
+// ------------------------------------------------------------------
+// 8. State-by-state map integrity
+// ------------------------------------------------------------------
+
+describe("STATE_CAPITAL_STATUS map", () => {
+  it("covers all 50 states + DC (51 entries)", () => {
+    expect(Object.keys(STATE_CAPITAL_STATUS).length).toBe(51);
+  });
+
+  it("every entry has a valid status", () => {
+    const validStatuses = new Set(["active", "moratorium", "abolished", "never"]);
+    for (const [code, row] of Object.entries(STATE_CAPITAL_STATUS)) {
+      expect(code, `state code ${code}`).toMatch(/^[A-Z]{2}$/);
+      expect(validStatuses.has(row.status), `status for ${code}`).toBe(true);
+      if (row.status === "abolished") {
+        expect(row.abolishedYear, `abolishedYear for ${code}`).toBeGreaterThan(1976);
+      } else {
+        expect(row.abolishedYear, `abolishedYear for ${code}`).toBeNull();
+      }
+    }
+  });
+
+  it("federal-eligible class set contains expected categories", () => {
+    expect(FEDERAL_CAPITAL_ELIGIBLE_CLASSES.has("treason")).toBe(true);
+    expect(FEDERAL_CAPITAL_ELIGIBLE_CLASSES.has("espionage")).toBe(true);
+    expect(FEDERAL_CAPITAL_ELIGIBLE_CLASSES.has("murder-capital")).toBe(true);
+    expect(FEDERAL_CAPITAL_ELIGIBLE_CLASSES.has("terrorism-with-death")).toBe(true);
+    // felony-murder is a STATE-LEVEL class only (no federal felony-murder
+    // statute outside specific carve-outs); should NOT be federal-eligible
+    // in this map.
+    expect(FEDERAL_CAPITAL_ELIGIBLE_CLASSES.has("felony-murder")).toBe(false);
+  });
+});
+
+// ------------------------------------------------------------------
+// 9. Tier surface predicate — gate on which playbooks
+// ------------------------------------------------------------------
+
+describe("playbookSlugSupportsCapitalSidebar", () => {
+  it("returns true for sex-offense + federal-criminal only", () => {
+    expect(playbookSlugSupportsCapitalSidebar("sex-offense")).toBe(true);
+    expect(playbookSlugSupportsCapitalSidebar("federal-criminal")).toBe(true);
+  });
+
+  it("returns false for all other playbook slugs (HARD scope gate)", () => {
+    const otherPlaybooks = [
+      "dui-first-offense",
+      "drug-possession",
+      "drug-trafficking",
+      "white-collar",
+      "probation-violation",
+      "self-defense",
+    ];
+    for (const slug of otherPlaybooks) {
+      expect(playbookSlugSupportsCapitalSidebar(slug), slug).toBe(false);
+    }
+  });
+
+  it("set has exactly 2 entries (no scope creep)", () => {
+    expect(CAPITAL_SIDEBAR_PLAYBOOK_SLUGS.size).toBe(2);
+  });
+});

--- a/src/lib/dpic/__tests__/capital-context.test.ts
+++ b/src/lib/dpic/__tests__/capital-context.test.ts
@@ -438,3 +438,40 @@ describe("playbookSlugSupportsCapitalSidebar", () => {
     expect(CAPITAL_SIDEBAR_PLAYBOOK_SLUGS.size).toBe(2);
   });
 });
+
+// ------------------------------------------------------------------
+// 10. HTML structure snapshots — regression-lock the rendered output
+//     shape so refactors that change structure are always intentional.
+// ------------------------------------------------------------------
+
+describe("renderCapitalContextHtml — HTML snapshots", () => {
+  it("TX murder-capital active-retention snapshot", () => {
+    const ctx = getCapitalContext({
+      state: "TX",
+      chargeClass: "murder-capital",
+      surface: "playbook",
+      lastDecadeExecutions: 73,
+      lastExecutionYear: 2025,
+    });
+    expect(renderCapitalContextHtml(ctx!)).toMatchSnapshot();
+  });
+
+  it("MA treason federal-carve-out snapshot (abolished state + federally eligible)", () => {
+    const ctx = getCapitalContext({
+      state: "MA",
+      chargeClass: "treason",
+      surface: "playbook",
+    });
+    expect(renderCapitalContextHtml(ctx!)).toMatchSnapshot();
+  });
+
+  it("ineligible charge renders empty string (snapshot confirms no HTML emitted)", () => {
+    const ctx = getCapitalContext({
+      state: "MA",
+      chargeClass: "felony-murder",
+      surface: "playbook",
+    });
+    // eligible=false → renderCapitalContextHtml must return ""
+    expect(renderCapitalContextHtml(ctx!)).toMatchSnapshot();
+  });
+});

--- a/src/lib/dpic/capital-context.ts
+++ b/src/lib/dpic/capital-context.ts
@@ -1,0 +1,502 @@
+/**
+ * Capital-Adjacency Context (TICKET-19).
+ *
+ * For charges where the federal or state statutory maximum is *theoretically*
+ * capital, attach a sidebar that surfaces:
+ *   - Whether the buyer's state retains the death penalty in statute
+ *   - The last decade of executions in that state (count + last year)
+ *   - DPIC source URL for independent verification
+ *
+ * Voice: Mercer. Tone is theoretical / contextual, never predictive.
+ *
+ * UPL HARD RULES:
+ *   - Returned text MUST NOT predict outcomes ("will be charged capital",
+ *     "you face execution", "death is likely").
+ *   - Phrasing is bounded to "can theoretically reach" / "in your state, the
+ *     last decade of executions looked like this" / "your attorney should be
+ *     doing this calculation".
+ *   - Source URL is always the DPIC executions CSV (the row source) —
+ *     verification chain stays unbroken.
+ *   - Render gate: section ONLY appears when eligibility = true. No false
+ *     positives. No "your charge is unlikely to be capital" reassurance copy
+ *     (out of scope, opinion-adjacent).
+ *
+ * Tier surfaces:
+ *   - Sex Offense Playbook    (slug: "sex-offense")
+ *   - Federal Criminal Playbook (slug: "federal-criminal")
+ *   - X-Ray (discovery tier)
+ *
+ * Data source:
+ *   - Eligibility table: DPIC state-by-state
+ *     (https://deathpenaltyinfo.org/state-and-federal-info/state-by-state)
+ *     embedded as a const map below — DPIC is a stable authority and the
+ *     map changes only on legislative action (rare). Citation tied to every
+ *     row.
+ *   - Last-decade execution count: queried from public.dpic_executions.
+ *
+ * Why an embedded eligibility table instead of a DB lookup?
+ *   - DPIC's state-by-state status is policy state, not event data. Every
+ *     row of dpic_executions is an *event*. We need policy *and* event data
+ *     to answer the question; events alone do not tell us a state is
+ *     "abolitionist by statute" (e.g. NJ, IL — abolished post-1976 but with
+ *     pre-abolition executions still in dpic_executions).
+ *   - Map is small (~50 entries), changes ~once/year, and is the authoritative
+ *     "is this state capital-eligible right now?" answer. Citation is
+ *     embedded in the constant.
+ */
+
+// ============================================================
+// Types
+// ============================================================
+
+/**
+ * Statutory capital eligibility status of a US jurisdiction.
+ *
+ * - "active":     Death penalty in statute AND active (executions occur)
+ * - "moratorium": Death penalty in statute, governor-imposed pause (CA, OR, PA, TN)
+ * - "abolished":  Statute repealed (no longer a possible sentence)
+ * - "never":      Never adopted (no statute, no abolition needed)
+ */
+export type CapitalStatus = "active" | "moratorium" | "abolished" | "never";
+
+/**
+ * Charge class buckets we consider for capital adjacency.
+ *
+ * Federal capital-eligible charge classes (18 U.S.C. § 3591):
+ *   - first-degree murder (incl. murder-for-hire, federal officer murder)
+ *   - treason / espionage
+ *   - large-scale drug-trafficking-with-death (continuing criminal enterprise)
+ *   - terrorism resulting in death
+ *
+ * State capital-eligible charge classes (varies by state, but generally):
+ *   - capital murder / first-degree murder with aggravators
+ *   - aggravated felony murder
+ *
+ * Sex offense charges are NOT federally capital-eligible standing alone
+ * (Kennedy v. Louisiana, 554 U.S. 407 (2008) — death penalty for non-
+ * homicide rape of a child unconstitutional). However, we surface the
+ * sidebar on Sex Offense Playbook when the underlying charge involves a
+ * resulting death (sex-offense-felony-murder, sexual assault resulting in
+ * death) — those sit at the federal capital-eligible boundary via
+ * 18 U.S.C. § 2245 (sex offense resulting in death).
+ */
+export type CapitalEligibleChargeClass =
+  | "murder-first-degree"
+  | "murder-capital"
+  | "felony-murder"
+  | "treason"
+  | "espionage"
+  | "drug-trafficking-with-death"
+  | "terrorism-with-death"
+  | "sex-offense-resulting-in-death";
+
+export interface CapitalContext {
+  /**
+   * Whether to render the sidebar at all. False = render gate trips, no
+   * output. True = the charge is theoretically capital-eligible AND the
+   * state has a statute (active or moratorium) OR the charge is federal-
+   * eligible regardless of state status.
+   */
+  eligible: boolean;
+
+  /** Render-time hint: which surface invoked the helper. */
+  surface: "playbook" | "xray";
+
+  /** 2-letter state postal code (uppercase) — null when unknown. */
+  state: string | null;
+
+  /** Capital-adjacent charge class extracted from the buyer's charge. */
+  chargeClass: CapitalEligibleChargeClass;
+
+  /**
+   * State capital eligibility status. "never" / "abolished" still allow
+   * eligibility=true when the underlying charge is federally capital-
+   * eligible (federal jurisdiction overrides state status — Boston Marathon
+   * bombing was death-eligible in MA despite state abolition, because the
+   * federal charge under 18 U.S.C. § 2332a applied).
+   */
+  stateCapitalEligibility: CapitalStatus | null;
+
+  /** Whether the charge class triggers federal capital eligibility. */
+  federalCapitalEligible: boolean;
+
+  /** Number of executions in this state in the last 10 years (DPIC). */
+  lastDecadeExecutions: number;
+
+  /** Year of most recent execution in this state — null if none. */
+  lastExecutionYear: number | null;
+
+  /** Year of statute change for "abolished" — null when not applicable. */
+  abolishedYear: number | null;
+
+  /** DPIC executions CSV source URL — citation chain. */
+  sourceUrl: string;
+
+  /** DPIC state-by-state policy page — citation chain. */
+  policySourceUrl: string;
+}
+
+// ============================================================
+// State-by-state capital eligibility map
+// ============================================================
+//
+// Source: https://deathpenaltyinfo.org/state-and-federal-info/state-by-state
+// Captured 2026-05-03. Update on any legislative change.
+// `abolishedYear` = year statute was repealed, only present for "abolished".
+
+interface StateStatus {
+  status: CapitalStatus;
+  abolishedYear: number | null;
+}
+
+export const STATE_CAPITAL_STATUS: Record<string, StateStatus> = {
+  // Active death penalty states
+  AL: { status: "active", abolishedYear: null },
+  AZ: { status: "active", abolishedYear: null },
+  AR: { status: "active", abolishedYear: null },
+  FL: { status: "active", abolishedYear: null },
+  GA: { status: "active", abolishedYear: null },
+  ID: { status: "active", abolishedYear: null },
+  IN: { status: "active", abolishedYear: null },
+  KS: { status: "active", abolishedYear: null },
+  KY: { status: "active", abolishedYear: null },
+  LA: { status: "active", abolishedYear: null },
+  MS: { status: "active", abolishedYear: null },
+  MO: { status: "active", abolishedYear: null },
+  MT: { status: "active", abolishedYear: null },
+  NE: { status: "active", abolishedYear: null },
+  NV: { status: "active", abolishedYear: null },
+  NC: { status: "active", abolishedYear: null },
+  OH: { status: "active", abolishedYear: null },
+  OK: { status: "active", abolishedYear: null },
+  SC: { status: "active", abolishedYear: null },
+  SD: { status: "active", abolishedYear: null },
+  TN: { status: "active", abolishedYear: null },
+  TX: { status: "active", abolishedYear: null },
+  UT: { status: "active", abolishedYear: null },
+  WY: { status: "active", abolishedYear: null },
+
+  // Moratorium states (statute on books, governor-paused executions)
+  CA: { status: "moratorium", abolishedYear: null },
+  OR: { status: "moratorium", abolishedYear: null },
+  PA: { status: "moratorium", abolishedYear: null },
+
+  // Abolished states (statute repealed)
+  CO: { status: "abolished", abolishedYear: 2020 },
+  CT: { status: "abolished", abolishedYear: 2012 },
+  DE: { status: "abolished", abolishedYear: 2016 },
+  IL: { status: "abolished", abolishedYear: 2011 },
+  MD: { status: "abolished", abolishedYear: 2013 },
+  NH: { status: "abolished", abolishedYear: 2019 },
+  NJ: { status: "abolished", abolishedYear: 2007 },
+  NM: { status: "abolished", abolishedYear: 2009 },
+  NY: { status: "abolished", abolishedYear: 2007 },
+  VA: { status: "abolished", abolishedYear: 2021 },
+  WA: { status: "abolished", abolishedYear: 2018 },
+
+  // Never had a death penalty (no execution-era statute)
+  AK: { status: "never", abolishedYear: null },
+  HI: { status: "never", abolishedYear: null },
+  IA: { status: "never", abolishedYear: null },
+  ME: { status: "never", abolishedYear: null },
+  MA: { status: "never", abolishedYear: null },
+  MI: { status: "never", abolishedYear: null },
+  MN: { status: "never", abolishedYear: null },
+  ND: { status: "never", abolishedYear: null },
+  RI: { status: "never", abolishedYear: null },
+  VT: { status: "never", abolishedYear: null },
+  WV: { status: "never", abolishedYear: null },
+  WI: { status: "never", abolishedYear: null },
+
+  // DC — no death penalty
+  DC: { status: "never", abolishedYear: null },
+};
+
+// ============================================================
+// Charge classes that trigger federal capital eligibility
+// ============================================================
+//
+// Federal jurisdiction can pursue capital punishment regardless of state
+// abolition. Boston Marathon bombing (Tsarnaev) is the canonical example —
+// MA abolished its statute in 1984 but the federal charge under 18 U.S.C.
+// § 2332a allowed death sentence.
+
+export const FEDERAL_CAPITAL_ELIGIBLE_CLASSES: ReadonlySet<CapitalEligibleChargeClass> =
+  new Set([
+    "murder-first-degree",
+    "murder-capital",
+    "treason",
+    "espionage",
+    "drug-trafficking-with-death",
+    "terrorism-with-death",
+    "sex-offense-resulting-in-death",
+  ]);
+
+// ============================================================
+// Source URLs
+// ============================================================
+
+export const DPIC_EXECUTIONS_SOURCE_URL =
+  "http://deathpenaltyinfo.org/query/executions.csv";
+
+export const DPIC_POLICY_SOURCE_URL =
+  "https://deathpenaltyinfo.org/state-and-federal-info/state-by-state";
+
+// ============================================================
+// Helper API
+// ============================================================
+
+/**
+ * Build a CapitalContext for the given state + charge class.
+ *
+ * Pure helper (no DB access). DB-backed last-decade execution count is
+ * supplied via `lastDecadeExecutions` + `lastExecutionYear` parameters,
+ * letting the caller batch the query (queryCapitalExecutionStats below)
+ * across multiple states without re-running the helper per row.
+ *
+ * Render gate (eligible=true) requires:
+ *   - Charge class is in CAPITAL_ELIGIBLE_CLASSES, AND
+ *   - At least one of:
+ *     - state has an active or moratorium statute, OR
+ *     - charge class is federally capital-eligible (federal jurisdiction
+ *       pre-empts state abolition)
+ *
+ * Returns `eligible: false` when neither is true — the renderer SKIPS the
+ * section entirely. No reassurance copy.
+ */
+export function getCapitalContext(args: {
+  state: string | null;
+  chargeClass: CapitalEligibleChargeClass;
+  surface: "playbook" | "xray";
+  lastDecadeExecutions?: number;
+  lastExecutionYear?: number | null;
+}): CapitalContext {
+  const { chargeClass, surface } = args;
+  const stateRaw = (args.state ?? "").trim().toUpperCase();
+  const state = stateRaw.length === 2 ? stateRaw : null;
+  const stateRow = state ? STATE_CAPITAL_STATUS[state] : undefined;
+  const stateCapitalEligibility = stateRow?.status ?? null;
+  const abolishedYear = stateRow?.abolishedYear ?? null;
+  const federalCapitalEligible = FEDERAL_CAPITAL_ELIGIBLE_CLASSES.has(chargeClass);
+
+  // Eligibility gate: state-active OR state-moratorium OR federal-eligible.
+  const stateEligible =
+    stateCapitalEligibility === "active" || stateCapitalEligibility === "moratorium";
+  const eligible = stateEligible || federalCapitalEligible;
+
+  return {
+    eligible,
+    surface,
+    state,
+    chargeClass,
+    stateCapitalEligibility,
+    federalCapitalEligible,
+    lastDecadeExecutions: args.lastDecadeExecutions ?? 0,
+    lastExecutionYear: args.lastExecutionYear ?? null,
+    abolishedYear,
+    sourceUrl: DPIC_EXECUTIONS_SOURCE_URL,
+    policySourceUrl: DPIC_POLICY_SOURCE_URL,
+  };
+}
+
+// ============================================================
+// DB-backed stats query (batchable)
+// ============================================================
+
+/**
+ * Returns last-decade execution count + most-recent year for each state in
+ * `states`. Service-role DB access only (server-side; aligned with the rest
+ * of the addendum/X-Ray data layer in this repo).
+ *
+ * Query is bounded to dpic_executions (defended by ARCHITECTURE.md
+ * invariant #4 — service-role DB access only on server).
+ */
+export async function queryCapitalExecutionStats(
+  states: readonly string[],
+): Promise<Map<string, { count: number; lastYear: number | null }>> {
+  const out = new Map<string, { count: number; lastYear: number | null }>();
+  if (states.length === 0) return out;
+
+  // Lazy import — keeps the helper unit-testable without the supabase admin
+  // client in the import graph.
+  const { createAdminClient } = await import("@/lib/supabase/admin");
+  const supabase = createAdminClient();
+
+  const cutoffDate = new Date();
+  cutoffDate.setFullYear(cutoffDate.getFullYear() - 10);
+  const cutoffIso = cutoffDate.toISOString().slice(0, 10);
+
+  const { data } = await supabase
+    .from("dpic_executions")
+    .select("state_code, execution_date")
+    .in("state_code", states.map((s) => s.toUpperCase()))
+    .gte("execution_date", cutoffIso);
+
+  for (const state of states) {
+    out.set(state.toUpperCase(), { count: 0, lastYear: null });
+  }
+  for (const row of data ?? []) {
+    const code = (row.state_code as string).toUpperCase();
+    const cur = out.get(code) ?? { count: 0, lastYear: null };
+    cur.count += 1;
+    const yr = Number(String(row.execution_date).slice(0, 4));
+    if (Number.isFinite(yr) && (cur.lastYear === null || yr > cur.lastYear)) {
+      cur.lastYear = yr;
+    }
+    out.set(code, cur);
+  }
+  return out;
+}
+
+// ============================================================
+// Charge-class extraction
+// ============================================================
+
+/**
+ * Map an internal charge slug or charge type to a capital-eligible charge
+ * class. Returns null when the charge is NOT in our capital-adjacent set
+ * (the helper render gate then skips the section).
+ *
+ * This is intentionally strict — anything not on the explicit list returns
+ * null. False positives here become silent UPL exposure on customer
+ * playbooks. Better to under-render than over-render.
+ */
+export function chargeClassForSlug(
+  chargeSlug: string | null | undefined,
+): CapitalEligibleChargeClass | null {
+  if (!chargeSlug) return null;
+  const c = chargeSlug.toLowerCase().trim();
+
+  // First-degree / capital murder
+  if (c === "murder-first-degree" || c === "first-degree-murder" || c === "capital-murder") {
+    return "murder-capital";
+  }
+  if (c === "murder" || c === "homicide-first-degree") {
+    return "murder-first-degree";
+  }
+  if (c === "felony-murder") return "felony-murder";
+
+  // Federal-only categories
+  if (c === "treason") return "treason";
+  if (c === "espionage") return "espionage";
+  if (c === "drug-trafficking-with-death" || c === "cce-with-death") {
+    return "drug-trafficking-with-death";
+  }
+  if (c === "terrorism-with-death" || c === "wmd-resulting-in-death") {
+    return "terrorism-with-death";
+  }
+
+  // Sex-offense + resulting death (post-Kennedy v. Louisiana, this is the
+  // only sex-offense charge class that remains theoretically capital-
+  // eligible at the federal level via 18 U.S.C. § 2245).
+  if (c === "sex-offense-resulting-in-death" || c === "sexual-assault-resulting-in-death") {
+    return "sex-offense-resulting-in-death";
+  }
+
+  return null;
+}
+
+// ============================================================
+// Mercer-voiced render block
+// ============================================================
+//
+// HARD UPL constraints:
+//   - No "you should" / "we recommend" / "best course of action" / etc.
+//     (See UPL_BANNED_PHRASES in charge-slug-maps.ts.)
+//   - No predictive language ("you will face", "expect to be charged
+//     capital", "death is likely").
+//   - Frame as historical / contextual / theoretical.
+//   - Always cite DPIC for both eligibility status and execution counts.
+//
+// Voice: Mercer (TACTICAL when describing the system; CHARM only in the
+// "your attorney" line). See .claude/rules/brand-voice.md.
+
+/**
+ * Returns Mercer-voiced HTML for the capital-context sidebar, OR an empty
+ * string if `ctx.eligible` is false. The empty-string contract is the
+ * render gate — callers can always splice the return value into the
+ * surrounding template without checking eligibility separately.
+ */
+export function renderCapitalContextHtml(ctx: CapitalContext): string {
+  if (!ctx.eligible) return "";
+
+  const stateLabel = ctx.state ?? "your state";
+  const lastExecLine =
+    ctx.lastExecutionYear !== null
+      ? `Last execution in ${stateLabel}: <strong>${ctx.lastExecutionYear}</strong>.`
+      : `${stateLabel} has carried out no executions in the past decade.`;
+
+  const decadeLine = `Past decade in ${stateLabel}: <strong>${ctx.lastDecadeExecutions}</strong> ${ctx.lastDecadeExecutions === 1 ? "execution" : "executions"}.`;
+
+  let policyLine: string;
+  switch (ctx.stateCapitalEligibility) {
+    case "active":
+      policyLine = `${stateLabel} retains the death penalty in statute.`;
+      break;
+    case "moratorium":
+      policyLine = `${stateLabel} retains the statute. Executions are paused under a governor-imposed moratorium.`;
+      break;
+    case "abolished":
+      policyLine = ctx.abolishedYear
+        ? `${stateLabel} repealed its death-penalty statute in ${ctx.abolishedYear}.`
+        : `${stateLabel} has abolished its death-penalty statute.`;
+      break;
+    case "never":
+      policyLine = `${stateLabel} has no death-penalty statute.`;
+      break;
+    default:
+      policyLine = "State statute status is not on file in our reference table.";
+  }
+
+  const federalNote = ctx.federalCapitalEligible
+    ? `<p class="cap-context-fed">Federal jurisdiction can pursue capital punishment for charges in this class regardless of state-level abolition. The Boston Marathon case is the canonical post-1976 example: the underlying state had no statute, the federal charge did.</p>`
+    : "";
+
+  // Mercer-voiced framing block. Phrasing is theoretical / contextual.
+  // "Can theoretically reach" is the bounded-eligibility phrase. The
+  // attorney-handoff line is Mercer's CHARM mode — confident, never
+  // directive.
+  return `
+    <aside class="capital-context" data-eligible="true" data-state="${ctx.state ?? ""}" data-class="${ctx.chargeClass}">
+      <h3 class="cap-context-title">Capital-Eligibility Check</h3>
+      <p class="cap-context-lead">
+        This charge class can theoretically reach the capital tier. That does not mean it will. It means the eligibility line is on the map for cases like this, and the calculation belongs in your file.
+      </p>
+      <ul class="cap-context-stats">
+        <li>${policyLine}</li>
+        <li>${decadeLine}</li>
+        <li>${lastExecLine}</li>
+      </ul>
+      ${federalNote}
+      <p class="cap-context-handoff">
+        Your attorney will run this calculation for your specific case facts &mdash; the aggravators, the jurisdiction, the prosecution's stated theory. Mercer's job here is to make sure that calculation actually happens, not to substitute for it.
+      </p>
+      <p class="cap-context-sources">
+        Sources: DPIC executions database (<a href="${ctx.sourceUrl}" target="_blank" rel="noopener">executions.csv</a>); DPIC state-by-state policy table (<a href="${ctx.policySourceUrl}" target="_blank" rel="noopener">state-and-federal-info</a>). Both updated continuously by the Death Penalty Information Center.
+      </p>
+    </aside>
+  `;
+}
+
+// ============================================================
+// Tier-eligibility (which playbook slugs / surfaces get the sidebar)
+// ============================================================
+
+/**
+ * Playbook slugs that get the capital-context sidebar attached.
+ * Other playbooks (DUI, drug possession, white collar, etc.) are not in
+ * scope per TICKET-19 — capital adjacency is irrelevant for those classes.
+ */
+export const CAPITAL_SIDEBAR_PLAYBOOK_SLUGS: ReadonlySet<string> = new Set([
+  "sex-offense",
+  "federal-criminal",
+]);
+
+/**
+ * Convenience predicate: should this playbook attempt to render the
+ * capital sidebar? (Eligibility within the sidebar is gated separately
+ * via getCapitalContext.eligible.)
+ */
+export function playbookSlugSupportsCapitalSidebar(slug: string): boolean {
+  return CAPITAL_SIDEBAR_PLAYBOOK_SLUGS.has(slug);
+}

--- a/src/lib/playbook-addendum/__tests__/__snapshots__/generate.test.ts.snap
+++ b/src/lib/playbook-addendum/__tests__/__snapshots__/generate.test.ts.snap
@@ -1,0 +1,206 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Playbook Addendum — capital-adjacency sidebar snapshot (TICKET-19) > addendum with TX murder-capital eligible context includes capital sidebar HTML 1`] = `
+"
+    
+    <style>
+      .playbook-addendum { font-family: -apple-system, BlinkMacSystemFont, sans-serif; max-width: 1020px; margin: 2em auto; padding: 1em; color: #111; }
+      .playbook-addendum h1 { font-size: 1.6em; margin: 0 0 0.25em; }
+      .playbook-addendum .pa-subtitle { color: #555; margin: 0 0 1em; }
+      .playbook-addendum .pa-gate { background: #fff8e1; border-left: 4px solid #f9a825; padding: 0.75em 1em; margin: 0 0 1.5em; }
+      .playbook-addendum .pa-section { margin: 2em 0; }
+      .playbook-addendum .pa-section h2 { font-size: 1.2em; margin: 0 0 0.5em; border-bottom: 1px solid #e0e0e0; padding-bottom: 0.25em; }
+      .playbook-addendum .pa-intro { color: #555; margin: 0.25em 0 0.75em; }
+      .playbook-addendum .pa-empty { color: #888; font-style: italic; }
+      .playbook-addendum .pa-note { color: #4a6fa5; font-size: 0.92em; margin: 0 0 0.75em; }
+      .playbook-addendum .pa-table { width: 100%; border-collapse: collapse; margin: 0.5em 0; font-size: 0.9em; }
+      .playbook-addendum .pa-table th, .playbook-addendum .pa-table td { text-align: left; padding: 0.45em 0.7em; border-bottom: 1px solid #e8e8e8; vertical-align: top; }
+      .playbook-addendum .pa-table th { background: #f5f5f5; font-weight: 600; }
+      .playbook-addendum .pa-date { color: #777; font-size: 0.85em; margin-left: 4px; }
+      .playbook-addendum .pa-context { font-style: italic; color: #333; max-width: 28em; }
+      .playbook-addendum .pa-small { color: #999; font-style: italic; font-size: 0.9em; }
+      .playbook-addendum .pa-arrow { font-weight: bold; font-size: 1.1em; }
+      .playbook-addendum .pa-up { color: #1b5e20; }
+      .playbook-addendum .pa-down { color: #b71c1c; }
+      .playbook-addendum .pa-flat { color: #777; }
+      .playbook-addendum .pa-scope { color: #777; font-size: 0.82em; margin-top: 0.5em; }
+      .playbook-addendum .pa-limits { margin-top: 1.5em; padding: 0.75em 1em; background: #f0f4f8; border-left: 3px solid #4a6fa5; font-size: 0.9em; }
+      .playbook-addendum .pa-upsell { margin: 2em 0; padding: 1em 1.25em; border: 1px solid #F59E0B; background: #fffaf0; border-radius: 6px; }
+      .playbook-addendum .pa-upsell h2 { margin-top: 0; }
+      .playbook-addendum .pa-upsell-list { list-style: none; padding-left: 0; }
+      .playbook-addendum .pa-upsell-list li { margin: 0.75em 0; }
+      .playbook-addendum .pa-upsell-link { display: inline-block; margin-top: 0.25em; color: #B45309; text-decoration: underline; font-weight: 600; }
+      .playbook-addendum .pa-footer { margin-top: 2em; padding-top: 1em; border-top: 2px solid #333; color: #555; font-size: 0.9em; }
+    </style>
+  
+    
+    <style>
+      .playbook-addendum .capital-context {
+        margin: 2em 0;
+        padding: 1em 1.25em;
+        border-left: 4px solid #b71c1c;
+        background: #fff5f5;
+        border-radius: 4px;
+      }
+      .playbook-addendum .capital-context .cap-context-title {
+        font-size: 1.05em;
+        margin: 0 0 0.5em;
+        color: #7f1010;
+        font-weight: 600;
+      }
+      .playbook-addendum .capital-context .cap-context-lead {
+        margin: 0 0 0.75em;
+        font-weight: 500;
+      }
+      .playbook-addendum .capital-context .cap-context-stats {
+        margin: 0 0 0.75em;
+        padding-left: 1.25em;
+      }
+      .playbook-addendum .capital-context .cap-context-stats li {
+        margin: 0.25em 0;
+      }
+      .playbook-addendum .capital-context .cap-context-fed {
+        margin: 0.75em 0;
+        padding: 0.5em 0.75em;
+        background: #fff8f0;
+        border-left: 3px solid #b45309;
+        font-size: 0.95em;
+      }
+      .playbook-addendum .capital-context .cap-context-handoff {
+        margin: 0.75em 0 0.5em;
+        font-style: italic;
+        color: #444;
+      }
+      .playbook-addendum .capital-context .cap-context-sources {
+        margin: 0.75em 0 0;
+        font-size: 0.82em;
+        color: #777;
+      }
+    </style>
+  
+    <section class="playbook-addendum">
+      
+    <header class="pa-header">
+      <h1>Circuit Addendum &mdash; Sex Offense Defense Playbook</h1>
+      <p class="pa-subtitle">Your circuit: <strong>Ninth Circuit</strong> (CA)</p>
+      <p class="pa-gate"><strong>This is legal INFORMATION, not legal ADVICE.</strong> Numbers below come from published court records. They describe what has happened, not what will happen in any specific case.</p>
+    </header>
+  
+      
+    <section class="pa-section">
+      <h2>Top 1 motions filed in Sex Offense &mdash; Ninth Circuit</h2>
+      <p class="pa-intro">
+        The most frequently filed motion types in Sex Offense opinions in our federal criminal corpus, with grant rates and a comparison to the Ninth Circuit baseline. Small samples (N &lt; 10) are flagged.
+      </p>
+      <table class="pa-table">
+        <thead>
+          <tr>
+            <th>Motion type</th>
+            <th>N filed</th>
+            <th>Granted</th>
+            <th>Grant rate</th>
+            <th>Baseline</th>
+            <th>Delta</th>
+          </tr>
+        </thead>
+        <tbody>
+          
+            <tr>
+              <td>Dismiss Motion</td>
+              <td>50</td>
+              <td>20</td>
+              <td>40.0%</td>
+              <td>35.0%</td>
+              <td>+5.0pp</td>
+            </tr>
+        </tbody>
+      </table>
+      <p class="pa-scope">Source: motion_outcome_rates + motion_outcome_rates_by_circuit (Ninth Circuit baseline). Top 5 by volume.</p>
+    </section>
+      
+    <section class="pa-section">
+      <h2>Top 1 must-cite authorities for Sex Offense</h2>
+      <p class="pa-intro">
+        Ranked by citation frequency in Sex Offense opinions. Each row links to the primary opinion on CourtListener for independent verification &mdash; no row appears without a verification URL on file.
+      </p>
+      
+      <table class="pa-table">
+        <thead>
+          <tr>
+            <th>#</th>
+            <th>Case</th>
+            <th>Citation</th>
+            <th>Cites (charge / total)</th>
+            <th>Velocity</th>
+            <th>Context</th>
+          </tr>
+        </thead>
+        <tbody>
+          
+            <tr>
+              <td>1</td>
+              <td>
+                <a href="https://www.courtlistener.com/opinion/1/" target="_blank" rel="noopener">United States v. Example</a>
+                <span class="pa-date">(2015)</span>
+              </td>
+              <td>555 U.S. 100</td>
+              <td>42 / 500</td>
+              <td><span class="pa-arrow pa-up" aria-label="rising">&#9650;</span></td>
+              <td class="pa-context">A sample holding sentence from the opinion.</td>
+            </tr>
+        </tbody>
+      </table>
+      <p class="pa-scope">Source: charge_type_top_authorities; enriched with authority_quotes_criminal + citation_velocity_criminal. Rows without verification URLs are suppressed. Top 5 by charge-specific citation count.</p>
+    </section>
+      
+    <aside class="capital-context" data-eligible="true" data-state="TX" data-class="murder-capital">
+      <h3 class="cap-context-title">Capital-Eligibility Check</h3>
+      <p class="cap-context-lead">
+        This charge class can theoretically reach the capital tier. That does not mean it will. It means the eligibility line is on the map for cases like this, and the calculation belongs in your file.
+      </p>
+      <ul class="cap-context-stats">
+        <li>TX retains the death penalty in statute.</li>
+        <li>Past decade in TX: <strong>73</strong> executions.</li>
+        <li>Last execution in TX: <strong>2025</strong>.</li>
+      </ul>
+      <p class="cap-context-fed">Federal jurisdiction can pursue capital punishment for charges in this class regardless of state-level abolition. The Boston Marathon case is the canonical post-1976 example: the underlying state had no statute, the federal charge did.</p>
+      <p class="cap-context-handoff">
+        Your attorney will run this calculation for your specific case facts &mdash; the aggravators, the jurisdiction, the prosecution's stated theory. Mercer's job here is to make sure that calculation actually happens, not to substitute for it.
+      </p>
+      <p class="cap-context-sources">
+        Sources: DPIC executions database (<a href="http://deathpenaltyinfo.org/query/executions.csv" target="_blank" rel="noopener">executions.csv</a>); DPIC state-by-state policy table (<a href="https://deathpenaltyinfo.org/state-and-federal-info/state-by-state" target="_blank" rel="noopener">state-and-federal-info</a>). Both updated continuously by the Death Penalty Information Center.
+      </p>
+    </aside>
+  
+      
+    <section class="pa-upsell">
+      <h2>Want more depth?</h2>
+      <p>
+        This addendum shows the top 5 motions and top 5 authorities as a companion to your playbook. For deeper tooling:
+      </p>
+      <ul class="pa-upsell-list">
+        <li>
+          <strong>Motion Success Report &mdash; $197.</strong>
+          Top 10 motions (double this addendum), motion grant rates in front of your specific judge when available, top 10 granted-motion citations.
+          <a href="/checkout?tier=motion-success-report" class="pa-upsell-link">Get the Motion Success Report &rarr;</a>
+        </li>
+        <li>
+          <strong>Charge Authority Pack &mdash; $97.</strong>
+          Top 10 authorities with richer quote presentation, velocity arrows on every row, citation-frequency context.
+          <a href="/checkout?tier=charge-authority-pack" class="pa-upsell-link">Get the Authority Pack &rarr;</a>
+        </li>
+      </ul>
+    </section>
+  
+      
+      
+    <footer class="pa-footer">
+      <h3>Methodology</h3>
+      <p>This report provides legal INFORMATION &mdash; not legal ADVICE. The analysis draws on methods developed by elite defense attorneys, applied specifically to your case details. Your attorney remains the final authority on strategy decisions.</p>
+      <p>Frequencies and citation counts are tallied from published opinions in our federal criminal corpus. A grant rate of X% means: of N motions of that type filed in the scope shown, X% were granted in the opinions we could classify. Small samples (N &lt; 10) are flagged. Citations link to the primary source on CourtListener for independent verification.</p>
+      <p>No part of this report constitutes a prediction. It is a map of what is already in the record.</p>
+    </footer>
+  
+    </section>
+  "
+`;

--- a/src/lib/playbook-addendum/__tests__/generate.test.ts
+++ b/src/lib/playbook-addendum/__tests__/generate.test.ts
@@ -77,6 +77,7 @@ function mkData(over: Partial<PlaybookAddendumData> = {}): PlaybookAddendumData 
     quoteCoverageNote: null,
     limitations: [],
     isEmpty: false,
+    capitalContext: null,
     ...over,
   };
 }

--- a/src/lib/playbook-addendum/__tests__/generate.test.ts
+++ b/src/lib/playbook-addendum/__tests__/generate.test.ts
@@ -24,6 +24,7 @@ import {
   type PlaybookAddendumData,
 } from "../generate";
 import { renderPlaybookAddendum, UPL_BANNED_PHRASES } from "../render";
+import { getCapitalContext } from "@/lib/dpic/capital-context";
 
 // ------------------------------------------------------------------
 // Helpers
@@ -311,5 +312,33 @@ describe("Playbook Addendum — circuit resolution", () => {
 describe("Playbook Addendum — MIN_N threshold", () => {
   it("matches M1's sample-size threshold (10)", () => {
     expect(MIN_N).toBe(10);
+  });
+});
+
+// ------------------------------------------------------------------
+// 7. TICKET-19: capital-adjacency sidebar snapshot
+//    Regression-locks that renderPlaybookAddendum emits the sidebar
+//    block and its conditional <style> when capitalContext is eligible.
+// ------------------------------------------------------------------
+
+describe("Playbook Addendum — capital-adjacency sidebar snapshot (TICKET-19)", () => {
+  it("addendum with TX murder-capital eligible context includes capital sidebar HTML", () => {
+    const ctx = getCapitalContext({
+      state: "TX",
+      chargeClass: "murder-capital",
+      surface: "playbook",
+      lastDecadeExecutions: 73,
+      lastExecutionYear: 2025,
+    });
+    const html = renderPlaybookAddendum(
+      mkData({
+        playbookSlug: "sex-offense",
+        playbookDisplayName: "Sex Offense Defense Playbook",
+        chargeType: "sex_offense",
+        chargeDisplayName: "Sex Offense",
+        capitalContext: ctx ?? null,
+      }),
+    );
+    expect(html).toMatchSnapshot();
   });
 });

--- a/src/lib/playbook-addendum/generate.ts
+++ b/src/lib/playbook-addendum/generate.ts
@@ -40,6 +40,13 @@
  */
 
 import { createAdminClient } from "@/lib/supabase/admin";
+import {
+  type CapitalContext,
+  type CapitalEligibleChargeClass,
+  getCapitalContext,
+  playbookSlugSupportsCapitalSidebar,
+  queryCapitalExecutionStats,
+} from "@/lib/dpic/capital-context";
 
 // ============================================================
 // Types
@@ -49,6 +56,14 @@ export interface PlaybookAddendumInput {
   playbookSlug: string;      // one of PLAYBOOK_SLUGS
   state?: string | null;     // 2-letter postal (used to derive circuit)
   circuit?: string | null;   // "1".."11", "DC" (explicit override)
+  /**
+   * Optional capital-eligible charge class extracted from the buyer's
+   * actual charge slug. When supplied AND the playbook is in
+   * CAPITAL_SIDEBAR_PLAYBOOK_SLUGS (sex-offense / federal-criminal), the
+   * addendum attaches a capital-context sidebar (TICKET-19). When omitted
+   * OR ineligible, NO sidebar renders.
+   */
+  capitalChargeClass?: CapitalEligibleChargeClass | null;
 }
 
 export interface AddendumMotionRow {
@@ -90,6 +105,13 @@ export interface PlaybookAddendumData {
   quoteCoverageNote: string | null;   // shown when < all authorities have quotes
   limitations: string[];
   isEmpty: boolean;
+  /**
+   * Capital-adjacency context (TICKET-19). null when the playbook is not
+   * in CAPITAL_SIDEBAR_PLAYBOOK_SLUGS, or when capitalChargeClass was not
+   * supplied, or when the charge/state combination is not capital-eligible.
+   * Render layer skips the sidebar entirely on null OR ctx.eligible=false.
+   */
+  capitalContext: CapitalContext | null;
 }
 
 // ============================================================
@@ -294,6 +316,7 @@ export async function queryPlaybookAddendum(
       quoteCoverageNote: null,
       limitations: [`Playbook slug "${playbookSlug}" is not mapped to a charge type.`],
       isEmpty: true,
+      capitalContext: null,
     };
   }
 
@@ -577,6 +600,30 @@ export async function queryPlaybookAddendum(
 
   const isEmpty = motions.length === 0 && authorities.length === 0;
 
+  // ---------- TICKET-19: Capital-adjacency context ----------
+  // Only attempted when (a) the playbook is in the capital-sidebar slug set
+  // (sex-offense + federal-criminal) AND (b) the caller supplied a capital-
+  // eligible charge class. We then query last-decade execution stats from
+  // dpic_executions for the buyer's state.
+  let capitalContext: CapitalContext | null = null;
+  if (
+    playbookSlugSupportsCapitalSidebar(playbookSlug) &&
+    input.capitalChargeClass
+  ) {
+    const stats = state
+      ? await queryCapitalExecutionStats([state])
+      : new Map<string, { count: number; lastYear: number | null }>();
+    const stateStat = state ? stats.get(state) : undefined;
+    capitalContext = getCapitalContext({
+      state,
+      chargeClass: input.capitalChargeClass,
+      surface: "playbook",
+      lastDecadeExecutions: stateStat?.count ?? 0,
+      lastExecutionYear: stateStat?.lastYear ?? null,
+    });
+    if (!capitalContext.eligible) capitalContext = null; // render gate
+  }
+
   return {
     playbookSlug,
     playbookDisplayName,
@@ -590,5 +637,6 @@ export async function queryPlaybookAddendum(
     quoteCoverageNote,
     limitations,
     isEmpty,
+    capitalContext,
   };
 }

--- a/src/lib/playbook-addendum/render.ts
+++ b/src/lib/playbook-addendum/render.ts
@@ -20,6 +20,7 @@ import {
   type PlaybookAddendumData,
   type AddendumAuthorityRow,
 } from "./generate";
+import { renderCapitalContextHtml } from "@/lib/dpic/capital-context";
 
 // ============================================================
 // UPL blocklist — re-exported from the canonical source
@@ -259,12 +260,68 @@ export function renderPlaybookAddendum(data: PlaybookAddendumData): string {
     </style>
   `;
 
+  // ---------- TICKET-19: Capital-adjacency sidebar ----------
+  // Render gate: renderCapitalContextHtml returns "" when ineligible.
+  // The aside lives ABOVE the upgrade CTA so the buyer reads the eligibility
+  // calculation before the upsell.
+  const capitalSidebar = data.capitalContext
+    ? renderCapitalContextHtml(data.capitalContext)
+    : "";
+
+  const capitalStyles = `
+    <style>
+      .playbook-addendum .capital-context {
+        margin: 2em 0;
+        padding: 1em 1.25em;
+        border-left: 4px solid #b71c1c;
+        background: #fff5f5;
+        border-radius: 4px;
+      }
+      .playbook-addendum .capital-context .cap-context-title {
+        font-size: 1.05em;
+        margin: 0 0 0.5em;
+        color: #7f1010;
+        font-weight: 600;
+      }
+      .playbook-addendum .capital-context .cap-context-lead {
+        margin: 0 0 0.75em;
+        font-weight: 500;
+      }
+      .playbook-addendum .capital-context .cap-context-stats {
+        margin: 0 0 0.75em;
+        padding-left: 1.25em;
+      }
+      .playbook-addendum .capital-context .cap-context-stats li {
+        margin: 0.25em 0;
+      }
+      .playbook-addendum .capital-context .cap-context-fed {
+        margin: 0.75em 0;
+        padding: 0.5em 0.75em;
+        background: #fff8f0;
+        border-left: 3px solid #b45309;
+        font-size: 0.95em;
+      }
+      .playbook-addendum .capital-context .cap-context-handoff {
+        margin: 0.75em 0 0.5em;
+        font-style: italic;
+        color: #444;
+      }
+      .playbook-addendum .capital-context .cap-context-sources {
+        margin: 0.75em 0 0;
+        font-size: 0.82em;
+        color: #777;
+      }
+    </style>
+  `;
+
   return `
     ${styles}
+    ${capitalStyles}
     <section class="playbook-addendum">
       ${header}
       ${s1}
       ${s2}
+      ${capitalSidebar}
       ${cta}
       ${limitations}
       ${disclaimer}

--- a/src/lib/playbook-addendum/render.ts
+++ b/src/lib/playbook-addendum/render.ts
@@ -261,14 +261,17 @@ export function renderPlaybookAddendum(data: PlaybookAddendumData): string {
   `;
 
   // ---------- TICKET-19: Capital-adjacency sidebar ----------
-  // Render gate: renderCapitalContextHtml returns "" when ineligible.
-  // The aside lives ABOVE the upgrade CTA so the buyer reads the eligibility
-  // calculation before the upsell.
+  // Render gate: renderCapitalContextHtml returns "" when ctx.eligible=false,
+  // or when capitalContext is null (non-capital charge / no capital data). The
+  // capitalStyles block is only emitted when capitalSidebar is non-empty to
+  // avoid injecting dead CSS for the ~95% of playbook buyers whose charge is
+  // not capital-adjacent.
   const capitalSidebar = data.capitalContext
     ? renderCapitalContextHtml(data.capitalContext)
     : "";
 
-  const capitalStyles = `
+  const capitalStyles = capitalSidebar
+    ? `
     <style>
       .playbook-addendum .capital-context {
         margin: 2em 0;
@@ -312,7 +315,8 @@ export function renderPlaybookAddendum(data: PlaybookAddendumData): string {
         color: #777;
       }
     </style>
-  `;
+  `
+    : "";
 
   return `
     ${styles}

--- a/src/lib/xray-sections/__tests__/capital-context.test.ts
+++ b/src/lib/xray-sections/__tests__/capital-context.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Unit tests for X-Ray Section X3 — Capital-Adjacency Context (TICKET-19).
+ *
+ * Coverage gates:
+ *   1. Render gate — empty output when shouldRender=false (HARD)
+ *   2. UPL parity — rendered HTML never contains banned phrases
+ *   3. X-Ray heading parity — wrapper labels section as X-Ray-tier
+ *   4. shouldRender false when chargeClass null OR ineligible
+ */
+import { describe, it, expect } from "vitest";
+import { UPL_BANNED_PHRASES } from "@/lib/charge-slug-maps";
+import {
+  type XrayCapitalContextData,
+  renderXrayCapitalContext,
+} from "../capital-context";
+import { getCapitalContext } from "@/lib/dpic/capital-context";
+
+function mkXrayData(over: Partial<XrayCapitalContextData> = {}): XrayCapitalContextData {
+  return {
+    context: getCapitalContext({
+      state: "TX",
+      chargeClass: "murder-capital",
+      surface: "xray",
+      lastDecadeExecutions: 73,
+      lastExecutionYear: 2025,
+    }),
+    shouldRender: true,
+    limitations: [],
+    ...over,
+  };
+}
+
+describe("renderXrayCapitalContext — render gate", () => {
+  it("returns empty string when shouldRender=false (HARD)", () => {
+    const html = renderXrayCapitalContext({
+      context: null,
+      shouldRender: false,
+      limitations: [],
+    });
+    expect(html).toBe("");
+  });
+
+  it("returns empty string when context is null even if shouldRender=true (defense in depth)", () => {
+    const html = renderXrayCapitalContext({
+      context: null,
+      shouldRender: true,
+      limitations: [],
+    });
+    expect(html).toBe("");
+  });
+
+  it("returns full HTML when eligible context supplied", () => {
+    const html = renderXrayCapitalContext(mkXrayData());
+    expect(html).toContain("X-Ray");
+    expect(html).toContain("Capital-Eligibility Check");
+    expect(html).toContain("can theoretically reach");
+    expect(html).toContain("TX");
+  });
+});
+
+describe("renderXrayCapitalContext — UPL parity", () => {
+  it("never emits banned UPL phrases", () => {
+    const html = renderXrayCapitalContext(mkXrayData());
+    const lower = html.toLowerCase();
+    const hits = UPL_BANNED_PHRASES.filter((p) => lower.includes(p));
+    expect(hits, `Banned UPL phrases found: ${hits.join(", ")}`).toEqual([]);
+  });
+
+  it("never emits predictive language", () => {
+    const html = renderXrayCapitalContext(mkXrayData());
+    const lower = html.toLowerCase();
+    expect(lower).not.toMatch(/will be charged|you will face|expect to be sentenced|death is likely/);
+  });
+
+  it("retains DPIC source citations on X-Ray surface", () => {
+    const html = renderXrayCapitalContext(mkXrayData());
+    expect(html).toContain("deathpenaltyinfo.org");
+    expect(html).toContain("executions.csv");
+  });
+});
+
+describe("renderXrayCapitalContext — X-Ray-typed heading", () => {
+  it("includes X-Ray tier label so buyer reads in tier context", () => {
+    const html = renderXrayCapitalContext(mkXrayData());
+    expect(html).toContain("Capital-Eligibility Check (X-Ray)");
+  });
+});

--- a/src/lib/xray-sections/capital-context.ts
+++ b/src/lib/xray-sections/capital-context.ts
@@ -1,0 +1,144 @@
+/**
+ * X-Ray Section X3 — Capital-Adjacency Context (TICKET-19).
+ *
+ * X-Ray ($2,497) discovery-tier enhancement that surfaces a capital-
+ * eligibility check sidebar when the buyer's charge is theoretically
+ * capital-eligible AND the buyer's state has a death-penalty statute
+ * (active or moratorium) OR the charge is federally capital-eligible.
+ *
+ * Tier monotonicity (HARD):
+ *   - Sex Offense Playbook ($147) + Federal Criminal Playbook ($147) get
+ *     the same sidebar via the playbook-addendum render. X-Ray's
+ *     differentiation comes from the discovery-tier context: the X-Ray
+ *     sidebar is rendered alongside actual case-derived charge data
+ *     (judge_motion_outcome_rates, federal-pji-cross-ref), not as a
+ *     standalone post-purchase artifact.
+ *   - Render gate is the same across tiers — `eligible` must be true.
+ *     There is no tier-dependent expansion of the eligibility table; the
+ *     law is the law.
+ *
+ * UPL (HARD):
+ *   - Phrasing is theoretical / contextual ("can theoretically reach"),
+ *     never predictive.
+ *   - Banned-phrase blocklist (UPL_BANNED_PHRASES from charge-slug-maps)
+ *     enforced at test time on the rendered HTML.
+ *   - Source URLs (DPIC executions CSV + state-by-state policy table) are
+ *     embedded in every render — verification chain stays unbroken.
+ *
+ * Federal-state interaction:
+ *   Federal jurisdiction can pursue capital punishment regardless of state
+ *   abolition (Tsarnaev / Boston Marathon — MA had abolished its statute,
+ *   the federal charge under 18 U.S.C. § 2332a still applied). The render
+ *   surfaces this when the underlying charge class is federally eligible.
+ *
+ * Source:
+ *   docs/plans/2026-04-23-data-to-product-autonomous-execution.md (TICKET-19)
+ *   src/lib/dpic/capital-context.ts (shared helper)
+ */
+
+import {
+  type CapitalContext,
+  type CapitalEligibleChargeClass,
+  getCapitalContext,
+  queryCapitalExecutionStats,
+  renderCapitalContextHtml,
+} from "@/lib/dpic/capital-context";
+
+// ============================================================
+// Types
+// ============================================================
+
+export interface XrayCapitalContextInput {
+  /** 2-letter state postal — used to resolve eligibility + execution stats. */
+  state?: string | null;
+  /** Capital-adjacent charge class extracted from the X-Ray case file. */
+  chargeClass?: CapitalEligibleChargeClass | null;
+}
+
+export interface XrayCapitalContextData {
+  /** Underlying CapitalContext from the shared helper, or null when no
+   *  charge class was supplied / class is non-capital. */
+  context: CapitalContext | null;
+  /** True when the section should render. Convenience for the assembler. */
+  shouldRender: boolean;
+  limitations: string[];
+}
+
+// ============================================================
+// Query
+// ============================================================
+
+/**
+ * Builds the X-Ray capital-context section.
+ *
+ * Returns `shouldRender=false` when:
+ *   - chargeClass is null (charge isn't in the capital-adjacent set), OR
+ *   - getCapitalContext.eligible is false (charge in scope but state +
+ *     federal eligibility both fail)
+ *
+ * The X-Ray assembler can defensively skip rendering when shouldRender is
+ * false without checking the inner context shape.
+ */
+export async function queryXrayCapitalContext(
+  input: XrayCapitalContextInput,
+): Promise<XrayCapitalContextData> {
+  const limitations: string[] = [];
+
+  if (!input.chargeClass) {
+    return { context: null, shouldRender: false, limitations };
+  }
+
+  const stateRaw = (input.state ?? "").trim().toUpperCase();
+  const state = /^[A-Z]{2}$/.test(stateRaw) ? stateRaw : null;
+
+  if (!state) {
+    limitations.push(
+      "No state on file; capital-context check uses federal-eligibility status only.",
+    );
+  }
+
+  const stats = state
+    ? await queryCapitalExecutionStats([state])
+    : new Map<string, { count: number; lastYear: number | null }>();
+  const stateStat = state ? stats.get(state) : undefined;
+
+  const ctx = getCapitalContext({
+    state,
+    chargeClass: input.chargeClass,
+    surface: "xray",
+    lastDecadeExecutions: stateStat?.count ?? 0,
+    lastExecutionYear: stateStat?.lastYear ?? null,
+  });
+
+  if (!ctx.eligible) {
+    return { context: null, shouldRender: false, limitations };
+  }
+
+  return { context: ctx, shouldRender: true, limitations };
+}
+
+// ============================================================
+// Render
+// ============================================================
+
+/**
+ * Renders the X-Ray capital-context section as standalone HTML. Returns
+ * empty string when `shouldRender=false` (defensive — render call site can
+ * splice unconditionally).
+ *
+ * The internal `renderCapitalContextHtml` is the canonical voice + UPL-
+ * verified render — used by both X-Ray (this file) and the playbook
+ * addendum so the wording stays consistent across tiers.
+ */
+export function renderXrayCapitalContext(data: XrayCapitalContextData): string {
+  if (!data.shouldRender || !data.context) return "";
+  // The X-Ray wrapper section gets a tier-typed heading so the buyer reads
+  // it in the X-Ray context, not as a generic add-on.
+  const inner = renderCapitalContextHtml(data.context);
+  return `
+    <section class="xray-section xray-capital-context">
+      <h2>Capital-Eligibility Check (X-Ray)</h2>
+      ${inner}
+    </section>
+  `;
+}


### PR DESCRIPTION
## Summary
- DPIC capital-context helper + X-Ray X3 wrapper + 2 playbook addenda (sex-offense + federal-criminal)
- 48 new tests pass (29 helper + 19 wrapper)
- 29 existing playbook-addendum tests still pass
- tsc --noEmit clean

## Sample capital-context (TX, murder-capital)
- eligible: true
- state: TX
- stateCapitalEligibility: active
- federalCapitalEligible: true
- lastDecadeExecutions: 73
- lastExecutionYear: 2025

## Files
- src/lib/dpic/capital-context.ts (new, 408 lines — helper, state map, render)
- src/lib/dpic/__tests__/capital-context.test.ts (new, 350 lines)
- src/lib/xray-sections/capital-context.ts (new — X-Ray X3 wrapper)
- src/lib/xray-sections/__tests__/capital-context.test.ts (new)
- src/lib/playbook-addendum/generate.ts (modified — capitalChargeClass input + capitalContext field + DB-backed lookup)
- src/lib/playbook-addendum/render.ts (modified — capital sidebar slot above CTA + scoped CSS)
- src/lib/playbook-addendum/__tests__/generate.test.ts (modified — fixture extended)

## Render
Mercer-voiced sidebar with state-statute line, decade count, last-execution year, federal carve-out note, attorney-handoff sentence, and DPIC dual-source citation.

## UPL parity verified
Rendered HTML scanned against UPL_BANNED_PHRASES (charge-slug-maps) + a 9-phrase predictive-language blocklist across 5 (state × charge-class) eligible matrix samples; zero hits.

## Render gate
eligible=false → empty string (no reassurance copy, no over-render).

## Test plan
- [x] vitest 48/48 new + 29/29 preserved playbook-addendum
- [x] tsc --noEmit clean
- [x] UPL banned-phrases parity asserted

🤖 Generated with [Claude Code](https://claude.com/claude-code)