### PR TITLE
docs(context): fix layout.tsx line drift breaking verify CI

### DIFF
--- a/src/app/CONTEXT.md
+++ b/src/app/CONTEXT.md
@@ -330,8 +330,8 @@ graph TD
 | `TIER_CORE` | 14 tiers (pricing + Stripe IDs) | `src/lib/tiers.ts:30-256` |
 | `PLAYBOOK_CONFIGS` | 8 charge-type sales pages | `src/lib/playbook-configs.ts` |
 | `SITE_URL` | `https://imnotanattorney.com` | `src/lib/site.ts:48-49` |
-| `metadataBase` | `new URL(SITE_URL)` | `layout.tsx:75` |
-| `title.template` | `"%s \| ImNotAnAttorney"` | `layout.tsx:78` |
+| `metadataBase` | `new URL(SITE_URL)` | `layout.tsx:74` |
+| `title.template` | `"%s \| ImNotAnAttorney"` | `layout.tsx:77` |
 | `maxDuration` (cron/demand-fetch) | 300s | `api/cron/demand-fetch/route.ts:19` |
 | `maxDuration` (cron/demand-score) | 120s | `api/cron/demand-score/route.ts:21` |
 | `maxDuration` (cron/blog-publish) | 60s | `api/cron/blog-publish/route.ts:22` |


### PR DESCRIPTION
`verify-architecture.js` pins exact `file:line` refs for documented constants. The two layout.tsx metadata constants (`metadataBase`, `title.template`) shifted up one line, so the check reported DRIFT and the `verify` CI job exited 1 on every -web PR (surfaced on #326).

Fix: sync `src/app/CONTEXT.md` line refs `layout.tsx:75→:74` and `:78→:77`. Values unchanged. `node docs/verify-architecture.js` now exits 0 (verified: both constants ✓, 0 drifted).