### PR TITLE
fix(scripts): T5 link-quotes default CSV path matches filter producer

### DIFF
--- a/scripts/link-quotes-to-judges.mjs
+++ b/scripts/link-quotes-to-judges.mjs
@@ -38,7 +38,7 @@ if (!dryRun && !apply) {
   process.exit(1);
 }
 
-const OPINIONS_CSV = resolve("data/bulk-verify/cl-bulk/opinions-filtered.csv");
+const OPINIONS_CSV = resolve(process.env.OPINIONS_CSV || "data/bulk-verify/cl-bulk/opinions-criminal.csv");
 
 // ── Step 1: Get unique cluster_ids from judge_quotes ──
 


### PR DESCRIPTION
## Summary
- T5 (link-quotes-to-judges) hardcoded `opinions-filtered.csv` but the upstream filter producer writes `opinions-criminal.csv`. ENOENT on every run.
- Default to `opinions-criminal.csv`, allow `OPINIONS_CSV` env override for backfills.

## Why
Caught at 00:02 ET 2026-05-04 when filter-criminal-opinions.py (pid 882980) completed producing the 19.8 GB CSV and the linker immediately died on startup with ENOENT. The currently-running T5 process had the in-memory fix from a hot edit; this PR makes it durable for any future restart.

## Test plan
- [x] tsc clean (no .ts changes — verified canonical worktree)
- [x] Hot-fixed in-process linker continues streaming successfully
- [ ] On merge: future T5 invocations resolve to opinions-criminal.csv by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)