### PR TITLE
chore(ci): retire two dead -web workflows

### DIFF
--- a/.github/workflows/auto-merge-claude-blog.yml
+++ b/.github/workflows/auto-merge-claude-blog.yml
@@ -1,97 +1,27 @@
-name: Auto-merge Claude blog posts
+# RETIRED 2026-07-06 — do not re-enable.
+#
+# Fired on push of `claude/blog-<slug>` branches to auto-merge blog MDX to master.
+# ORPHANED: it has zero runs in its entire history, and blog publishing moved to
+# the monorepo (`rahim0kapadia/ImNotAnAttorney`) — publish.ts commits blog posts
+# to the monorepo directly (verified 0 blog MDX stranded in -web). Nothing pushes
+# `claude/blog-*` branches to this legacy repo anymore.
+#
+# The auto-firing `push` trigger is removed. Kept as a documented tombstone
+# (git-reversible). See gbrain: inaa-cutover-complete-2026-07-06.
 
-# Fires when a CC Routine session pushes a claude/blog-<slug> branch to origin.
-# Defense-in-depth gates (round-2 hardening, 2026-04-21):
-#   1. Slug regex validation — blocks path-traversal (../) + shell-injection.
-#   2. Commit author gate — only commits by "INAA Routines Bot" fast-forward.
-#   3. Sidecar schema check — all_passed must be the JSON literal `true`.
-#   4. MDX content lint — reject <script>, dangerouslySetInnerHTML, <iframe>.
-#   5. Fetch-then-ff-merge-then-push with retry — handles racing merges.
-#   6. Idempotent delete — dangling branches never block future runs.
-#   7. Concurrency group — serializes merges to master, no stacked races.
+name: Auto-merge Claude blog posts (RETIRED)
 
 on:
-  push:
-    branches:
-      - 'claude/blog-*'
-
-concurrency:
-  group: auto-merge-claude-blog
-  cancel-in-progress: false
+  workflow_dispatch: {}
 
 jobs:
-  auto-merge:
+  retired-notice:
+    name: Retired — blog publishing lives in the monorepo
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
-      - uses: actions/checkout@v4
-      - name: Validate slug + actor + sidecar + MDX
+      - name: Explain
         run: |
-          set -euo pipefail
-          BRANCH="${GITHUB_REF#refs/heads/}"
-          SLUG="${BRANCH#claude/blog-}"
-          # 1. Slug regex — letters, digits, dashes only; 1-80 chars; no dot segments.
-          if ! [[ "$SLUG" =~ ^[a-z0-9][a-z0-9-]{0,79}$ ]]; then
-            echo "Slug failed regex check: '$SLUG' — refusing auto-merge."
-            exit 1
-          fi
-          # 2. Commit author gate — must be INAA Routines Bot.
-          AUTHOR_EMAIL=$(git log -1 --format='%ae' "origin/$BRANCH")
-          if [ "$AUTHOR_EMAIL" != "routines@imnotanattorney.com" ]; then
-            echo "Head commit author is '$AUTHOR_EMAIL' — only routines@imnotanattorney.com allowed. Refusing auto-merge."
-            exit 1
-          fi
-          # 3. Sidecar exists + all_passed strictly true (JSON boolean).
-          SIDECAR="content/blog/.qa-state/${SLUG}.json"
-          if [ ! -f "$SIDECAR" ]; then
-            echo "Sidecar missing: $SIDECAR — refusing auto-merge."
-            exit 1
-          fi
-          ALL_PASSED=$(jq 'if .all_passed == true then "true" else "false" end' "$SIDECAR" | tr -d '"')
-          if [ "$ALL_PASSED" != "true" ]; then
-            echo "Sidecar all_passed is not boolean true (slug=$SLUG) — refusing auto-merge."
-            exit 1
-          fi
-          # 4. MDX present + no dangerous constructs.
-          MDX="content/blog/${SLUG}.mdx"
-          if [ ! -f "$MDX" ]; then
-            echo "MDX missing: $MDX — refusing auto-merge."
-            exit 1
-          fi
-          FORBIDDEN='(<script[[:space:]>]|dangerouslySetInnerHTML|<iframe[[:space:]>]|javascript:|data:text/html)'
-          if grep -E "$FORBIDDEN" "$MDX" > /dev/null; then
-            echo "MDX contains forbidden construct — refusing auto-merge."
-            grep -nE "$FORBIDDEN" "$MDX" || true
-            exit 1
-          fi
-          echo "All gates passed for $SLUG."
-      - name: Fast-forward master with retry
-        run: |
-          set -euo pipefail
-          BRANCH="${GITHUB_REF#refs/heads/}"
-          git config user.name "INAA Routines Auto-Merge"
-          git config user.email "routines-automerge@imnotanattorney.com"
-          for attempt in 1 2 3; do
-            git fetch origin master "${BRANCH}"
-            git checkout master
-            git reset --hard origin/master
-            if ! git merge --ff-only "origin/${BRANCH}"; then
-              echo "Fast-forward not possible — branch diverged from master. Manual review needed."
-              exit 1
-            fi
-            if git push origin master; then
-              echo "Merged ${BRANCH} to master (attempt $attempt)."
-              exit 0
-            fi
-            echo "Push rejected on attempt $attempt — refetching and retrying."
-            sleep $((attempt * 3))
-          done
-          echo "Push still rejected after 3 attempts — giving up."
-          exit 1
-      - name: Delete merged branch
-        if: success()
-        continue-on-error: true
-        run: |
-          BRANCH="${GITHUB_REF#refs/heads/}"
-          git push origin --delete "${BRANCH}" || echo "Delete failed (already gone?) — non-fatal."
+          echo "RETIRED. Blog publishing moved to the monorepo rahim0kapadia/ImNotAnAttorney"
+          echo "(publish.ts commits posts directly). This repo is legacy; nothing pushes"
+          echo "claude/blog-* branches here anymore."
+          exit 0

--- a/.github/workflows/generate-report.yml
+++ b/.github/workflows/generate-report.yml
@@ -1,59 +1,32 @@
-name: Generate Case Decoder Report
-
-# Backup worker: picks up cases stuck in "generating" status for >3 minutes.
-# The Supabase Edge Function (primary path) has a 150s timeout — Opus 4.6 sometimes
-# takes 250-294s. This worker catches timeout cases with no timeout constraint.
+# RETIRED 2026-07-06 — do not re-enable.
 #
-# Schedule trigger REMOVED — GitHub suspended account for excessive cron usage.
-# Now triggered by cron-job.org -> Vercel /api/cron/generate-backup -> workflow_dispatch.
-# See src/app/api/cron/generate-backup/route.ts for the dispatch route.
+# Case Decoder backup worker (catches paid reports stuck in "generating" >3min).
+# Its dispatch path is DEAD: cron-job.org -> Vercel /api/cron/generate-backup ->
+# workflow_dispatch, and Vercel was retired 2026-07-06 (site now self-hosts on
+# the netcup box). This lane can no longer be triggered.
+#
+# The function was rebuilt on the box and is LIVE (verified 2026-07-06, log fresh,
+# "No timed-out cases to process"):
+#   /etc/cron.d/inaa-generate-worker — */5 * * * *, docker node:22-alpine,
+#   runs the same frozen -web scripts/generate-worker.mjs from /opt/inaa-worker.
+# So the paid-report safety net is covered off-GitHub; this lane is redundant.
+#
+# Kept as a documented tombstone (git-reversible). See gbrain:
+# inaa-selfhost-netcup-deployed-2026-07-05, inaa-supabase-migrations-resolved-2026-07-06.
+
+name: Generate Case Decoder Report (RETIRED)
 
 on:
-  workflow_dispatch: {}      # Triggered by cron-job.org via Vercel dispatch route
+  workflow_dispatch: {}
 
 jobs:
-  generate:
+  retired-notice:
+    name: Retired — worker runs on the netcup box
     runs-on: ubuntu-latest
-    timeout-minutes: 15
-
     steps:
-      - uses: actions/checkout@v4
-        with:
-          sparse-checkout: |
-            scripts
-            supabase/functions/generate-report
-
-      - name: Check for pending work
-        id: check
+      - name: Explain
         run: |
-          RESULT=$(curl -s \
-            -H "apikey: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}" \
-            -H "Authorization: Bearer ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}" \
-            "${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}/rest/v1/cases?status=eq.generating&select=id&limit=1")
-          if [ "$RESULT" = "[]" ]; then
-            echo "skip=true" >> $GITHUB_OUTPUT
-            echo "No generating cases found — skipping."
-          else
-            echo "skip=false" >> $GITHUB_OUTPUT
-            echo "Found generating case(s) — proceeding."
-          fi
-
-      - if: steps.check.outputs.skip == 'false'
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-
-      - if: steps.check.outputs.skip == 'false'
-        run: npm ci --ignore-scripts
-
-      - if: steps.check.outputs.skip == 'false'
-        run: node scripts/generate-worker.mjs
-        env:
-          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
-          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
-          RESEND_FROM_EMAIL: ${{ secrets.RESEND_FROM_EMAIL }}
-          OPERATOR_EMAIL: ${{ secrets.OPERATOR_EMAIL }}
-          OPERATOR_SECRET: ${{ secrets.OPERATOR_SECRET }}
-          NEXT_PUBLIC_SITE_URL: ${{ secrets.NEXT_PUBLIC_SITE_URL }}
+          echo "RETIRED. The Case Decoder backup worker now runs on the netcup box:"
+          echo "  /etc/cron.d/inaa-generate-worker (*/5) -> /opt/inaa-worker/scripts/generate-worker.mjs"
+          echo "This repo (ImNotAnAttorney-web) is legacy; Vercel dispatch path is gone."
+          exit 0


### PR DESCRIPTION
Legacy `-web` repo housekeeping — two workflows are dead after the netcup cutover.

## generate-report.yml (Case Decoder paid-report backup worker)
- Dispatch path was cron-job.org → **Vercel** `/api/cron/generate-backup` → `workflow_dispatch`. Vercel retired 2026-07-06, so the lane **can no longer be triggered**.
- Function rebuilt on the box and **verified LIVE**: `/etc/cron.d/inaa-generate-worker` (`*/5`), log fresh 2026-07-06 06:20, last run `No timed-out cases to process`.
- Paid-report safety net is covered off-GitHub → this lane is redundant.

## auto-merge-claude-blog.yml
- **Zero runs** in its entire history; blog publishing moved to the monorepo (`publish.ts` commits posts directly). Orphaned.

Both neutered to documented tombstones (git-reversible). Same disposition as `supabase-migrations.yml` and `backup.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)