### PR TITLE
scripts(motion-success): TICKET-3 substrate probe + 4-option unblock plan

### DIFF
--- a/docs/coverage/2026-05-03-ticket-3-motion-success-substrate.md
+++ b/docs/coverage/2026-05-03-ticket-3-motion-success-substrate.md
@@ -1,0 +1,112 @@
+# TICKET-3 Substrate Coverage — Motion-Success-by-Judge
+
+**Date:** 2026-05-03
+**Ticket:** TICKET-3 — Per-judge motion-success rates for MSR ($197), JRC, X-Ray
+**Status:** BLOCKED on substrate (T6-class). No matview shipped.
+**Pattern:** Mirrors TICKET-1 PR #293 substrate-doc handoff.
+
+## Customer-feature target (from ticket)
+
+> "Motion to Suppress in front of Judge X: filed 47 times, granted 6 (12.8%). Compare district median 18.4%."
+
+Per-judge numerator/denominator on 8 canonical motion types (Suppress, Dismiss, in Limine, Summary Judgment, Compel, Sever, Discovery, Strike). District-level fallback when judge sample N < 10. Anti-hallucination: every percentage backed by judge_id + motion_type + N + source docket-id list with source URL.
+
+## Substrate findings
+
+Probes (read-only, run from `scripts/`):
+- `probe-motion-signal.mjs` — schema + rowcount + 500K signal scan on `cl_docket_entries`
+- `probe-motion-success-rowcounts.mjs` — rowcounts + judge-distinct-count probe
+- `probe-motion-variance.mjs` — judge-coverage on existing patterns table; outcome-string variance on `classified_opinions`
+
+### Source-of-truth tables
+
+| Table | Rows | Notes |
+|---|---|---|
+| `cl_dockets` | 71,243,855 | `assigned_to_id bigint` populated. Distinct-judge query timed out at 60s — judge cardinality is large. |
+| `cl_docket_entries` | **30** | Empty cache. JIT read-through populated by ImNotAnAttorney-engine `docket-fetcher.mjs` (per migration 20260425a comment). NO bulk load has occurred. Schema: `description text` + `short_description text` present and ready to receive bulk data. |
+| `motion_success_patterns` | 1,353 | Already populated, but `judge_id` is NULL on **all 1,353 rows** (with_judge=0). Existing customer-facing data is jurisdiction-level only. |
+| `classified_opinions` | 1,462,909 | Has `motion_outcomes jsonb` — 76,896 rows match `granted`, 70,818 match `denied`. Variance present. **No judge column** — cannot bridge to per-judge data. Outcomes are appellate ("affirmed"/"reversed" per sample), not trial-court grant/deny. |
+
+### Why the matview cannot ship today
+
+1. **Trial-court substrate is empty.** The ticket spec — "Motion to Suppress filed 47 times, granted 6" — is a trial-court grant/deny pattern. The only table that could carry that text is `cl_docket_entries.description`. It has 30 rows. No bulk extraction has landed yet. Per ticket pre-flight: "If signal absent ... that's the blocker."
+
+2. **Existing `motion_success_patterns` is judge-blind by row, not by schema.** Schema has `judge_id uuid` already (migration `20260414c`), but every row has `judge_id IS NULL`. The populator (not located in this audit) only writes jurisdiction-level aggregates. Adding a judge pivot to a NULL column doesn't produce the customer feature.
+
+3. **Existing 1,353 rows show data-quality concerns** (deferred to separate worry, not this ticket):
+    - Top 5 rows: `motion_type='case_disposition'` (NOT a real motion type).
+    - All 5 have `granted_count=0`, `denied_count=filed_count`, `grant_rate=0.0000`.
+    - Pattern smells like "every disposition got tagged as a denied motion." This populator should be audited before extending it with judge-pivot logic.
+
+4. **`classified_opinions` is wrong-substrate.** It has motion outcomes with real variance, but:
+    - **No judge bridge** (no `judge_id` / `judge_name` column on the table).
+    - Outcomes are appellate (`affirmed`, `reversed`) — semantically different from trial-court motion grant/deny.
+    - Per T1 PR #293 finding: `is_good_law` uniformly true on this table — populator known to have variance issues.
+
+## Unblock options (cheapest → most expensive)
+
+### Option A — Bulk-load `cl_docket_entries` from CourtListener bulk dump (RECOMMENDED)
+
+CourtListener publishes daily docket-entry bz2 dumps at `https://storage.courtlistener.com/bulk-data/`. The 22-column `cl_dockets` cache shows we already use bulk loads from this source. Per `cl-bulk-data-defensive #19`: "CSV bulk download BEFORE API. Check bulk-download endpoint FIRST."
+
+- **Approach:** New script `scripts/bulk-load-cl-docket-entries.mjs` modeled on `scripts/cl-bulk-loader.mjs`. Uses `bulkCopyCsv` per `pg-bulk-defaults.mjs`. UNLOGGED → COPY → SET LOGGED.
+- **Then:** Re-run TICKET-3 build. With ~M-row description text, the winners-pattern matview from the ticket spec becomes shippable.
+- **Estimated size:** Federal RECAP docket-entries dump is in the multi-GB bz2 range. Tier-XL workstation can handle.
+- **Pre-req:** Run `WebSearch "courtlistener bulk-data docket-entries csv"` to confirm current filename + size before queuing.
+
+### Option B — Audit + repair existing `motion_success_patterns` populator first
+
+Find where the existing 1,353 rows were written. The "case_disposition / 0% grant rate" pattern suggests the populator is mistreating final dispositions as denied motions. Repair the populator, repopulate the table, THEN add judge-pivot column population.
+
+- Avoids needing the bulk dump.
+- But: source data is still `classified_opinions` (which has no judge column) so even a repaired populator cannot produce the per-judge numbers TICKET-3 needs.
+
+### Option C — Engine-side opportunistic capture
+
+Modify ImNotAnAttorney-engine's `docket-fetcher.mjs` (per migration comment in `20260425a_cl_docket_entries_cache.sql`) so every customer-driven docket fetch ALSO classifies motions in the entries it pulls. Over time the cache fills.
+
+- Zero bulk-load cost.
+- Coverage scales only with paying-customer flow. Cold-start: a judge with zero customers gets no data.
+- Strands the JRC and X-Ray product surfaces (which need broad judge coverage from day one).
+
+### Option D — Defer ticket; ship judge-pivot infrastructure with district-only fallback today
+
+Add `judge_id uuid` resolver helper and "district median" calculator to the existing `motion_success_patterns` consumer code. No new data, but the moment substrate lands the matview slots in.
+
+- Zero new data risk.
+- Customer-visible value = zero today.
+
+## Recommended unblock
+
+**Option A.** Bulk-load `cl_docket_entries` from CourtListener bz2 dump, then re-open TICKET-3. Same pattern as TICKET-1's recommended unblock (run `scripts/bulk-appeal-outcome-correlator.mjs`). The substrate gap is well-understood and the fix is mechanical.
+
+If Option A's bulk dump is unavailable or excessive, fall back to Option C (engine-side opportunistic capture) and document that JRC/X-Ray motion-success will populate over weeks, not on day one.
+
+## What was NOT done (per ticket "STOP and report")
+
+- No matview migration written.
+- No `motion_success_*` table extended.
+- No helper at `src/lib/motions/success-rates.ts` written.
+- No MSR / JRC / X-Ray wiring.
+- No cron-job.org registration.
+- No vitest fixtures.
+
+Per ticket Pre-flight step 4: "If `cl_docket_entries.description` is sparse / empty, that's the blocker. STOP."
+
+## Reproduction
+
+```bash
+# from worktree root
+node scripts/probe-motion-signal.mjs
+node scripts/probe-motion-success-rowcounts.mjs
+node scripts/probe-motion-variance.mjs
+```
+
+All three are read-only. `SET statement_timeout = '60s'` (or 120s on variance) on every probe.
+
+## Files (this PR draft)
+
+- `docs/coverage/2026-05-03-ticket-3-motion-success-substrate.md` (this doc)
+- `scripts/probe-motion-signal.mjs` — pre-flight
+- `scripts/probe-motion-success-rowcounts.mjs` — rowcount + judge-distinct
+- `scripts/probe-motion-variance.mjs` — variance + judge-bridge

--- a/scripts/probe-motion-signal.mjs
+++ b/scripts/probe-motion-signal.mjs
@@ -1,0 +1,204 @@
+// Pre-flight probe for TICKET-3: motion-success-by-judge
+// Confirms required tables + columns + signal exist before building.
+// Read-only. Bounded queries. No DDL.
+//
+// Per cl-bulk-data-defensive: uses scripts/lib/db.mjs (direct Postgres),
+// timeouts on long queries, no per-row INSERT, no LLM.
+
+import { query, end } from "./lib/db.mjs";
+
+async function main() {
+  const out = [];
+
+  // --- Step 1: confirm cl_dockets exists, find judge column
+  console.log("=== Step 1: cl_dockets schema ===");
+  try {
+    await query(`SET statement_timeout = '60s'`);
+    const cols = await query(
+      `SELECT column_name, data_type
+         FROM information_schema.columns
+        WHERE table_schema = 'public' AND table_name = 'cl_dockets'
+        ORDER BY ordinal_position`
+    );
+    if (cols.length === 0) {
+      console.log("  MISSING: cl_dockets table not found");
+      out.push({ step: 1, status: "MISSING", detail: "cl_dockets" });
+    } else {
+      const judgeCols = cols.filter((c) =>
+        /judge|assigned/i.test(c.column_name)
+      );
+      console.log(`  cl_dockets has ${cols.length} columns`);
+      console.log(
+        `  judge-related columns: ${
+          judgeCols.map((c) => `${c.column_name}(${c.data_type})`).join(", ") ||
+          "NONE"
+        }`
+      );
+      out.push({
+        step: 1,
+        status: "OK",
+        rowCount: cols.length,
+        judgeCols: judgeCols.map((c) => c.column_name),
+      });
+    }
+  } catch (e) {
+    console.log("  ERROR:", e.message);
+    out.push({ step: 1, status: "ERROR", error: e.message });
+  }
+
+  // --- Step 2: confirm cl_docket_entries exists, find description column
+  console.log("\n=== Step 2: cl_docket_entries schema ===");
+  let descCol = null;
+  try {
+    const cols = await query(
+      `SELECT column_name, data_type
+         FROM information_schema.columns
+        WHERE table_schema = 'public' AND table_name = 'cl_docket_entries'
+        ORDER BY ordinal_position`
+    );
+    if (cols.length === 0) {
+      console.log("  MISSING: cl_docket_entries table not found");
+      out.push({ step: 2, status: "MISSING", detail: "cl_docket_entries" });
+    } else {
+      console.log(`  cl_docket_entries has ${cols.length} columns:`);
+      for (const c of cols) console.log(`    - ${c.column_name} (${c.data_type})`);
+      // Look for the text-bearing column
+      const textCols = cols.filter(
+        (c) =>
+          /description|text|long_description|short_description|entry|body/i.test(
+            c.column_name
+          ) && /text|character|varchar/i.test(c.data_type)
+      );
+      descCol = textCols[0]?.column_name || null;
+      out.push({
+        step: 2,
+        status: "OK",
+        cols: cols.length,
+        textColCandidates: textCols.map((c) => c.column_name),
+      });
+    }
+  } catch (e) {
+    console.log("  ERROR:", e.message);
+    out.push({ step: 2, status: "ERROR", error: e.message });
+  }
+
+  // --- Step 3: rowcount on cl_docket_entries (bounded, fast)
+  console.log("\n=== Step 3: cl_docket_entries rowcount estimate ===");
+  try {
+    // Use pg_class reltuples for fast estimate (no full scan)
+    const est = await query(
+      `SELECT reltuples::bigint AS estimated_rows,
+              pg_size_pretty(pg_total_relation_size(oid)) AS total_size
+         FROM pg_class
+        WHERE relname = 'cl_docket_entries' AND relkind = 'r'`
+    );
+    console.log("  estimate:", JSON.stringify(est[0] || {}));
+    out.push({ step: 3, status: "OK", estimate: est[0] || null });
+  } catch (e) {
+    console.log("  ERROR:", e.message);
+    out.push({ step: 3, status: "ERROR", error: e.message });
+  }
+
+  // --- Step 4: signal probe — only if we found a description column
+  console.log("\n=== Step 4: motion signal probe ===");
+  if (!descCol) {
+    console.log(
+      "  SKIP: no text column in cl_docket_entries — bulk extractor needed (T6 substrate gap)"
+    );
+    out.push({
+      step: 4,
+      status: "SKIP_NO_TEXT_COL",
+      detail:
+        "cl_docket_entries lacks text-bearing column for motion classification",
+    });
+  } else {
+    console.log(`  using column: ${descCol}`);
+    try {
+      // Bounded scan: use a TABLESAMPLE or LIMIT-friendly probe
+      // Cap at 60s; if it spills, treat as SKIP
+      await query(`SET statement_timeout = '60s'`);
+      const probe = await query(
+        `SELECT
+           COUNT(*) FILTER (WHERE ${descCol} ILIKE '%motion to suppress%') AS suppress,
+           COUNT(*) FILTER (WHERE ${descCol} ILIKE '%motion to dismiss%')  AS dismiss,
+           COUNT(*) FILTER (WHERE ${descCol} ILIKE '%granted%')            AS granted,
+           COUNT(*) FILTER (WHERE ${descCol} ILIKE '%denied%')             AS denied,
+           COUNT(*) AS sampled
+         FROM (
+           SELECT ${descCol} FROM cl_docket_entries LIMIT 500000
+         ) s`
+      );
+      console.log("  500K-sample signal:", JSON.stringify(probe[0]));
+      out.push({ step: 4, status: "OK", signal: probe[0] });
+    } catch (e) {
+      console.log("  ERROR/TIMEOUT:", e.message);
+      out.push({ step: 4, status: "ERROR", error: e.message });
+    }
+  }
+
+  // --- Step 5: existing motion_success_* tables
+  console.log("\n=== Step 5: existing motion_success_* schema ===");
+  try {
+    const tables = await query(
+      `SELECT table_name
+         FROM information_schema.tables
+        WHERE table_schema = 'public'
+          AND (table_name LIKE 'motion_success%' OR table_name LIKE 'motion_outcomes%')
+        ORDER BY table_name`
+    );
+    if (tables.length === 0) {
+      console.log("  none — fresh build territory");
+      out.push({ step: 5, status: "EMPTY" });
+    } else {
+      for (const t of tables) console.log(`  - ${t.table_name}`);
+      out.push({
+        step: 5,
+        status: "OK",
+        tables: tables.map((t) => t.table_name),
+      });
+    }
+  } catch (e) {
+    console.log("  ERROR:", e.message);
+    out.push({ step: 5, status: "ERROR", error: e.message });
+  }
+
+  // --- Step 6: judge_disposition_stats precedent reference (T2 PR #290 pattern)
+  console.log("\n=== Step 6: judge_disposition_stats precedent ===");
+  try {
+    const exists = await query(
+      `SELECT relkind FROM pg_class WHERE relname = 'judge_disposition_stats'`
+    );
+    if (exists.length === 0) {
+      console.log("  judge_disposition_stats not present");
+      out.push({ step: 6, status: "ABSENT" });
+    } else {
+      console.log(`  exists, relkind=${exists[0].relkind}`);
+      const cnt = await query(
+        `SELECT COUNT(*)::bigint AS n FROM judge_disposition_stats`
+      );
+      console.log(`  rows: ${cnt[0].n}`);
+      out.push({
+        step: 6,
+        status: "OK",
+        relkind: exists[0].relkind,
+        rows: cnt[0].n,
+      });
+    }
+  } catch (e) {
+    console.log("  ERROR:", e.message);
+    out.push({ step: 6, status: "ERROR", error: e.message });
+  }
+
+  console.log("\n=== SUMMARY ===");
+  console.log(JSON.stringify(out, null, 2));
+
+  await end();
+}
+
+main().catch(async (e) => {
+  console.error("FATAL:", e);
+  try {
+    await end();
+  } catch {}
+  process.exit(1);
+});

--- a/scripts/probe-motion-success-rowcounts.mjs
+++ b/scripts/probe-motion-success-rowcounts.mjs
@@ -1,0 +1,53 @@
+// TICKET-3 supplemental probe: rowcounts on the four tables that would feed
+// the motion-success-by-judge matview. Run after probe-motion-signal.mjs.
+// Read-only.
+
+import { query, end } from "./lib/db.mjs";
+
+const TABLES = [
+  "motion_success_patterns",
+  "classified_opinions",
+  "cl_docket_entries",
+  "cl_dockets",
+];
+
+async function main() {
+  await query(`SET statement_timeout = '60s'`);
+  for (const t of TABLES) {
+    try {
+      const r = await query(`SELECT COUNT(*)::bigint AS n FROM ${t}`);
+      console.log(`${t}: ${r[0].n} rows`);
+    } catch (e) {
+      console.log(`${t}: ERROR ${e.message}`);
+    }
+  }
+  // Distinct judges in cl_dockets (for denominator if matview built today)
+  try {
+    const r = await query(
+      `SELECT COUNT(DISTINCT assigned_to_id)::bigint AS judges
+         FROM cl_dockets WHERE assigned_to_id IS NOT NULL`
+    );
+    console.log(`cl_dockets distinct assigned_to_id: ${r[0].judges}`);
+  } catch (e) {
+    console.log("distinct judges ERROR:", e.message);
+  }
+  // Motion-text signal in classified_opinions (alt substrate)
+  try {
+    const r = await query(
+      `SELECT COUNT(*)::bigint AS n,
+              COUNT(*) FILTER (WHERE motion_types <> '{}'::text[]) AS with_motions,
+              COUNT(*) FILTER (WHERE motion_outcomes IS NOT NULL) AS with_outcomes
+         FROM classified_opinions`
+    );
+    console.log("classified_opinions motion-fields:", JSON.stringify(r[0]));
+  } catch (e) {
+    console.log("classified_opinions probe ERROR:", e.message);
+  }
+  await end();
+}
+
+main().catch(async (e) => {
+  console.error("FATAL:", e);
+  try { await end(); } catch {}
+  process.exit(1);
+});

--- a/scripts/probe-motion-variance.mjs
+++ b/scripts/probe-motion-variance.mjs
@@ -1,0 +1,72 @@
+// TICKET-3 substrate variance probe.
+// Tests whether classified_opinions.motion_outcomes carries usable signal,
+// and whether existing motion_success_patterns covers judges.
+
+import { query, end } from "./lib/db.mjs";
+
+async function main() {
+  await query(`SET statement_timeout = '120s'`);
+
+  console.log("=== A. motion_success_patterns judge coverage ===");
+  const a = await query(
+    `SELECT COUNT(*) AS total,
+            COUNT(*) FILTER (WHERE judge_id IS NOT NULL) AS with_judge,
+            COUNT(DISTINCT motion_type) AS distinct_motions,
+            COUNT(DISTINCT charge_slug) AS distinct_charges,
+            COUNT(DISTINCT jurisdiction) AS distinct_juris
+       FROM motion_success_patterns`
+  );
+  console.log(JSON.stringify(a[0], null, 2));
+
+  console.log("\n=== B. motion_success_patterns sample ===");
+  const b = await query(
+    `SELECT motion_type, charge_slug, jurisdiction, judge_id,
+            filed_count, granted_count, denied_count, grant_rate
+       FROM motion_success_patterns
+       ORDER BY filed_count DESC NULLS LAST
+       LIMIT 5`
+  );
+  for (const row of b) console.log(JSON.stringify(row));
+
+  console.log("\n=== C. classified_opinions.motion_outcomes shape ===");
+  const c = await query(
+    `SELECT motion_outcomes
+       FROM classified_opinions
+      WHERE motion_outcomes IS NOT NULL
+        AND jsonb_typeof(motion_outcomes) <> 'null'
+      LIMIT 5`
+  );
+  for (const row of c) console.log(JSON.stringify(row.motion_outcomes));
+
+  console.log("\n=== D. classified_opinions outcome-value histogram ===");
+  const d = await query(
+    `SELECT
+        COUNT(*) FILTER (WHERE motion_outcomes::text ILIKE '%granted%') AS has_granted,
+        COUNT(*) FILTER (WHERE motion_outcomes::text ILIKE '%denied%')  AS has_denied,
+        COUNT(*) FILTER (WHERE motion_outcomes::text = '{}')            AS empty_obj,
+        COUNT(*) FILTER (WHERE motion_outcomes::text = 'null')          AS null_str,
+        COUNT(*) AS total
+       FROM classified_opinions
+      WHERE motion_outcomes IS NOT NULL`
+  );
+  console.log(JSON.stringify(d[0], null, 2));
+
+  console.log("\n=== E. classified_opinions judge bridge ===");
+  // Does classified_opinions carry a judge linkage?
+  const e = await query(
+    `SELECT column_name, data_type
+       FROM information_schema.columns
+      WHERE table_schema='public' AND table_name='classified_opinions'
+        AND column_name ILIKE '%judge%'`
+  );
+  if (e.length === 0) console.log("  no judge column on classified_opinions");
+  for (const row of e) console.log(`  ${row.column_name} ${row.data_type}`);
+
+  await end();
+}
+
+main().catch(async (err) => {
+  console.error("FATAL:", err);
+  try { await end(); } catch {}
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
TICKET-3 (motion-success per judge per motion type) is BLOCKED on substrate. Probe scripts + coverage doc shipped; matview deferred to follow-up.

## Substrate findings
- cl_dockets: 71,243,855 rows (assigned_to_id populated)
- cl_docket_entries: **30 rows** (JIT cache, no bulk load — per migration 20260425a comment)
- motion_success_patterns: 1,353 rows but judge_id NULL on every row; populator only writes jurisdiction-level
- classified_opinions: 1.46M rows w/ 76K granted / 70K denied variance, but NO judge column

## Why nothing else built
Ticket spec — "Motion to Suppress filed 47 times, granted 6 (12.8%)" — is trial-court text classification. The only table that can carry that text is cl_docket_entries.description, which is empty (30 rows). Per ticket spec STOP condition.

## Files
- docs/coverage/2026-05-03-ticket-3-motion-success-substrate.md — 4 unblock options A/B/C/D
- scripts/probe-motion-signal.mjs
- scripts/probe-motion-success-rowcounts.mjs
- scripts/probe-motion-variance.mjs

## Same blocker class as T6 (PR #281)
cl_docket_entries needs bulk-load from CourtListener bz2 dump per cl-bulk-data-defensive #19. Source bz2 download in flight tonight (~29% complete at last check).

## Recommended unblock
Once bz2 lands + cl_docket_entries bulk-loaded → re-open TICKET-3 with matview build per Option A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)