### PR TITLE
fix(scripts): T6 charge-extractor DB-first rewrite (Phase 1)

### DIFF
--- a/scripts/bulk-extract-charge-types.mjs
+++ b/scripts/bulk-extract-charge-types.mjs
@@ -1,13 +1,19 @@
 /**
- * Bulk Charge Type Extraction, Focused Pipeline
+ * Bulk Charge Type Extraction — DB-first (Phase 1 of 2026-05-04 plan)
  *
- * Streams opinions-criminal.csv (45GB pre-filtered criminal opinions),
- * runs keyword-based charge classification on full opinion text, and
+ * Streams cl_opinion_bodies via keyset pagination (cluster_id),
+ * runs keyword-based charge classification on plain_text, and
  * updates classified_opinions.charge_types via direct Postgres.
  *
- * This is a focused counterpart to bulk-classify-full-corpus.mjs,
- * it ONLY extracts charge_types (not motions, theories, outcomes).
- * Much faster: skips statute parsing, motion extraction, cross-validation.
+ * REPLACES the prior CSV-stream design (opinions-criminal.csv +
+ * csv-parse). The csv-parse config (relax_quotes:true, escape:'\\\\')
+ * silently shifts trailing columns when legal text contains unquoted
+ * commas, corrupting cluster_id (2026-05-04 incident: T6 smoke
+ * processed 600K rows, script reported 2,278 classified, n_tup_upd
+ * stayed at 264 — zero actual writes). cl_opinion_bodies is the
+ * already-loaded DB version of the same source data; the JOIN is
+ * 1.5M rows with cluster_id (bigint) + plain_text (text) + text_length
+ * (integer), so no parser is involved.
  *
  * Three extraction methods (from mechanical-extractor.mjs):
  *   1. Direct charge name keywords (120+ phrases across 10 categories)
@@ -15,19 +21,18 @@
  *   3. Existing statute matches are preserved (merge, not replace)
  *
  * Usage:
- *   node scripts/bulk-extract-charge-types.mjs                  # Dry-run stats
- *   node scripts/bulk-extract-charge-types.mjs --apply          # Write to DB
- *   node scripts/bulk-extract-charge-types.mjs --apply --limit 1000  # Test first 1000
- *   node scripts/bulk-extract-charge-types.mjs --apply --resume-from 500000
+ *   node scripts/bulk-extract-charge-types.mjs                            # Dry-run stats
+ *   node scripts/bulk-extract-charge-types.mjs --apply                    # Write to DB
+ *   node scripts/bulk-extract-charge-types.mjs --apply --limit 1000       # Test first 1000 rows
+ *   node scripts/bulk-extract-charge-types.mjs --apply --resume-from 5000000  # cluster_id > 5M
+ *   node scripts/bulk-extract-charge-types.mjs --apply --chunk-size 2000  # smaller chunks
+ *   node scripts/bulk-extract-charge-types.mjs --apply --no-delta-gate    # full re-scan
  *
- * Runtime: ~30-90 minutes depending on disk speed.
- * CRITICAL: Do NOT run while other bulk CSV scripts are running (OOM gotcha).
+ * Runtime: ~5-15 minutes for 1.39M with-text rows (vs broken CSV's 4-6h).
+ * Verification: pg_stat_user_tables.n_tup_upd on classified_opinions is
+ * the ground truth — script-reported counters were unreliable when the
+ * old csv-parse path corrupted cluster_id.
  */
-
-import fs from "fs";
-import path from "path";
-import { parse } from "csv-parse";
-import { fileURLToPath } from "url";
 
 import {
   extractChargesFromKeywords,
@@ -35,15 +40,10 @@ import {
 } from "./lib/mechanical-extractor.mjs";
 import { query, end } from "./lib/db.mjs";
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const PROJECT_ROOT = path.resolve(__dirname, "..");
-
-const OPINIONS_CSV = path.join(
-  PROJECT_ROOT, "data", "bulk-verify", "cl-bulk", "opinions-criminal.csv"
-);
-
 const MIN_TEXT_LEN = 200;
 const UPDATE_BATCH_SIZE = 500;
+const DEFAULT_CHUNK_SIZE = 5000;
+const STATEMENT_TIMEOUT = "300s";
 
 // ── CLI flags ────────────────────────────────────────────────────────────────
 const args = process.argv.slice(2);
@@ -56,17 +56,8 @@ const processLimit = limitIdx >= 0 ? parseInt(args[limitIdx + 1], 10) : Infinity
 const resumeIdx = args.indexOf("--resume-from");
 const resumeFrom = resumeIdx >= 0 ? parseInt(args[resumeIdx + 1], 10) : 0;
 
-// ── HTML stripping (no regex, project rule) ─────────────────────────────────
-function stripHtml(html) {
-  if (!html) return "";
-  const parts = html.split("<");
-  const out = [];
-  for (const part of parts) {
-    const closeIdx = part.indexOf(">");
-    out.push(closeIdx >= 0 ? part.slice(closeIdx + 1) : part);
-  }
-  return out.join("").trim();
-}
+const chunkIdx = args.indexOf("--chunk-size");
+const chunkSize = chunkIdx >= 0 ? parseInt(args[chunkIdx + 1], 10) : DEFAULT_CHUNK_SIZE;
 
 // ── Memory logging ───────────────────────────────────────────────────────────
 function logMem(label) {
@@ -102,12 +93,6 @@ async function loadTheoryMap() {
 }
 
 // ── Load already-classified cluster_ids (delta gate) ─────────────────────────
-// Pre-filters the source CSV stream to skip clusters that already have
-// charge_types populated. Eliminates ~95% no-op work when re-running the
-// extractor against historical data. See docs/handoffs/2026-05-04-t6-delta-gate-rewrite.md.
-//
-// Override with --no-delta-gate to force full re-scan (e.g. after a theory_map
-// change that needs to propagate to every existing classification).
 async function loadAlreadyClassifiedClusters() {
   console.log("Loading already-classified cluster_ids (delta gate)...");
   const t0 = Date.now();
@@ -130,13 +115,12 @@ async function loadAlreadyClassifiedClusters() {
 async function flushBatch(batch) {
   if (batch.length === 0) return { applied: 0, errors: 0 };
 
-  // Build VALUES clause: ('cluster_id', ARRAY['slug1','slug2'])
   const valuesClauses = [];
   const params = [];
   let paramIdx = 1;
 
   for (const { cluster_id, charge_types } of batch) {
-    valuesClauses.push("($" + paramIdx + ", $" + (paramIdx + 1) + "::text[])");
+    valuesClauses.push("($" + paramIdx + "::text, $" + (paramIdx + 1) + "::text[])");
     params.push(cluster_id, charge_types);
     paramIdx += 2;
   }
@@ -153,7 +137,7 @@ async function flushBatch(batch) {
     "AND NOT (COALESCE(co.charge_types, '{}') @> v.new_charges)";
 
   try {
-    const result = await query(sql, params);
+    await query(sql, params);
     return { applied: batch.length, errors: 0 };
   } catch (e) {
     console.error("  Batch UPDATE error: " + e.message.slice(0, 200));
@@ -161,23 +145,29 @@ async function flushBatch(batch) {
   }
 }
 
+// ── Fetch one chunk via keyset pagination ────────────────────────────────────
+async function fetchChunk(afterClusterId, size) {
+  return query(
+    "SELECT cluster_id, plain_text " +
+    "FROM cl_opinion_bodies " +
+    "WHERE cluster_id > $1 AND text_length >= $2 " +
+    "ORDER BY cluster_id " +
+    "LIMIT $3",
+    [afterClusterId, MIN_TEXT_LEN, size]
+  );
+}
+
 // ── Main ─────────────────────────────────────────────────────────────────────
 async function main() {
-  console.log("=== BULK CHARGE TYPE EXTRACTION ===\n");
-  console.log("Source:     " + OPINIONS_CSV);
+  console.log("=== BULK CHARGE TYPE EXTRACTION (DB-first) ===\n");
+  console.log("Source:     cl_opinion_bodies (DB, keyset by cluster_id)");
   console.log("Mode:       " + (applyMode ? "APPLY (writes to DB)" : "DRY RUN (stats only)"));
   console.log("Limit:      " + (isFinite(processLimit) ? processLimit : "unlimited"));
-  console.log("Resume:     row " + resumeFrom);
+  console.log("Resume:     cluster_id > " + resumeFrom);
+  console.log("Chunk size: " + chunkSize);
   console.log("Delta gate: " + (noDeltaGate ? "DISABLED (--no-delta-gate, full re-scan)" : "ENABLED (skip already-classified clusters)"));
   console.log("");
 
-  if (!fs.existsSync(OPINIONS_CSV)) {
-    console.error("ERROR: opinions-criminal.csv not found.");
-    console.error("  Run: python3 scripts/filter-criminal-opinions.py");
-    process.exit(1);
-  }
-
-  // Crash diagnostics
   process.on("uncaughtException", (e) => {
     console.error("UNCAUGHT: " + (e.stack || e.message));
     end().then(() => process.exit(2));
@@ -187,34 +177,17 @@ async function main() {
     end().then(() => process.exit(3));
   });
 
+  await query("SET statement_timeout = '" + STATEMENT_TIMEOUT + "'");
+
   const theoryMap = await loadTheoryMap();
   logMem("post-load");
 
-  // Delta gate: load Set of cluster_ids already classified (skip in main loop)
   const skipSet = noDeltaGate ? new Set() : await loadAlreadyClassifiedClusters();
   if (!noDeltaGate) logMem("post-skipset");
 
-  // ── Stream CSV ─────────────────────────────────────────────────────────────
-  const csvStream = fs.createReadStream(OPINIONS_CSV);
-  const parser = csvStream.pipe(
-    parse({
-      columns: true,
-      skip_empty_lines: true,
-      escape: "\\",
-      relax_column_count: true,
-      relax_quotes: true,
-    })
-  );
-  parser.on("error", (e) =>
-    console.error("csv-parse error at row ~" + rowCount + ": " + e.message.slice(0, 150))
-  );
-
   // ── Counters ───────────────────────────────────────────────────────────────
   let rowCount = 0;
-  let skippedResume = 0;
   let skippedAlreadyDone = 0;
-  let skippedNoText = 0;
-  let skippedNoCluster = 0;
   let processed = 0;
   let withCharges = 0;
   let noCharges = 0;
@@ -225,83 +198,55 @@ async function main() {
   let totalErrors = 0;
   const startTime = Date.now();
 
-  // ── Stream + process ───────────────────────────────────────────────────────
-  try {
-    for await (const record of parser) {
+  let cursor = resumeFrom;
+  let chunkIdx = 0;
+
+  // ── Chunk loop ─────────────────────────────────────────────────────────────
+  while (true) {
+    if (processed >= processLimit) {
+      console.log("\n--limit " + processLimit + " reached. Stopping.");
+      break;
+    }
+
+    const chunkStart = Date.now();
+    let rows;
+    try {
+      rows = await fetchChunk(cursor, chunkSize);
+    } catch (e) {
+      console.error("\nChunk fetch error at cursor=" + cursor + ": " + e.message.slice(0, 300));
+      console.error("Flushing remaining batch and exiting.");
+      break;
+    }
+
+    if (rows.length === 0) {
+      console.log("\nReached end of cl_opinion_bodies at cluster_id=" + cursor + ".");
+      break;
+    }
+
+    chunkIdx++;
+    const chunkMs = Date.now() - chunkStart;
+
+    for (const r of rows) {
       rowCount++;
+      cursor = r.cluster_id; // advance keyset cursor
 
-      // Resume support
-      if (rowCount <= resumeFrom) {
-        skippedResume++;
-        if (rowCount % 500000 === 0) {
-          process.stdout.write("  Skipping (resume): " + (rowCount / 1000000).toFixed(1) + "M rows...\n");
-        }
-        continue;
-      }
+      if (processed >= processLimit) break;
 
-      // Progress every 100K rows
-      if ((rowCount - resumeFrom) % 100000 === 0) {
-        const elapsed = ((Date.now() - startTime) / 1000).toFixed(0);
-        const rate = ((rowCount - resumeFrom) / ((Date.now() - startTime) * 0.001)).toFixed(0);
-        process.stdout.write(
-          "  " + (rowCount / 1000000).toFixed(2) + "M rows | " +
-          withCharges + " classified | " +
-          skippedAlreadyDone + " skipped(done) | " +
-          pendingBatch.length + " queued | " +
-          elapsed + "s | " + rate + " rows/sec\n"
-        );
-        if ((rowCount - resumeFrom) % 500000 === 0) logMem((rowCount / 1000000).toFixed(1) + "M");
-      }
+      const cluster_id = String(r.cluster_id);
 
-      // Enforce --limit
-      if (processed >= processLimit) {
-        console.log("\n--limit " + processLimit + " reached. Stopping stream.");
-        break;
-      }
-
-      // CL CSVs quote ALL values, strip surrounding quotes
-      const cluster_id = (record.cluster_id || "").split('"').join("").trim();
-      if (!cluster_id) { skippedNoCluster++; continue; }
-
-      // Delta gate: skip clusters already classified (95% no-op cull)
       if (skipSet.has(cluster_id)) {
         skippedAlreadyDone++;
         continue;
       }
 
-      // Get text: prefer plain_text, fall back to HTML variants
-      let text = record.plain_text || "";
-      if (text.length < MIN_TEXT_LEN) {
-        const htmlSources = [
-          record.html_with_citations,
-          record.html,
-          record.html_columbia,
-          record.html_lawbox,
-          record.html_anon_2020,
-        ];
-        for (const src of htmlSources) {
-          if (src && src.length > MIN_TEXT_LEN) {
-            text = stripHtml(src);
-            break;
-          }
-        }
-      }
-
-      if (text.length < MIN_TEXT_LEN) {
-        skippedNoText++;
-        continue;
-      }
+      const text = r.plain_text || "";
+      if (text.length < MIN_TEXT_LEN) continue;
 
       processed++;
 
-      // ── Charge extraction ────────────────────────────────────────────────
       const chargeSet = new Set();
-
-      // Method 1: Direct charge name keywords
       const kwCharges = extractChargesFromKeywords(text);
       for (const slug of kwCharges) chargeSet.add(slug);
-
-      // Method 2: Theory keyword aggregation (3+ keywords per charge)
       const theoryCharges = extractChargesFromTheoryKeywords(text, theoryMap);
       for (const slug of theoryCharges) chargeSet.add(slug);
 
@@ -312,16 +257,12 @@ async function main() {
 
       withCharges++;
       const charge_types = Array.from(chargeSet);
-
-      // Track per-charge counts
       for (const slug of charge_types) {
         chargeCounts[slug] = (chargeCounts[slug] || 0) + 1;
       }
 
-      // Queue for batch update
       pendingBatch.push({ cluster_id, charge_types });
 
-      // Flush batch when full
       if (applyMode && pendingBatch.length >= UPDATE_BATCH_SIZE) {
         const { applied, errors } = await flushBatch(pendingBatch);
         totalApplied += applied;
@@ -329,9 +270,20 @@ async function main() {
         pendingBatch = [];
       }
     }
-  } catch (e) {
-    console.error("\nStream error at row " + rowCount + ": " + e.message.slice(0, 300));
-    console.error("Partial data collected. Flushing remaining batch...");
+
+    // Per-chunk progress
+    const elapsed = ((Date.now() - startTime) / 1000).toFixed(0);
+    const rate = (rowCount / ((Date.now() - startTime) * 0.001)).toFixed(0);
+    process.stdout.write(
+      "  chunk #" + chunkIdx + " | " +
+      "scanned=" + rowCount.toLocaleString() + " | " +
+      "classified=" + withCharges.toLocaleString() + " | " +
+      "skipped(done)=" + skippedAlreadyDone.toLocaleString() + " | " +
+      "queued=" + pendingBatch.length + " | " +
+      "cursor=" + cursor + " | " +
+      elapsed + "s | " + rate + " r/s (chunk " + chunkMs + "ms)\n"
+    );
+    if (chunkIdx % 20 === 0) logMem("chunk " + chunkIdx);
   }
 
   // Flush remaining
@@ -345,14 +297,12 @@ async function main() {
   const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
 
   console.log("\n=== RESULTS ===\n");
-  console.log("Total CSV rows:     " + rowCount.toLocaleString());
-  console.log("Skipped (resume):   " + skippedResume.toLocaleString());
+  console.log("Total scanned:      " + rowCount.toLocaleString());
   console.log("Skipped (delta):    " + skippedAlreadyDone.toLocaleString() + " (already in classified_opinions)");
-  console.log("Skipped (no text):  " + skippedNoText.toLocaleString());
-  console.log("Skipped (no ID):    " + skippedNoCluster.toLocaleString());
   console.log("Processed:          " + processed.toLocaleString());
   console.log("With charges:       " + withCharges.toLocaleString() + " (" + (processed > 0 ? ((withCharges / processed) * 100).toFixed(1) : 0) + "%)");
   console.log("No charges:         " + noCharges.toLocaleString());
+  console.log("Last cluster_id:    " + cursor);
   console.log("Elapsed:            " + elapsed + "s");
   console.log("");
 
@@ -364,6 +314,7 @@ async function main() {
 
   if (applyMode) {
     console.log("\nDB updates:         " + totalApplied.toLocaleString() + " applied, " + totalErrors.toLocaleString() + " errors");
+    console.log("\nGround-truth check: SELECT n_tup_upd FROM pg_stat_user_tables WHERE relname='classified_opinions';");
   } else {
     console.log("\nDry run, no DB writes. Use --apply to write.");
   }


### PR DESCRIPTION
## Summary

- Replaces broken csv-parse stream in `scripts/bulk-extract-charge-types.mjs` with chunked SQL keyset pagination over `cl_opinion_bodies` (1.5M rows already loaded).
- Same architectural fix as #307 (T5). Source plan: `docs/plans/2026-05-04-t6-and-bulk-master-db-first-rewrite.md`.

## Why

`csv-parse` with `relax_quotes:true, escape:'\\'` silently corrupts trailing columns on legal text with unquoted commas. T5 incident (#307) caught 15.5% column-shift. T6 smoke (#306) caught zero actual writes despite 600K rows scanned (n_tup_upd flat at 264 while script reported 2,278 classified). Same parser, same source, same bug.

`cl_opinion_bodies` IS the parsed-and-loaded version of the bz2 source. Re-streaming via csv-parse re-introduces the parser bug. DB layer is the correct boundary.

## Smoke test (2026-05-04)

`node scripts/bulk-extract-charge-types.mjs --apply --limit 500 --chunk-size 1000`

| metric | value |
|--------|-------|
| applied | 134 |
| errors | 0 |
| elapsed | 4.4s |
| pg_stat_user_tables.n_tup_upd jump | 264 → 398 (+134, exact match) |
| classified_opinions count jump | 4,384 → 4,518 (+134, exact match) |
| hit rate | 26.8% (vs broken CSV's near-zero) |
| sample cluster_ids | parse as bigint + match cl_opinion_bodies (no corruption) |

## Test plan

- [x] Dry-run on 100 rows passes
- [x] `--apply --limit 500` writes 134 rows, n_tup_upd advances exactly 134
- [ ] Full run (`--apply` no limit) — deferred to next session for the long pass

## Notes

- Fixed param cast bug found in smoke: `classified_opinions.cluster_id` is text, not bigint. SQL VALUES clause uses `::text`.
- Preserves all flags: `--apply`, `--limit`, `--resume-from`, `--no-delta-gate`. Adds `--chunk-size` (default 5000).