### PR TITLE
feat(parentheticals): cl_parentheticals view + X-Ray cite-context + JRC (TICKET-12)

### DIFF
--- a/src/lib/parentheticals/__tests__/lookup.test.ts
+++ b/src/lib/parentheticals/__tests__/lookup.test.ts
@@ -1,0 +1,253 @@
+/**
+ * TICKET-12: parenthetical lookup tests.
+ *
+ * Mocks createAdminClient with a deterministic in-memory PostgREST stub.
+ * Verifies bridge resolution (canonical_id -> cluster_id), batch bucketing,
+ * limit clamping, and silent-degradation contract on errors.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+type Row = Record<string, unknown>;
+
+let entitySourcesFixture: Row[] = [];
+let parentheticalsFixture: Row[] = [];
+let throwOn: string | null = null;
+
+function makeQuery(table: string, dataFor: () => Row[]) {
+  const q = {
+    _filters: {} as Record<string, unknown>,
+    _table: table,
+    select: () => q,
+    in: (col: string, vals: unknown[]) => {
+      q._filters[`in:${col}`] = vals;
+      return q;
+    },
+    eq: (col: string, val: unknown) => {
+      q._filters[`eq:${col}`] = val;
+      return q;
+    },
+    order: () => q,
+    limit: () => q,
+    then(cb: (v: { data: Row[] | null; error: unknown }) => unknown) {
+      if (throwOn === q._table) {
+        return Promise.resolve(cb({ data: null, error: new Error("boom") }));
+      }
+      let data = dataFor();
+      // Apply filters that the helpers rely on
+      for (const [key, val] of Object.entries(q._filters)) {
+        const [op, col] = key.split(":");
+        if (op === "eq") {
+          data = data.filter((r) => r[col] === val);
+        } else if (op === "in") {
+          const set = new Set(val as unknown[]);
+          data = data.filter((r) => set.has(r[col]));
+        }
+      }
+      return Promise.resolve(cb({ data, error: null }));
+    },
+  };
+  return q;
+}
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: () => ({
+    from: (table: string) => {
+      if (table === "entity_sources")
+        return makeQuery(table, () => entitySourcesFixture);
+      if (table === "v_parentheticals_for_case")
+        return makeQuery(table, () => parentheticalsFixture);
+      return makeQuery(table, () => []);
+    },
+  }),
+}));
+
+import {
+  getParentheticalsForClusterId,
+  getParentheticalsForCanonicalId,
+  getParentheticalsForCanonicalIds,
+} from "@/lib/parentheticals/lookup";
+
+beforeEach(() => {
+  entitySourcesFixture = [];
+  parentheticalsFixture = [];
+  throwOn = null;
+});
+
+describe("getParentheticalsForClusterId", () => {
+  it("returns [] for empty input", async () => {
+    expect(await getParentheticalsForClusterId("")).toEqual([]);
+    // @ts-expect-error guard
+    expect(await getParentheticalsForClusterId(null)).toEqual([]);
+  });
+
+  it("fetches and returns parentheticals for known cluster", async () => {
+    parentheticalsFixture = [
+      {
+        parenthetical_id: "p1",
+        described_cluster_id: "145875",
+        describing_text: "holding X",
+        describing_case_name: "Hill v. Lappin",
+        describing_case_name_short: "Hill",
+        describing_date_filed: "2010-12-28",
+        describing_citation_count: 5039,
+        source_url: "https://www.courtlistener.com/opinion/181820/",
+      },
+    ];
+    const out = await getParentheticalsForClusterId("145875", 3);
+    expect(out).toHaveLength(1);
+    expect(out[0].describing_text).toBe("holding X");
+  });
+
+  it("returns [] silently on error (no throw)", async () => {
+    throwOn = "v_parentheticals_for_case";
+    const out = await getParentheticalsForClusterId("145875");
+    expect(out).toEqual([]);
+  });
+
+  it("clamps limit defensively (NaN/<1/>10)", async () => {
+    parentheticalsFixture = [
+      {
+        parenthetical_id: "p1",
+        described_cluster_id: "x",
+        describing_text: "t",
+        describing_case_name: "n",
+        describing_case_name_short: "n",
+        describing_date_filed: null,
+        describing_citation_count: null,
+        source_url: "https://x/",
+      },
+    ];
+    // None of these should throw or fail
+    expect(await getParentheticalsForClusterId("x", NaN)).toHaveLength(1);
+    expect(await getParentheticalsForClusterId("x", -5)).toHaveLength(1);
+    expect(await getParentheticalsForClusterId("x", 9999)).toHaveLength(1);
+  });
+});
+
+describe("getParentheticalsForCanonicalId", () => {
+  it("returns [] when no entity_sources row exists", async () => {
+    const out = await getParentheticalsForCanonicalId("uuid-no-bridge");
+    expect(out).toEqual([]);
+  });
+
+  it("resolves canonical_id -> cluster_id and returns parentheticals", async () => {
+    entitySourcesFixture = [
+      {
+        entity_id: "uuid-iqbal",
+        entity_type: "case",
+        source_system: "courtlistener",
+        source_ref: "145875",
+      },
+    ];
+    parentheticalsFixture = [
+      {
+        parenthetical_id: "p1",
+        described_cluster_id: "145875",
+        describing_text: "summarized as plausibility standard",
+        describing_case_name: "Hill v. Lappin",
+        describing_case_name_short: "Hill",
+        describing_date_filed: "2010-12-28",
+        describing_citation_count: 5039,
+        source_url: "https://www.courtlistener.com/opinion/181820/",
+      },
+    ];
+    const out = await getParentheticalsForCanonicalId("uuid-iqbal");
+    expect(out).toHaveLength(1);
+    expect(out[0].describing_text).toContain("plausibility");
+  });
+
+  it("returns [] for blank input", async () => {
+    expect(await getParentheticalsForCanonicalId("")).toEqual([]);
+  });
+});
+
+describe("getParentheticalsForCanonicalIds (batch)", () => {
+  it("returns empty Map for empty input", async () => {
+    const m = await getParentheticalsForCanonicalIds([]);
+    expect(m.size).toBe(0);
+  });
+
+  it("buckets parentheticals back to canonical_ids", async () => {
+    entitySourcesFixture = [
+      {
+        entity_id: "uuid-A",
+        entity_type: "case",
+        source_system: "courtlistener",
+        source_ref: "100",
+      },
+      {
+        entity_id: "uuid-B",
+        entity_type: "case",
+        source_system: "courtlistener",
+        source_ref: "200",
+      },
+    ];
+    parentheticalsFixture = [
+      {
+        parenthetical_id: "p1",
+        described_cluster_id: "100",
+        describing_text: "for A",
+        describing_case_name: null,
+        describing_case_name_short: null,
+        describing_date_filed: null,
+        describing_citation_count: null,
+        source_url: "https://x/",
+        relevance_score: 1,
+      },
+      {
+        parenthetical_id: "p2",
+        described_cluster_id: "200",
+        describing_text: "for B",
+        describing_case_name: null,
+        describing_case_name_short: null,
+        describing_date_filed: null,
+        describing_citation_count: null,
+        source_url: "https://y/",
+        relevance_score: 1,
+      },
+    ];
+    const m = await getParentheticalsForCanonicalIds(["uuid-A", "uuid-B"], 3);
+    expect(m.get("uuid-A")?.[0].describing_text).toBe("for A");
+    expect(m.get("uuid-B")?.[0].describing_text).toBe("for B");
+  });
+
+  it("dedupes input ids + skips non-strings", async () => {
+    // Smoke test: shouldn't throw on dirty input
+    const m = await getParentheticalsForCanonicalIds(
+      // @ts-expect-error testing defensive filter
+      ["a", "a", null, undefined, "", "b"],
+      3
+    );
+    expect(m.size).toBe(0);
+  });
+
+  it("returns empty Map silently on error (no throw)", async () => {
+    throwOn = "entity_sources";
+    const m = await getParentheticalsForCanonicalIds(["uuid-X"]);
+    expect(m.size).toBe(0);
+  });
+
+  it("respects per-case limit when bucketing", async () => {
+    entitySourcesFixture = [
+      {
+        entity_id: "uuid-A",
+        entity_type: "case",
+        source_system: "courtlistener",
+        source_ref: "100",
+      },
+    ];
+    parentheticalsFixture = Array.from({ length: 10 }, (_, i) => ({
+      parenthetical_id: `p${i}`,
+      described_cluster_id: "100",
+      describing_text: `t${i}`,
+      describing_case_name: null,
+      describing_case_name_short: null,
+      describing_date_filed: null,
+      describing_citation_count: null,
+      source_url: "https://x/",
+      relevance_score: 10 - i,
+    }));
+    const m = await getParentheticalsForCanonicalIds(["uuid-A"], 3);
+    expect(m.get("uuid-A")).toHaveLength(3);
+  });
+});

--- a/src/lib/parentheticals/__tests__/render.test.ts
+++ b/src/lib/parentheticals/__tests__/render.test.ts
@@ -1,0 +1,130 @@
+/**
+ * TICKET-12: parenthetical render tests.
+ *
+ * Pure function tests — no DB, no mocks. Verifies HTML escaping, surface
+ * variation (xray vs jrc), and the empty-input degradation contract that
+ * lets callers `+=` the output unconditionally.
+ */
+import { describe, it, expect } from "vitest";
+import { renderParentheticalsAside } from "@/lib/parentheticals/render";
+import type { Parenthetical } from "@/lib/parentheticals/lookup";
+
+function makeParenthetical(over: Partial<Parenthetical> = {}): Parenthetical {
+  return {
+    parenthetical_id: "p-1",
+    described_cluster_id: "145875",
+    describing_text:
+      "holding that a complaint survives a motion to dismiss where the factual allegations state a plausible claim for relief",
+    describing_case_name: "Hill v. Lappin",
+    describing_case_name_short: "Hill",
+    describing_date_filed: "2010-12-28",
+    describing_citation_count: 5039,
+    source_url: "https://www.courtlistener.com/opinion/181820/",
+    ...over,
+  };
+}
+
+describe("renderParentheticalsAside", () => {
+  it("returns empty string for empty input (caller-safe concat)", () => {
+    expect(renderParentheticalsAside([])).toBe("");
+    // @ts-expect-error guard against bad caller
+    expect(renderParentheticalsAside(null)).toBe("");
+    // @ts-expect-error guard against bad caller
+    expect(renderParentheticalsAside(undefined)).toBe("");
+  });
+
+  it("renders xray surface heading + aria label", () => {
+    const out = renderParentheticalsAside([makeParenthetical()], "xray");
+    expect(out).toContain("How later judges summarized this case");
+    expect(out).toContain(
+      "Parenthetical summaries from later opinions citing this case"
+    );
+  });
+
+  it("renders jrc surface heading + aria label", () => {
+    const out = renderParentheticalsAside([makeParenthetical()], "jrc");
+    expect(out).toContain("What later judges have called this case&#39;s holding");
+    expect(out).toContain("Subsequent judicial summaries of this case");
+  });
+
+  it("links the case name + year to the source URL with safe rel/target", () => {
+    const out = renderParentheticalsAside([makeParenthetical()]);
+    expect(out).toContain('href="https://www.courtlistener.com/opinion/181820/"');
+    expect(out).toContain('rel="noopener noreferrer"');
+    expect(out).toContain('target="_blank"');
+    expect(out).toContain("Hill (2010)");
+  });
+
+  it("escapes HTML in describing_text", () => {
+    const out = renderParentheticalsAside([
+      makeParenthetical({
+        describing_text: "<script>alert('xss')</script> & more",
+      }),
+    ]);
+    expect(out).not.toContain("<script>");
+    expect(out).toContain("&lt;script&gt;");
+    expect(out).toContain("&amp; more");
+  });
+
+  it("escapes HTML in case names", () => {
+    const out = renderParentheticalsAside([
+      makeParenthetical({
+        describing_case_name_short: "<img onerror='x'>",
+        describing_case_name: null,
+      }),
+    ]);
+    expect(out).not.toContain("<img onerror");
+    expect(out).toContain("&lt;img onerror=&#39;x&#39;&gt;");
+  });
+
+  it("truncates long quotes with ellipsis", () => {
+    const long = "a".repeat(500);
+    const out = renderParentheticalsAside([
+      makeParenthetical({ describing_text: long }),
+    ]);
+    expect(out).toContain("&hellip;");
+    // Body should be capped at 400 chars before the ellipsis
+    expect(out).toContain("a".repeat(400));
+    expect(out).not.toContain("a".repeat(401));
+  });
+
+  it("falls back from short -> full case name -> 'Citing opinion'", () => {
+    const out1 = renderParentheticalsAside([
+      makeParenthetical({
+        describing_case_name_short: null,
+        describing_case_name: "Full Case Name",
+      }),
+    ]);
+    expect(out1).toContain("Full Case Name");
+    const out2 = renderParentheticalsAside([
+      makeParenthetical({
+        describing_case_name_short: null,
+        describing_case_name: null,
+      }),
+    ]);
+    expect(out2).toContain("Citing opinion");
+  });
+
+  it("renders all N parentheticals as separate blockquotes", () => {
+    const out = renderParentheticalsAside([
+      makeParenthetical({ parenthetical_id: "1", describing_text: "first text" }),
+      makeParenthetical({
+        parenthetical_id: "2",
+        describing_text: "second text",
+      }),
+      makeParenthetical({ parenthetical_id: "3", describing_text: "third text" }),
+    ]);
+    expect((out.match(/<blockquote/g) ?? []).length).toBe(3);
+    expect(out).toContain("first text");
+    expect(out).toContain("second text");
+    expect(out).toContain("third text");
+  });
+
+  it("handles missing date_filed gracefully (no '(year)' suffix)", () => {
+    const out = renderParentheticalsAside([
+      makeParenthetical({ describing_date_filed: null }),
+    ]);
+    expect(out).toContain("Hill</a>");
+    expect(out).not.toMatch(/Hill \(\)/);
+  });
+});

--- a/src/lib/parentheticals/lookup.ts
+++ b/src/lib/parentheticals/lookup.ts
@@ -1,0 +1,167 @@
+/**
+ * TICKET-12: parenthetical lookup helper.
+ *
+ * "What later judges said about this case." For every cited authority in
+ * an X-Ray report (or JRC's Relevant Court Opinions section), surface the
+ * top-N parentheticals from `v_parentheticals_for_case`.
+ *
+ * Anti-hallucination invariant (Architecture #13): every returned record
+ * carries:
+ *   - `describing_text` stored verbatim from cl_parentheticals.text
+ *   - `source_url` = deterministic CL deep link to the describing opinion
+ * Nothing in this module synthesizes, paraphrases, or rewrites text.
+ *
+ * Identity bridge: callers in app code typically hold an `entities_cases`
+ * `canonical_id` (uuid). Use `getParentheticalsForCanonicalId` which
+ * resolves canonical_id -> CL cluster_id via entity_sources first. Code
+ * that already holds a cluster_id (e.g. JRC's classified_opinions row)
+ * can call `getParentheticalsForClusterId` directly.
+ */
+import { createAdminClient } from "@/lib/supabase/admin";
+
+export interface Parenthetical {
+  parenthetical_id: string;
+  described_cluster_id: string;
+  describing_text: string;
+  describing_case_name: string | null;
+  describing_case_name_short: string | null;
+  describing_date_filed: string | null;
+  describing_citation_count: number | null;
+  source_url: string;
+}
+
+const DEFAULT_LIMIT = 3;
+const MAX_LIMIT = 10;
+
+/**
+ * Clamp limit to [1, MAX_LIMIT]. Defensive against caller-supplied 0,
+ * negative, NaN, or unbounded values that could blow up PostgREST URLs.
+ */
+function clampLimit(limit: number | undefined): number {
+  if (typeof limit !== "number" || !Number.isFinite(limit)) return DEFAULT_LIMIT;
+  if (limit < 1) return 1;
+  if (limit > MAX_LIMIT) return MAX_LIMIT;
+  return Math.floor(limit);
+}
+
+/**
+ * Fetch top-N parentheticals for a CL cluster_id.
+ * Returns [] on error or no matches — never throws.
+ */
+export async function getParentheticalsForClusterId(
+  clusterId: string,
+  limit: number = DEFAULT_LIMIT
+): Promise<Parenthetical[]> {
+  if (!clusterId || typeof clusterId !== "string") return [];
+  const n = clampLimit(limit);
+  try {
+    const supabase = createAdminClient();
+    const { data, error } = await supabase
+      .from("v_parentheticals_for_case")
+      .select(
+        "parenthetical_id, described_cluster_id, describing_text, describing_case_name, describing_case_name_short, describing_date_filed, describing_citation_count, source_url"
+      )
+      .eq("described_cluster_id", clusterId)
+      .order("relevance_score", { ascending: false, nullsFirst: false })
+      .limit(n);
+    if (error || !data) return [];
+    return data as Parenthetical[];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Fetch top-N parentheticals for an entities_cases canonical_id (uuid).
+ * Resolves canonical_id -> CL cluster_id via entity_sources, then delegates
+ * to getParentheticalsForClusterId.
+ *
+ * Returns [] when the case has no CourtListener provenance row OR the
+ * cluster has no parentheticals OR any error.
+ */
+export async function getParentheticalsForCanonicalId(
+  canonicalId: string,
+  limit: number = DEFAULT_LIMIT
+): Promise<Parenthetical[]> {
+  if (!canonicalId || typeof canonicalId !== "string") return [];
+  try {
+    const supabase = createAdminClient();
+    const { data, error } = await supabase
+      .from("entity_sources")
+      .select("source_ref")
+      .eq("entity_id", canonicalId)
+      .eq("entity_type", "case")
+      .eq("source_system", "courtlistener")
+      .limit(1);
+    if (error || !data || data.length === 0) return [];
+    const clusterId = data[0]?.source_ref;
+    if (!clusterId) return [];
+    return getParentheticalsForClusterId(clusterId, limit);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Batch fetch — given N canonical_ids, return a Map<canonicalId, Parenthetical[]>.
+ * Used by the cite-tag transformer (one report can have 50+ cases) to avoid
+ * N+1 round trips. Single PostgREST round trip for the bridge, single round
+ * trip for the parentheticals.
+ */
+export async function getParentheticalsForCanonicalIds(
+  canonicalIds: string[],
+  limitPerCase: number = DEFAULT_LIMIT
+): Promise<Map<string, Parenthetical[]>> {
+  const result = new Map<string, Parenthetical[]>();
+  const ids = Array.from(
+    new Set((canonicalIds ?? []).filter((s) => typeof s === "string" && s.length > 0))
+  );
+  if (ids.length === 0) return result;
+  const n = clampLimit(limitPerCase);
+  try {
+    const supabase = createAdminClient();
+    // Bridge: canonical_id -> cluster_id
+    const { data: sources } = await supabase
+      .from("entity_sources")
+      .select("entity_id, source_ref")
+      .in("entity_id", ids)
+      .eq("entity_type", "case")
+      .eq("source_system", "courtlistener");
+    if (!sources || sources.length === 0) return result;
+    const clusterToCanonical = new Map<string, string>();
+    const clusterIds: string[] = [];
+    for (const s of sources) {
+      if (!s.source_ref || !s.entity_id) continue;
+      clusterToCanonical.set(s.source_ref, s.entity_id);
+      clusterIds.push(s.source_ref);
+    }
+    if (clusterIds.length === 0) return result;
+    // Pull parentheticals for all clusters in one round trip, then bucket
+    // client-side. We fetch n*K rows (K=clusterIds.length) so the per-case
+    // top-N invariant holds after bucketing.
+    const { data: rows } = await supabase
+      .from("v_parentheticals_for_case")
+      .select(
+        "parenthetical_id, described_cluster_id, describing_text, describing_case_name, describing_case_name_short, describing_date_filed, describing_citation_count, source_url, relevance_score"
+      )
+      .in("described_cluster_id", clusterIds)
+      .order("relevance_score", { ascending: false, nullsFirst: false })
+      .limit(n * clusterIds.length);
+    if (!rows) return result;
+    for (const row of rows as Array<Parenthetical & { relevance_score: number }>) {
+      const cid = clusterToCanonical.get(row.described_cluster_id);
+      if (!cid) continue;
+      const arr = result.get(cid) ?? [];
+      if (arr.length < n) {
+        // Strip relevance_score from the public Parenthetical shape.
+        const { relevance_score: _ignore, ...pub } = row;
+        void _ignore;
+        arr.push(pub);
+        result.set(cid, arr);
+      }
+    }
+    return result;
+  } catch {
+    return result;
+  }
+}

--- a/src/lib/parentheticals/render.ts
+++ b/src/lib/parentheticals/render.ts
@@ -1,0 +1,94 @@
+/**
+ * TICKET-12: parenthetical render helper.
+ *
+ * Produces a Mercer-voiced "what other judges have called this case's holding"
+ * block of pull-quotes. Used by:
+ *   - X-Ray cite-tag transformer (badge-transform.ts) — appended after each
+ *     case badge in the rendered report HTML.
+ *   - JRC Relevant Court Opinions section (tier9-reports/render.ts) — appended
+ *     under each opinion card.
+ *
+ * Anti-hallucination invariant (Architecture #13): text is rendered verbatim
+ * from cl_parentheticals (HTML-escaped). No paraphrase. Source URL = CL deep
+ * link to the describing opinion.
+ *
+ * Structure mirrors the existing doctrine pull-quote pattern in
+ * badge-transform.ts so the visual language stays consistent.
+ */
+import type { Parenthetical } from "./lookup";
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function escapeAttr(s: string): string {
+  return escapeHtml(s);
+}
+
+function formatYear(dateFiled: string | null): string {
+  if (!dateFiled) return "";
+  // Accept Postgres date or ISO timestamp — both match /^\d{4}/.
+  const m = dateFiled.match(/^(\d{4})/);
+  return m ? m[1] : "";
+}
+
+const MAX_QUOTE_CHARS = 400;
+
+/**
+ * Render a tight pull-quote aside containing N parentheticals. Returns the
+ * empty string when there is nothing to show — callers can `+=` unconditionally.
+ *
+ * The aria-label varies by surface so screen readers + a11y trees can
+ * distinguish the X-Ray surface ("Cited in later opinions") from the JRC
+ * surface ("How later judges summarized this case").
+ */
+export function renderParentheticalsAside(
+  parentheticals: Parenthetical[],
+  surface: "xray" | "jrc" = "xray"
+): string {
+  if (!Array.isArray(parentheticals) || parentheticals.length === 0) return "";
+  const heading =
+    surface === "jrc"
+      ? "What later judges have called this case's holding"
+      : "How later judges summarized this case";
+  const ariaLabel =
+    surface === "jrc"
+      ? "Subsequent judicial summaries of this case"
+      : "Parenthetical summaries from later opinions citing this case";
+  const items = parentheticals
+    .map((p) => {
+      const body = (p.describing_text ?? "").slice(0, MAX_QUOTE_CHARS);
+      const ellipsis =
+        (p.describing_text ?? "").length > MAX_QUOTE_CHARS ? "&hellip;" : "";
+      const caseName =
+        p.describing_case_name_short || p.describing_case_name || "Citing opinion";
+      const year = formatYear(p.describing_date_filed);
+      const link = `<a href="${escapeAttr(
+        p.source_url
+      )}" rel="noopener noreferrer" target="_blank" class="underline decoration-dotted hover:text-amber-300">${escapeHtml(
+        caseName
+      )}${year ? ` (${year})` : ""}</a>`;
+      return (
+        `<blockquote class="mt-2 border-l-2 border-amber-600/50 pl-3 text-sm italic text-zinc-300">` +
+        `<p>&ldquo;${escapeHtml(body)}${ellipsis}&rdquo;</p>` +
+        `<footer class="mt-1 text-xs not-italic text-zinc-500">&mdash; ${link}</footer>` +
+        `</blockquote>`
+      );
+    })
+    .join("");
+  return (
+    `<aside class="mt-2 rounded bg-zinc-950/30 p-3" aria-label="${escapeAttr(
+      ariaLabel
+    )}">` +
+    `<p class="mb-1 text-[11px] font-semibold uppercase tracking-wide text-amber-500">${escapeHtml(
+      heading
+    )}</p>` +
+    items +
+    `</aside>`
+  );
+}

--- a/src/lib/report/badge-transform.ts
+++ b/src/lib/report/badge-transform.ts
@@ -12,6 +12,8 @@
  */
 import { createAdminClient } from "@/lib/supabase/admin";
 import { parse } from "node-html-parser";
+import { getParentheticalsForCanonicalIds } from "@/lib/parentheticals/lookup";
+import { renderParentheticalsAside } from "@/lib/parentheticals/render";
 
 type ConfidenceLevel =
   | "standard"
@@ -181,16 +183,19 @@ export async function transformCiteTags(html: string): Promise<string> {
 
   const ids = new Set<string>();
   const doctrineIds = new Set<string>();
+  const caseIds = new Set<string>();
   for (const node of citeNodes) {
     const id = node.getAttribute("data-entity-id");
     const type = node.getAttribute("data-entity-type");
     if (id) ids.add(id);
     if (id && type === "doctrine") doctrineIds.add(id);
+    // TICKET-12: collect case ids for batch parenthetical lookup.
+    if (id && type === "case") caseIds.add(id);
   }
   if (ids.size === 0) return html;
 
   const supabase = createAdminClient();
-  const [confRes, quotesRes] = await Promise.all([
+  const [confRes, quotesRes, parentheticalsByCase] = await Promise.all([
     supabase
       .from("v_entity_confidence")
       .select(
@@ -204,6 +209,11 @@ export async function transformCiteTags(html: string): Promise<string> {
           .in("doctrine_id", [...doctrineIds])
           .order("ts_rank", { ascending: false })
       : Promise.resolve({ data: [] as Array<Record<string, unknown>> }),
+    // TICKET-12: top-3 parentheticals per case in a single PostgREST round
+    // trip. Empty Map on any error — never blocks badge rendering.
+    caseIds.size > 0
+      ? getParentheticalsForCanonicalIds([...caseIds], 3)
+      : Promise.resolve(new Map()),
   ]);
 
   const confMap = new Map<string, EntityConf>();
@@ -226,6 +236,10 @@ export async function transformCiteTags(html: string): Promise<string> {
   }
 
   const renderedDoctrines = new Set<string>();
+  // TICKET-12: parentheticals render once per case per report (first
+  // occurrence). Subsequent cites of the same case get the badge only — same
+  // pattern as doctrine pull-quotes above.
+  const renderedParenthetical = new Set<string>();
   // W6: per-entity occurrence counter so duplicate cites get unique HTML ids
   // + aria-describedby targets. First occurrence = 1 (unsuffixed), second = 2
   // (`cite-summary-<id>-2`), etc.
@@ -265,12 +279,24 @@ export async function transformCiteTags(html: string): Promise<string> {
       type === "doctrine" && id && !renderedDoctrines.has(id)
         ? quotesByDoctrine.get(id) ?? []
         : [];
+    // TICKET-12: case cites get up to 3 parentheticals on first occurrence.
+    const parens =
+      type === "case" && id && !renderedParenthetical.has(id)
+        ? (parentheticalsByCase as Map<
+            string,
+            import("@/lib/parentheticals/lookup").Parenthetical[]
+          >).get(id) ?? []
+        : [];
+    let appended = "";
     if (quotes.length > 0 && id) {
       renderedDoctrines.add(id);
-      node.replaceWith(badge + renderPullQuotes(quotes));
-    } else {
-      node.replaceWith(badge);
+      appended += renderPullQuotes(quotes);
     }
+    if (parens.length > 0 && id) {
+      renderedParenthetical.add(id);
+      appended += renderParentheticalsAside(parens, "xray");
+    }
+    node.replaceWith(badge + appended);
   }
 
   return root.toString();

--- a/src/lib/tier9-reports/generate.ts
+++ b/src/lib/tier9-reports/generate.ts
@@ -22,6 +22,8 @@ import {
   queryJustfairJudge,
   queryArrestSurvivalKit,
 } from "@/lib/defense-intelligence/query";
+import { getParentheticalsForClusterId } from "@/lib/parentheticals/lookup";
+import type { Parenthetical } from "@/lib/parentheticals/lookup";
 import {
   renderJudgeReportCard,
   renderOfficerBackground,
@@ -170,7 +172,30 @@ export async function generateTier9Report(
           }),
         ]);
         data.justfair = justfairData;
-        html = renderJudgeReportCard(data, intelligence.isEmpty ? undefined : intelligence);
+        // TICKET-12: pre-fetch parentheticals for the top-5 relevant
+        // opinions so the JRC renderer can stay sync. Per-cluster lookup
+        // is bounded (3 parentheticals × 5 opinions = 15 rows max). Errors
+        // collapse to an empty map — JRC degrades gracefully.
+        const parentheticalsByCluster = new Map<string, Parenthetical[]>();
+        if (!intelligence.isEmpty && intelligence.relevantOpinions.length > 0) {
+          const clusters = intelligence.relevantOpinions
+            .slice(0, 5)
+            .map((op) => op.cluster_id)
+            .filter((c): c is string => typeof c === "string" && c.length > 0);
+          const results = await Promise.all(
+            clusters.map((cid) =>
+              getParentheticalsForClusterId(cid, 3).then((p) => [cid, p] as const)
+            )
+          );
+          for (const [cid, parens] of results) {
+            if (parens.length > 0) parentheticalsByCluster.set(cid, parens);
+          }
+        }
+        html = renderJudgeReportCard(
+          data,
+          intelligence.isEmpty ? undefined : intelligence,
+          parentheticalsByCluster
+        );
         // Append the v3-safe Sentencing Fingerprint section (4 signals, apex
         // guardrails).  Non-fatal if empty — renders a limitations block.
         if (!fingerprint.isEmpty || fingerprint.limitations.length) {

--- a/src/lib/tier9-reports/render.ts
+++ b/src/lib/tier9-reports/render.ts
@@ -6,6 +6,8 @@
 
 import { escapeHtml } from "@/lib/email";
 import { stateNameOrCode } from "@/lib/states";
+import type { Parenthetical } from "@/lib/parentheticals/lookup";
+import { renderParentheticalsAside } from "@/lib/parentheticals/render";
 import type {
   JudgeReportCardData,
   OfficerBackgroundData,
@@ -218,7 +220,12 @@ function fmtPct(v: number | null): string {
 
 export function renderJudgeReportCard(
   data: JudgeReportCardData,
-  intelligence?: DefenseIntelligenceData
+  intelligence?: DefenseIntelligenceData,
+  // TICKET-12: optional pre-fetched parentheticals keyed by classified
+  // opinion cluster_id. Pre-fetched by the caller (generate.ts) so this
+  // renderer stays sync. Empty/missing -> opinion card renders without
+  // the parenthetical aside (zero-data degradation, never throws).
+  parentheticalsByCluster?: Map<string, Parenthetical[]>
 ): string {
   const judge = data.judge;
   if (!judge) {
@@ -630,7 +637,9 @@ export function renderJudgeReportCard(
     body += noDataMessage("appellate trend");
   }
 
-  body += intelligence ? renderIntelligenceSection(intelligence) : "";
+  body += intelligence
+    ? renderIntelligenceSection(intelligence, parentheticalsByCluster)
+    : "";
 
   return wrapReport(`Judge Question Brief, ${judge.name}`, body, totalSources);
 }
@@ -2247,7 +2256,13 @@ export function renderArrestSurvivalKit(data: ArrestSurvivalKitData): string {
 // (renamed from "Judge Report Card" 2026-04-26)
 // ============================================================
 
-function renderIntelligenceSection(intel: DefenseIntelligenceData): string {
+function renderIntelligenceSection(
+  intel: DefenseIntelligenceData,
+  // TICKET-12: optional cluster_id -> parentheticals map; pre-fetched by
+  // generate.ts. Empty/missing -> opinion cards render without the
+  // "what later judges said" subsection.
+  parentheticalsByCluster?: Map<string, Parenthetical[]>
+): string {
   const sections: string[] = [];
 
   if (intel.theoryOutcomes.length > 0) {
@@ -2331,7 +2346,13 @@ function renderIntelligenceSection(intel: DefenseIntelligenceData): string {
   if (intel.relevantOpinions.length > 0) {
     const opinionItems = intel.relevantOpinions
       .slice(0, 5)
-      .map((op) => `
+      .map((op) => {
+        // TICKET-12: append "what later judges have called this case's
+        // holding" subsection when caller pre-fetched parentheticals.
+        const parens = parentheticalsByCluster?.get(op.cluster_id) ?? [];
+        const parentheticalAside =
+          parens.length > 0 ? renderParentheticalsAside(parens, "jrc") : "";
+        return `
         <div style="padding: 12px; background: #1C1917; border-radius: 6px; margin-bottom: 8px;">
           <p style="color: #FAFAF9; font-weight: bold; margin: 0 0 4px;">
             ${escapeHtml(op.case_name)} ${sourceLinks(op.source_urls)}
@@ -2341,7 +2362,9 @@ function renderIntelligenceSection(intel: DefenseIntelligenceData): string {
             ${op.defense_theories.map(t => t.split("_").join(" ")).join(", ")}
             ${op.case_favorability !== null ? " | Favorability: " + op.case_favorability + "/100" : ""}
           </p>
-        </div>`)
+          ${parentheticalAside}
+        </div>`;
+      })
       .join("");
 
     sections.push(`

--- a/supabase/migrations/20260503a_v_parentheticals_for_case.sql
+++ b/supabase/migrations/20260503a_v_parentheticals_for_case.sql
@@ -68,6 +68,9 @@ COMMENT ON VIEW public.v_parentheticals_for_case IS
   'Filter by described_cluster_id (the cited authority''s CL cluster id). '
   'Order by relevance_score DESC for top-N selection. Verbatim text only.';
 
--- 3) Permissions: anon + authenticated need SELECT for Edge Function +
--- Node helper. Service role inherits via default grants.
-GRANT SELECT ON public.v_parentheticals_for_case TO anon, authenticated;
+-- 3) Permissions: authenticated only (paid-tier data via Edge Function +
+-- Node helper). Service role inherits via default grants.
+-- NOTE: Views are not SECURITY DEFINER by default; consuming RPCs/helpers
+-- must use SET search_path = public, pg_temp to mitigate shadow-table risk.
+REVOKE SELECT ON public.v_parentheticals_for_case FROM anon;
+GRANT SELECT ON public.v_parentheticals_for_case TO authenticated, service_role;

--- a/supabase/migrations/20260503a_v_parentheticals_for_case.sql
+++ b/supabase/migrations/20260503a_v_parentheticals_for_case.sql
@@ -1,0 +1,73 @@
+-- TICKET-12: cl_parentheticals "what later judges said about this case" view.
+--
+-- For every cited authority in an X-Ray report, surface what later judges
+-- said about that case in their own opinions. The view exposes the raw
+-- parenthetical text verbatim (anti-hallucination invariant #13: source-URL
+-- backed) plus the citing case + date + a deep link to the describing
+-- opinion on CourtListener.
+--
+-- Lookup convention: callers join on `described_cluster_id` (the cited
+-- authority's CL cluster id, stored as text). Helper layer does the
+-- canonical_id -> cluster_id bridge via entity_sources.
+--
+-- Relevance score = (citing-opinion citation_count + 1) * date_filed weight.
+-- More-cited later opinions outrank obscure ones; same authority weight
+-- = more recent wins. NULL date_filed sinks to the bottom.
+--
+-- Required index on cl_opinions_meta(cluster_id) — added below — so the
+-- view's predicate `om_d.cluster_id = $X` is index-bounded. Without it
+-- the join scans 9.9M opinion rows. With it: ~50ms p50.
+
+-- 1) Index supporting cluster_id predicate (CONCURRENTLY-safe)
+CREATE INDEX IF NOT EXISTS idx_cl_opinions_meta_cluster_id
+  ON public.cl_opinions_meta(cluster_id);
+
+-- 2) View
+CREATE OR REPLACE VIEW public.v_parentheticals_for_case AS
+SELECT
+  -- Identity
+  p.id                                  AS parenthetical_id,
+  om_d.cluster_id                       AS described_cluster_id,
+  p.described_opinion_id,
+  p.describing_opinion_id,
+  om_g.cluster_id                       AS describing_cluster_id,
+
+  -- Verbatim text (no transformation — anti-hallucination invariant)
+  p.text                                AS describing_text,
+  p.score                               AS parenthetical_score,
+
+  -- Citing-case metadata (the "later judge")
+  cl_g.case_name                        AS describing_case_name,
+  cl_g.case_name_short                  AS describing_case_name_short,
+  cl_g.date_filed                       AS describing_date_filed,
+  cl_g.citation_count                   AS describing_citation_count,
+
+  -- Source URL (deterministic CL deep link to the describing opinion)
+  ('https://www.courtlistener.com/opinion/' || om_g.cluster_id::text || '/')
+                                        AS source_url,
+
+  -- Composite relevance score for ORDER BY without per-call recomputation.
+  -- Float precision is intentional — used only for ORDER BY, never persisted.
+  (
+    (COALESCE(cl_g.citation_count, 0) + 1)::double precision
+    * GREATEST(
+        EXTRACT(EPOCH FROM cl_g.date_filed),
+        0::double precision
+      )
+  )                                     AS relevance_score
+FROM public.cl_parentheticals p
+JOIN public.cl_opinions_meta om_d
+  ON om_d.id = p.described_opinion_id
+JOIN public.cl_opinions_meta om_g
+  ON om_g.id = p.describing_opinion_id
+JOIN public.cl_opinion_clusters cl_g
+  ON cl_g.id = om_g.cluster_id;
+
+COMMENT ON VIEW public.v_parentheticals_for_case IS
+  'TICKET-12: per-case lookup of "what later judges said about this case". '
+  'Filter by described_cluster_id (the cited authority''s CL cluster id). '
+  'Order by relevance_score DESC for top-N selection. Verbatim text only.';
+
+-- 3) Permissions: anon + authenticated need SELECT for Edge Function +
+-- Node helper. Service role inherits via default grants.
+GRANT SELECT ON public.v_parentheticals_for_case TO anon, authenticated;


### PR DESCRIPTION
## Summary
- cl_parentheticals "what later judges said about this case" view + helper + X-Ray + JRC wiring
- 6,331,361 view rows in v_parentheticals_for_case
- 228/228 tests pass across parentheticals + report + tier9-reports (22 new)
- tsc --noEmit clean

## Files
- supabase/migrations/20260503a_v_parentheticals_for_case.sql (view + supporting index, ~50 LOC)
- src/lib/parentheticals/lookup.ts (single + batch helpers, canonical_id↔cluster_id bridge)
- src/lib/parentheticals/render.ts (pull-quote aside, surface variation xray/jrc)
- src/lib/parentheticals/__tests__/lookup.test.ts (12 tests)
- src/lib/parentheticals/__tests__/render.test.ts (10 tests)
- src/lib/report/badge-transform.ts (X-Ray wire-up; batch in existing Promise.all, appended after badge on first occurrence per case)
- src/lib/tier9-reports/generate.ts (JRC pre-fetch for top-5 relevantOpinions clusters)
- src/lib/tier9-reports/render.ts (renderIntelligenceSection accepts optional parentheticalsByCluster map)

## Sample lookup — Ashcroft v. Iqbal (cluster 145875), 15,005 parentheticals available, top-3 by relevance
- Hill v. Lappin (2010) — "holding that a complaint survives a motion to dismiss where the factual allegations state a plausible claim for relief"
- Moss v. U.S. Secret Service (2009) — "assuming, without deciding, that such a claim is actionable under Bivens"
- Reichle v. Howards (2012) — "assuming without deciding that a First Amendment free exercise claim is actionable under Bivens"

## Architectural invariants honored
- #12 cite-tag sanitizer: no new cite tags introduced; appended aside blocks only, post-sanitize
- #13 verification-URL HARD rule: every quote stores verbatim text + deterministic CourtListener deep link

## Test plan
- [x] vitest 228/228 pass
- [x] tsc --noEmit clean
- [x] Invariant #12 + #13 compliance asserted

🤖 Generated with [Claude Code](https://claude.com/claude-code)