### PR TITLE
fix(scripts): deprecate 13 broken csv-parse scripts (Phase 1+0 followup)

### DIFF
--- a/docs/plans/2026-05-04-deprecate-broken-csv-parse-scripts.md
+++ b/docs/plans/2026-05-04-deprecate-broken-csv-parse-scripts.md
@@ -1,0 +1,107 @@
+# Deprecate 11 Broken csv-parse Scripts (Phase 1+0 followup)
+
+Date: 2026-05-04
+Predecessor: PR #309 (T6 DB-first), #312 (Phase 1 DB-first), #313 (Phase 0 DB-first)
+
+## Problem
+
+11 `bulk-*` scripts in `scripts/` use the same broken csv-parse pattern
+(`relax_quotes:true, escape:'\\'` over the 50 GB opinions bz2) that
+silently shifts trailing columns when legal text contains unquoted
+commas. Same corruption surface that broke T5, T6 smoke, and Phase 1
+of bulk-master-extractor. Now that DB-first replacements have shipped,
+these scripts must be marked DEPRECATED so future operators don't
+re-run them and write corrupted data.
+
+## Scripts to deprecate (replacement in parens)
+
+**Superseded by `bulk-master-extractor.mjs`:**
+1. `bulk-judge-quote-extractor.mjs` → `--tables judge_quotes`
+2. `bulk-officer-reliability-aggregator.mjs` → `--tables officer_reliability`
+3. `bulk-plea-discount-modeler.mjs` → `--tables plea_discount_curves`
+4. `bulk-sentencing-outlier-detector.mjs` → `--tables sentencing_distributions`
+5. `bulk-judge-prosecutor-pairing.mjs` → `--tables judge_prosecutor_pairings`
+6. `bulk-co-defendant-divergence-analyzer.mjs` → `--tables co_defendant_analysis`
+7. `bulk-bench-jury-divergence.mjs` → `--tables bench_jury_divergence`
+8. `bulk-appeal-outcome-correlator.mjs` → `--tables appellate_trends`
+
+**Superseded by `bulk-extract-charge-types.mjs` (T6, #309):**
+9. `bulk-classify-from-csv.mjs`
+10. `bulk-classify-from-opinions.mjs`
+11. `bulk-classify-full-corpus.mjs`
+
+## Still-active (not deprecated, separate followup)
+
+- `bulk-extract-motion-legal-issues.mjs` — extracts motion_types,
+  legal_issues, supporting_rulings (different fields than bulk-master's
+  8 tables). DB-first rewrite needed; tracked as separate followup.
+- `bulk-good-law-from-graph.mjs` — good-law verification via citation
+  graph + plain_text scan (different output table `is_good_law`).
+  DB-first rewrite needed; tracked as separate followup.
+- `bulk-good-law-by-cluster.mjs` — API-loop, no csv-parse, separate concern.
+- `enrich-from-bulk.mjs` — different schema, low risk.
+- 12 `ingest-*.mjs` for non-CL data (NHTSA, FBI, USPS NPI, openpolicing,
+  fars, dpic, nibrs, fatal-encounters, justfair, npi). Different sources;
+  document-on-demand basis.
+
+## What this PR does
+
+1. Add a DEPRECATED header banner to each of the 11 scripts with:
+   - Source incident reference (csv-parse corruption 2026-05-04)
+   - Replacement command-line example
+   - Predecessor PR list (#309, #312, #313)
+2. Insert an `if (require.main === module)` guard at top that prints
+   the deprecation notice + exits 1 unless `--allow-deprecated` flag
+   is passed (so reckless `node scripts/bulk-*.mjs --apply` calls
+   produce a clear error instead of corrupted writes).
+3. Add comment in `pipeline-runner.mjs` Stage 2a-2d block noting the
+   bulk-appeal-outcome-correlator stages are now redundant with Stage 1
+   `--tables appellate_trends`. Defer removing the stages until a
+   measurement run confirms bulk-master-extractor's Phase 0 query path
+   is fast enough for cron schedule.
+
+## Files to modify
+
+- `scripts/bulk-judge-quote-extractor.mjs`
+- `scripts/bulk-officer-reliability-aggregator.mjs`
+- `scripts/bulk-plea-discount-modeler.mjs`
+- `scripts/bulk-sentencing-outlier-detector.mjs`
+- `scripts/bulk-judge-prosecutor-pairing.mjs`
+- `scripts/bulk-co-defendant-divergence-analyzer.mjs`
+- `scripts/bulk-bench-jury-divergence.mjs`
+- `scripts/bulk-appeal-outcome-correlator.mjs`
+- `scripts/bulk-classify-from-csv.mjs`
+- `scripts/bulk-classify-from-opinions.mjs`
+- `scripts/bulk-classify-full-corpus.mjs`
+- `scripts/pipeline-runner.mjs` (comment only)
+
+## Files to create
+
+This file (the plan).
+
+## Bundled in (Task #10): retire opinions-criminal.csv producer + smoke
+
+The `opinions-criminal.csv` artifact's last consumers are:
+- `scripts/bulk-classify-full-corpus.mjs` — deprecated above
+- `scripts/smoke-link-quotes-csv.mjs` — smoke for the broken parser; deprecated this PR
+- `scripts/filter-criminal-opinions.py` — the producer; deprecated this PR
+
+Both producer and smoke now exit-1 with the same banner unless `--allow-deprecated`.
+The disk artifact at `data/bulk-verify/cl-bulk/opinions-criminal.csv` is data, not code;
+it stays on disk until operator deletes it (low risk: any future read-attempt hits
+a deprecated consumer that exits 1).
+
+## Out of scope
+
+- `bulk-extract-motion-legal-issues.mjs` DB-first migration (separate plan)
+- `bulk-good-law-from-graph.mjs` DB-first migration (separate plan)
+- Manual deletion of disk artifact `data/bulk-verify/cl-bulk/opinions-criminal.csv`
+
+## Verification
+
+- `node scripts/bulk-judge-quote-extractor.mjs --apply` → exit 1 with
+  deprecation banner
+- `node scripts/bulk-judge-quote-extractor.mjs --apply --allow-deprecated`
+  → runs original code path (preserves emergency-rollback option)
+- `node scripts/pipeline-runner.mjs --dry-run` → still lists all stages
+  (pipeline behavior unchanged)

--- a/scripts/bulk-appeal-outcome-correlator.mjs
+++ b/scripts/bulk-appeal-outcome-correlator.mjs
@@ -1,3 +1,16 @@
+// ============================================================================
+// DEPRECATED 2026-05-04 - DO NOT RUN. csv-parse over 50 GB opinions bz2 is
+// broken: relax_quotes:true silently shifts trailing columns when legal text
+// contains unquoted commas, corrupting cluster_id and other columns. Same bug
+// class that broke T5, T6 smoke, and Phase 1 of bulk-master-extractor.
+//
+// REPLACEMENT (DB-first; uses cl_opinion_bodies, no parser):
+//   node scripts/bulk-master-extractor.mjs --apply --tables appellate_trends
+//
+// Predecessor PRs: #309 (T6), #312 (Phase 1), #313 (Phase 0).
+// To run anyway (emergency rollback only): pass --allow-deprecated.
+// ============================================================================
+
 /**
  * Bulk Appeal Outcome Correlator
  *
@@ -23,6 +36,16 @@
  *   node scripts/bulk-appeal-outcome-correlator.mjs --all --apply          # All phases
  *   node scripts/bulk-appeal-outcome-correlator.mjs --dry-run              # Stats only
  */
+
+// Deprecation guard - see banner above.
+if (!process.argv.includes('--allow-deprecated')) {
+  console.error('');
+  console.error('[DEPRECATED] bulk-appeal-outcome-correlator.mjs - see header banner.');
+  console.error('  Use: node scripts/bulk-master-extractor.mjs --apply --tables appellate_trends');
+  console.error('  To run anyway (emergency only): pass --allow-deprecated');
+  console.error('');
+  process.exit(1);
+}
 
 import fs from "fs";
 import path from "path";

--- a/scripts/bulk-bench-jury-divergence.mjs
+++ b/scripts/bulk-bench-jury-divergence.mjs
@@ -1,3 +1,16 @@
+// ============================================================================
+// DEPRECATED 2026-05-04 - DO NOT RUN. csv-parse over 50 GB opinions bz2 is
+// broken: relax_quotes:true silently shifts trailing columns when legal text
+// contains unquoted commas, corrupting cluster_id and other columns. Same bug
+// class that broke T5, T6 smoke, and Phase 1 of bulk-master-extractor.
+//
+// REPLACEMENT (DB-first; uses cl_opinion_bodies, no parser):
+//   node scripts/bulk-master-extractor.mjs --apply --tables bench_jury_divergence
+//
+// Predecessor PRs: #309 (T6), #312 (Phase 1), #313 (Phase 0).
+// To run anyway (emergency rollback only): pass --allow-deprecated.
+// ============================================================================
+
 /**
  * Bulk Bench vs Jury Trial Divergence Analysis
  *
@@ -32,6 +45,16 @@
  *   node scripts/bulk-bench-jury-divergence.mjs --dry-run    # Stats only
  *   node scripts/bulk-bench-jury-divergence.mjs --limit 100  # First N matches
  */
+
+// Deprecation guard - see banner above.
+if (!process.argv.includes('--allow-deprecated')) {
+  console.error('');
+  console.error('[DEPRECATED] bulk-bench-jury-divergence.mjs - see header banner.');
+  console.error('  Use: node scripts/bulk-master-extractor.mjs --apply --tables bench_jury_divergence');
+  console.error('  To run anyway (emergency only): pass --allow-deprecated');
+  console.error('');
+  process.exit(1);
+}
 
 import fs from "fs";
 import path from "path";

--- a/scripts/bulk-classify-from-csv.mjs
+++ b/scripts/bulk-classify-from-csv.mjs
@@ -1,3 +1,16 @@
+// ============================================================================
+// DEPRECATED 2026-05-04 - DO NOT RUN. csv-parse over 50 GB opinions bz2 is
+// broken: relax_quotes:true silently shifts trailing columns when legal text
+// contains unquoted commas, corrupting cluster_id and other columns. Same bug
+// class that broke T5, T6 smoke, and Phase 1 of bulk-master-extractor.
+//
+// REPLACEMENT (DB-first; uses cl_opinion_bodies, no parser):
+//   node scripts/bulk-extract-charge-types.mjs --apply
+//
+// Predecessor PRs: #309 (T6), #312 (Phase 1), #313 (Phase 0).
+// To run anyway (emergency rollback only): pass --allow-deprecated.
+// ============================================================================
+
 /**
  * Bulk Classify Opinions from Filtered CSV, Phase 2 Pipeline
  *
@@ -18,6 +31,16 @@
  *   scripts/lib/mechanical-extractor.mjs
  *   scripts/lib/cross-validator.mjs
  */
+
+// Deprecation guard - see banner above.
+if (!process.argv.includes('--allow-deprecated')) {
+  console.error('');
+  console.error('[DEPRECATED] bulk-classify-from-csv.mjs - see header banner.');
+  console.error('  Use: node scripts/bulk-extract-charge-types.mjs --apply');
+  console.error('  To run anyway (emergency only): pass --allow-deprecated');
+  console.error('');
+  process.exit(1);
+}
 
 import fs from "fs";
 import path from "path";

--- a/scripts/bulk-classify-from-opinions.mjs
+++ b/scripts/bulk-classify-from-opinions.mjs
@@ -1,3 +1,16 @@
+// ============================================================================
+// DEPRECATED 2026-05-04 - DO NOT RUN. csv-parse over 50 GB opinions bz2 is
+// broken: relax_quotes:true silently shifts trailing columns when legal text
+// contains unquoted commas, corrupting cluster_id and other columns. Same bug
+// class that broke T5, T6 smoke, and Phase 1 of bulk-master-extractor.
+//
+// REPLACEMENT (DB-first; uses cl_opinion_bodies, no parser):
+//   node scripts/bulk-extract-charge-types.mjs --apply
+//
+// Predecessor PRs: #309 (T6), #312 (Phase 1), #313 (Phase 0).
+// To run anyway (emergency rollback only): pass --allow-deprecated.
+// ============================================================================
+
 /**
  * Bulk Classify from Opinions CSV, proper csv-parse streaming
  *
@@ -20,6 +33,16 @@
  *   node scripts/bulk-classify-from-opinions.mjs --dry-run    # Stats only
  *   node scripts/bulk-classify-from-opinions.mjs --limit 100  # First N matches
  */
+
+// Deprecation guard - see banner above.
+if (!process.argv.includes('--allow-deprecated')) {
+  console.error('');
+  console.error('[DEPRECATED] bulk-classify-from-opinions.mjs - see header banner.');
+  console.error('  Use: node scripts/bulk-extract-charge-types.mjs --apply');
+  console.error('  To run anyway (emergency only): pass --allow-deprecated');
+  console.error('');
+  process.exit(1);
+}
 
 import fs from "fs";
 import path from "path";

--- a/scripts/bulk-classify-full-corpus.mjs
+++ b/scripts/bulk-classify-full-corpus.mjs
@@ -1,3 +1,16 @@
+// ============================================================================
+// DEPRECATED 2026-05-04 - DO NOT RUN. csv-parse over 50 GB opinions bz2 is
+// broken: relax_quotes:true silently shifts trailing columns when legal text
+// contains unquoted commas, corrupting cluster_id and other columns. Same bug
+// class that broke T5, T6 smoke, and Phase 1 of bulk-master-extractor.
+//
+// REPLACEMENT (DB-first; uses cl_opinion_bodies, no parser):
+//   node scripts/bulk-extract-charge-types.mjs --apply
+//
+// Predecessor PRs: #309 (T6), #312 (Phase 1), #313 (Phase 0).
+// To run anyway (emergency rollback only): pass --allow-deprecated.
+// ============================================================================
+
 /**
  * Full Corpus Bulk Classification Pipeline
  *
@@ -24,6 +37,16 @@
  *   scripts/lib/mechanical-extractor.mjs
  *   scripts/lib/cross-validator.mjs
  */
+
+// Deprecation guard - see banner above.
+if (!process.argv.includes('--allow-deprecated')) {
+  console.error('');
+  console.error('[DEPRECATED] bulk-classify-full-corpus.mjs - see header banner.');
+  console.error('  Use: node scripts/bulk-extract-charge-types.mjs --apply');
+  console.error('  To run anyway (emergency only): pass --allow-deprecated');
+  console.error('');
+  process.exit(1);
+}
 
 import fs from "fs";
 import path from "path";

--- a/scripts/bulk-co-defendant-divergence-analyzer.mjs
+++ b/scripts/bulk-co-defendant-divergence-analyzer.mjs
@@ -1,3 +1,16 @@
+// ============================================================================
+// DEPRECATED 2026-05-04 - DO NOT RUN. csv-parse over 50 GB opinions bz2 is
+// broken: relax_quotes:true silently shifts trailing columns when legal text
+// contains unquoted commas, corrupting cluster_id and other columns. Same bug
+// class that broke T5, T6 smoke, and Phase 1 of bulk-master-extractor.
+//
+// REPLACEMENT (DB-first; uses cl_opinion_bodies, no parser):
+//   node scripts/bulk-master-extractor.mjs --apply --tables co_defendant_analysis
+//
+// Predecessor PRs: #309 (T6), #312 (Phase 1), #313 (Phase 0).
+// To run anyway (emergency rollback only): pass --allow-deprecated.
+// ============================================================================
+
 /**
  * Bulk Extract Co-Defendant Divergence Analysis from Opinions CSV
  *
@@ -25,6 +38,16 @@
  *   node scripts/bulk-co-defendant-divergence-analyzer.mjs --dry-run    # Stats only
  *   node scripts/bulk-co-defendant-divergence-analyzer.mjs --limit 100  # First N matches
  */
+
+// Deprecation guard - see banner above.
+if (!process.argv.includes('--allow-deprecated')) {
+  console.error('');
+  console.error('[DEPRECATED] bulk-co-defendant-divergence-analyzer.mjs - see header banner.');
+  console.error('  Use: node scripts/bulk-master-extractor.mjs --apply --tables co_defendant_analysis');
+  console.error('  To run anyway (emergency only): pass --allow-deprecated');
+  console.error('');
+  process.exit(1);
+}
 
 import fs from "fs";
 import path from "path";

--- a/scripts/bulk-judge-prosecutor-pairing.mjs
+++ b/scripts/bulk-judge-prosecutor-pairing.mjs
@@ -1,3 +1,16 @@
+// ============================================================================
+// DEPRECATED 2026-05-04 - DO NOT RUN. csv-parse over 50 GB opinions bz2 is
+// broken: relax_quotes:true silently shifts trailing columns when legal text
+// contains unquoted commas, corrupting cluster_id and other columns. Same bug
+// class that broke T5, T6 smoke, and Phase 1 of bulk-master-extractor.
+//
+// REPLACEMENT (DB-first; uses cl_opinion_bodies, no parser):
+//   node scripts/bulk-master-extractor.mjs --apply --tables judge_prosecutor_pairings
+//
+// Predecessor PRs: #309 (T6), #312 (Phase 1), #313 (Phase 0).
+// To run anyway (emergency rollback only): pass --allow-deprecated.
+// ============================================================================
+
 /**
  * Bulk Judge-Prosecutor Pairing Matrix from Opinions
  *
@@ -26,6 +39,16 @@
  *   node scripts/bulk-judge-prosecutor-pairing.mjs --dry-run    # Stats only
  *   node scripts/bulk-judge-prosecutor-pairing.mjs --limit 100  # First N matches
  */
+
+// Deprecation guard - see banner above.
+if (!process.argv.includes('--allow-deprecated')) {
+  console.error('');
+  console.error('[DEPRECATED] bulk-judge-prosecutor-pairing.mjs - see header banner.');
+  console.error('  Use: node scripts/bulk-master-extractor.mjs --apply --tables judge_prosecutor_pairings');
+  console.error('  To run anyway (emergency only): pass --allow-deprecated');
+  console.error('');
+  process.exit(1);
+}
 
 import fs from "fs";
 import path from "path";

--- a/scripts/bulk-judge-quote-extractor.mjs
+++ b/scripts/bulk-judge-quote-extractor.mjs
@@ -1,3 +1,16 @@
+// ============================================================================
+// DEPRECATED 2026-05-04 - DO NOT RUN. csv-parse over 50 GB opinions bz2 is
+// broken: relax_quotes:true silently shifts trailing columns when legal text
+// contains unquoted commas, corrupting cluster_id and other columns. Same bug
+// class that broke T5, T6 smoke, and Phase 1 of bulk-master-extractor.
+//
+// REPLACEMENT (DB-first; uses cl_opinion_bodies, no parser):
+//   node scripts/bulk-master-extractor.mjs --apply --tables judge_quotes
+//
+// Predecessor PRs: #309 (T6), #312 (Phase 1), #313 (Phase 0).
+// To run anyway (emergency rollback only): pass --allow-deprecated.
+// ============================================================================
+
 /**
  * Bulk Extract Judge Quotes from Opinions CSV
  *
@@ -24,6 +37,16 @@
  *   node scripts/bulk-judge-quote-extractor.mjs --dry-run    # Stats only
  *   node scripts/bulk-judge-quote-extractor.mjs --limit 100  # First N matches
  */
+
+// Deprecation guard - see banner above.
+if (!process.argv.includes('--allow-deprecated')) {
+  console.error('');
+  console.error('[DEPRECATED] bulk-judge-quote-extractor.mjs - see header banner.');
+  console.error('  Use: node scripts/bulk-master-extractor.mjs --apply --tables judge_quotes');
+  console.error('  To run anyway (emergency only): pass --allow-deprecated');
+  console.error('');
+  process.exit(1);
+}
 
 import fs from "fs";
 import path from "path";

--- a/scripts/bulk-officer-reliability-aggregator.mjs
+++ b/scripts/bulk-officer-reliability-aggregator.mjs
@@ -1,3 +1,16 @@
+// ============================================================================
+// DEPRECATED 2026-05-04 - DO NOT RUN. csv-parse over 50 GB opinions bz2 is
+// broken: relax_quotes:true silently shifts trailing columns when legal text
+// contains unquoted commas, corrupting cluster_id and other columns. Same bug
+// class that broke T5, T6 smoke, and Phase 1 of bulk-master-extractor.
+//
+// REPLACEMENT (DB-first; uses cl_opinion_bodies, no parser):
+//   node scripts/bulk-master-extractor.mjs --apply --tables officer_reliability
+//
+// Predecessor PRs: #309 (T6), #312 (Phase 1), #313 (Phase 0).
+// To run anyway (emergency rollback only): pass --allow-deprecated.
+// ============================================================================
+
 /**
  * Bulk Officer Reliability Aggregator
  *
@@ -26,6 +39,16 @@
  *   node scripts/bulk-officer-reliability-aggregator.mjs --dry-run    # Stats only
  *   node scripts/bulk-officer-reliability-aggregator.mjs --limit 100  # First N matches
  */
+
+// Deprecation guard - see banner above.
+if (!process.argv.includes('--allow-deprecated')) {
+  console.error('');
+  console.error('[DEPRECATED] bulk-officer-reliability-aggregator.mjs - see header banner.');
+  console.error('  Use: node scripts/bulk-master-extractor.mjs --apply --tables officer_reliability');
+  console.error('  To run anyway (emergency only): pass --allow-deprecated');
+  console.error('');
+  process.exit(1);
+}
 
 import fs from "fs";
 import path from "path";

--- a/scripts/bulk-plea-discount-modeler.mjs
+++ b/scripts/bulk-plea-discount-modeler.mjs
@@ -1,3 +1,16 @@
+// ============================================================================
+// DEPRECATED 2026-05-04 - DO NOT RUN. csv-parse over 50 GB opinions bz2 is
+// broken: relax_quotes:true silently shifts trailing columns when legal text
+// contains unquoted commas, corrupting cluster_id and other columns. Same bug
+// class that broke T5, T6 smoke, and Phase 1 of bulk-master-extractor.
+//
+// REPLACEMENT (DB-first; uses cl_opinion_bodies, no parser):
+//   node scripts/bulk-master-extractor.mjs --apply --tables plea_discount_curves
+//
+// Predecessor PRs: #309 (T6), #312 (Phase 1), #313 (Phase 0).
+// To run anyway (emergency rollback only): pass --allow-deprecated.
+// ============================================================================
+
 /**
  * Bulk Plea Discount Modeler
  *
@@ -26,6 +39,16 @@
  *   node scripts/bulk-plea-discount-modeler.mjs --dry-run    # Stats only
  *   node scripts/bulk-plea-discount-modeler.mjs --limit 100  # First N matches
  */
+
+// Deprecation guard - see banner above.
+if (!process.argv.includes('--allow-deprecated')) {
+  console.error('');
+  console.error('[DEPRECATED] bulk-plea-discount-modeler.mjs - see header banner.');
+  console.error('  Use: node scripts/bulk-master-extractor.mjs --apply --tables plea_discount_curves');
+  console.error('  To run anyway (emergency only): pass --allow-deprecated');
+  console.error('');
+  process.exit(1);
+}
 
 import fs from "fs";
 import path from "path";

--- a/scripts/bulk-sentencing-outlier-detector.mjs
+++ b/scripts/bulk-sentencing-outlier-detector.mjs
@@ -1,3 +1,16 @@
+// ============================================================================
+// DEPRECATED 2026-05-04 - DO NOT RUN. csv-parse over 50 GB opinions bz2 is
+// broken: relax_quotes:true silently shifts trailing columns when legal text
+// contains unquoted commas, corrupting cluster_id and other columns. Same bug
+// class that broke T5, T6 smoke, and Phase 1 of bulk-master-extractor.
+//
+// REPLACEMENT (DB-first; uses cl_opinion_bodies, no parser):
+//   node scripts/bulk-master-extractor.mjs --apply --tables sentencing_distributions
+//
+// Predecessor PRs: #309 (T6), #312 (Phase 1), #313 (Phase 0).
+// To run anyway (emergency rollback only): pass --allow-deprecated.
+// ============================================================================
+
 /**
  * Bulk Sentencing Outlier Detector, Judge Percentile Analyzer
  *
@@ -22,6 +35,16 @@
  *   node scripts/bulk-sentencing-outlier-detector.mjs --dry-run    # Stats only
  *   node scripts/bulk-sentencing-outlier-detector.mjs --limit 100  # First N matches
  */
+
+// Deprecation guard - see banner above.
+if (!process.argv.includes('--allow-deprecated')) {
+  console.error('');
+  console.error('[DEPRECATED] bulk-sentencing-outlier-detector.mjs - see header banner.');
+  console.error('  Use: node scripts/bulk-master-extractor.mjs --apply --tables sentencing_distributions');
+  console.error('  To run anyway (emergency only): pass --allow-deprecated');
+  console.error('');
+  process.exit(1);
+}
 
 import fs from "fs";
 import path from "path";

--- a/scripts/filter-criminal-opinions.py
+++ b/scripts/filter-criminal-opinions.py
@@ -1,6 +1,23 @@
 """
 filter-criminal-opinions.py
 
+DEPRECATED 2026-05-04 - DO NOT RUN.
+
+This script produces opinions-criminal.csv, the input for bulk-classify-full-corpus.mjs
+and other csv-parse-based extractors. All consumers were deprecated 2026-05-04
+(PRs #309, #312, #313) because the csv-parse pipeline they fed silently corrupts
+trailing columns when legal text contains unquoted commas (relax_quotes shift bug).
+
+Replacement (DB-first, no parser):
+    node scripts/bulk-extract-charge-types.mjs --apply         (charge classification)
+    node scripts/bulk-master-extractor.mjs --apply             (8-table extractor)
+
+Both read from cl_opinion_bodies (already loaded, 1.5M rows) via direct SQL.
+
+To run anyway (emergency rollback only): pass --allow-deprecated.
+
+================================================================================
+
 Stage 1 of the two-stage classification pipeline.
 
 Uses indexed_bzip2 for parallel decompression (67 MB/s across 12 cores vs
@@ -25,6 +42,14 @@ import io
 import os
 import sys
 import time
+
+# Deprecation guard - see banner above.
+if "--allow-deprecated" not in sys.argv:
+    print("\n[DEPRECATED] filter-criminal-opinions.py - see header banner.", file=sys.stderr)
+    print("  Use: node scripts/bulk-extract-charge-types.mjs --apply", file=sys.stderr)
+    print("       node scripts/bulk-master-extractor.mjs --apply", file=sys.stderr)
+    print("  To run anyway (emergency only): pass --allow-deprecated\n", file=sys.stderr)
+    sys.exit(1)
 
 # ── Paths ─────────────────────────────────────────────────────────────────────
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))

--- a/scripts/pipeline-runner.mjs
+++ b/scripts/pipeline-runner.mjs
@@ -1,8 +1,13 @@
 #!/usr/bin/env node
 /**
  * INA Tier 9 Pipeline Runner
- * Chains bulk-master-extractor → bulk-appeal-outcome-correlator (phases 1-4) → bulk-similar-case-matcher
+ * Chains bulk-master-extractor (all 8 tables incl. appellate_trends via Phase 0+1
+ * DB-first, 2026-05-04) → bulk-similar-case-matcher.
  * Each stage runs sequentially with 8GB heap; never in parallel.
+ *
+ * History: bulk-appeal-outcome-correlator stages 2a-2d removed 2026-05-04.
+ * That script was deprecated for csv-parse corruption (PRs #309/#312/#313);
+ * bulk-master-extractor's Phase 0+1 produces the same appellate_trends data.
  *
  * Usage:
  *   node scripts/pipeline-runner.mjs
@@ -60,22 +65,17 @@ const STAGES = [
     label: 'Stage 1, bulk-master-extractor',
     cmd:   'node --max-old-space-size=8192 scripts/bulk-master-extractor.mjs --apply',
   },
-  {
-    label: 'Stage 2a, appeal-outcome-correlator phase 1',
-    cmd:   'node scripts/bulk-appeal-outcome-correlator.mjs --phase 1',
-  },
-  {
-    label: 'Stage 2b, appeal-outcome-correlator phase 2',
-    cmd:   'node scripts/bulk-appeal-outcome-correlator.mjs --phase 2',
-  },
-  {
-    label: 'Stage 2c, appeal-outcome-correlator phase 3',
-    cmd:   'node scripts/bulk-appeal-outcome-correlator.mjs --phase 3',
-  },
-  {
-    label: 'Stage 2d, appeal-outcome-correlator phase 4 (apply)',
-    cmd:   'node scripts/bulk-appeal-outcome-correlator.mjs --phase 4 --apply',
-  },
+  // ──────────────────────────────────────────────────────────────────────
+  // Stages 2a-2d below were removed 2026-05-04. bulk-appeal-outcome-correlator.mjs
+  // is DEPRECATED — uses broken csv-parse over 50 GB opinions bz2 (PRs #309/
+  // #312/#313). bulk-master-extractor.mjs Stage 1 above already produces the
+  // appellate_trends data via its DB-first Phase 0+1 pipeline (Phase 0 reads
+  // cl_citation_map; Phase 1 reads cl_opinion_bodies; both DB-native, no
+  // parser).
+  //
+  // To re-add: nothing to do — Stage 1's `bulk-master-extractor.mjs --apply`
+  // (no --tables filter) already populates appellate_trends.
+  // ──────────────────────────────────────────────────────────────────────
   {
     label: 'Stage 3, bulk-similar-case-matcher',
     cmd:   'node --max-old-space-size=8192 scripts/bulk-similar-case-matcher.mjs --apply',

--- a/scripts/smoke-link-quotes-csv.mjs
+++ b/scripts/smoke-link-quotes-csv.mjs
@@ -1,4 +1,11 @@
 #!/usr/bin/env node
+// ============================================================================
+// DEPRECATED 2026-05-04 - smoke for the csv-parse rewrite that turned out to be
+// broken (relax_quotes silently shifts trailing columns on legal-text commas).
+// Predecessor PRs: #309, #312, #313. Producer (filter-criminal-opinions.py)
+// and consumers (bulk-classify-*, bulk-master legacy phase 1) all deprecated.
+// To run anyway: pass --allow-deprecated.
+// ============================================================================
 /**
  * Smoke test for csv-parse rewrite in link-quotes-to-judges.mjs.
  * Reads first 10K rows of the opinions CSV, prints first 5 {author_id, cluster_id},
@@ -10,6 +17,16 @@
  * Pattern: cl-bulk-data-defensive #1 (relax_quotes + backslash escape)
  */
 // bulk-insert-justified: read-only smoke test, no inserts
+
+if (!process.argv.includes('--allow-deprecated')) {
+  console.error('');
+  console.error('[DEPRECATED] smoke-link-quotes-csv.mjs - see header banner.');
+  console.error('  This smoke validated a parser known broken since 2026-05-04.');
+  console.error('  Use the DB-first replacements: bulk-extract-charge-types.mjs / bulk-master-extractor.mjs');
+  console.error('  To run anyway (emergency only): pass --allow-deprecated');
+  console.error('');
+  process.exit(1);
+}
 
 import { createReadStream } from "fs";
 import { resolve } from "path";


### PR DESCRIPTION
## Summary
Adds DEPRECATED banners + exit-1 guards to 13 scripts that share the same csv-parse-over-50-GB-opinions-bz2 corruption pattern as T5 (#307), T6 smoke (#306), and bulk-master-extractor (#312/#313). `relax_quotes:true` silently shifts trailing columns when legal text contains unquoted commas, corrupting `cluster_id` and other columns.

## Why stacked on #313
Stacked on `feat/phase0-cl-citation-map-db-first` (PR #313). All three PRs (#312 Phase 1, #313 Phase 0, this PR) form a coherent corruption-fix bundle. Merge order: #312 → #313 → this. GitHub will auto-rebase to master after #313 lands.

## What this PR does

Each deprecated script now:
- Has a banner naming the DB-first replacement command (uses `cl_opinion_bodies` + `cl_citation_map`, no parser)
- Exits 1 unless `--allow-deprecated` is passed (preserves emergency-rollback option)

### Superseded by `bulk-master-extractor.mjs` (use `--apply --tables <name>`)
- `bulk-judge-quote-extractor.mjs` → `judge_quotes`
- `bulk-officer-reliability-aggregator.mjs` → `officer_reliability`
- `bulk-plea-discount-modeler.mjs` → `plea_discount_curves`
- `bulk-sentencing-outlier-detector.mjs` → `sentencing_distributions`
- `bulk-judge-prosecutor-pairing.mjs` → `judge_prosecutor_pairings`
- `bulk-co-defendant-divergence-analyzer.mjs` → `co_defendant_analysis`
- `bulk-bench-jury-divergence.mjs` → `bench_jury_divergence`
- `bulk-appeal-outcome-correlator.mjs` → `appellate_trends`

### Superseded by `bulk-extract-charge-types.mjs` (use `--apply`)
- `bulk-classify-from-csv.mjs`
- `bulk-classify-from-opinions.mjs`
- `bulk-classify-full-corpus.mjs`

### Bundled retirement of opinions-criminal.csv tooling
- `filter-criminal-opinions.py` (Python producer) — `sys.exit(1)` guard
- `smoke-link-quotes-csv.mjs` (smoke for the broken parser) — `process.exit(1)` guard

### `pipeline-runner.mjs` change
Stage 2a-2d block (`bulk-appeal-outcome-correlator` phases 1-4) removed. Stage 1 `bulk-master-extractor.mjs --apply` (no `--tables` filter) already populates `appellate_trends` via DB-first Phase 0+1.

## Active scripts NOT deprecated (separate followups)
Still using csv-parse over CL opinions, but extract DIFFERENT fields than the 8 bulk-master tables / charge classification — DB-first migration tracked separately:
- `bulk-extract-motion-legal-issues.mjs` (extracts `motion_types`, `legal_issues`, `supporting_rulings`)
- `bulk-good-law-from-graph.mjs` (writes `is_good_law` via citation graph + plain_text scan)

## Verification
- [x] `node scripts/bulk-judge-quote-extractor.mjs` → exit 1 with banner
- [x] `node scripts/bulk-judge-quote-extractor.mjs --allow-deprecated` → runs original code (emergency-rollback preserved)
- [x] `python3 scripts/filter-criminal-opinions.py` → exit 1 with banner
- [x] All 13 .mjs files: `node --check` passes
- [x] `pipeline-runner.mjs`: `node --check` passes; STAGES count reduced 6→2

## Test plan
- [x] Syntax check all 14 modified scripts (13 deprecated + 1 pipeline-runner update)
- [x] Smoke-test deprecation guard fires + exits 1
- [x] Smoke-test --allow-deprecated bypasses guard
- [ ] Full `pipeline-runner.mjs` run (no `--dry-run`) post-merge to confirm Stage 1 `bulk-master --apply` produces expected `appellate_trends` count

Plan: `docs/plans/2026-05-04-deprecate-broken-csv-parse-scripts.md`
Stacks on: #313 (Phase 0)
Predecessors: #309 (T6), #312 (Phase 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)