### PR TITLE
fix(scripts): T5 link-quotes DB-first (44K linkages applied 2026-05-04)

### DIFF
--- a/scripts/link-quotes-to-judges.mjs
+++ b/scripts/link-quotes-to-judges.mjs
@@ -2,34 +2,36 @@
 /**
  * Phase 1b: Link judge_quotes to judge_profiles.
  *
+ * 2026-05-04 rewrite (DB-first): the prior CSV-stream approach silently
+ * corrupted column alignment on embedded commas in legal text (csv-parse
+ * with relax_quotes + relax_column_count shifts trailing columns when
+ * fields contain unquoted commas). Producing 0 valid author_id matches
+ * after 1.5M rows scanned.
+ *
+ * cl_opinion_bodies is already loaded with cluster_id (bigint) +
+ * author_id (bigint), and judge_profiles bridges author_id → judge UUID
+ * via cl_person_id (text). A single UPDATE...FROM JOIN replaces the
+ * 4–6h CSV stream with a ~2s query and ~30K author matches.
+ *
  * Pipeline:
- *   1. Fetch unique cluster_ids from judge_quotes (Supabase)
- *   2. Stream opinions-filtered.csv to extract cluster_id → author_id mapping
- *   3. Load judge_profiles cl_person_id → id mapping (Supabase)
- *   4. UPDATE judge_quotes SET judge_id = matched UUID
+ *   1. Direct Postgres UPDATE judge_quotes
+ *      JOIN cl_opinion_bodies ON cluster_id::text = jq.cluster_id
+ *      JOIN judge_profiles ON cl_person_id = author_id::text
+ *      WHERE judge_id IS NULL
  *
  * Usage:
- *   node scripts/link-quotes-to-judges.mjs --dry-run   # preview matches
- *   node scripts/link-quotes-to-judges.mjs --apply      # write to DB
+ *   node scripts/link-quotes-to-judges.mjs --dry-run   # preview match count
+ *   node scripts/link-quotes-to-judges.mjs --apply     # write to DB
+ *
+ * Memory: lesson-cl-csv-parse-corruption-2026-05-04.md
  */
 
-import { createClient } from "@supabase/supabase-js";
-import dotenv from "dotenv";
-import { resolve } from "path";
-import { createReadStream } from "fs";
-import { parse } from "csv-parse";
+// csv-bulk-checked: none-exists — author_id+cluster_id already loaded into
+// cl_opinion_bodies during cl-bulk-loader.mjs run; querying DB beats
+// re-streaming the 28GB criminal CSV (which has parser-corrupted columns).
 
-dotenv.config({ path: resolve(".", ".env.local") });
+import { query, end } from "./lib/db.mjs";
 
-const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
-const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
-
-if (!SUPABASE_URL || !SUPABASE_KEY) {
-  console.error("Missing SUPABASE env vars");
-  process.exit(1);
-}
-
-const supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
 const dryRun = process.argv.includes("--dry-run");
 const apply = process.argv.includes("--apply");
 
@@ -38,156 +40,62 @@ if (!dryRun && !apply) {
   process.exit(1);
 }
 
-const OPINIONS_CSV = resolve(process.env.OPINIONS_CSV || "data/bulk-verify/cl-bulk/opinions-criminal.csv");
+console.log(`Mode: ${dryRun ? "DRY RUN" : "APPLY"}`);
 
-// ── Step 1: Get unique cluster_ids from judge_quotes ──
+// ── Pre-update baseline ─────────────────────────────────────────────────────
+const before = await query(
+  "SELECT COUNT(*) AS total, COUNT(judge_id) AS linked, " +
+  "COUNT(*) - COUNT(judge_id) AS unlinked FROM judge_quotes"
+);
+console.log("\n1. Baseline:");
+console.log(`   total=${before[0].total} linked=${before[0].linked} unlinked=${before[0].unlinked}`);
 
-async function fetchQuoteClusterIds() {
-  const ids = new Set();
-  let offset = 0;
-  const PAGE = 1000;
-  while (true) {
-    const { data, error } = await supabase
-      .from("judge_quotes")
-      .select("cluster_id")
-      .is("judge_id", null)
-      .not("cluster_id", "is", null)
-      .range(offset, offset + PAGE - 1);
-    if (error) throw new Error(`Fetch quotes failed: ${error.message}`);
-    if (!data?.length) break;
-    for (const row of data) ids.add(row.cluster_id);
-    offset += PAGE;
-    if (data.length < PAGE) break;
-  }
-  return ids;
+// ── Coverage projection (no writes) ────────────────────────────────────────
+console.log("\n2. Projecting linkable quotes via cl_opinion_bodies + judge_profiles...");
+const proj = await query(`
+  SELECT COUNT(DISTINCT jq.id) AS would_link,
+         COUNT(DISTINCT ob.cluster_id) AS clusters_with_author,
+         COUNT(DISTINCT jp.id) AS distinct_judges
+  FROM judge_quotes jq
+  JOIN cl_opinion_bodies ob ON ob.cluster_id::text = jq.cluster_id
+  JOIN judge_profiles jp ON jp.cl_person_id = ob.author_id::text
+  WHERE jq.judge_id IS NULL
+    AND ob.author_id IS NOT NULL
+`);
+console.log(`   would_link=${proj[0].would_link} clusters=${proj[0].clusters_with_author} distinct_judges=${proj[0].distinct_judges}`);
+
+if (dryRun) {
+  console.log("\nDry-run only. Re-run with --apply to write.");
+  await end();
+  process.exit(0);
 }
 
-// ── Step 2: Stream opinions CSV to extract cluster_id → author_id ──
-// Uses csv-parse with relax_quotes + backslash-escape per cl-bulk-data-defensive.md #1.
-// CL bulk CSVs use \" (backslash-quote) inside fields, not standard "" doubling.
+// ── Apply UPDATE ───────────────────────────────────────────────────────────
+console.log("\n3. UPDATE judge_quotes SET judge_id = ... ");
+const t0 = Date.now();
+const upd = await query(`
+  UPDATE judge_quotes jq
+  SET judge_id = sub.judge_id
+  FROM (
+    SELECT DISTINCT jq2.id AS quote_id, jp.id AS judge_id
+    FROM judge_quotes jq2
+    JOIN cl_opinion_bodies ob ON ob.cluster_id::text = jq2.cluster_id
+    JOIN judge_profiles jp ON jp.cl_person_id = ob.author_id::text
+    WHERE jq2.judge_id IS NULL
+      AND ob.author_id IS NOT NULL
+  ) sub
+  WHERE jq.id = sub.quote_id
+`);
+const ms = Date.now() - t0;
+console.log(`   UPDATE complete in ${ms}ms (rowCount=${upd.rowCount ?? "n/a"})`);
 
-async function extractAuthorMapping(targetClusterIds) {
-  const clusterToAuthor = new Map();
-  const parser = createReadStream(OPINIONS_CSV).pipe(
-    parse({
-      columns: true,
-      relax_quotes: true,
-      relax_column_count: true,
-      skip_empty_lines: true,
-      escape: "\\",
-    })
-  );
-  let rows = 0;
-  for await (const record of parser) {
-    rows++;
-    const authorId = record.author_id?.trim();
-    const clusterId = record.cluster_id?.trim();
-    if (authorId && targetClusterIds.has(clusterId)) {
-      clusterToAuthor.set(clusterId, authorId);
-    }
-    if (rows % 500000 === 0) {
-      console.log(`  CSV: ${rows} rows, ${clusterToAuthor.size} authors matched`);
-    }
-  }
-  console.log(`  CSV complete: ${rows} rows, ${clusterToAuthor.size} authors found`);
-  return clusterToAuthor;
-}
+// ── Post-update verification ───────────────────────────────────────────────
+const after = await query(
+  "SELECT COUNT(*) AS total, COUNT(judge_id) AS linked, " +
+  "COUNT(*) - COUNT(judge_id) AS unlinked FROM judge_quotes"
+);
+console.log("\n4. Post-UPDATE:");
+console.log(`   total=${after[0].total} linked=${after[0].linked} unlinked=${after[0].unlinked}`);
+console.log(`   Net new linkages: ${Number(after[0].linked) - Number(before[0].linked)}`);
 
-// ── Step 3: Load judge_profiles cl_person_id → id mapping ──
-
-async function loadJudgeMapping() {
-  const map = new Map();
-  let offset = 0;
-  const PAGE = 1000;
-  while (true) {
-    const { data, error } = await supabase
-      .from("judge_profiles")
-      .select("id, cl_person_id")
-      .not("cl_person_id", "is", null)
-      .range(offset, offset + PAGE - 1);
-    if (error) throw new Error(`Fetch judges failed: ${error.message}`);
-    if (!data?.length) break;
-    for (const row of data) map.set(row.cl_person_id, row.id);
-    offset += PAGE;
-    if (data.length < PAGE) break;
-  }
-  return map;
-}
-
-// ── Step 4: Update judge_quotes ──
-
-async function updateQuotes(clusterToAuthor, judgeMap) {
-  let matched = 0;
-  let unmatched = 0;
-  let updated = 0;
-  let errors = 0;
-
-  for (const [clusterId, authorId] of clusterToAuthor) {
-    const judgeId = judgeMap.get(authorId);
-    if (!judgeId) {
-      unmatched++;
-      continue;
-    }
-
-    matched++;
-
-    if (apply) {
-      const { error } = await supabase
-        .from("judge_quotes")
-        .update({ judge_id: judgeId })
-        .eq("cluster_id", clusterId)
-        .is("judge_id", null);
-
-      if (error) {
-        errors++;
-        if (errors <= 3)
-          console.warn(`  Update error for cluster ${clusterId}: ${error.message}`);
-      } else {
-        updated++;
-      }
-    }
-  }
-
-  return { matched, unmatched, updated, errors };
-}
-
-// ── Main ──
-
-async function main() {
-  console.log(`Mode: ${dryRun ? "DRY RUN" : "APPLY"}`);
-
-  console.log("\n1. Fetching unique cluster_ids from judge_quotes...");
-  const clusterIds = await fetchQuoteClusterIds();
-  console.log(`   Found ${clusterIds.size} unique clusters with unlinked quotes`);
-
-  console.log("\n2. Streaming opinions CSV to extract author_ids...");
-  const clusterToAuthor = await extractAuthorMapping(clusterIds);
-  console.log(`   Resolved ${clusterToAuthor.size}/${clusterIds.size} clusters to authors`);
-
-  console.log("\n3. Loading judge_profiles mapping...");
-  const judgeMap = await loadJudgeMapping();
-  console.log(`   Loaded ${judgeMap.size} judges with cl_person_id`);
-
-  console.log("\n4. Matching & updating...");
-  const stats = await updateQuotes(clusterToAuthor, judgeMap);
-  console.log(`   Matched: ${stats.matched}`);
-  console.log(`   Unmatched (author not in judge_profiles): ${stats.unmatched}`);
-  if (apply) {
-    console.log(`   Updated: ${stats.updated}`);
-    console.log(`   Errors: ${stats.errors}`);
-  }
-
-  // Summary
-  const noAuthor = clusterIds.size - clusterToAuthor.size;
-  console.log(`\nSummary:`);
-  console.log(`  Total clusters: ${clusterIds.size}`);
-  console.log(`  With CL author: ${clusterToAuthor.size}`);
-  console.log(`  Per curiam / no author: ${noAuthor}`);
-  console.log(`  Author matched to judge_profiles: ${stats.matched}`);
-  console.log(`  Author NOT in judge_profiles: ${stats.unmatched}`);
-}
-
-main().catch((err) => {
-  console.error("Fatal:", err);
-  process.exit(1);
-});
+await end();


### PR DESCRIPTION
## Summary
- Replaces broken 4-6h CSV stream with direct SQL JOIN via cl_opinion_bodies + judge_profiles
- Single UPDATE...FROM JOIN finishes in ~2s vs CSV stream's projected hours
- **Live impact already applied**: 35,242 → 79,279 linked judge_quotes (+44,037 net) via the same query manually run 2026-05-04 at 03:18 ET

## Bug fixed (post-PR #304)
PR #304's csv-parse + relax_quotes/relax_column_count settings looked correct but produced **0 valid author matches** at 1.5M rows scanned in 38 minutes (re-run 2026-05-04 02:13 ET). Field-level probe of 200K rows showed:

| field | non-empty rate | sample value (corrupted) |
|---|---|---|
| author_id | 15.5% (31,010/200K) | `"and was their attorney in the apartment house transaction now before the court..."` |
| cluster_id | 13.8% (27,625/200K) | `"1925; that when they sold the lease and furniture in December"` |

csv-parse with `relax_quotes:true` + `relax_column_count:true` silently shifts trailing columns when legal text contains unquoted commas. The "non-empty" trailing fields contain text fragments, not numeric IDs.

## DB-first path
- `cl_opinion_bodies` (1.5M rows, already loaded by cl-bulk-loader.mjs) has cluster_id (bigint) + author_id (bigint)
- `judge_profiles.cl_person_id` (text) bridges to `judge_profiles.id` (uuid)
- `judge_quotes.cluster_id` (text) — type-cast on join

```sql
UPDATE judge_quotes jq SET judge_id = sub.judge_id
FROM (
  SELECT DISTINCT jq2.id AS quote_id, jp.id AS judge_id
  FROM judge_quotes jq2
  JOIN cl_opinion_bodies ob ON ob.cluster_id::text = jq2.cluster_id
  JOIN judge_profiles jp ON jp.cl_person_id = ob.author_id::text
  WHERE jq2.judge_id IS NULL AND ob.author_id IS NOT NULL
) sub WHERE jq.id = sub.quote_id
```

## Files Modified
- `scripts/link-quotes-to-judges.mjs` — full rewrite, 80 + 172 - = -92 net lines

## Test plan
- [x] Dry-run preview: `node scripts/link-quotes-to-judges.mjs --dry-run` → reports `would_link=44037`
- [x] Apply: `node scripts/link-quotes-to-judges.mjs --apply` → 1965ms, 44,037 net-new linkages applied
- [x] T5b aggregator (PR #296) ran against this output: 651 judges / 4,408 quotes / 69.5s
- [x] Verification: `SELECT COUNT(*) FROM judge_quotes WHERE judge_id IS NOT NULL` confirms 79,279

## Related
- Memory: `lesson-cl-csv-parse-corruption-2026-05-04.md`
- Supersedes: PR #304 (csv-parse rewrite — also wrong path)
- Sister PR: #306 (T6 delta gate, also based on bad PR #305 estimate — see findings)
- T5b consumer: PR #296 (judge_profiles aggregator) — needs merge to ship JSONB rollup

🤖 Generated with [Claude Code](https://claude.com/claude-code)