### PR TITLE
feat(judge-quotes): aggregate-to-profiles JSONB rollup script (TICKET-5b)

### DIFF
--- a/scripts/__tests__/aggregate-judge-quotes-to-profiles.test.mjs
+++ b/scripts/__tests__/aggregate-judge-quotes-to-profiles.test.mjs
@@ -1,0 +1,244 @@
+// test-isolation-na: no Supabase writes — unit tests against in-memory fixtures only
+import { describe, it, expect } from "vitest";
+import {
+  computeScore,
+  dedupKey,
+  sourceUrlFromCluster,
+  selectTopQuotes,
+} from "../aggregate-judge-quotes-to-profiles.mjs";
+
+// ── sourceUrlFromCluster ─────────────────────────────────────────────────
+
+describe("sourceUrlFromCluster (anti-hallucination)", () => {
+  it("generates canonical CL URL for numeric cluster_id", () => {
+    expect(sourceUrlFromCluster("1234567")).toBe(
+      "https://www.courtlistener.com/opinion/1234567/"
+    );
+  });
+
+  it("accepts numeric input", () => {
+    expect(sourceUrlFromCluster(42)).toBe(
+      "https://www.courtlistener.com/opinion/42/"
+    );
+  });
+
+  it("returns null for null/undefined/empty", () => {
+    expect(sourceUrlFromCluster(null)).toBeNull();
+    expect(sourceUrlFromCluster(undefined)).toBeNull();
+    expect(sourceUrlFromCluster("")).toBeNull();
+  });
+
+  it("returns null for non-numeric (never invents URL)", () => {
+    expect(sourceUrlFromCluster("not-a-number")).toBeNull();
+    expect(sourceUrlFromCluster("123abc")).toBeNull();
+    expect(sourceUrlFromCluster("../etc/passwd")).toBeNull();
+  });
+});
+
+// ── dedupKey ─────────────────────────────────────────────────────────────
+
+describe("dedupKey", () => {
+  it("treats two rows with same case+topic+head-text as duplicates", () => {
+    // Same first 80 chars after whitespace normalization — extra trailing
+    // content beyond char 80 should not affect the dedup key.
+    const head = "We hold that the district court erred when it admitted the unreliable identification.";
+    const a = {
+      quote: head + " More words follow that exceed the 80-char head.",
+      topic: "evidence",
+      case_cited: "State v. Bentley",
+    };
+    const b = {
+      quote: "  " + head + " Different trailing words altogether after the head.",
+      topic: "evidence",
+      case_cited: "State v. Bentley",
+    };
+    expect(dedupKey(a)).toBe(dedupKey(b));
+  });
+
+  it("differentiates by topic", () => {
+    const a = { quote: "Same text", topic: "sentencing", case_cited: "X" };
+    const b = { quote: "Same text", topic: "evidence", case_cited: "X" };
+    expect(dedupKey(a)).not.toBe(dedupKey(b));
+  });
+
+  it("differentiates by case_cited", () => {
+    const a = { quote: "Same text", topic: "sentencing", case_cited: "X v. Y" };
+    const b = { quote: "Same text", topic: "sentencing", case_cited: "A v. B" };
+    expect(dedupKey(a)).not.toBe(dedupKey(b));
+  });
+});
+
+// ── computeScore ─────────────────────────────────────────────────────────
+
+describe("computeScore", () => {
+  const ctx = { newestTs: 2_000_000, oldestTs: 1_000_000 };
+
+  it("ranks suppression > sentencing > general (topic priority)", () => {
+    const longText = "x".repeat(300);
+    const ts = new Date(1_500_000).toISOString();
+    const supp = computeScore({ topic: "suppression", quote: longText, createdAt: ts }, ctx);
+    const sent = computeScore({ topic: "sentencing", quote: longText, createdAt: ts }, ctx);
+    const gen = computeScore({ topic: "general", quote: longText, createdAt: ts }, ctx);
+    expect(supp).toBeGreaterThan(sent);
+    expect(sent).toBeGreaterThan(gen);
+  });
+
+  it("rewards longer quotes within same topic", () => {
+    const ts = new Date(1_500_000).toISOString();
+    const long = computeScore({ topic: "evidence", quote: "x".repeat(700), createdAt: ts }, ctx);
+    const short = computeScore({ topic: "evidence", quote: "x".repeat(100), createdAt: ts }, ctx);
+    expect(long).toBeGreaterThan(short);
+  });
+
+  it("returns integer 0-100", () => {
+    const score = computeScore(
+      { topic: "general", quote: "tiny", createdAt: new Date(1_000_000).toISOString() },
+      ctx
+    );
+    expect(Number.isInteger(score)).toBe(true);
+    expect(score).toBeGreaterThanOrEqual(0);
+    expect(score).toBeLessThanOrEqual(100);
+  });
+
+  it("handles missing topic / null quote", () => {
+    const score = computeScore({ topic: null, quote: null, createdAt: null }, ctx);
+    expect(Number.isFinite(score)).toBe(true);
+  });
+});
+
+// ── selectTopQuotes ──────────────────────────────────────────────────────
+
+const sampleRows = [
+  // 5 dups of low-priority "general" quote
+  ...Array.from({ length: 5 }, (_, i) => ({
+    judge_id: "j1",
+    quote: "Finding no error, we affirm the ruling below.",
+    topic: "general",
+    case_cited: "State v. Frye",
+    cluster_id: String(1331508 + i), // different cluster_ids
+    source_url: "https://www.courtlistener.com/opinion/1331508/",
+    created_at: new Date(Date.parse("2024-01-01")).toISOString(),
+  })),
+  // 1 high-priority suppression quote
+  {
+    judge_id: "j1",
+    quote:
+      "We hold that the warrantless search of the defendant's vehicle violated " +
+      "the Fourth Amendment because no probable cause supported the intrusion " +
+      "and no exigency justified the bypass of the warrant requirement, and we " +
+      "therefore reverse the conviction. " + "x".repeat(200),
+    topic: "suppression",
+    case_cited: "State v. Bentley",
+    cluster_id: "1199578",
+    source_url: "https://www.courtlistener.com/opinion/1199578/",
+    created_at: new Date(Date.parse("2025-06-01")).toISOString(),
+  },
+  // 1 sentencing quote
+  {
+    judge_id: "j1",
+    quote: "x".repeat(500),
+    topic: "sentencing",
+    case_cited: "State v. McClain",
+    cluster_id: "1326341",
+    source_url: "https://www.courtlistener.com/opinion/1326341/",
+    created_at: new Date(Date.parse("2025-01-01")).toISOString(),
+  },
+];
+
+describe("selectTopQuotes", () => {
+  it("dedupes near-identical quotes by case+topic+head-text", () => {
+    const top = selectTopQuotes(sampleRows, 10);
+    // 5 dups of the same Frye quote should collapse to 1
+    const fryeQuotes = top.filter((q) => q.cite === "State v. Frye");
+    expect(fryeQuotes.length).toBe(1);
+  });
+
+  it("ranks high-priority topic first", () => {
+    const top = selectTopQuotes(sampleRows, 3);
+    expect(top[0].topic).toBe("suppression");
+  });
+
+  it("respects topN cap", () => {
+    const top = selectTopQuotes(sampleRows, 2);
+    expect(top.length).toBe(2);
+  });
+
+  it("emits source_url derived from cluster_id (anti-hallucination)", () => {
+    const top = selectTopQuotes(sampleRows, 10);
+    for (const q of top) {
+      if (q.cluster_id) {
+        expect(q.source_url).toBe(
+          `https://www.courtlistener.com/opinion/${q.cluster_id}/`
+        );
+      }
+      // Every quote with cluster_id must have source_url
+      expect(q.source_url).toBeTruthy();
+    }
+  });
+
+  it("emits superset shape (cluster_id + cite + topic + score + source_url + quote + case_cited)", () => {
+    const top = selectTopQuotes(sampleRows, 1);
+    const q = top[0];
+    expect(q).toHaveProperty("cluster_id");
+    expect(q).toHaveProperty("cite");
+    expect(q).toHaveProperty("topic");
+    expect(q).toHaveProperty("score");
+    expect(q).toHaveProperty("source_url");
+    expect(q).toHaveProperty("quote");
+    expect(q).toHaveProperty("case_cited");
+  });
+
+  it("score is integer 0-100", () => {
+    const top = selectTopQuotes(sampleRows, 10);
+    for (const q of top) {
+      expect(Number.isInteger(q.score)).toBe(true);
+      expect(q.score).toBeGreaterThanOrEqual(0);
+      expect(q.score).toBeLessThanOrEqual(100);
+    }
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(selectTopQuotes([], 10)).toEqual([]);
+    expect(selectTopQuotes(null, 10)).toEqual([]);
+  });
+
+  it("falls back to row source_url when cluster_id missing", () => {
+    const rows = [
+      {
+        judge_id: "j2",
+        quote: "x".repeat(300),
+        topic: "evidence",
+        case_cited: "X v. Y",
+        cluster_id: null,
+        source_url: "https://example.com/legacy/123",
+        created_at: new Date().toISOString(),
+      },
+    ];
+    const top = selectTopQuotes(rows, 1);
+    expect(top[0].cluster_id).toBeNull();
+    expect(top[0].source_url).toBe("https://example.com/legacy/123");
+  });
+
+  it("handles invalid created_at (per-row missing) without crashing", () => {
+    const rows = sampleRows.map((r) => ({ ...r, created_at: null }));
+    const top = selectTopQuotes(rows, 5);
+    expect(Array.isArray(top)).toBe(true);
+    expect(top.length).toBeGreaterThan(0);
+    for (const q of top) expect(Number.isFinite(q.score)).toBe(true);
+  });
+});
+
+// ── DRY-RUN no-write contract (documentation, not exec) ──────────────────
+
+describe("DRY-RUN contract", () => {
+  it("module export surface matches spec (cluster_id/cite/topic/score/source_url)", () => {
+    // This is a contract test: if anyone changes the emit shape, it breaks.
+    const rows = [sampleRows[5]]; // suppression row
+    const [q] = selectTopQuotes(rows, 1);
+    expect(typeof q.cluster_id === "string" || q.cluster_id === null).toBe(true);
+    expect(typeof q.cite === "string" || q.cite === null).toBe(true);
+    expect(typeof q.topic === "string" || q.topic === null).toBe(true);
+    expect(typeof q.score).toBe("number");
+    expect(typeof q.source_url === "string" || q.source_url === null).toBe(true);
+  });
+});

--- a/scripts/aggregate-judge-quotes-to-profiles.mjs
+++ b/scripts/aggregate-judge-quotes-to-profiles.mjs
@@ -1,0 +1,375 @@
+#!/usr/bin/env node
+/**
+ * Aggregate judge_quotes -> judge_profiles.judicial_quotes JSONB rollup.
+ *
+ * TICKET-5b: closes the missing-aggregator blocker named in PR #282 (T5).
+ *
+ * Reads judge_quotes WHERE judge_id IS NOT NULL, groups per judge,
+ * deduplicates near-identical quotes (same case_cited + topic + first 80 chars),
+ * ranks by topic-priority + quote-length-tier + recency, picks top-N per judge,
+ * and UPDATEs judge_profiles.judicial_quotes (preserves all other columns).
+ *
+ * Each emitted quote carries: { cluster_id, cite, topic, score, source_url,
+ * quote, case_cited } — superset of the historical shape (used by Tier 9
+ * reports per src/lib/tier9-reports/query.ts) and TICKET-5b spec shape
+ * (cluster_id + cite + score requested). Downstream code that reads either
+ * shape keeps working.
+ *
+ * Anti-hallucination (Architectural Invariant #13): every emitted source_url
+ * is generated from cluster_id via the canonical CourtListener pattern
+ * https://www.courtlistener.com/opinion/<cluster_id>/ — never invented.
+ * If cluster_id is missing/non-numeric, falls back to the row's stored
+ * source_url (which itself was harvested by bulk-master-extractor.mjs from
+ * CL bulk data and is verifiable).
+ *
+ * Substitute-for-missing-score note: judge_quotes has no `score` column.
+ * Score is computed deterministically from:
+ *   60% topic_priority (suppression/dismissal/sentencing > general)
+ *   30% length_tier (>=400 chars > >=200 chars > shorter)
+ *   10% recency-within-judge (newer created_at preferred)
+ * Range 0-100. See computeScore() for exact weights.
+ *
+ * Update strategy: per-judge UPDATE judge_profiles SET judicial_quotes = $1
+ * WHERE id = $2 — preserves all other columns (sentencing_distributions,
+ * bench_acquittal_rate, etc.). ~640 distinct judges currently linked, so
+ * per-row UPDATE finishes in <30s. COPY cannot express the
+ * UPDATE-existing-row-preserve-other-columns semantics needed here.
+ *
+ * Defenses (cl-bulk-data-defensive #14, #17):
+ *   - Force port 5432 (session mode) — pooler 6543 has 2-min statement_timeout
+ *   - SET statement_timeout = 30min, idle_in_transaction = 5min, TCP keepalives
+ *
+ * Usage:
+ *   node scripts/aggregate-judge-quotes-to-profiles.mjs --dry-run --verbose
+ *   node scripts/aggregate-judge-quotes-to-profiles.mjs --apply --verbose
+ *   node scripts/aggregate-judge-quotes-to-profiles.mjs --apply --limit-judges=10
+ *   node scripts/aggregate-judge-quotes-to-profiles.mjs --apply --top-n=15
+ */
+
+// bulk-insert-justified: per-judge UPDATE with custom JSONB rollup; only ~640
+// judges have linked quotes so per-row UPDATE finishes in seconds; COPY
+// cannot express UPDATE-existing-row-preserve-other-columns semantics.
+//
+// Template: scripts/link-quotes-to-judges.mjs (sibling Tier 9 quote pipeline)
+// Pattern: cl-bulk-data-defensive #14 (port-5432 override) + #17 (session
+// defenses)
+// csv-bulk-checked: none-exists — source data lives in judge_quotes Postgres
+// table; no upstream bulk file applies (judge_quotes is itself a derivative
+// table extracted by bulk-master-extractor.mjs from the CL bulk dump).
+
+import pg from "pg";
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// ── CLI ──────────────────────────────────────────────────────────────────
+
+const ARGV = process.argv.slice(2);
+const APPLY = ARGV.includes("--apply");
+const DRY_RUN = ARGV.includes("--dry-run") || !APPLY;
+const VERBOSE = ARGV.includes("--verbose");
+
+function flagInt(name, fallback) {
+  const arg = ARGV.find((a) => a.startsWith(`--${name}=`));
+  if (!arg) return fallback;
+  const n = Number.parseInt(arg.split("=")[1], 10);
+  if (!Number.isFinite(n) || n <= 0) {
+    console.error(`Invalid --${name} value`);
+    process.exit(1);
+  }
+  return n;
+}
+
+const TOP_N = flagInt("top-n", 10);
+const LIMIT_JUDGES = flagInt("limit-judges", 0); // 0 = no limit
+const MIN_QUOTES = flagInt("min-quotes", 1);
+
+// ── DB connection (port-5432 override per gotcha #14) ────────────────────
+
+function loadDbUrl() {
+  const envPath = path.resolve(__dirname, "..", ".env.local");
+  if (!fs.existsSync(envPath)) {
+    throw new Error(`Missing .env.local at ${envPath}`);
+  }
+  const envFile = fs.readFileSync(envPath, "utf8");
+  for (const line of envFile.split("\n")) {
+    if (line.startsWith("SUPABASE_DB_URL=")) {
+      return line.slice(line.indexOf("=") + 1).trim();
+    }
+  }
+  throw new Error("Missing SUPABASE_DB_URL in .env.local");
+}
+
+function buildSessionDbUrl() {
+  const u = new URL(loadDbUrl());
+  u.port = "5432"; // session-mode pooler — bulk ops, no 2-min statement_timeout
+  return u.toString();
+}
+
+async function newClient() {
+  const c = new pg.Client({
+    connectionString: buildSessionDbUrl(),
+    ssl: { rejectUnauthorized: false },
+  });
+  await c.connect();
+  // cl-bulk-data-defensive #17
+  await c.query(`SET statement_timeout = '30min'`);
+  await c.query(`SET idle_in_transaction_session_timeout = '5min'`);
+  await c.query(`SET tcp_keepalives_idle = 60`);
+  await c.query(`SET tcp_keepalives_interval = 10`);
+  await c.query(`SET tcp_keepalives_count = 6`);
+  return c;
+}
+
+// ── Scoring ──────────────────────────────────────────────────────────────
+
+// Higher = more legally interesting. Tuned for criminal-defense relevance.
+const TOPIC_PRIORITY = {
+  suppression: 100,
+  dismissal: 95,
+  probable_cause: 90,
+  search_seizure: 90,
+  constitutional: 85,
+  jury_instruction: 80,
+  evidence: 75,
+  sentencing: 70,
+  habeas: 65,
+  plea: 60,
+  procedure: 50,
+  credibility: 50,
+  general: 20,
+};
+
+function topicWeight(topic) {
+  if (!topic) return 10;
+  return TOPIC_PRIORITY[topic.toLowerCase()] ?? 30;
+}
+
+function lengthTier(text) {
+  const len = text ? text.length : 0;
+  if (len >= 600) return 100;
+  if (len >= 400) return 80;
+  if (len >= 250) return 60;
+  if (len >= 150) return 40;
+  return 20;
+}
+
+function recencyWeight(createdAt, newestTs, oldestTs) {
+  if (!createdAt) return 0;
+  const t = new Date(createdAt).getTime();
+  if (!Number.isFinite(t)) return 0;
+  const span = Math.max(1, newestTs - oldestTs);
+  return Math.round(((t - oldestTs) / span) * 100);
+}
+
+/**
+ * Composite score 0-100, deterministic.
+ *   60% topic priority
+ *   30% length tier
+ *   10% recency-within-judge-set
+ */
+export function computeScore({ topic, quote, createdAt }, ctx) {
+  const t = topicWeight(topic) * 0.6;
+  const l = lengthTier(quote) * 0.3;
+  const r = recencyWeight(createdAt, ctx.newestTs, ctx.oldestTs) * 0.1;
+  return Math.round(t + l + r);
+}
+
+// ── Source URL generator (anti-hallucination, Invariant #13) ─────────────
+
+/**
+ * Generate the canonical CourtListener opinion URL from a cluster_id.
+ * Returns null if cluster_id is falsy or non-numeric (never invents a URL).
+ */
+export function sourceUrlFromCluster(clusterId) {
+  if (!clusterId) return null;
+  const s = String(clusterId).trim();
+  if (!/^\d+$/.test(s)) return null;
+  return `https://www.courtlistener.com/opinion/${s}/`;
+}
+
+// ── Dedup key ────────────────────────────────────────────────────────────
+
+/**
+ * Two quotes are "the same" if they share case_cited + topic + first 80 chars
+ * of normalized quote text. Catches the common pattern of one opinion getting
+ * extracted N times across slightly different cluster IDs / re-runs of
+ * bulk-master-extractor.mjs.
+ */
+export function dedupKey(row) {
+  const text = (row.quote || "").replace(/\s+/g, " ").trim().slice(0, 80);
+  const cite = (row.case_cited || "").trim();
+  const topic = (row.topic || "").trim();
+  return `${cite}\x1f${topic}\x1f${text}`;
+}
+
+// ── Selection ────────────────────────────────────────────────────────────
+
+/**
+ * Given an array of judge_quotes rows for ONE judge, return top-N as
+ * the JSONB array shape we write into judge_profiles.judicial_quotes.
+ */
+export function selectTopQuotes(rows, topN) {
+  if (!rows || rows.length === 0) return [];
+
+  let newestTs = -Infinity;
+  let oldestTs = Infinity;
+  for (const r of rows) {
+    if (!r.created_at) continue;
+    const t = new Date(r.created_at).getTime();
+    if (!Number.isFinite(t)) continue;
+    if (t > newestTs) newestTs = t;
+    if (t < oldestTs) oldestTs = t;
+  }
+  if (!Number.isFinite(newestTs)) {
+    newestTs = Date.now();
+    oldestTs = newestTs;
+  }
+  const ctx = { newestTs, oldestTs };
+
+  // Dedup by composite key, keeping highest-scored variant
+  const seen = new Map();
+  for (const row of rows) {
+    const key = dedupKey(row);
+    const score = computeScore(
+      { topic: row.topic, quote: row.quote, createdAt: row.created_at },
+      ctx
+    );
+    const prev = seen.get(key);
+    if (!prev || score > prev.score) {
+      seen.set(key, { row, score });
+    }
+  }
+
+  const ranked = [...seen.values()].sort((a, b) => b.score - a.score);
+  const picked = ranked.slice(0, topN);
+
+  return picked.map(({ row, score }) => {
+    const sourceUrl =
+      sourceUrlFromCluster(row.cluster_id) ||
+      (row.source_url ? String(row.source_url) : null);
+    return {
+      cluster_id: row.cluster_id ? String(row.cluster_id) : null,
+      cite: row.case_cited || null,
+      topic: row.topic || null,
+      score,
+      source_url: sourceUrl,
+      // Preserve historical shape consumed by tier9-reports/query.ts:
+      quote: row.quote,
+      case_cited: row.case_cited || null,
+    };
+  });
+}
+
+// ── Main pipeline ────────────────────────────────────────────────────────
+
+async function fetchAllLinkedQuotes(client, limitJudges) {
+  const judgesSql = limitJudges
+    ? `SELECT DISTINCT judge_id FROM judge_quotes
+       WHERE judge_id IS NOT NULL ORDER BY judge_id LIMIT ${limitJudges}`
+    : `SELECT DISTINCT judge_id FROM judge_quotes
+       WHERE judge_id IS NOT NULL`;
+  const judgesRes = await client.query(judgesSql);
+  const judgeIds = judgesRes.rows.map((r) => r.judge_id);
+  if (judgeIds.length === 0) return new Map();
+
+  const quotesRes = await client.query(
+    `SELECT judge_id, quote, topic, case_cited, source_url, cluster_id, created_at
+     FROM judge_quotes
+     WHERE judge_id = ANY($1::uuid[])`,
+    [judgeIds]
+  );
+
+  const byJudge = new Map();
+  for (const row of quotesRes.rows) {
+    const arr = byJudge.get(row.judge_id) || [];
+    arr.push(row);
+    byJudge.set(row.judge_id, arr);
+  }
+  return byJudge;
+}
+
+async function main() {
+  const startedAt = Date.now();
+  const mode = APPLY ? "APPLY" : "DRY-RUN";
+  console.log(`[aggregate-judge-quotes] mode=${mode} top-n=${TOP_N} ` +
+    `limit-judges=${LIMIT_JUDGES || "none"} min-quotes=${MIN_QUOTES}`);
+
+  const client = await newClient();
+  try {
+    console.log("[1/4] Fetching all linked judge_quotes ...");
+    const byJudge = await fetchAllLinkedQuotes(client, LIMIT_JUDGES);
+    console.log(`      ${byJudge.size} distinct judges have linked quotes`);
+
+    console.log("[2/4] Computing top-N rollup per judge ...");
+    let judgesWithRollup = 0;
+    let totalEmitted = 0;
+    let skippedLowQuote = 0;
+    const writes = [];
+    for (const [judgeId, rows] of byJudge) {
+      if (rows.length < MIN_QUOTES) {
+        skippedLowQuote++;
+        continue;
+      }
+      const top = selectTopQuotes(rows, TOP_N);
+      if (top.length === 0) continue;
+      writes.push([judgeId, top]);
+      judgesWithRollup++;
+      totalEmitted += top.length;
+      if (VERBOSE && writes.length <= 3) {
+        console.log(`      sample judge=${judgeId} picked=${top.length}/${rows.length}`);
+        console.log(`      top1: ${JSON.stringify(top[0]).slice(0, 220)}...`);
+      }
+    }
+    console.log(`      ${judgesWithRollup} judges will be UPDATEd, ` +
+      `${totalEmitted} quotes total, skipped ${skippedLowQuote} (<${MIN_QUOTES} quotes)`);
+
+    if (DRY_RUN) {
+      console.log("[3/4] DRY-RUN: skipping writes");
+      console.log("[4/4] DRY-RUN complete (no DB writes performed)");
+      console.log(`elapsed=${((Date.now() - startedAt) / 1000).toFixed(1)}s`);
+      return;
+    }
+
+    console.log(`[3/4] APPLY: UPDATEing ${writes.length} judge_profiles rows ...`);
+    let updated = 0;
+    let notFound = 0;
+    let errors = 0;
+    for (const [judgeId, jsonArr] of writes) {
+      try {
+        const res = await client.query(
+          `UPDATE judge_profiles
+             SET judicial_quotes = $1::jsonb
+           WHERE id = $2::uuid`,
+          [JSON.stringify(jsonArr), judgeId]
+        );
+        if (res.rowCount === 1) updated++;
+        else notFound++;
+        if (VERBOSE && (updated + notFound) % 100 === 0) {
+          console.log(`      progress: updated=${updated} notFound=${notFound}`);
+        }
+      } catch (e) {
+        errors++;
+        if (errors <= 3) console.error(`      error judge=${judgeId}: ${e.message}`);
+      }
+    }
+    console.log(`      updated=${updated} notFound=${notFound} errors=${errors}`);
+
+    console.log("[4/4] APPLY complete");
+    console.log(`elapsed=${((Date.now() - startedAt) / 1000).toFixed(1)}s`);
+  } finally {
+    try { await client.end(); } catch { /* ignore */ }
+  }
+}
+
+// Allow `import { computeScore, dedupKey, sourceUrlFromCluster, selectTopQuotes }`
+// without auto-running main.
+const isDirectRun = process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
+if (isDirectRun) {
+  main().catch((err) => {
+    console.error("Fatal:", err);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary
Closes the missing-aggregator blocker from PR #282 (T5). Rolls judge_quotes WHERE judge_id IS NOT NULL → judge_profiles.judicial_quotes JSONB. Each quote carries cluster_id + cite + topic + score + source_url.

## Pre-flight (live)
- judge_quotes WHERE judge_id IS NOT NULL: 35,242
- judge_profiles WHERE jsonb_array_length(judicial_quotes) >= 5: 381
- distinct judge_id in judge_quotes: 640
- judge_profiles WHERE judicial_quotes IS NOT NULL: 492

## Files
- scripts/aggregate-judge-quotes-to-profiles.mjs
- scripts/__tests__/aggregate-judge-quotes-to-profiles.test.mjs

## Tests
21/21 vitest pass (sourceUrlFromCluster, dedupKey, computeScore, selectTopQuotes — dedup/topN/score-shape/empty/invalid-date/source_url-fallback contracts)

## Live apply
640 judges UPDATEd, 4,309 quotes total, 0 errors, 82.3s. Run with \`--apply --verbose\`.

## Post-state
- judge_profiles WHERE jsonb_array_length(judicial_quotes) >= 5: 431 (+50)
- judge_profiles WHERE jsonb_array_length(judicial_quotes) >= 1: 640 (+148)
- 0 quotes have NULL source_url (anti-hallucination Invariant 13 holds)

## Sample emit shape
\`\`\`json
{
  \"cluster_id\": \"1199578\",
  \"cite\": \"State v. Bentley\",
  \"topic\": \"search_seizure\",
  \"score\": 82,
  \"source_url\": \"https://www.courtlistener.com/opinion/1199578/\",
  \"quote\": \"We hold that the district court correctly concluded...\",
  \"case_cited\": \"State v. Bentley\"
}
\`\`\`

## Substitute scoring
judge_quotes lacks score column → composite score from 60% topic_priority + 30% length_tier + 10% recency-within-judge. Documented in commit message.

## Acceptance gap (escalation)
Spec asks for >=3,000 judges with >=5 quotes. Only 640 distinct judges have linked quotes in source data. The aggregator now rolls 100% of what's linked; bottleneck is upstream link rate (link-quotes-to-judges.mjs CSV-match rate against opinions-filtered.csv on the bulk source — D drive). Closing the link-rate gap is a separate ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)