### PR TITLE
feat(admin): extraction-coverage + matview-freshness operator dashboard (mirror)

### DIFF
--- a/src/app/admin/data-quality/page.tsx
+++ b/src/app/admin/data-quality/page.tsx
@@ -1,0 +1,295 @@
+/**
+ * /admin/data-quality — Operator extraction coverage + matview freshness dashboard.
+ *
+ * Server component. Fetches /api/admin/extraction-coverage and renders three
+ * sections: Extraction Coverage, Provenance Attribution, Matview Freshness.
+ *
+ * Auth: ADMIN_PASSWORD via X-Admin-Password header — same guard as all /admin/* routes.
+ * No client-side JS required beyond standard Next.js hydration.
+ */
+import { headers } from "next/headers";
+import Link from "next/link";
+import type { ExtractionCoveragePayload } from "@/app/api/admin/extraction-coverage/route";
+
+// ── Fetch helper ──────────────────────────────────────────────────────────
+
+async function fetchCoverage(): Promise<ExtractionCoveragePayload | null> {
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "http://localhost:3000";
+  const adminPassword = process.env.ADMIN_PASSWORD ?? "";
+
+  try {
+    const res = await fetch(`${baseUrl}/api/admin/extraction-coverage`, {
+      method: "GET",
+      headers: {
+        "x-admin-password": adminPassword,
+      },
+      cache: "no-store",
+    });
+
+    if (!res.ok) return null;
+    return res.json() as Promise<ExtractionCoveragePayload>;
+  } catch {
+    return null;
+  }
+}
+
+// ── Sub-components ────────────────────────────────────────────────────────
+
+interface PctBarProps {
+  pct: number;
+}
+
+function PctBar({ pct }: PctBarProps) {
+  const color =
+    pct >= 80 ? "bg-emerald-500" :
+    pct >= 40 ? "bg-amber-500" :
+    "bg-red-500";
+
+  return (
+    <div className="flex items-center gap-3">
+      <div className="flex-1 bg-zinc-800 rounded-full h-1.5">
+        <div
+          className={`h-1.5 rounded-full ${color}`}
+          style={{ width: `${Math.min(pct, 100)}%` }}
+        />
+      </div>
+      <span className="text-xs tabular-nums w-14 text-right text-zinc-300">
+        {pct.toFixed(1)}%
+      </span>
+    </div>
+  );
+}
+
+function SectionHeader({ title, subtitle }: { title: string; subtitle?: string }) {
+  return (
+    <div className="mb-4">
+      <h2 className="text-lg font-semibold text-white">{title}</h2>
+      {subtitle && <p className="text-sm text-zinc-400 mt-0.5">{subtitle}</p>}
+    </div>
+  );
+}
+
+function TableWrapper({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="overflow-x-auto rounded-lg border border-zinc-700">
+      <table className="w-full text-sm text-left">{children}</table>
+    </div>
+  );
+}
+
+function Th({ children }: { children: React.ReactNode }) {
+  return (
+    <th className="px-4 py-2.5 text-xs font-medium text-zinc-400 uppercase tracking-wider bg-zinc-800/60 border-b border-zinc-700">
+      {children}
+    </th>
+  );
+}
+
+function Td({ children, mono }: { children: React.ReactNode; mono?: boolean }) {
+  return (
+    <td className={`px-4 py-2.5 text-zinc-200 border-b border-zinc-800 ${mono ? "font-mono text-xs" : ""}`}>
+      {children}
+    </td>
+  );
+}
+
+// ── Page ─────────────────────────────────────────────────────────────────
+
+export const dynamic = "force-dynamic";
+
+export default async function DataQualityPage() {
+  const data = await fetchCoverage();
+
+  return (
+    <div className="min-h-screen bg-zinc-950 text-zinc-100 p-6 max-w-5xl mx-auto">
+      {/* Header */}
+      <div className="mb-8">
+        <nav className="flex items-center gap-4 text-sm text-zinc-400 mb-5">
+          <Link href="/admin/inbox" className="hover:text-white transition-colors">Inbox</Link>
+          <Link href="/admin/demand" className="hover:text-white transition-colors">Demand Intel</Link>
+          <Link href="/admin/partners" className="hover:text-white transition-colors">Partners</Link>
+          <span className="text-amber-400 font-medium">Data Quality</span>
+        </nav>
+        <h1 className="text-2xl font-bold text-white">Data Quality Dashboard</h1>
+        <p className="text-zinc-400 text-sm mt-1">
+          Extraction coverage, provenance attribution, and matview freshness.
+        </p>
+      </div>
+
+      {data == null ? (
+        <div className="rounded-lg border border-red-700 bg-red-900/20 px-5 py-4 text-red-300 text-sm">
+          Failed to load coverage data. Check ADMIN_PASSWORD env var and ensure the API route is deployed.
+        </div>
+      ) : (
+        <div className="space-y-10">
+
+          {/* ── Section 1: Extraction Coverage ───────────────────────────── */}
+          <section>
+            <SectionHeader
+              title="Extraction Coverage"
+              subtitle={`classified_opinions — ${data.classified_opinions.total.toLocaleString()} total rows`}
+            />
+            <TableWrapper>
+              <thead>
+                <tr>
+                  <Th>Column</Th>
+                  <Th>Populated</Th>
+                  <Th>Coverage</Th>
+                </tr>
+              </thead>
+              <tbody>
+                {(
+                  [
+                    ["officer_names", "Officer Names"],
+                    ["witness_names", "Witness Names"],
+                    ["expert_witness_names", "Expert Witness Names"],
+                    ["prosecutor_names", "Prosecutor Names"],
+                    ["defense_attorney_names", "Defense Attorney Names"],
+                    ["sentence_months_extracted", "Sentence Months"],
+                    ["fine_dollars_extracted", "Fine ($)"],
+                    ["restitution_dollars_extracted", "Restitution ($)"],
+                  ] as const
+                ).map(([key, label]) => {
+                  const col = data.classified_opinions[key];
+                  return (
+                    <tr key={key} className="hover:bg-zinc-900/40 transition-colors">
+                      <Td>{label}</Td>
+                      <Td mono>{col.populated.toLocaleString()}</Td>
+                      <Td>
+                        <PctBar pct={col.pct} />
+                      </Td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </TableWrapper>
+            {(data.classified_opinions.extracted_at_oldest || data.classified_opinions.extracted_at_newest) && (
+              <p className="text-xs text-zinc-500 mt-2">
+                Extraction range:{" "}
+                {data.classified_opinions.extracted_at_oldest
+                  ? new Date(data.classified_opinions.extracted_at_oldest).toLocaleDateString()
+                  : "—"}
+                {" "}→{" "}
+                {data.classified_opinions.extracted_at_newest
+                  ? new Date(data.classified_opinions.extracted_at_newest).toLocaleDateString()
+                  : "—"}
+              </p>
+            )}
+          </section>
+
+          {/* ── Section 2: Provenance Attribution ────────────────────────── */}
+          <section>
+            <SectionHeader
+              title="Provenance Attribution"
+              subtitle={`entities_officers — ${data.entities_officers.total.toLocaleString()} total rows`}
+            />
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-5">
+              <div className="rounded-lg border border-zinc-700 bg-zinc-900 px-4 py-3">
+                <div className="text-xs text-zinc-400 mb-1">Total Officers</div>
+                <div className="text-2xl font-semibold tabular-nums text-white">
+                  {data.entities_officers.total.toLocaleString()}
+                </div>
+              </div>
+              <div className="rounded-lg border border-zinc-700 bg-zinc-900 px-4 py-3">
+                <div className="text-xs text-zinc-400 mb-1">With Provenance</div>
+                <div className="text-2xl font-semibold tabular-nums text-white">
+                  {data.entities_officers.with_provenance.toLocaleString()}
+                </div>
+              </div>
+              <div className="rounded-lg border border-zinc-700 bg-zinc-900 px-4 py-3">
+                <div className="text-xs text-zinc-400 mb-1">Attribution Rate</div>
+                <div className={`text-2xl font-semibold tabular-nums ${data.entities_officers.pct >= 99 ? "text-emerald-400" : data.entities_officers.pct >= 80 ? "text-amber-400" : "text-red-400"}`}>
+                  {data.entities_officers.pct.toFixed(3)}%
+                </div>
+              </div>
+            </div>
+
+            {Object.keys(data.entities_officers.by_source).length > 0 && (
+              <TableWrapper>
+                <thead>
+                  <tr>
+                    <Th>Source</Th>
+                    <Th>Count</Th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {Object.entries(data.entities_officers.by_source)
+                    .sort((a, b) => b[1] - a[1])
+                    .map(([source, count]) => (
+                      <tr key={source} className="hover:bg-zinc-900/40 transition-colors">
+                        <Td mono>{source}</Td>
+                        <Td mono>{count.toLocaleString()}</Td>
+                      </tr>
+                    ))}
+                </tbody>
+              </TableWrapper>
+            )}
+          </section>
+
+          {/* ── Section 3: Matview Freshness ──────────────────────────────── */}
+          <section>
+            <SectionHeader
+              title="Matview Freshness"
+              subtitle="Cross-corpus materialized views — refreshed via cron-job.org weekly"
+            />
+            <TableWrapper>
+              <thead>
+                <tr>
+                  <Th>View</Th>
+                  <Th>Rows</Th>
+                  <Th>Last Refresh</Th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.matviews.map((mv) => (
+                  <tr key={mv.name} className="hover:bg-zinc-900/40 transition-colors">
+                    <Td mono>{mv.name}</Td>
+                    <Td mono>{mv.rows.toLocaleString()}</Td>
+                    <Td mono>
+                      {mv.last_refresh
+                        ? new Date(mv.last_refresh).toLocaleString()
+                        : <span className="text-zinc-500">—</span>}
+                    </Td>
+                  </tr>
+                ))}
+              </tbody>
+            </TableWrapper>
+
+            {/* Cron status */}
+            <div className="mt-4 rounded-lg border border-zinc-700 bg-zinc-900 px-4 py-3">
+              <div className="flex items-center justify-between">
+                <div>
+                  <div className="text-xs text-zinc-400 mb-0.5">Cron: /api/cron/refresh-cross-corpus-matviews</div>
+                  <div className="text-sm text-zinc-200">
+                    Last run:{" "}
+                    {data.cron.last_run
+                      ? new Date(data.cron.last_run).toLocaleString()
+                      : <span className="text-zinc-500">never</span>}
+                  </div>
+                </div>
+                <div>
+                  {data.cron.last_status === "ok" && (
+                    <span className="inline-flex items-center rounded-full bg-emerald-900/50 border border-emerald-600 text-emerald-300 text-xs px-2.5 py-0.5 font-medium">
+                      ok
+                    </span>
+                  )}
+                  {data.cron.last_status === "error" && (
+                    <span className="inline-flex items-center rounded-full bg-red-900/50 border border-red-600 text-red-300 text-xs px-2.5 py-0.5 font-medium">
+                      error
+                    </span>
+                  )}
+                  {data.cron.last_status === null && (
+                    <span className="inline-flex items-center rounded-full bg-zinc-800 border border-zinc-600 text-zinc-400 text-xs px-2.5 py-0.5 font-medium">
+                      not registered
+                    </span>
+                  )}
+                </div>
+              </div>
+            </div>
+          </section>
+
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/api/admin/extraction-coverage/__tests__/route.test.ts
+++ b/src/app/api/admin/extraction-coverage/__tests__/route.test.ts
@@ -1,0 +1,420 @@
+/**
+ * Unit tests for GET /api/admin/extraction-coverage.
+ *
+ * Tests auth (401 without header, 200 with valid header) and response
+ * shape validation. Stubs Supabase + requireAdmin so no real DB calls.
+ *
+ * Shape contract: all fields in ExtractionCoveragePayload must be present
+ * with correct types regardless of whether the admin_extraction_coverage
+ * RPC path or the manual-count fallback executes.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Mock requireAdmin ────────────────────────────────────────────────────
+vi.mock("@/lib/auth/guards", () => ({
+  requireAdmin: vi.fn(),
+}));
+
+// ── Mock createAdminClient ────────────────────────────────────────────────
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(),
+}));
+
+import { requireAdmin } from "@/lib/auth/guards";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { GET } from "../route";
+import type { ExtractionCoveragePayload } from "../route";
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+function makeReq(adminPassword?: string): NextRequest {
+  const headers: HeadersInit = adminPassword
+    ? { "x-admin-password": adminPassword }
+    : {};
+  return new NextRequest("http://localhost/api/admin/extraction-coverage", {
+    headers,
+  });
+}
+
+function makeUnauthorizedResponse() {
+  const { NextResponse } = require("next/server");
+  return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+}
+
+// Builds a stub Supabase client that returns the provided coverage data
+// from the admin_extraction_coverage RPC and minimal data for other calls.
+function makeStubSupabase(opts: {
+  rpcData?: Record<string, unknown> | null;
+  rpcError?: boolean;
+  officersTotal?: number;
+  officersGrouped?: Array<{ provenance_source: string }>;
+  cronRow?: { started_at: string; completed_at: string | null; errors: string[] } | null;
+} = {}) {
+  const {
+    rpcData = null,
+    rpcError = false,
+    officersTotal = 506031,
+    officersGrouped = [
+      { provenance_source: "cpd" },
+      { provenance_source: "nypd" },
+      { provenance_source: "cpd" },
+    ],
+    cronRow = { started_at: "2026-05-04T00:00:00Z", completed_at: "2026-05-04T00:01:00Z", errors: [] },
+  } = opts;
+
+  // Tracks which RPC was called.
+  const rpcCalls: string[] = [];
+
+  const fromHandlers: Record<string, unknown> = {
+    entities_officers: {
+      select: (cols: string, selectOpts?: unknown) => {
+        if (typeof selectOpts === "object" && selectOpts !== null && (selectOpts as { head?: boolean }).head) {
+          return { count: officersTotal, error: null };
+        }
+        // grouped query (no head)
+        return {
+          not: (_col: string, _op: string, _val: unknown) => ({
+            data: officersGrouped,
+            error: null,
+          }),
+          data: officersGrouped,
+          error: null,
+        };
+      },
+    },
+    mv_judge_officer_motion_rates: {
+      select: () => ({ count: 309, error: null }),
+    },
+    mv_judge_bench_fingerprint: {
+      select: () => ({ count: 2822, error: null }),
+    },
+    mv_judge_docket_caseload: {
+      select: () => ({ count: 3306, error: null }),
+    },
+    cron_runs: {
+      select: () => ({
+        order: () => ({
+          limit: () => ({
+            maybeSingle: async () => ({ data: cronRow, error: null }),
+          }),
+        }),
+      }),
+    },
+  };
+
+  return {
+    rpc: vi.fn(async (name: string) => {
+      rpcCalls.push(name);
+      if (name === "admin_extraction_coverage") {
+        if (rpcError) return { data: null, error: { message: "rpc not found" } };
+        return {
+          data: rpcData ?? {
+            total: 400000,
+            officer_names: 136000,
+            witness_names: 235000,
+            expert_witness_names: 100000,
+            prosecutor_names: 10000,
+            defense_attorney_names: 4000,
+            sentence_months_extracted: 86000,
+            fine_dollars_extracted: 19000,
+            restitution_dollars_extracted: 4000,
+            extracted_at_oldest: "2023-01-01T00:00:00Z",
+            extracted_at_newest: "2026-05-04T00:00:00Z",
+          },
+          error: null,
+        };
+      }
+      if (name === "admin_matview_last_refresh") {
+        return { data: "2026-05-04T03:00:00Z", error: null };
+      }
+      return { data: null, error: { message: "unknown rpc" } };
+    }),
+    from: vi.fn((table: string) => fromHandlers[table] ?? {
+      select: () => ({ count: 0, error: null }),
+    }),
+    _rpcCalls: rpcCalls,
+  };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────
+
+describe("GET /api/admin/extraction-coverage", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("returns 401 without admin password header", async () => {
+    const mockGuard = requireAdmin as ReturnType<typeof vi.fn>;
+    const errorRes = makeUnauthorizedResponse();
+    mockGuard.mockReturnValue({ authorized: false, error: errorRes });
+
+    const res = await GET(makeReq());
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 200 with valid admin password", async () => {
+    const mockGuard = requireAdmin as ReturnType<typeof vi.fn>;
+    mockGuard.mockReturnValue({ authorized: true, error: null });
+
+    const mockClient = makeStubSupabase();
+    (createAdminClient as ReturnType<typeof vi.fn>).mockReturnValue(mockClient);
+
+    const res = await GET(makeReq("correct-password"));
+    expect(res.status).toBe(200);
+  });
+
+  it("response has correct top-level shape", async () => {
+    const mockGuard = requireAdmin as ReturnType<typeof vi.fn>;
+    mockGuard.mockReturnValue({ authorized: true, error: null });
+
+    const mockClient = makeStubSupabase();
+    (createAdminClient as ReturnType<typeof vi.fn>).mockReturnValue(mockClient);
+
+    const res = await GET(makeReq("pw"));
+    const body = await res.json() as ExtractionCoveragePayload;
+
+    expect(body).toHaveProperty("classified_opinions");
+    expect(body).toHaveProperty("entities_officers");
+    expect(body).toHaveProperty("matviews");
+    expect(body).toHaveProperty("cron");
+  });
+
+  it("classified_opinions section has all required columns", async () => {
+    const mockGuard = requireAdmin as ReturnType<typeof vi.fn>;
+    mockGuard.mockReturnValue({ authorized: true, error: null });
+
+    const mockClient = makeStubSupabase();
+    (createAdminClient as ReturnType<typeof vi.fn>).mockReturnValue(mockClient);
+
+    const res = await GET(makeReq("pw"));
+    const body = await res.json() as ExtractionCoveragePayload;
+    const co = body.classified_opinions;
+
+    expect(typeof co.total).toBe("number");
+    const colKeys = [
+      "officer_names",
+      "witness_names",
+      "expert_witness_names",
+      "prosecutor_names",
+      "defense_attorney_names",
+      "sentence_months_extracted",
+      "fine_dollars_extracted",
+      "restitution_dollars_extracted",
+    ] as const;
+    for (const key of colKeys) {
+      expect(typeof co[key].populated).toBe("number");
+      expect(typeof co[key].pct).toBe("number");
+    }
+    // extracted_at fields: null or ISO string
+    expect(co.extracted_at_oldest === null || typeof co.extracted_at_oldest === "string").toBe(true);
+    expect(co.extracted_at_newest === null || typeof co.extracted_at_newest === "string").toBe(true);
+  });
+
+  it("pct values are 0-100 and match populated/total ratio", async () => {
+    const mockGuard = requireAdmin as ReturnType<typeof vi.fn>;
+    mockGuard.mockReturnValue({ authorized: true, error: null });
+
+    const mockClient = makeStubSupabase();
+    (createAdminClient as ReturnType<typeof vi.fn>).mockReturnValue(mockClient);
+
+    const res = await GET(makeReq("pw"));
+    const body = await res.json() as ExtractionCoveragePayload;
+    const co = body.classified_opinions;
+
+    // officer_names: 136000 / 400000 = 34.00
+    expect(co.officer_names.pct).toBeCloseTo(34.0, 1);
+    expect(co.officer_names.pct).toBeGreaterThanOrEqual(0);
+    expect(co.officer_names.pct).toBeLessThanOrEqual(100);
+  });
+
+  it("entities_officers has correct shape with provenance grouping", async () => {
+    const mockGuard = requireAdmin as ReturnType<typeof vi.fn>;
+    mockGuard.mockReturnValue({ authorized: true, error: null });
+
+    const mockClient = makeStubSupabase({
+      officersGrouped: [
+        { provenance_source: "cpd" },
+        { provenance_source: "cpd" },
+        { provenance_source: "oei" },
+      ],
+    });
+    (createAdminClient as ReturnType<typeof vi.fn>).mockReturnValue(mockClient);
+
+    const res = await GET(makeReq("pw"));
+    const body = await res.json() as ExtractionCoveragePayload;
+    const eo = body.entities_officers;
+
+    expect(typeof eo.total).toBe("number");
+    expect(typeof eo.with_provenance).toBe("number");
+    expect(typeof eo.pct).toBe("number");
+    expect(eo.by_source["cpd"]).toBe(2);
+    expect(eo.by_source["oei"]).toBe(1);
+    expect(eo.with_provenance).toBe(3);
+  });
+
+  it("matviews array has correct length and shape", async () => {
+    const mockGuard = requireAdmin as ReturnType<typeof vi.fn>;
+    mockGuard.mockReturnValue({ authorized: true, error: null });
+
+    const mockClient = makeStubSupabase();
+    (createAdminClient as ReturnType<typeof vi.fn>).mockReturnValue(mockClient);
+
+    const res = await GET(makeReq("pw"));
+    const body = await res.json() as ExtractionCoveragePayload;
+
+    expect(Array.isArray(body.matviews)).toBe(true);
+    expect(body.matviews.length).toBe(3);
+    for (const mv of body.matviews) {
+      expect(typeof mv.name).toBe("string");
+      expect(typeof mv.rows).toBe("number");
+      expect(mv.last_refresh === null || typeof mv.last_refresh === "string").toBe(true);
+    }
+  });
+
+  it("matviews rows match expected values", async () => {
+    const mockGuard = requireAdmin as ReturnType<typeof vi.fn>;
+    mockGuard.mockReturnValue({ authorized: true, error: null });
+
+    const mockClient = makeStubSupabase();
+    (createAdminClient as ReturnType<typeof vi.fn>).mockReturnValue(mockClient);
+
+    const res = await GET(makeReq("pw"));
+    const body = await res.json() as ExtractionCoveragePayload;
+
+    const mv = Object.fromEntries(body.matviews.map((m) => [m.name, m]));
+    expect(mv["mv_judge_officer_motion_rates"].rows).toBe(309);
+    expect(mv["mv_judge_bench_fingerprint"].rows).toBe(2822);
+    expect(mv["mv_judge_docket_caseload"].rows).toBe(3306);
+  });
+
+  it("cron section reflects ok status when no errors", async () => {
+    const mockGuard = requireAdmin as ReturnType<typeof vi.fn>;
+    mockGuard.mockReturnValue({ authorized: true, error: null });
+
+    const mockClient = makeStubSupabase({
+      cronRow: { started_at: "2026-05-04T00:00:00Z", completed_at: "2026-05-04T00:01:00Z", errors: [] },
+    });
+    (createAdminClient as ReturnType<typeof vi.fn>).mockReturnValue(mockClient);
+
+    const res = await GET(makeReq("pw"));
+    const body = await res.json() as ExtractionCoveragePayload;
+
+    expect(body.cron.last_status).toBe("ok");
+    expect(body.cron.last_run).toBe("2026-05-04T00:00:00Z");
+  });
+
+  it("cron section reflects error status when cron_runs.errors is non-empty", async () => {
+    const mockGuard = requireAdmin as ReturnType<typeof vi.fn>;
+    mockGuard.mockReturnValue({ authorized: true, error: null });
+
+    const mockClient = makeStubSupabase({
+      cronRow: { started_at: "2026-05-04T00:00:00Z", completed_at: null, errors: ["mv refresh failed"] },
+    });
+    (createAdminClient as ReturnType<typeof vi.fn>).mockReturnValue(mockClient);
+
+    const res = await GET(makeReq("pw"));
+    const body = await res.json() as ExtractionCoveragePayload;
+
+    expect(body.cron.last_status).toBe("error");
+  });
+
+  it("cron section is null when no cron runs exist", async () => {
+    const mockGuard = requireAdmin as ReturnType<typeof vi.fn>;
+    mockGuard.mockReturnValue({ authorized: true, error: null });
+
+    const mockClient = makeStubSupabase({ cronRow: null });
+    (createAdminClient as ReturnType<typeof vi.fn>).mockReturnValue(mockClient);
+
+    const res = await GET(makeReq("pw"));
+    const body = await res.json() as ExtractionCoveragePayload;
+
+    expect(body.cron.last_run).toBeNull();
+    expect(body.cron.last_status).toBeNull();
+  });
+
+  it("falls back gracefully when admin_extraction_coverage RPC is not deployed", async () => {
+    const mockGuard = requireAdmin as ReturnType<typeof vi.fn>;
+    mockGuard.mockReturnValue({ authorized: true, error: null });
+
+    // When RPC fails the route falls back to manual COUNT queries on
+    // classified_opinions. Provide a stub that returns a count for every
+    // .select(..., { head: true }) call and null for the maybeSingle date
+    // range queries, plus the standard entities_officers / matviews / cron.
+    const countStub = {
+      select: (_cols: string, opts?: { count?: string; head?: boolean }) => {
+        if (opts?.head) {
+          // Return a chainable object satisfying COUNT result and two chained .not() calls
+          // (array cols call .not(col,"is",null).not(col,"eq","{}")).
+          const leafCount = { count: 200000, error: null };
+          const notChain = { count: 200000, error: null, not: () => leafCount };
+          const countResult = { count: 400000, error: null, not: () => notChain };
+          return countResult;
+        }
+        // extracted_at maybeSingle queries
+        return {
+          not: (_c: string, _o: string, _v: unknown) => ({
+            order: () => ({
+              limit: () => ({
+                maybeSingle: async () => ({ data: null, error: null }),
+              }),
+            }),
+          }),
+        };
+      },
+    };
+
+    const client = {
+      rpc: vi.fn(async (name: string) => {
+        if (name === "admin_extraction_coverage") {
+          return { data: null, error: { message: "rpc not found" } };
+        }
+        if (name === "admin_matview_last_refresh") {
+          return { data: null, error: null };
+        }
+        return { data: null, error: { message: "unknown" } };
+      }),
+      from: vi.fn((table: string) => {
+        if (table === "classified_opinions") return countStub;
+        if (table === "entities_officers") {
+          return {
+            select: (_cols: string, opts?: { count?: string; head?: boolean }) => {
+              if (opts?.head) return { count: 506031, error: null };
+              return {
+                not: () => ({ data: [{ provenance_source: "cpd" }], error: null }),
+              };
+            },
+          };
+        }
+        if (
+          table === "mv_judge_officer_motion_rates" ||
+          table === "mv_judge_bench_fingerprint" ||
+          table === "mv_judge_docket_caseload"
+        ) {
+          return { select: () => ({ count: 0, error: null }) };
+        }
+        if (table === "cron_runs") {
+          return {
+            select: () => ({
+              order: () => ({
+                limit: () => ({
+                  maybeSingle: async () => ({ data: null, error: null }),
+                }),
+              }),
+            }),
+          };
+        }
+        return { select: () => ({ count: 0, error: null }) };
+      }),
+    };
+
+    (createAdminClient as ReturnType<typeof vi.fn>).mockReturnValue(client);
+
+    const res = await GET(makeReq("pw"));
+    // Should still return 200 — fallback path is non-fatal.
+    expect(res.status).toBe(200);
+    const body = await res.json() as ExtractionCoveragePayload;
+    expect(body).toHaveProperty("classified_opinions");
+    expect(body.classified_opinions.total).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/src/app/api/admin/extraction-coverage/route.ts
+++ b/src/app/api/admin/extraction-coverage/route.ts
@@ -1,0 +1,255 @@
+/**
+ * GET /api/admin/extraction-coverage
+ *
+ * Returns per-column extraction coverage on classified_opinions,
+ * provenance attribution rate on entities_officers, matview row counts
+ * and last-refresh timestamps, and cron last-run status for
+ * /api/cron/refresh-cross-corpus-matviews.
+ *
+ * Auth: ADMIN_PASSWORD via X-Admin-Password header.
+ * Used by: /admin/data-quality operator dashboard.
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/auth/guards";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// ── Types ─────────────────────────────────────────────────────────────────
+
+interface ColumnCoverage {
+  populated: number;
+  pct: number;
+}
+
+export interface ExtractionCoveragePayload {
+  classified_opinions: {
+    total: number;
+    officer_names: ColumnCoverage;
+    witness_names: ColumnCoverage;
+    expert_witness_names: ColumnCoverage;
+    prosecutor_names: ColumnCoverage;
+    defense_attorney_names: ColumnCoverage;
+    sentence_months_extracted: ColumnCoverage;
+    fine_dollars_extracted: ColumnCoverage;
+    restitution_dollars_extracted: ColumnCoverage;
+    extracted_at_oldest: string | null;
+    extracted_at_newest: string | null;
+  };
+  entities_officers: {
+    total: number;
+    with_provenance: number;
+    pct: number;
+    by_source: Record<string, number>;
+  };
+  matviews: Array<{ name: string; rows: number; last_refresh: string | null }>;
+  cron: {
+    last_run: string | null;
+    last_status: "ok" | "error" | null;
+    next_run: string | null;
+  };
+}
+
+// Array columns: populated when not null AND not empty array.
+const ARRAY_COLS = [
+  "officer_names",
+  "witness_names",
+  "expert_witness_names",
+  "prosecutor_names",
+  "defense_attorney_names",
+] as const;
+
+// Scalar numeric columns: populated when not null.
+const SCALAR_COLS = [
+  "sentence_months_extracted",
+  "fine_dollars_extracted",
+  "restitution_dollars_extracted",
+] as const;
+
+// Materialized views to report on.
+const MATVIEW_NAMES = [
+  "mv_judge_officer_motion_rates",
+  "mv_judge_bench_fingerprint",
+  "mv_judge_docket_caseload",
+] as const;
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+function pct(populated: number, total: number): number {
+  if (total === 0) return 0;
+  return Math.round((populated / total) * 10000) / 100;
+}
+
+// ── Route handler ─────────────────────────────────────────────────────────
+
+export async function GET(req: NextRequest) {
+  const auth = requireAdmin(req);
+  if (!auth.authorized) return auth.error;
+
+  const supabase = createAdminClient();
+
+  // ── 1. classified_opinions coverage via RPC (or manual fallback) ────────
+  const opinionsCoverageResult = await supabase.rpc("admin_extraction_coverage");
+
+  // ── 2. entities_officers: total count + grouped by provenance_source ────
+  const [officersTotalResult, officersGroupedResult] = await Promise.all([
+    supabase
+      .from("entities_officers")
+      .select("*", { count: "exact", head: true }),
+    supabase
+      .from("entities_officers")
+      .select("provenance_source")
+      .not("provenance_source", "is", null),
+  ]);
+
+  // ── 3. Matview row counts + last_refresh ────────────────────────────────
+  const matviewsData = await Promise.all(
+    MATVIEW_NAMES.map(async (name) => {
+      const { count } = await supabase
+        .from(name)
+        .select("*", { count: "exact", head: true });
+
+      // Try RPC for last_refresh; gracefully degrade to null if not deployed.
+      const { data: stat } = await supabase.rpc("admin_matview_last_refresh", {
+        mv_name: name,
+      });
+
+      return {
+        name,
+        rows: count ?? 0,
+        last_refresh: (stat as string | null) ?? null,
+      };
+    })
+  );
+
+  // ── 4. Cron last run ────────────────────────────────────────────────────
+  const cronResult = await supabase
+    .from("cron_runs")
+    .select("started_at, completed_at, errors")
+    .order("started_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  // ── Build classified_opinions section ─────────────────────────────────
+  let coSection: ExtractionCoveragePayload["classified_opinions"];
+
+  if (!opinionsCoverageResult.error && opinionsCoverageResult.data) {
+    const d = opinionsCoverageResult.data as Record<string, unknown>;
+    const total = Number(d.total ?? 0);
+
+    coSection = {
+      total,
+      officer_names: { populated: Number(d.officer_names ?? 0), pct: pct(Number(d.officer_names ?? 0), total) },
+      witness_names: { populated: Number(d.witness_names ?? 0), pct: pct(Number(d.witness_names ?? 0), total) },
+      expert_witness_names: { populated: Number(d.expert_witness_names ?? 0), pct: pct(Number(d.expert_witness_names ?? 0), total) },
+      prosecutor_names: { populated: Number(d.prosecutor_names ?? 0), pct: pct(Number(d.prosecutor_names ?? 0), total) },
+      defense_attorney_names: { populated: Number(d.defense_attorney_names ?? 0), pct: pct(Number(d.defense_attorney_names ?? 0), total) },
+      sentence_months_extracted: { populated: Number(d.sentence_months_extracted ?? 0), pct: pct(Number(d.sentence_months_extracted ?? 0), total) },
+      fine_dollars_extracted: { populated: Number(d.fine_dollars_extracted ?? 0), pct: pct(Number(d.fine_dollars_extracted ?? 0), total) },
+      restitution_dollars_extracted: { populated: Number(d.restitution_dollars_extracted ?? 0), pct: pct(Number(d.restitution_dollars_extracted ?? 0), total) },
+      extracted_at_oldest: (d.extracted_at_oldest as string | null) ?? null,
+      extracted_at_newest: (d.extracted_at_newest as string | null) ?? null,
+    };
+  } else {
+    // Fallback: parallel COUNT queries when admin_extraction_coverage RPC is not yet deployed.
+    const allCols = [...ARRAY_COLS, ...SCALAR_COLS];
+
+    const countResults = await Promise.all([
+      supabase.from("classified_opinions").select("*", { count: "exact", head: true }),
+      ...ARRAY_COLS.map((col) =>
+        supabase
+          .from("classified_opinions")
+          .select("*", { count: "exact", head: true })
+          .not(col, "is", null)
+          .not(col, "eq", "{}")
+      ),
+      ...SCALAR_COLS.map((col) =>
+        supabase
+          .from("classified_opinions")
+          .select("*", { count: "exact", head: true })
+          .not(col, "is", null)
+      ),
+      supabase
+        .from("classified_opinions")
+        .select("extracted_at")
+        .not("extracted_at", "is", null)
+        .order("extracted_at", { ascending: true })
+        .limit(1)
+        .maybeSingle(),
+      supabase
+        .from("classified_opinions")
+        .select("extracted_at")
+        .not("extracted_at", "is", null)
+        .order("extracted_at", { ascending: false })
+        .limit(1)
+        .maybeSingle(),
+    ]);
+
+    const total = countResults[0].count ?? 0;
+
+    const colMap: Record<string, ColumnCoverage> = {};
+    allCols.forEach((col, i) => {
+      const populated = countResults[i + 1]?.count ?? 0;
+      colMap[col] = { populated, pct: pct(populated, total) };
+    });
+
+    const oldestRes = countResults[countResults.length - 2] as { data: { extracted_at: string } | null };
+    const newestRes = countResults[countResults.length - 1] as { data: { extracted_at: string } | null };
+
+    coSection = {
+      total,
+      officer_names: colMap["officer_names"] ?? { populated: 0, pct: 0 },
+      witness_names: colMap["witness_names"] ?? { populated: 0, pct: 0 },
+      expert_witness_names: colMap["expert_witness_names"] ?? { populated: 0, pct: 0 },
+      prosecutor_names: colMap["prosecutor_names"] ?? { populated: 0, pct: 0 },
+      defense_attorney_names: colMap["defense_attorney_names"] ?? { populated: 0, pct: 0 },
+      sentence_months_extracted: colMap["sentence_months_extracted"] ?? { populated: 0, pct: 0 },
+      fine_dollars_extracted: colMap["fine_dollars_extracted"] ?? { populated: 0, pct: 0 },
+      restitution_dollars_extracted: colMap["restitution_dollars_extracted"] ?? { populated: 0, pct: 0 },
+      extracted_at_oldest: oldestRes.data?.extracted_at ?? null,
+      extracted_at_newest: newestRes.data?.extracted_at ?? null,
+    };
+  }
+
+  // ── Build entities_officers section ──────────────────────────────────
+  const officersTotal = officersTotalResult.count ?? 0;
+
+  const bySource: Record<string, number> = {};
+  for (const row of (officersGroupedResult.data ?? [])) {
+    const src = (row as { provenance_source: string | null }).provenance_source;
+    if (src) {
+      bySource[src] = (bySource[src] ?? 0) + 1;
+    }
+  }
+  const withProvenance = Object.values(bySource).reduce((s, n) => s + n, 0);
+
+  const officersSection: ExtractionCoveragePayload["entities_officers"] = {
+    total: officersTotal,
+    with_provenance: withProvenance,
+    pct: pct(withProvenance, officersTotal),
+    by_source: bySource,
+  };
+
+  // ── Build cron section ────────────────────────────────────────────────
+  const cronRow = cronResult.data;
+  const cronSection: ExtractionCoveragePayload["cron"] = {
+    last_run: cronRow?.started_at ?? null,
+    last_status:
+      cronRow == null
+        ? null
+        : Array.isArray(cronRow.errors) && (cronRow.errors as unknown[]).length > 0
+          ? "error"
+          : "ok",
+    next_run: null,
+  };
+
+  const payload: ExtractionCoveragePayload = {
+    classified_opinions: coSection,
+    entities_officers: officersSection,
+    matviews: matviewsData,
+    cron: cronSection,
+  };
+
+  return NextResponse.json(payload);
+}

--- a/src/lib/intelligence-brief/render.ts
+++ b/src/lib/intelligence-brief/render.ts
@@ -344,6 +344,8 @@ export function renderIntelligenceBriefHtml(
     sectionOutputs["ib-appendix-g"] || "",
     // Appendix H: Live Authority Map (IB $997 E1, 2026-04-23, mechanical render)
     sectionOutputs["ib-appendix-h"] || "",
+    // Appendix I: Judge Intelligence (cross-corpus bench fingerprint + caseload + conflicts)
+    sectionOutputs["ib-cross-corpus"] || "",
   ];
 
   const bodyHtml = sections


### PR DESCRIPTION
## Summary

Mirror of ImNotAnAttorney monorepo PR #98.

- Adds `GET /api/admin/extraction-coverage` — `requireAdmin` guard, RPC-first (`admin_extraction_coverage`) + parallel-COUNT fallback, returns classified_opinions column coverage (8 cols), entities_officers provenance attribution + by_source breakdown, matview row counts + last_refresh, cron last-run status
- Adds `/admin/data-quality` server component — 3 sections: Extraction Coverage table with PctBar progress bars, Provenance Attribution stat cards + source breakdown, Matview Freshness table + cron status badge
- 12 vitest tests (12/12 pass verified in worktree); tsc clean on new files

## Test plan

- [ ] `GET /api/admin/extraction-coverage` with valid `x-admin-password` → 200 + JSON payload
- [ ] `GET /api/admin/extraction-coverage` with missing/wrong password → 401
- [ ] `/admin/data-quality` page renders all 3 sections with real data
- [ ] Fallback path (RPC not deployed) → parallel COUNT queries populate coverage correctly
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)